### PR TITLE
Setting up a quick example of an envelop method

### DIFF
--- a/envelope.go
+++ b/envelope.go
@@ -42,6 +42,17 @@ func NewEnvelope() *Envelope {
 	return e
 }
 
+// Envelop is a convenience method that will build a new envelope and insert
+// the contents document provided in a single swoop. The resulting envelope
+// will still need to be signed afterwards.
+func Envelop(doc interface{}) (*Envelope, error) {
+	e := NewEnvelope()
+	if err := e.Insert(doc); err != nil {
+		return nil, err
+	}
+	return e, nil
+}
+
 // Validate ensures that the envelope contains everything it should to be considered valid GoBL.
 func (e *Envelope) Validate() error {
 	err := validation.ValidateStruct(e,

--- a/envelope_test.go
+++ b/envelope_test.go
@@ -16,6 +16,15 @@ import (
 
 var testKey = dsig.NewES256Key()
 
+func TestEnvelop(t *testing.T) {
+	msg := &note.Message{Content: "This is test content."}
+	e, err := gobl.Envelop(msg)
+	require.NoError(t, err)
+	if assert.NotNil(t, e) {
+		assert.Equal(t, "c6a5148ce90f70c24ebfe6de1abed0d0aafde4323a9bcf47cc4a5d544af9ea19", e.Head.Digest.Value)
+	}
+}
+
 func TestEnvelopeDocument(t *testing.T) {
 	m := new(note.Message)
 	m.Content = "This is test content."


### PR DESCRIPTION
Very simple implementation of an `Envelop` (verb) method that will create an envelope from the provided document contents, or provide an error.

This is mainly meant as an example of the terminology to use.