### PR TITLE
Basic digital Inbox definition support

### DIFF
--- a/envelope.go
+++ b/envelope.go
@@ -76,7 +76,10 @@ func (e *Envelope) verifyDigest() error {
 	if err != nil {
 		return err
 	}
-	return fmt.Errorf("document: %w", d1.Equals(d2))
+	if err := d1.Equals(d2); err != nil {
+		return fmt.Errorf("document: %w", err)
+	}
+	return nil
 }
 
 // Sign uses the private key to the envelope headers.

--- a/envelope.go
+++ b/envelope.go
@@ -1,6 +1,8 @@
 package gobl
 
 import (
+	"fmt"
+
 	validation "github.com/go-ozzo/ozzo-validation/v4"
 
 	"github.com/invopop/gobl/dsig"
@@ -74,7 +76,7 @@ func (e *Envelope) verifyDigest() error {
 	if err != nil {
 		return err
 	}
-	return d1.Equals(d2)
+	return fmt.Errorf("document: %w", d1.Equals(d2))
 }
 
 // Sign uses the private key to the envelope headers.

--- a/envelope_test.go
+++ b/envelope_test.go
@@ -176,7 +176,7 @@ func TestEnvelopeValidate(t *testing.T) {
 				msg.Content = "bar"
 				return env
 			},
-			want: "digest mismatch",
+			want: "document: digest mismatch",
 		},
 	}
 

--- a/org/inbox.go
+++ b/org/inbox.go
@@ -1,0 +1,62 @@
+package org
+
+import (
+	"regexp"
+
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"github.com/invopop/gobl/uuid"
+)
+
+// Inboxes defines an array of inboxes.
+type Inboxes []*Inbox
+
+// InboxKey determines the type of inbox data being provided. Pre-defined
+// keys are available in the regions package.
+type InboxKey string
+
+var (
+	inboxKeyValidationRegexp = regexp.MustCompile(`^[a-z][a-z0-9-]*[a-z0-9]$`)
+)
+
+// Inbox is used to store data about a connection with a service that is responsible
+// for potentially receiving copies of GOBL envelopes or other document formats
+// defined locally.
+type Inbox struct {
+	// Unique ID. Useful if inbox is stored in a database.
+	UUID *uuid.UUID `json:"uuid,omitempty" jsonschema:"title=UUID"`
+
+	// Type of inbox being defined.
+	Key InboxKey `json:"key" jsonschema:"title=Key"`
+
+	// Role assigned to this inbox that may be relevant for the consumer.
+	Role InboxKey `json:"role,omitempty" jsonschema:"title=Role"`
+
+	// Human name for the inbox.
+	Name string `json:"name,omitempty" jsonschema:"title=Name"`
+
+	// Actual Code or ID that identifies the Inbox.
+	Code string `json:"code"`
+}
+
+// Validate ensures the inbox's fields look good.
+func (i *Inbox) Validate() error {
+	return validation.ValidateStruct(i,
+		validation.Field(&i.UUID),
+		validation.Field(&i.Key, validation.Required),
+		validation.Field(&i.Role),
+		validation.Field(&i.Code, validation.Required),
+	)
+}
+
+// Validate ensures the key complies with the basic syntax
+// requirements.
+func (k InboxKey) Validate() error {
+	return validation.Validate(string(k),
+		validation.Match(inboxKeyValidationRegexp),
+	)
+}
+
+// String provides string representation of key
+func (k InboxKey) String() string {
+	return string(k)
+}

--- a/org/inbox.go
+++ b/org/inbox.go
@@ -7,9 +7,6 @@ import (
 	"github.com/invopop/gobl/uuid"
 )
 
-// Inboxes defines an array of inboxes.
-type Inboxes []*Inbox
-
 // InboxKey determines the type of inbox data being provided. Pre-defined
 // keys are available in the regions package.
 type InboxKey string

