### PR TITLE
Consistent usage of percent instead of rate

### DIFF
--- a/bill/charges.go
+++ b/bill/charges.go
@@ -11,8 +11,8 @@ import (
 // applied before taxes.
 // TODO: use UNTDID 7161 code list
 type LineCharge struct {
-	// Percentage rate if fixed amount not applied
-	Rate *num.Percentage `json:"rate,omitempty" jsonschema:"title=Rate"`
+	// Percentage if fixed amount not applied
+	Percent *num.Percentage `json:"percent,omitempty" jsonschema:"title=Percent"`
 	// Fixed or resulting charge amount to apply
 	Amount num.Amount `json:"amount" jsonschema:"title=Amount"`
 	// Reference code.
@@ -40,12 +40,12 @@ type Charge struct {
 	Index int `json:"i" jsonschema:"title=Index"`
 	// Code to used to refer to the this charge
 	Ref string `json:"ref,omitempty" jsonschema:"title=Reference"`
-	// Base represents the value used as a base for rate calculations.
+	// Base represents the value used as a base for percent calculations.
 	// If not already provided, we'll take the invoices sum before
 	// discounts.
 	Base *num.Amount `json:"base,omitempty" jsonschema:"title=Base"`
-	// Percentage rate to apply to the invoice's Sum
-	Rate *num.Percentage `json:"rate,omitempty" jsonschema:"title=Rate"`
+	// Percentage to apply to the invoice's Sum
+	Percent *num.Percentage `json:"percent,omitempty" jsonschema:"title=Percent"`
 	// Amount to apply
 	Amount num.Amount `json:"amount" jsonschema:"title=Amount"`
 	// List of taxes to apply to the charge

--- a/bill/discounts.go
+++ b/bill/discounts.go
@@ -11,8 +11,8 @@ import (
 // applied before taxes.
 // TODO: use UNTDID 5189 code list
 type LineDiscount struct {
-	// Percentage rate if fixed amount not applied
-	Rate *num.Percentage `json:"rate,omitempty" jsonschema:"title=Rate"`
+	// Percentage if fixed amount not applied
+	Percent *num.Percentage `json:"percent,omitempty" jsonschema:"title=Percent"`
 	// Fixed discount amount to apply
 	Amount num.Amount `json:"amount" jsonschema:"title=Value"`
 	// Reason code.
@@ -42,11 +42,11 @@ type Discount struct {
 	Index int `json:"i" jsonschema:"title=Index"`
 	// Reference or ID for this Discount
 	Ref string `json:"ref,omitempty" jsonschema:"title=Reference"`
-	// Base represents the value used as a base for rate calculations.
+	// Base represents the value used as a base for percent calculations.
 	// If not already provided, we'll take the invoices sum.
 	Base *num.Amount `json:"base,omitempty" jsonschema:"title=Base"`
-	// Percentage rate to apply to the invoice's Sum
-	Rate *num.Percentage `json:"rate,omitempty" jsonschema:"title=Rate"`
+	// Percentage to apply to the invoice's Sum
+	Percent *num.Percentage `json:"percent,omitempty" jsonschema:"title=Percent"`
 	// Amount to apply
 	Amount num.Amount `json:"amount" jsonschema:"title=Amount"`
 	// List of taxes to apply to the discount

--- a/bill/invoice.go
+++ b/bill/invoice.go
@@ -258,11 +258,11 @@ func (inv *Invoice) calculate(r *tax.Region) error {
 	discounts := zero
 	for i, l := range inv.Discounts {
 		l.Index = i + 1
-		if l.Rate != nil && !l.Rate.IsZero() {
+		if l.Percent != nil && !l.Percent.IsZero() {
 			if l.Base == nil {
 				l.Base = &t.Sum
 			}
-			l.Amount = l.Rate.Of(*l.Base)
+			l.Amount = l.Percent.Of(*l.Base)
 		}
 		discounts = discounts.Add(l.Amount)
 		tls = append(tls, l)
@@ -276,11 +276,11 @@ func (inv *Invoice) calculate(r *tax.Region) error {
 	charges := zero
 	for i, l := range inv.Charges {
 		l.Index = i + 1
-		if l.Rate != nil && !l.Rate.IsZero() {
+		if l.Percent != nil && !l.Percent.IsZero() {
 			if l.Base == nil {
 				l.Base = &t.Sum
 			}
-			l.Amount = l.Rate.Of(*l.Base)
+			l.Amount = l.Percent.Of(*l.Base)
 		}
 		charges = charges.Add(l.Amount)
 		tls = append(tls, l)

--- a/bill/line.go
+++ b/bill/line.go
@@ -66,15 +66,15 @@ func (l *Line) calculate() {
 	l.Total = l.Sum
 
 	for _, d := range l.Discounts {
-		if d.Rate != nil && !d.Rate.IsZero() {
-			d.Amount = d.Rate.Of(l.Sum) // always override
+		if d.Percent != nil && !d.Percent.IsZero() {
+			d.Amount = d.Percent.Of(l.Sum) // always override
 		}
 		l.Total = l.Total.Subtract(d.Amount)
 	}
 
 	for _, c := range l.Charges {
-		if c.Rate != nil && !c.Rate.IsZero() {
-			c.Amount = c.Rate.Of(l.Sum) // always override
+		if c.Percent != nil && !c.Percent.IsZero() {
+			c.Amount = c.Percent.Of(l.Sum) // always override
 		}
 		l.Total = l.Total.Add(c.Amount)
 	}

--- a/pay/advance.go
+++ b/pay/advance.go
@@ -26,7 +26,7 @@ type Advance struct {
 	// Details about the advance.
 	Description string `json:"desc" jsonschema:"title=Description"`
 	// How much as a percentage of the total with tax was paid
-	Rate *num.Percentage `json:"rate,omitempty" jsonschema:"title=Rate"`
+	Percent *num.Percentage `json:"percent,omitempty" jsonschema:"title=Percent"`
 	// How much was paid.
 	Amount num.Amount `json:"amount" jsonschema:"title=Amount"`
 	// If different from the parent document's base currency.
@@ -44,7 +44,7 @@ func (a *Advance) Validate() error {
 // Calculate will update the amount using the rate of the provided
 // total, if defined.
 func (a *Advance) Calculate(totalWithTax num.Amount) {
-	if a.Rate != nil {
-		a.Amount = a.Rate.Of(totalWithTax)
+	if a.Percent != nil {
+		a.Amount = a.Percent.Of(totalWithTax)
 	}
 }

--- a/samples/es/invoice-es-es.yaml
+++ b/samples/es/invoice-es-es.yaml
@@ -30,6 +30,9 @@ lines:
       name: "Development services"
       price: "90.00"
       unit: "h"
+    discounts:
+      - percent: "10%"
+        reason: "Special discount"
     taxes:
       - cat: VAT
         rate: standard

--- a/version.go
+++ b/version.go
@@ -8,7 +8,7 @@ import (
 type Version string
 
 // VERSION is the current version of the GOBL library.
-const VERSION Version = "v0.21.1"
+const VERSION Version = "v0.22.0"
 
 // Semver parses and returns semver
 func (v Version) Semver() *semver.Version {


### PR DESCRIPTION
In order to be consistent with the meaning of "rate", which is mainly used with taxes, percentage values are now normally associated with attributes named `percent` instead of `rate`.