### PR TITLE
Check empty envelope before extraction

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,8 +14,8 @@ on:
   push:
     branches:
       - main
-    #paths:
-    #  - "version.go"
+    paths:
+      - "version.go"
     #paths-ignore:
     #  - "docs/**"
 

--- a/envelope.go
+++ b/envelope.go
@@ -138,6 +138,9 @@ func (e *Envelope) Insert(doc Document) error {
 
 // Extract the contents of the envelope into the provided document type.
 func (e *Envelope) Extract(doc Document) error {
+	if e.Document == nil {
+		return ErrNoDocument.WithErrorf("cannot extract document from empty envelope")
+	}
 	return e.Document.extract(doc)
 }
 

--- a/envelope_test.go
+++ b/envelope_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/invopop/gobl"
+	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/dsig"
 	"github.com/invopop/gobl/note"
 	"github.com/invopop/gobl/region"
@@ -46,6 +47,13 @@ func TestEnvelopePayload(t *testing.T) {
 	nm := new(note.Message)
 	assert.NoError(t, e.Extract(nm))
 	assert.Equal(t, m.Content, nm.Content, "content mismatch")
+}
+
+func TestEnvelopeExtract(t *testing.T) {
+	e := &gobl.Envelope{}
+	inv := new(bill.Invoice)
+	err := e.Extract(inv)
+	assert.ErrorIs(t, err, gobl.ErrNoDocument)
 }
 
 func TestEnvelopeValidate(t *testing.T) {

--- a/errors.go
+++ b/errors.go
@@ -17,6 +17,10 @@ var (
 	// ErrNoRegion is used when the envelope is missing a region.
 	ErrNoRegion = NewError("no-region")
 
+	// ErrNoDocument is provided when the envelope does not contain a
+	// document payload.
+	ErrNoDocument = NewError("no-document")
+
 	// ErrValidation is used when a document fails a validation request.
 	ErrValidation = NewError("validation")
 


### PR DESCRIPTION
Quick check for empty envelope payloads in extract call to avoid panics.