### PR TITLE
Copying over the JKU functionality from the Invopop jose lib

### DIFF
--- a/samples/message.yaml
+++ b/samples/message.yaml
@@ -1,0 +1,5 @@
+doc:
+  $schema: "https://gobl.org/draft-0/note/message"
+  title: "Test Message"
+  content: |-
+    We hope you like this test message!


### PR DESCRIPTION
Simple change to support the `"jku"` property inside signatures. This was already implemented in Invopop's "jose" lib, so we're just copy and pasting here. Will fast track, but your welcome to have a look.