### PR TITLE
Tax Set Combo requires either rate key or percent

### DIFF
--- a/samples/es/invoice-es-es-freelance.yaml
+++ b/samples/es/invoice-es-es-freelance.yaml
@@ -1,0 +1,50 @@
+$schema: "https://gobl.org/draft-0/bill/invoice"
+currency: "EUR"
+issue_date: "2022-02-01"
+code: "SAMPLE-001"
+
+supplier:
+  tax_id:
+    country: "ES"
+    code: "B98602642" # random
+  name: "Provide One S.L."
+  emails:
+    - addr: "billing@example.com"
+  addresses:
+    - num: "42"
+      street: "Calle Pradillo"
+      locality: "Madrid"
+      region: "Madrid"
+      code: "28002"
+      country: "ES"
+
+customer:
+  tax_id:
+    country: "ES"
+    code: "54387763P"
+  name: "Sample Consumer"
+
+lines:
+  - quantity: 20
+    item:
+      name: "Development services"
+      price: "90.00"
+      unit: "h"
+    discounts:
+      - percent: "10%"
+        reason: "Special discount"
+    taxes:
+      - cat: VAT
+        rate: standard
+        percent: 21.0%
+      - cat: IRPF
+        percent: 15.0%
+        retained: true
+
+  - quantity: 1
+    item:
+      name: "Financial service"
+      price: "10.00"
+    taxes:
+      - cat: VAT
+        percent: "0%"

--- a/samples/es/invoice-es-es-freelance.yaml
+++ b/samples/es/invoice-es-es-freelance.yaml
@@ -39,7 +39,6 @@ lines:
         percent: 21.0%
       - cat: IRPF
         percent: 15.0%
-        retained: true
 
   - quantity: 1
     item:

