### PR TITLE
Extracting Schema extractor, adding general parser

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -9,7 +9,7 @@ import (
 // The contents can also be serialised as JSON ready to send to a client
 // if needed.
 type Error struct {
-	Code  string `json:"code"`
+	Key   string `json:"key"`
 	Cause error  `json:"cause"`
 }
 
@@ -32,6 +32,10 @@ var (
 	// or marshal an object, usually into JSON.
 	ErrMarshal = NewError("marshal")
 
+	// ErrUnmarshal is used when that has been a problem attempting to read the
+	// source data.
+	ErrUnmarshal = NewError("unmarshal")
+
 	// ErrSignature identifies an issue related to signatures.
 	ErrSignature = NewError("signature")
 
@@ -45,16 +49,16 @@ var (
 
 // NewError provides a new error with a code that is meant to provide
 // a context.
-func NewError(code string) *Error {
-	return &Error{Code: code}
+func NewError(key string) *Error {
+	return &Error{Key: key}
 }
 
 // Error provides a string representation of the error.
 func (e *Error) Error() string {
 	if e.Cause != nil {
-		return fmt.Sprintf("%s: %s", e.Code, e.Cause.Error())
+		return fmt.Sprintf("%s: %s", e.Key, e.Cause.Error())
 	}
-	return e.Code
+	return e.Key
 }
 
 // WithCause is used to copy and add an underlying error to this one.
@@ -85,5 +89,5 @@ func (e *Error) Is(target error) bool {
 	if !ok {
 		return errors.Is(e.Cause, target)
 	}
-	return e.Code == t.Code
+	return e.Key == t.Key
 }

--- a/parse.go
+++ b/parse.go
@@ -1,0 +1,28 @@
+package gobl
+
+import (
+	"encoding/json"
+
+	"github.com/invopop/gobl/schema"
+)
+
+// Parse unmarshals the provided data and uses the schema ID
+// to determine what type of object we're dealing with. As long as the
+// provided data contains a schema registered in GOBL, a new
+// object instance will be returned.
+func Parse(data []byte) (interface{}, error) {
+	id, err := schema.Extract(data)
+	if err != nil {
+		return nil, ErrUnmarshal.WithCause(err)
+	}
+	if id == schema.UnknownID {
+		return nil, ErrUnknownSchema
+	}
+
+	obj := id.Interface()
+	if err := json.Unmarshal(data, obj); err != nil {
+		return nil, ErrUnmarshal.WithCause(err)
+	}
+
+	return obj, nil
+}

--- a/parse_test.go
+++ b/parse_test.go
@@ -1,0 +1,48 @@
+package gobl_test
+
+import (
+	"testing"
+
+	"github.com/invopop/gobl"
+	"github.com/invopop/gobl/note"
+	"github.com/stretchr/testify/assert"
+)
+
+var parseExampleDoc = `{
+	"$schema": "https://gobl.org/draft-0/note/message",
+	"title": "Test Message",
+	"content": "We hope you like this test message!"
+}`
+var parseExampleEnvelope = `{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "1aec7332-ee67-11ec-8f98-3e7e00ce5635",
+		"dig": {
+			"alg": "sha256",
+			"val": "45ac3115c8569a1789e58af8d0dc91ef3baa1fb71daaf38f5aef94f82b4d0033"
+		}
+	},"doc":` + parseExampleDoc + `,"sigs": [
+		"eyJhbGciOiJFUzI1NiIsImtpZCI6IjY0ZjBhMDFhLWUzOTktNDZmMy04ZmI0LTgxNDNhMzc3MGY4OSJ9.eyJ1dWlkIjoiMWFlYzczMzItZWU2Ny0xMWVjLThmOTgtM2U3ZTAwY2U1NjM1IiwiZGlnIjp7ImFsZyI6InNoYTI1NiIsInZhbCI6IjQ1YWMzMTE1Yzg1NjlhMTc4OWU1OGFmOGQwZGM5MWVmM2JhYTFmYjcxZGFhZjM4ZjVhZWY5NGY4MmI0ZDAwMzMifX0.QJQS83I7Q7Hl0pySv49pNo1fr0tL7IIgI73HTsqiwO-cOjZak1CUnpE6-us6797Q856spghseX0cD4yogAhmqg"
+	]
+}`
+
+func TestParse(t *testing.T) {
+	doc, err := gobl.Parse([]byte(parseExampleDoc))
+	assert.NoError(t, err)
+	assert.IsType(t, &note.Message{}, doc)
+	n, ok := doc.(*note.Message)
+	assert.True(t, ok)
+	assert.Equal(t, "Test Message", n.Title)
+
+	doc, err = gobl.Parse([]byte(parseExampleEnvelope))
+	assert.NoError(t, err)
+	assert.IsType(t, &gobl.Envelope{}, doc)
+	env, ok := doc.(*gobl.Envelope)
+	assert.True(t, ok)
+	assert.Contains(t, env.Head.Digest.Value, "45ac3115c8569a1")
+
+	n = env.Extract().(*note.Message)
+	assert.NotNil(t, n)
+	assert.Equal(t, "Test Message", n.Title)
+
+}

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -25,3 +25,30 @@ func TestID(t *testing.T) {
 	assert.Contains(t, err.Error(), "valid URL")
 
 }
+
+func TestExtract(t *testing.T) {
+	base := `https://gobl.org/` + schema.VERSION + ``
+	data := []byte(`{"$schema":"` + base + `/test/bar","random":"message"}`)
+
+	id, err := schema.Extract(data)
+	assert.NoError(t, err)
+	assert.Equal(t, "https://gobl.org/draft-0/test/bar", id.String())
+
+	data = []byte(`{"random":"message"}`)
+	id, err = schema.Extract(data)
+	assert.NoError(t, err)
+	assert.Equal(t, schema.UnknownID, id)
+
+	data = []byte(`bad-data`)
+	_, err = schema.Extract(data)
+	assert.Error(t, err)
+}
+
+func TestInsert(t *testing.T) {
+	id := schema.ID(`https://gobl.org/` + schema.VERSION + `/test/bar`)
+	data := []byte(`{"random":"message"}`)
+	var err error
+	data, err = schema.Insert(id, data)
+	assert.NoError(t, err)
+	assert.Equal(t, "{\"$schema\":\"https://gobl.org/draft-0/test/bar\",\"random\":\"message\"}", string(data))
+}


### PR DESCRIPTION
* Schema ID extraction from any JSON document is now more generic.
* Added a new `gobl.Parse` method that extracts **any** GOBL structure defined with a known schema. This is useful for when you don't know if you'll need to handle an Envelope or a document payload.
* Root errors now use `key` instead of `code`, which is more consistent with usage in rest of library.