--- a/org/org.go
+++ b/org/org.go
@@ -16,6 +16,7 @@ func init() {
 		TaxIdentity{},
 		Meta{},
 		Notes{},
+		Inbox{},
 	}
 	schema.RegisterAll(schema.GOBL.Add("org"), objs)
 }

--- a/org/party.go
+++ b/org/party.go
@@ -9,58 +9,94 @@ import (
 
 // Party represents a person or business entity.
 type Party struct {
-	ID           string        `json:"id,omitempty" jsonschema:"title=ID,description=Internal ID used to identify the party inside a document."`
-	UUID         *uuid.UUID    `json:"uuid,omitempty" jsonschema:"title=UUID,description=Unique identity code."`
-	TaxID        *TaxIdentity  `json:"tax_id,omitempty" jsonschema:"title=Tax Identity,description=The entity's legal ID code used for tax purposes. They may have other numbers, but we're only interested in those valid for tax pruposes."`
-	Name         string        `json:"name" jsonschema:"title=Name,description=Legal name or representation of the organization."`
-	Alias        string        `json:"alias,omitempty" jsonschema:"title=Alias,description=Alternate short name."`
-	People       []*Person     `json:"people,omitempty" jsonschema:"title=People,description=Details of physical people who represent the party."`
-	Addresses    []*Address    `json:"addresses,omitempty" jsonschema:"title=Postal Addresses,description=Regular post addresses for where information should be sent if needed."`
-	Emails       []*Email      `json:"emails,omitempty" jsonschema:"title=Email Addresses"`
-	Telephones   []*Telephone  `json:"telephones,omitempty" jsonschema:"title=Telephone Numbers"`
-	Registration *Registration `json:"registration,omitempty" jsonschema:"title=Registration,description=Additional registration details about the company that may need to be included in a document."`
-	Meta         Meta          `json:"meta,omitempty" jsonschema:"title=Meta,description=Any additional semi-structured information that does not fit into the rest of the party."`
+	// Internal ID used to identify the party inside a document.
+	ID string `json:"id,omitempty" jsonschema:"title=ID"`
+	// Unique identity code
+	UUID *uuid.UUID `json:"uuid,omitempty" jsonschema:"title=UUID"`
+	// The entity's legal ID code used for tax purposes. They may have other numbers, but we're only interested in those valid for tax purposes.
+	TaxID *TaxIdentity `json:"tax_id,omitempty" jsonschema:"title=Tax Identity"`
+	// Legal name or representation of the organization.
+	Name string `json:"name" jsonschema:"title=Name"`
+	// Alternate short name.
+	Alias string `json:"alias,omitempty" jsonschema:"title=Alias"`
+	// Details of physical people who represent the party.
+	People []*Person `json:"people,omitempty" jsonschema:"title=People"`
+	// Digital inboxes used for forwarding electronic versions of documents
+	Inboxes Inboxes `json:"inboxes,omitempty" jsonschema:"title=Inboxes"`
+	// Regular post addresses for where information should be sent if needed.
+	Addresses []*Address `json:"addresses,omitempty" jsonschema:"title=Postal Addresses"`
+	// Electronic mail addresses
+	Emails []*Email `json:"emails,omitempty" jsonschema:"title=Email Addresses"`
+	// Regular telephone numbers
+	Telephones []*Telephone `json:"telephones,omitempty" jsonschema:"title=Telephone Numbers"`
+	// Additional registration details about the company that may need to be included in a document.
+	Registration *Registration `json:"registration,omitempty" jsonschema:"title=Registration"`
+	// Any additional semi-structured information that does not fit into the rest of the party.
+	Meta Meta `json:"meta,omitempty" jsonschema:"title=Meta"`
 }
 
 // Person represents a human, and how to contact them electronically.
 type Person struct {
-	ID         string       `json:"id,omitempty" jsonschema:"title=ID,description=Internal ID used to identify the person inside a document."`
-	UUID       *uuid.UUID   `json:"uuid,omitempty" jsonschema:"title=UUID,description=Unique identity code"`
-	Name       Name         `json:"name" jsonschema:"title=Name,description=Complete details on the name of the person"`
-	Role       string       `json:"role,omitempty" jsonschema:"title=Role,description=What they do within an organization"`
-	Emails     []*Email     `json:"emails,omitempty" jsonschema:"title=Email Addresses,description=Electronic mail addresses that belong to the person."`
+	// Internal ID used to identify the person inside a document.
+	ID string `json:"id,omitempty" jsonschema:"title=ID"`
+	// Unique identity code
+	UUID *uuid.UUID `json:"uuid,omitempty" jsonschema:"title=UUID"`
+	// Complete details on the name of the person
+	Name Name `json:"name" jsonschema:"title=Name"`
+	// What they do within an organization
+	Role string `json:"role,omitempty" jsonschema:"title=Role"`
+	// Electronic mail addresses that belong to the person.
+	Emails []*Email `json:"emails,omitempty" jsonschema:"title=Email Addresses"`
+	// Regular phone or mobile numbers
 	Telephones []*Telephone `json:"telephones,omitempty" jsonschema:"title=Telephone Numbers"`
-	Meta       Meta         `json:"meta,omitempty" jsonschema:"title=Meta,description=Data about the data."`
+	// Data about the data.
+	Meta Meta `json:"meta,omitempty" jsonschema:"title=Meta"`
 }
 
 // Name represents what a human is called. This is a complex subject, see this
 // w3 article for some insights:
 // https://www.w3.org/International/questions/qa-personal-names
 type Name struct {
-	UUID     *uuid.UUID `json:"uuid,omitempty" jsonschema:"title=UUID,description=Unique identity code"`
-	Alias    string     `json:"alias,omitempty" jsonschema:"title=Alias,description=What the person would like to be called"`
-	Prefix   string     `json:"prefix,omitempty" jsonschema:"title=Prefix"`
-	Given    string     `json:"given" jsonschema:"title=Given,description=The person's given name"`
-	Middle   string     `json:"middle,omitempty" jsonschema:"title=Middle,description=Middle names or initials"`
-	Surname  string     `json:"surname" jsonschema:"title=Surname"`
-	Surname2 string     `json:"surname2,omitempty" jsonschema:"title=Second Surname"`
-	Suffix   string     `json:"suffix,omitempty" jsonschema:"title=Suffix"`
-	Meta     Meta       `json:"meta,omitempty" jsonschema:"title=Meta"`
+	// Unique identity code
+	UUID *uuid.UUID `json:"uuid,omitempty" jsonschema:"title=UUID"`
+	// What the person would like to be called
+	Alias string `json:"alias,omitempty" jsonschema:"title=Alias"`
+	// Additional prefix to add to name, like Mrs. or Mr.
+	Prefix string `json:"prefix,omitempty" jsonschema:"title=Prefix"`
+	// Person's given or first name
+	Given string `json:"given" jsonschema:"title=Given"`
+	// Middle names or initials
+	Middle string `json:"middle,omitempty" jsonschema:"title=Middle"`
+	// Second or Family name.
+	Surname string `json:"surname" jsonschema:"title=Surname"`
+	// Additional second of family name.
+	Surname2 string `json:"surname2,omitempty" jsonschema:"title=Second Surname"`
+	// Titles to include after the name.
+	Suffix string `json:"suffix,omitempty" jsonschema:"title=Suffix"`
+	// Any additional useful data.
+	Meta Meta `json:"meta,omitempty" jsonschema:"title=Meta"`
 }
 
 // Email describes the electronic mailing details.
 type Email struct {
-	UUID    *uuid.UUID `json:"uuid,omitempty"`
-	Label   string     `json:"label,omitempty" jsonschema:"title=Label,description=Identifier for the email."`
-	Address string     `json:"addr" jsonschema:"title=Address,description=Electronic mailing address."`
-	Meta    Meta       `json:"meta,omitempty" jsonschema:"title=Meta,description=Additional fields."`
+	// Unique identity code
+	UUID *uuid.UUID `json:"uuid,omitempty"`
+	// Identifier for the email.
+	Label string `json:"label,omitempty" jsonschema:"title=Label"`
+	// Electronic mailing address.
+	Address string `json:"addr" jsonschema:"title=Address"`
+	// Additional fields.
+	Meta Meta `json:"meta,omitempty" jsonschema:"title=Meta"`
 }
 
 // Telephone describes what is expected for a telephone number.
 type Telephone struct {
-	UUID   *uuid.UUID `json:"uuid,omitempty" jsonschema:"title=UUID"`
-	Label  string     `json:"label,omitempty" jsonschema:"title=Label,description=Identifier for this number."`
-	Number string     `json:"num" jsonschema:"title=Number,description=The number to be dialed in ITU E.164 international format."`
+	// Unique identity code
+	UUID *uuid.UUID `json:"uuid,omitempty" jsonschema:"title=UUID"`
+	// Identifier for this number.
+	Label string `json:"label,omitempty" jsonschema:"title=Label"`
+	// The number to be dialed in ITU E.164 international format.
+	Number string `json:"num" jsonschema:"title=Number"`
 }
 
 // Registration is used in countries that require additional information to be associated
@@ -69,7 +105,7 @@ type Telephone struct {
 // If your country requires additional fields, please let us know.
 type Registration struct {
 	UUID    *uuid.UUID `json:"uuid,omitempty" jsonschema:"title=UUID"`
-	Office  string     `json:"office,omitempty" jsonschema:"title=Office,description=Office where the company is registered."`
+	Office  string     `json:"office,omitempty" jsonschema:"title=Office"`
 	Book    string     `json:"book,omitempty" jsonschema:"title=Book"`
 	Volume  string     `json:"volume,omitempty" jsonschema:"title=Volume"`
 	Sheet   string     `json:"sheet,omitempty" jsonschema:"title=Sheet"`

--- a/org/party.go
+++ b/org/party.go
@@ -22,7 +22,7 @@ type Party struct {
 	// Details of physical people who represent the party.
 	People []*Person `json:"people,omitempty" jsonschema:"title=People"`
 	// Digital inboxes used for forwarding electronic versions of documents
-	Inboxes Inboxes `json:"inboxes,omitempty" jsonschema:"title=Inboxes"`
+	Inboxes []*Inbox `json:"inboxes,omitempty" jsonschema:"title=Inboxes"`
 	// Regular post addresses for where information should be sent if needed.
 	Addresses []*Address `json:"addresses,omitempty" jsonschema:"title=Postal Addresses"`
 	// Electronic mail addresses

--- a/regions/common/common.go
+++ b/regions/common/common.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"github.com/invopop/gobl/org"
 	"github.com/invopop/gobl/tax"
 )
 
@@ -21,4 +22,9 @@ const (
 const (
 	SchemeReverseCharge tax.Key = "reverse-charge"
 	SchemeCustomerRates tax.Key = "customer-rates"
+)
+
+// Common inbox keys
+const (
+	InboxKeyPEPPOL org.InboxKey = "peppol-id"
 )

--- a/regions/es/es.go
+++ b/regions/es/es.go
@@ -43,6 +43,18 @@ const (
 	SchemeCashBasis       tax.Key = "cash-basis"
 )
 
+// Inbox key and role definitions
+const (
+	InboxKeyFACE org.InboxKey = "face"
+
+	// Main roles defined in FACE
+	InboxRoleFiscal    org.InboxKey = "fiscal"    // Fiscal / 01
+	InboxRoleRecipient org.InboxKey = "recipient" // Receptor / 02
+	InboxRolePayer     org.InboxKey = "payer"     // Pagador / 03
+	InboxRoleCustomer  org.InboxKey = "customer"  // Comprador / 04
+
+)
+
 // New provides the Spanish region definition
 func New() *tax.Region {
 	return &tax.Region{


### PR DESCRIPTION
* Initial attempt at defining an "Inbox" model defined inside an `org.Party` to be used to add details about where digital copies of documents could be sent.