--- a/tax/code.go
+++ b/tax/code.go
@@ -34,3 +34,14 @@ func (c Code) IsEmpty() bool {
 func (c Code) String() string {
 	return string(c)
 }
+
+// In returns true if the code's value matches one of those
+// in the provided array.
+func (c Code) In(ary []Code) bool {
+	for _, v := range ary {
+		if v == c {
+			return true
+		}
+	}
+	return false
+}

--- a/tax/errors.go
+++ b/tax/errors.go
@@ -9,6 +9,7 @@ type Error Key
 
 // Standard list of tax errors
 const (
+	ErrMissingRegion        Error = "missing-region"
 	ErrInvalidCategory      Error = "invalid-category"
 	ErrInvalidRate          Error = "invalid-rate"
 	ErrInvalidDate          Error = "invalid-date"

--- a/tax/key.go
+++ b/tax/key.go
@@ -14,6 +14,9 @@ var (
 	keyValidationRegexp = regexp.MustCompile(`^[a-z][a-z0-9-]+$`)
 )
 
+// KeyEmpty is used when no key is available.
+const KeyEmpty Key = ""
+
 // Validate ensures the key complies with the basic syntax
 // requirements.
 func (k Key) Validate() error {

--- a/tax/region.go
+++ b/tax/region.go
@@ -175,21 +175,3 @@ func (r *Rate) On(date cal.Date) *RateValue {
 	}
 	return nil
 }
-
-// prepareCombo updates the Combo object's internal properties to include the objects
-// for the region on a given date.
-func (r *Region) prepareCombo(c *Combo, date cal.Date) error {
-	c.category = r.Category(c.Category)
-	if c.category == nil {
-		return ErrInvalidCategory.WithMessage("'%s'", c.Category.String())
-	}
-	c.rate = c.category.Rate(c.Rate)
-	if c.rate == nil {
-		return ErrInvalidRate.WithMessage("'%s' not in category '%s'", c.Rate.String(), c.Category.String())
-	}
-	c.value = c.rate.On(date)
-	if c.value == nil {
-		return ErrInvalidDate.WithMessage("data unavailable for '%s' in '%s' on '%s'", c.Rate.String(), c.Category.String(), date.String())
-	}
-	return nil
-}

--- a/tax/set.go
+++ b/tax/set.go
@@ -4,31 +4,59 @@ import (
 	"fmt"
 
 	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"github.com/invopop/gobl/cal"
+	"github.com/invopop/gobl/num"
 )
 
 // Set defines a list of tax categories and their rates to be used alongside taxable items.
 type Set []*Combo
 
-// Combo represents the tax combination of a category code and rate key.
+// Combo represents the tax combination of a category code and rate key. The percent
+// and retained attributes will be determined automatically from the Rate key if set
+// during calculation.
 type Combo struct {
 	// Tax category code from those available inside a region.
 	Category Code `json:"cat" jsonschema:"title=Category"`
 	// Rate within a category to apply.
-	Rate Key `json:"rate" jsonschema:"title=Rate"`
-
-	// Objects used internally for making calculations on specific dates
-	// see the Region#prepareCombo method for usage.
-	category *Category
-	rate     *Rate
-	value    *RateValue
+	Rate Key `json:"rate,omitempty" jsonschema:"title=Rate"`
+	// Percent defines the percentage set manually or determined from the rate key.
+	Percent num.Percentage `json:"percent" jsonschema:"title=Percent"`
+	// Retained when true indicates the percent is retained from the totals
+	// instead of added.
+	Retained bool `json:"retained,omitempty" jsonschema:"title=Retained"`
 }
 
 // Validate ensures the Combo contains all the details required.
 func (c *Combo) Validate() error {
 	return validation.ValidateStruct(c,
 		validation.Field(&c.Category, validation.Required),
-		validation.Field(&c.Rate, validation.Required),
+		validation.Field(&c.Rate),
+		validation.Field(&c.Percent, validation.Required),
 	)
+}
+
+// prepare updates the Combo object's Percent and Retained properties according
+// to the region and date provided.
+func (c *Combo) prepare(r *Region, date cal.Date) error {
+	category := r.Category(c.Category)
+	if category == nil {
+		return ErrInvalidCategory.WithMessage("'%s' is not defined in region", c.Category.String())
+	}
+
+	if c.Rate != KeyEmpty {
+		rate := category.Rate(c.Rate)
+		if rate == nil {
+			return ErrInvalidRate.WithMessage("'%s' not in category '%s'", c.Rate.String(), c.Category.String())
+		}
+		value := rate.On(date)
+		if value == nil {
+			return ErrInvalidDate.WithMessage("data unavailable for '%s' in '%s' on '%s'", c.Rate.String(), c.Category.String(), date.String())
+		}
+		c.Percent = value.Percent
+		c.Retained = category.Retained
+	}
+
+	return nil
 }
 
 // Validate ensures the set of tax combos looks correct

--- a/tax/set.go
+++ b/tax/set.go
@@ -26,11 +26,11 @@ type Combo struct {
 	Retained bool `json:"retained,omitempty" jsonschema:"title=Retained"`
 }
 
-// Validate ensures the Combo contains all the details required.
+// Validate ensures the Combo has the correct details.
 func (c *Combo) Validate() error {
 	return validation.ValidateStruct(c,
 		validation.Field(&c.Category, validation.Required),
-		validation.Field(&c.Rate),
+		validation.Field(&c.Rate), // optional, but should be checked if present
 		validation.Field(&c.Percent, validation.Required),
 	)
 }

--- a/tax/set.go
+++ b/tax/set.go
@@ -42,6 +42,8 @@ func (c *Combo) prepare(r *Region, date cal.Date) error {
 	if category == nil {
 		return ErrInvalidCategory.WithMessage("'%s' not in region", c.Category.String())
 	}
+	// always override retained value as this comes from category
+	c.Retained = category.Retained
 
 	if c.Rate != KeyEmpty {
 		rate := category.Rate(c.Rate)
@@ -53,7 +55,6 @@ func (c *Combo) prepare(r *Region, date cal.Date) error {
 			return ErrInvalidDate.WithMessage("data unavailable for '%s' in '%s' on '%s'", c.Rate.String(), c.Category.String(), date.String())
 		}
 		c.Percent = value.Percent
-		c.Retained = category.Retained
 	}
 
 	return nil

--- a/tax/set.go
+++ b/tax/set.go
@@ -40,7 +40,7 @@ func (c *Combo) Validate() error {
 func (c *Combo) prepare(r *Region, date cal.Date) error {
 	category := r.Category(c.Category)
 	if category == nil {
-		return ErrInvalidCategory.WithMessage("'%s' is not defined in region", c.Category.String())
+		return ErrInvalidCategory.WithMessage("'%s' not in region", c.Category.String())
 	}
 
 	if c.Rate != KeyEmpty {

--- a/tax/totals.go
+++ b/tax/totals.go
@@ -129,7 +129,10 @@ func (t *Total) Calculate(reg *Region, lines []TaxableLine, taxIncluded Code, da
 	// Go through each line and add the price to the base of each tax
 	for _, tl := range taxLines {
 		for _, c := range tl.taxes {
-			rt := t.rateTotalFor(c, zero)
+			rt, err := t.rateTotalFor(c, zero)
+			if err != nil {
+				return err
+			}
 			rt.Base = rt.Base.MatchPrecision(tl.price)
 			rt.Base = rt.Base.Add(tl.price)
 		}
@@ -163,7 +166,8 @@ func (ct *CategoryTotal) calculate(zero num.Amount) {
 }
 
 // rateTotalFor either finds of creates total objects for the category and rate.
-func (t *Total) rateTotalFor(c *Combo, zero num.Amount) *RateTotal {
+// May error if we detect and incorrect combination.
+func (t *Total) rateTotalFor(c *Combo, zero num.Amount) (*RateTotal, error) {
 	var catTotal *CategoryTotal
 	for _, ct := range t.Categories {
 		if ct.Code == c.Category {
@@ -180,6 +184,9 @@ func (t *Total) rateTotalFor(c *Combo, zero num.Amount) *RateTotal {
 	var rateTotal *RateTotal
 	for _, rt := range catTotal.Rates {
 		if rt.Percent.Equals(c.Percent) {
+			if catTotal.Retained != c.Retained {
+				return nil, ErrInvalidRate.WithMessage("'%s' cannot mix retained values", c.Category)
+			}
 			rateTotal = rt
 			break
 		}
@@ -189,7 +196,7 @@ func (t *Total) rateTotalFor(c *Combo, zero num.Amount) *RateTotal {
 		catTotal.Rates = append(catTotal.Rates, rateTotal)
 	}
 
-	return rateTotal
+	return rateTotal, nil
 }
 
 // taxLine is used to replace

--- a/tax/totals.go
+++ b/tax/totals.go
@@ -5,15 +5,6 @@ import (
 	"github.com/invopop/gobl/num"
 )
 
-// RateTotal contains a sum of all the tax rates in the document with
-// a matching category and definition.
-type RateTotal struct {
-	Key     Key            `json:"key" jsonschema:"title=Key"`
-	Base    num.Amount     `json:"base" jsonschema:"title=Base"`
-	Percent num.Percentage `json:"percent" jsonschema:"title=Percent"`
-	Amount  num.Amount     `json:"amount" jsonschema:"title=Amount"`
-}
-
 // CategoryTotal groups together all rates inside a given category.
 type CategoryTotal struct {
 	Code     Code         `json:"code" jsonschema:"title=Code"`
@@ -21,6 +12,16 @@ type CategoryTotal struct {
 	Rates    []*RateTotal `json:"rates" jsonschema:"title=Rates"`
 	Base     num.Amount   `json:"base" jsonschema:"title=Base"`
 	Amount   num.Amount   `json:"amount" jsonschema:"title=Amount"`
+}
+
+// RateTotal contains a sum of all the tax rates in the document with
+// a matching category and rate. The Key is optional as we may be using
+// the percentage to group rates.
+type RateTotal struct {
+	Key     Key            `json:"key,omitempty" jsonschema:"title=Key"`
+	Base    num.Amount     `json:"base" jsonschema:"title=Base"`
+	Percent num.Percentage `json:"percent" jsonschema:"title=Percent"`
+	Amount  num.Amount     `json:"amount" jsonschema:"title=Amount"`
 }
 
 // Total contains a set of Category Totals which in turn
@@ -48,22 +49,22 @@ func NewTotal(zero num.Amount) *Total {
 	return t
 }
 
-// NewCategoryTotal prepares a category total calculation.
-func NewCategoryTotal(code Code, retained bool, zero num.Amount) *CategoryTotal {
+// newCategoryTotal prepares a category total calculation.
+func newCategoryTotal(c *Combo, zero num.Amount) *CategoryTotal {
 	ct := new(CategoryTotal)
-	ct.Code = code
+	ct.Code = c.Category
 	ct.Rates = make([]*RateTotal, 0)
 	ct.Base = zero
 	ct.Amount = zero
-	ct.Retained = retained
+	ct.Retained = c.Retained
 	return ct
 }
 
-// NewRateTotal returns a rate total.
-func NewRateTotal(key Key, percent num.Percentage, zero num.Amount) *RateTotal {
+// newRateTotal returns a rate total.
+func newRateTotal(c *Combo, zero num.Amount) *RateTotal {
 	rt := new(RateTotal)
-	rt.Key = key
-	rt.Percent = percent
+	rt.Key = c.Rate // may be empty!
+	rt.Percent = c.Percent
 	rt.Base = zero
 	rt.Amount = zero
 	return rt
@@ -110,7 +111,7 @@ func (t *Total) Calculate(reg *Region, lines []TaxableLine, taxIncluded Code, da
 	// First, prepare all tax combos with the region and date details
 	for _, tl := range taxLines {
 		for _, c := range tl.taxes {
-			if err := reg.prepareCombo(c, date); err != nil {
+			if err := c.prepare(reg, date); err != nil {
 				return err
 			}
 		}
@@ -123,13 +124,13 @@ func (t *Total) Calculate(reg *Region, lines []TaxableLine, taxIncluded Code, da
 		for _, tl := range taxLines {
 			if rate := tl.rateForCategory(taxIncluded); rate != "" {
 				c := tl.taxes.Get(taxIncluded)
-				if c.category.Retained {
+				if c.Retained {
 					return ErrInvalidPricesInclude.WithMessage("cannot include retained category '%s'", taxIncluded.String())
 				}
 
 				// update the price scale, add two 0s, this will be removed later.
 				tl.price = tl.price.Rescale(tl.price.Exp() + 2)
-				tl.price = tl.price.Subtract(c.value.Percent.From(tl.price))
+				tl.price = tl.price.Subtract(c.Percent.From(tl.price))
 			}
 		}
 	}
@@ -180,20 +181,20 @@ func (t *Total) rateTotalFor(c *Combo, zero num.Amount) *RateTotal {
 		}
 	}
 	if catTotal == nil {
-		catTotal = NewCategoryTotal(c.Category, c.category.Retained, zero)
+		catTotal = newCategoryTotal(c, zero)
 		t.Categories = append(t.Categories, catTotal)
 	}
 
-	// Prepare the Rate
+	// Prepare the Rate, match using percent value
 	var rateTotal *RateTotal
 	for _, rt := range catTotal.Rates {
-		if rt.Key == c.Rate {
+		if rt.Percent.Equals(c.Percent) {
 			rateTotal = rt
 			break
 		}
 	}
 	if rateTotal == nil {
-		rateTotal = NewRateTotal(c.Rate, c.value.Percent, zero)
+		rateTotal = newRateTotal(c, zero)
 		catTotal.Rates = append(catTotal.Rates, rateTotal)
 	}
 

--- a/tax/totals.go
+++ b/tax/totals.go
@@ -92,18 +92,9 @@ func (ct *CategoryTotal) Rate(key Key) *RateTotal {
 
 // Calculate figures out the total taxes for the set of `TaxableLine`s provided.
 func (t *Total) Calculate(reg *Region, lines []TaxableLine, taxIncluded Code, date cal.Date, zero num.Amount) error {
-	// NOTE: This method looks more complex than it could be as we're providing
-	// additional logic that will deal with situations whereby a tax is included
-	// in line prices potentially with other taxes.
-	//
-	// A typical use case for this is in Spain whereby regular VAT needs to be applied
-	// alongside IRPF (income tax) which is retained by the client.
-	//
-	// Tax surcharges (another very rare addition) are also not included in prices that
-	// include tax.
-	//
-	// As a general rule, invoice taxes must always be calculated at the last possible
-	// moment to avoid accumulating rounding errors.
+	if reg == nil {
+		return ErrMissingRegion
+	}
 
 	// get a simplified list of lines we can manipulate if needed
 	taxLines := mapTaxLines(lines)

--- a/tax/totals.go
+++ b/tax/totals.go
@@ -129,10 +129,7 @@ func (t *Total) Calculate(reg *Region, lines []TaxableLine, taxIncluded Code, da
 	// Go through each line and add the price to the base of each tax
 	for _, tl := range taxLines {
 		for _, c := range tl.taxes {
-			rt, err := t.rateTotalFor(c, zero)
-			if err != nil {
-				return err
-			}
+			rt := t.rateTotalFor(c, zero)
 			rt.Base = rt.Base.MatchPrecision(tl.price)
 			rt.Base = rt.Base.Add(tl.price)
 		}
@@ -167,7 +164,7 @@ func (ct *CategoryTotal) calculate(zero num.Amount) {
 
 // rateTotalFor either finds of creates total objects for the category and rate.
 // May error if we detect and incorrect combination.
-func (t *Total) rateTotalFor(c *Combo, zero num.Amount) (*RateTotal, error) {
+func (t *Total) rateTotalFor(c *Combo, zero num.Amount) *RateTotal {
 	var catTotal *CategoryTotal
 	for _, ct := range t.Categories {
 		if ct.Code == c.Category {
@@ -184,9 +181,6 @@ func (t *Total) rateTotalFor(c *Combo, zero num.Amount) (*RateTotal, error) {
 	var rateTotal *RateTotal
 	for _, rt := range catTotal.Rates {
 		if rt.Percent.Equals(c.Percent) {
-			if catTotal.Retained != c.Retained {
-				return nil, ErrInvalidRate.WithMessage("'%s' cannot mix retained values", c.Category)
-			}
 			rateTotal = rt
 			break
 		}
@@ -196,7 +190,7 @@ func (t *Total) rateTotalFor(c *Combo, zero num.Amount) (*RateTotal, error) {
 		catTotal.Rates = append(catTotal.Rates, rateTotal)
 	}
 
-	return rateTotal, nil
+	return rateTotal
 }
 
 // taxLine is used to replace

--- a/tax/totals_test.go
+++ b/tax/totals_test.go
@@ -239,6 +239,49 @@ func TestTotalCalculate(t *testing.T) {
 			},
 		},
 		{
+			desc: "with multiline VAT as percentages correcting invalid rectified property",
+			lines: []tax.TaxableLine{
+				&taxableLine{
+					taxes: tax.Set{
+						{
+							Category: common.TaxCategoryVAT,
+							Percent:  num.MakePercentage(210, 3),
+						},
+					},
+					amount: num.MakeAmount(10000, 2),
+				},
+				&taxableLine{
+					taxes: tax.Set{
+						{
+							Category: common.TaxCategoryVAT,
+							Percent:  num.MakePercentage(210, 3),
+							Retained: true, // this will be ignored
+						},
+					},
+					amount: num.MakeAmount(15000, 2),
+				},
+			},
+			taxIncluded: "",
+			want: &tax.Total{
+				Categories: []*tax.CategoryTotal{
+					{
+						Code:     common.TaxCategoryVAT,
+						Retained: false,
+						Rates: []*tax.RateTotal{
+							{
+								Base:    num.MakeAmount(25000, 2),
+								Percent: num.MakePercentage(210, 3),
+								Amount:  num.MakeAmount(5250, 2),
+							},
+						},
+						Base:   num.MakeAmount(25000, 2),
+						Amount: num.MakeAmount(5250, 2),
+					},
+				},
+				Sum: num.MakeAmount(5250, 2),
+			},
+		},
+		{
 			desc: "with multirate VAT",
 			lines: []tax.TaxableLine{
 				&taxableLine{
@@ -552,32 +595,7 @@ func TestTotalCalculate(t *testing.T) {
 			err:        tax.ErrInvalidRate,
 			errContent: "invalid-rate: 'standard' not in category 'IRPF'",
 		},
-		{
-			desc: "with multirate VAT as percentages",
-			lines: []tax.TaxableLine{
-				&taxableLine{
-					taxes: tax.Set{
-						{
-							Category: common.TaxCategoryVAT,
-							Percent:  num.MakePercentage(210, 3),
-						},
-					},
-					amount: num.MakeAmount(10000, 2),
-				},
-				&taxableLine{
-					taxes: tax.Set{
-						{
-							Category: common.TaxCategoryVAT,
-							Percent:  num.MakePercentage(210, 3),
-							Retained: true,
-						},
-					},
-					amount: num.MakeAmount(15000, 2),
-				},
-			},
-			err:        tax.ErrInvalidRate,
-			errContent: "invalid-rate: 'VAT' cannot mix retained values",
-		},
+
 		{
 			desc: "with invalid rate on date",
 			date: cal.NewDate(2005, 1, 1),

--- a/tax/totals_test.go
+++ b/tax/totals_test.go
@@ -553,6 +553,32 @@ func TestTotalCalculate(t *testing.T) {
 			errContent: "invalid-rate: 'standard' not in category 'IRPF'",
 		},
 		{
+			desc: "with multirate VAT as percentages",
+			lines: []tax.TaxableLine{
+				&taxableLine{
+					taxes: tax.Set{
+						{
+							Category: common.TaxCategoryVAT,
+							Percent:  num.MakePercentage(210, 3),
+						},
+					},
+					amount: num.MakeAmount(10000, 2),
+				},
+				&taxableLine{
+					taxes: tax.Set{
+						{
+							Category: common.TaxCategoryVAT,
+							Percent:  num.MakePercentage(210, 3),
+							Retained: true,
+						},
+					},
+					amount: num.MakeAmount(15000, 2),
+				},
+			},
+			err:        tax.ErrInvalidRate,
+			errContent: "invalid-rate: 'VAT' cannot mix retained values",
+		},
+		{
 			desc: "with invalid rate on date",
 			date: cal.NewDate(2005, 1, 1),
 			lines: []tax.TaxableLine{
@@ -596,10 +622,10 @@ func TestTotalCalculate(t *testing.T) {
 			}
 			tot := tax.NewTotal(zero)
 			err := tot.Calculate(spain, test.lines, test.taxIncluded, d, zero)
-			if test.err != nil {
+			if test.err != nil && assert.Error(t, err) {
 				assert.ErrorIs(t, err, test.err)
 			}
-			if test.errContent != "" {
+			if test.errContent != "" && assert.Error(t, err) {
 				assert.Contains(t, err.Error(), test.errContent)
 			}
 			if test.want != nil {

--- a/tax/totals_test.go
+++ b/tax/totals_test.go
@@ -85,6 +85,75 @@ func TestTotalCalculate(t *testing.T) {
 			},
 		},
 		{
+			desc: "with VAT percents defined",
+			lines: []tax.TaxableLine{
+				&taxableLine{
+					taxes: tax.Set{
+						{
+							Category: common.TaxCategoryVAT,
+							Percent:  num.MakePercentage(210, 3),
+						},
+					},
+					amount: num.MakeAmount(10000, 2),
+				},
+			},
+			taxIncluded: "",
+			want: &tax.Total{
+				Categories: []*tax.CategoryTotal{
+					{
+						Code:     common.TaxCategoryVAT,
+						Retained: false,
+						Rates: []*tax.RateTotal{
+							{
+								// Key:     common.TaxRateStandard,
+								Base:    num.MakeAmount(10000, 2),
+								Percent: num.MakePercentage(210, 3),
+								Amount:  num.MakeAmount(2100, 2),
+							},
+						},
+						Base:   num.MakeAmount(10000, 2),
+						Amount: num.MakeAmount(2100, 2),
+					},
+				},
+				Sum: num.MakeAmount(2100, 2),
+			},
+		},
+		{
+			desc: "with VAT percents defined, rate override",
+			lines: []tax.TaxableLine{
+				&taxableLine{
+					taxes: tax.Set{
+						{
+							Category: common.TaxCategoryVAT,
+							Rate:     common.TaxRateStandard,
+							Percent:  num.MakePercentage(200, 3),
+						},
+					},
+					amount: num.MakeAmount(10000, 2),
+				},
+			},
+			taxIncluded: "",
+			want: &tax.Total{
+				Categories: []*tax.CategoryTotal{
+					{
+						Code:     common.TaxCategoryVAT,
+						Retained: false,
+						Rates: []*tax.RateTotal{
+							{
+								Key:     common.TaxRateStandard,
+								Base:    num.MakeAmount(10000, 2),
+								Percent: num.MakePercentage(210, 3),
+								Amount:  num.MakeAmount(2100, 2),
+							},
+						},
+						Base:   num.MakeAmount(10000, 2),
+						Amount: num.MakeAmount(2100, 2),
+					},
+				},
+				Sum: num.MakeAmount(2100, 2),
+			},
+		},
+		{
 			desc: "with multiline VAT",
 			lines: []tax.TaxableLine{
 				&taxableLine{
@@ -115,6 +184,48 @@ func TestTotalCalculate(t *testing.T) {
 						Rates: []*tax.RateTotal{
 							{
 								Key:     common.TaxRateStandard,
+								Base:    num.MakeAmount(25000, 2),
+								Percent: num.MakePercentage(210, 3),
+								Amount:  num.MakeAmount(5250, 2),
+							},
+						},
+						Base:   num.MakeAmount(25000, 2),
+						Amount: num.MakeAmount(5250, 2),
+					},
+				},
+				Sum: num.MakeAmount(5250, 2),
+			},
+		},
+		{
+			desc: "with multiline VAT as percentages",
+			lines: []tax.TaxableLine{
+				&taxableLine{
+					taxes: tax.Set{
+						{
+							Category: common.TaxCategoryVAT,
+							Percent:  num.MakePercentage(210, 3),
+						},
+					},
+					amount: num.MakeAmount(10000, 2),
+				},
+				&taxableLine{
+					taxes: tax.Set{
+						{
+							Category: common.TaxCategoryVAT,
+							Percent:  num.MakePercentage(2100, 4), // different exp.
+						},
+					},
+					amount: num.MakeAmount(15000, 2),
+				},
+			},
+			taxIncluded: "",
+			want: &tax.Total{
+				Categories: []*tax.CategoryTotal{
+					{
+						Code:     common.TaxCategoryVAT,
+						Retained: false,
+						Rates: []*tax.RateTotal{
+							{
 								Base:    num.MakeAmount(25000, 2),
 								Percent: num.MakePercentage(210, 3),
 								Amount:  num.MakeAmount(5250, 2),
@@ -164,6 +275,55 @@ func TestTotalCalculate(t *testing.T) {
 							},
 							{
 								Key:     common.TaxRateReduced,
+								Base:    num.MakeAmount(15000, 2),
+								Percent: num.MakePercentage(100, 3),
+								Amount:  num.MakeAmount(1500, 2),
+							},
+						},
+						Base:   num.MakeAmount(25000, 2),
+						Amount: num.MakeAmount(3600, 2),
+					},
+				},
+				Sum: num.MakeAmount(3600, 2),
+			},
+		},
+		{
+			desc: "with multirate VAT as percentages",
+			lines: []tax.TaxableLine{
+				&taxableLine{
+					taxes: tax.Set{
+						{
+							Category: common.TaxCategoryVAT,
+							Percent:  num.MakePercentage(210, 3),
+						},
+					},
+					amount: num.MakeAmount(10000, 2),
+				},
+				&taxableLine{
+					taxes: tax.Set{
+						{
+							Category: common.TaxCategoryVAT,
+							Percent:  num.MakePercentage(100, 3),
+						},
+					},
+					amount: num.MakeAmount(15000, 2),
+				},
+			},
+			taxIncluded: "",
+			want: &tax.Total{
+				Categories: []*tax.CategoryTotal{
+					{
+						Code:     common.TaxCategoryVAT,
+						Retained: false,
+						Rates: []*tax.RateTotal{
+							{
+								// Key:     common.TaxRateStandard,
+								Base:    num.MakeAmount(10000, 2),
+								Percent: num.MakePercentage(210, 3),
+								Amount:  num.MakeAmount(2100, 2),
+							},
+							{
+								// Key:     common.TaxRateReduced,
 								Base:    num.MakeAmount(15000, 2),
 								Percent: num.MakePercentage(100, 3),
 								Amount:  num.MakeAmount(1500, 2),


### PR DESCRIPTION
Important change to the way taxes are handled per-line. The "Rate Key" is now optional, which means that taxes in invoice lines can go from:

```yaml
tax:
  - cat: VAT
     rate: standard
```
To:
```yaml
tax:
  - cat: VAT
     percent: "21.0%"
```

Upon output, the `percent` value will always be set. If the `rate` property is present, the Region's data will always be used to update the line. Tax totals are now grouped by percentage values as opposed to rate keys, making them optional.

This allows users to define their own tax rates, if applicable for their situation.