### PR TITLE
Manage gobl version manually

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,10 +26,15 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: "0" # make sure we get all commits!
+      - name: Read current version
+        run: |
+          grep 'const VERSION' version.go | sed -e 's/const VERSION Version = "gobl.org\//GOBL_VERSION="/' >> $GITHUB_ENV
 
       - name: Bump version and push tag
         id: bump
         uses: anothrNick/github-tag-action@1.26.0
+        with:
+          custom_tag: ${{ env.GOBL_VERSION }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_BRANCHES: main

--- a/version.go
+++ b/version.go
@@ -1,0 +1,21 @@
+package gobl
+
+import "strings"
+
+// Version contains a domain and semver for this version of GOBL.
+type Version string
+
+// VERSION is the version of the GOBL library.
+const VERSION Version = "gobl.org/v0.10.0"
+
+// Domain returns the domain portion of the version.
+func (v Version) Domain() string {
+	parts := strings.SplitN(string(v), "/", 2)
+	return parts[0]
+}
+
+// Semver returns the semver portion of the version.
+func (v Version) Semver() string {
+	parts := strings.SplitN(string(v), "/", 2)
+	return parts[1]
+}


### PR DESCRIPTION
This isn't tested. I'm not sure what'll happen if the tag already exists...