### PR TITLE
Fix email validation, only check syntax and not DNS

### DIFF
--- a/org/party.go
+++ b/org/party.go
@@ -128,7 +128,7 @@ func (p *Party) Validate() error {
 // Validate ensures email address looks valid.
 func (e *Email) Validate() error {
 	return validation.ValidateStruct(e,
-		validation.Field(&e.Address, validation.Required, is.Email),
+		validation.Field(&e.Address, validation.Required, is.EmailFormat),
 	)
 }
 

--- a/org/party_test.go
+++ b/org/party_test.go
@@ -1,0 +1,21 @@
+package org_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/invopop/gobl/org"
+)
+
+func TestEmailValidation(t *testing.T) {
+	valid := org.Email{
+		Address: "foobar@invopop.example.com",
+	}
+	assert.NoError(t, valid.Validate())
+
+	invalid := org.Email{
+		Address: "foobar",
+	}
+	assert.EqualError(t, invalid.Validate(), "addr: must be a valid email address.")
+}


### PR DESCRIPTION
Email addresses of a party are [validated](https://pkg.go.dev/github.com/invopop/gobl/org#Email.Validate). We [use](https://github.com/invopop/gobl/blob/v0.26.1/org/party.go#L131) the [`is.Email`](https://pkg.go.dev/github.com/go-ozzo/ozzo-validation/v4/is#Email) validator, which checks syntax but _also_ does this:

> “It also checks if the MX record exists for the email domain.”

With `GOOS=js` and `GOARCH=wasm`, because there is no local DNS resolver when `net.LookupMX` is used, validation fails for valid email addresses.

This PR replaces usages of `is.Email` with [`is.EmailFormat`](https://pkg.go.dev/github.com/go-ozzo/ozzo-validation/v4/is#EmailFormat). That way we still validate the syntax of email addresses, but just don’t validate that the domain has valid MX record(s).