### PR TITLE
Locality key code refactor

### DIFF
--- a/bill/charges.go
+++ b/bill/charges.go
@@ -75,7 +75,7 @@ func (m *Charge) GetTotal() num.Amount {
 	return m.Amount
 }
 
-func (m *Charge) removeIncludedTaxes(cat tax.Code, accuracy uint32) *Charge {
+func (m *Charge) removeIncludedTaxes(cat org.Code, accuracy uint32) *Charge {
 	rate := m.Taxes.Get(cat)
 	if rate == nil {
 		return m

--- a/bill/discounts.go
+++ b/bill/discounts.go
@@ -77,7 +77,7 @@ func (m *Discount) GetTotal() num.Amount {
 	return m.Amount.Invert()
 }
 
-func (m *Discount) removeIncludedTaxes(cat tax.Code, accuracy uint32) *Discount {
+func (m *Discount) removeIncludedTaxes(cat org.Code, accuracy uint32) *Discount {
 	rate := m.Taxes.Get(cat)
 	if rate == nil {
 		return m

--- a/bill/invoice.go
+++ b/bill/invoice.go
@@ -328,7 +328,7 @@ func (inv *Invoice) calculate(r *tax.Region) error {
 	}
 
 	// Now figure out the tax totals (with some interface conversion)
-	var pit tax.Code
+	var pit org.Code
 	if inv.Tax != nil && inv.Tax.PricesInclude != "" {
 		pit = inv.Tax.PricesInclude
 	}

--- a/bill/line.go
+++ b/bill/line.go
@@ -80,7 +80,7 @@ func (l *Line) calculate() {
 	}
 }
 
-func (l *Line) removeIncludedTaxes(cat tax.Code, accuracy uint32) *Line {
+func (l *Line) removeIncludedTaxes(cat org.Code, accuracy uint32) *Line {
 	rate := l.Taxes.Get(cat)
 	if rate == nil {
 		return l

--- a/bill/tax.go
+++ b/bill/tax.go
@@ -14,7 +14,7 @@ type Tax struct {
 	// Category of the tax already included in the line item prices, especially
 	// useful for B2C retailers with customers who prefer final prices inclusive of
 	// tax.
-	PricesInclude tax.Code `json:"prices_include,omitempty" jsonschema:"title=Prices Include"`
+	PricesInclude org.Code `json:"prices_include,omitempty" jsonschema:"title=Prices Include"`
 
 	// Special tax schemes that apply to this invoice according to local requirements.
 	Schemes tax.SchemeKeys `json:"schemes,omitempty" jsonschema:"title=Schemes"`

--- a/build/data/tax/ES.json
+++ b/build/data/tax/ES.json
@@ -5,6 +5,503 @@
     "es": "España"
   },
   "country": "ES",
+  "localities": [
+    {
+      "code": "VI",
+      "name": {
+        "es": "Ávila"
+      },
+      "meta": {
+        "post": "01"
+      }
+    },
+    {
+      "code": "AB",
+      "name": {
+        "es": "Albacete"
+      },
+      "meta": {
+        "post": "02"
+      }
+    },
+    {
+      "code": "A",
+      "name": {
+        "es": "Alicante"
+      },
+      "meta": {
+        "post": "03"
+      }
+    },
+    {
+      "code": "AL",
+      "name": {
+        "es": "Almería"
+      },
+      "meta": {
+        "post": "04"
+      }
+    },
+    {
+      "code": "AV",
+      "name": {
+        "es": "Ávila"
+      },
+      "meta": {
+        "post": "05"
+      }
+    },
+    {
+      "code": "BA",
+      "name": {
+        "es": "Badajoz"
+      },
+      "meta": {
+        "post": "06"
+      }
+    },
+    {
+      "code": "PM",
+      "name": {
+        "es": "Baleares"
+      },
+      "meta": {
+        "post": "07"
+      }
+    },
+    {
+      "code": "IB",
+      "name": {
+        "es": "Baleares"
+      },
+      "meta": {
+        "post": "07"
+      }
+    },
+    {
+      "code": "B",
+      "name": {
+        "es": "Barcelona"
+      },
+      "meta": {
+        "post": "08"
+      }
+    },
+    {
+      "code": "BU",
+      "name": {
+        "es": "Burgos"
+      },
+      "meta": {
+        "post": "09"
+      }
+    },
+    {
+      "code": "CC",
+      "name": {
+        "es": "Cáceres"
+      },
+      "meta": {
+        "post": "10"
+      }
+    },
+    {
+      "code": "CA",
+      "name": {
+        "es": "Cadiz"
+      },
+      "meta": {
+        "post": "11"
+      }
+    },
+    {
+      "code": "CS",
+      "name": {
+        "es": "Castellón"
+      },
+      "meta": {
+        "post": "12"
+      }
+    },
+    {
+      "code": "CR",
+      "name": {
+        "es": "Ciudad Real"
+      },
+      "meta": {
+        "post": "13"
+      }
+    },
+    {
+      "code": "CO",
+      "name": {
+        "es": "Cordoba"
+      },
+      "meta": {
+        "post": "14"
+      }
+    },
+    {
+      "code": "C",
+      "name": {
+        "es": "La Coruña"
+      },
+      "meta": {
+        "post": "15"
+      }
+    },
+    {
+      "code": "CU",
+      "name": {
+        "es": "Cuenca"
+      },
+      "meta": {
+        "post": "16"
+      }
+    },
+    {
+      "code": "GE",
+      "name": {
+        "es": "Gerona"
+      },
+      "meta": {
+        "post": "17"
+      }
+    },
+    {
+      "code": "GI",
+      "name": {
+        "es": "Girona"
+      },
+      "meta": {
+        "post": "17"
+      }
+    },
+    {
+      "code": "GR",
+      "name": {
+        "es": "Granada"
+      },
+      "meta": {
+        "post": "18"
+      }
+    },
+    {
+      "code": "GU",
+      "name": {
+        "es": "Guadalajara"
+      },
+      "meta": {
+        "post": "19"
+      }
+    },
+    {
+      "code": "SS",
+      "name": {
+        "es": "Guipúzcoa"
+      },
+      "meta": {
+        "post": "20"
+      }
+    },
+    {
+      "code": "H",
+      "name": {
+        "es": "Huelva"
+      },
+      "meta": {
+        "post": "21"
+      }
+    },
+    {
+      "code": "HU",
+      "name": {
+        "es": "Huesca"
+      },
+      "meta": {
+        "post": "22"
+      }
+    },
+    {
+      "code": "J",
+      "name": {
+        "es": "Jaén"
+      },
+      "meta": {
+        "post": "23"
+      }
+    },
+    {
+      "code": "LE",
+      "name": {
+        "es": "León"
+      },
+      "meta": {
+        "post": "24"
+      }
+    },
+    {
+      "code": "L",
+      "name": {
+        "es": "Lérida / Lleida"
+      },
+      "meta": {
+        "post": "25"
+      }
+    },
+    {
+      "code": "LO",
+      "name": {
+        "es": "La Rioja"
+      },
+      "meta": {
+        "post": "26"
+      }
+    },
+    {
+      "code": "LU",
+      "name": {
+        "es": "Lugo"
+      },
+      "meta": {
+        "post": "27"
+      }
+    },
+    {
+      "code": "M",
+      "name": {
+        "es": "Madrid"
+      },
+      "meta": {
+        "post": "28"
+      }
+    },
+    {
+      "code": "MA",
+      "name": {
+        "es": "Málaga"
+      },
+      "meta": {
+        "post": "29"
+      }
+    },
+    {
+      "code": "MU",
+      "name": {
+        "es": "Murcia"
+      },
+      "meta": {
+        "post": "30"
+      }
+    },
+    {
+      "code": "NA",
+      "name": {
+        "es": "Navarra"
+      },
+      "meta": {
+        "post": "31"
+      }
+    },
+    {
+      "code": "OR",
+      "name": {
+        "es": "Orense"
+      },
+      "meta": {
+        "post": "32"
+      }
+    },
+    {
+      "code": "OU",
+      "name": {
+        "es": "Orense"
+      },
+      "meta": {
+        "post": "32"
+      }
+    },
+    {
+      "code": "O",
+      "name": {
+        "es": "Asturias"
+      },
+      "meta": {
+        "post": "33"
+      }
+    },
+    {
+      "code": "P",
+      "name": {
+        "es": "Palencia"
+      },
+      "meta": {
+        "post": "34"
+      }
+    },
+    {
+      "code": "GC",
+      "name": {
+        "es": "Las Palmas"
+      },
+      "meta": {
+        "post": "35"
+      }
+    },
+    {
+      "code": "PO",
+      "name": {
+        "es": "Pontevedra"
+      },
+      "meta": {
+        "post": "36"
+      }
+    },
+    {
+      "code": "SA",
+      "name": {
+        "es": "Salamanca"
+      },
+      "meta": {
+        "post": "37"
+      }
+    },
+    {
+      "code": "TF",
+      "name": {
+        "es": "Santa Cruz de Tenerife"
+      },
+      "meta": {
+        "post": "38"
+      }
+    },
+    {
+      "code": "S",
+      "name": {
+        "es": "Cantabria"
+      },
+      "meta": {
+        "post": "39"
+      }
+    },
+    {
+      "code": "SG",
+      "name": {
+        "es": "Segovia"
+      },
+      "meta": {
+        "post": "40"
+      }
+    },
+    {
+      "code": "SE",
+      "name": {
+        "es": "Sevilla"
+      },
+      "meta": {
+        "post": "41"
+      }
+    },
+    {
+      "code": "SO",
+      "name": {
+        "es": "Soria"
+      },
+      "meta": {
+        "post": "42"
+      }
+    },
+    {
+      "code": "T",
+      "name": {
+        "es": "Tarragona"
+      },
+      "meta": {
+        "post": "43"
+      }
+    },
+    {
+      "code": "TE",
+      "name": {
+        "es": "Teruel"
+      },
+      "meta": {
+        "post": "44"
+      }
+    },
+    {
+      "code": "TO",
+      "name": {
+        "es": "Toledo"
+      },
+      "meta": {
+        "post": "45"
+      }
+    },
+    {
+      "code": "V",
+      "name": {
+        "es": "Valencia"
+      },
+      "meta": {
+        "post": "46"
+      }
+    },
+    {
+      "code": "VA",
+      "name": {
+        "es": "Valladolid"
+      },
+      "meta": {
+        "post": "47"
+      }
+    },
+    {
+      "code": "BI",
+      "name": {
+        "es": "Vizcaya"
+      },
+      "meta": {
+        "post": "48"
+      }
+    },
+    {
+      "code": "ZA",
+      "name": {
+        "es": "Zamora"
+      },
+      "meta": {
+        "post": "49"
+      }
+    },
+    {
+      "code": "Z",
+      "name": {
+        "es": "Zaragoza"
+      },
+      "meta": {
+        "post": "50"
+      }
+    },
+    {
+      "code": "CE",
+      "name": {
+        "es": "Ceuta"
+      },
+      "meta": {
+        "post": "51"
+      }
+    },
+    {
+      "code": "ML",
+      "name": {
+        "es": "Melilla"
+      },
+      "meta": {
+        "post": "52"
+      }
+    }
+  ],
   "currency": "EUR",
   "schemes": [
     {

--- a/build/schemas/bill/invoice.json
+++ b/build/schemas/bill/invoice.json
@@ -591,7 +591,7 @@
     },
     "SchemeKeys": {
       "items": {
-        "type": "string"
+        "$ref": "https://gobl.org/draft-0/org/key"
       },
       "type": "array",
       "description": "SchemeKeys stores a list of keys that makes it easier to perform matches."
@@ -599,7 +599,7 @@
     "Tax": {
       "properties": {
         "prices_include": {
-          "type": "string",
+          "$ref": "https://gobl.org/draft-0/org/code",
           "title": "Prices Include",
           "description": "Category of the tax already included in the line item prices, especially\nuseful for B2C retailers with customers who prefer final prices inclusive of\ntax."
         },
@@ -690,5 +690,5 @@
       "description": "Totals contains the summaries of all calculations for the invoice."
     }
   },
-  "$comment": "Generated with GOBL v0.26.0"
+  "$comment": "Generated with GOBL v0.27.0"
 }

--- a/build/schemas/cal/date.json
+++ b/build/schemas/cal/date.json
@@ -10,5 +10,5 @@
       "description": "Civil date in simplified ISO format, like 2021-05-26"
     }
   },
-  "$comment": "Generated with GOBL v0.26.0"
+  "$comment": "Generated with GOBL v0.27.0"
 }

--- a/build/schemas/cal/period.json
+++ b/build/schemas/cal/period.json
@@ -20,5 +20,5 @@
       "description": "Period represents two dates with a start and finish."
     }
   },
-  "$comment": "Generated with GOBL v0.26.0"
+  "$comment": "Generated with GOBL v0.27.0"
 }

--- a/build/schemas/currency/exchange-rate.json
+++ b/build/schemas/currency/exchange-rate.json
@@ -24,5 +24,5 @@
       "description": "ExchangeRate contains data on the rate to be used when converting amounts from the document's base currency to whatever is defined."
     }
   },
-  "$comment": "Generated with GOBL v0.26.0"
+  "$comment": "Generated with GOBL v0.27.0"
 }

--- a/build/schemas/dsig/digest.json
+++ b/build/schemas/dsig/digest.json
@@ -24,5 +24,5 @@
       "description": "Digest defines a structure to hold a digest value including the algorithm used to generate it."
     }
   },
-  "$comment": "Generated with GOBL v0.26.0"
+  "$comment": "Generated with GOBL v0.27.0"
 }

--- a/build/schemas/dsig/signature.json
+++ b/build/schemas/dsig/signature.json
@@ -9,5 +9,5 @@
       "description": "JSON Web Signature in compact form."
     }
   },
-  "$comment": "Generated with GOBL v0.26.0"
+  "$comment": "Generated with GOBL v0.27.0"
 }

--- a/build/schemas/envelope.json
+++ b/build/schemas/envelope.json
@@ -115,5 +115,5 @@
       "description": "Stamp defines an official seal of approval from a third party like a governmental agency or intermediary and should thus be included in any official envelopes."
     }
   },
-  "$comment": "Generated with GOBL v0.26.0"
+  "$comment": "Generated with GOBL v0.27.0"
 }

--- a/build/schemas/i18n/string.json
+++ b/build/schemas/i18n/string.json
@@ -15,5 +15,5 @@
       "description": "Map of 2-Letter language codes to their translations."
     }
   },
-  "$comment": "Generated with GOBL v0.26.0"
+  "$comment": "Generated with GOBL v0.27.0"
 }

--- a/build/schemas/note/message.json
+++ b/build/schemas/note/message.json
@@ -28,5 +28,5 @@
       "description": "Message represents the minimum possible contents for a GoBL document type."
     }
   },
-  "$comment": "Generated with GOBL v0.26.0"
+  "$comment": "Generated with GOBL v0.27.0"
 }

--- a/build/schemas/num/amount.json
+++ b/build/schemas/num/amount.json
@@ -10,5 +10,5 @@
       "description": "Quantity with optional decimal places that determine accuracy."
     }
   },
-  "$comment": "Generated with GOBL v0.26.0"
+  "$comment": "Generated with GOBL v0.27.0"
 }

--- a/build/schemas/num/percentage.json
+++ b/build/schemas/num/percentage.json
@@ -10,5 +10,5 @@
       "description": "Similar to an Amount, but designed for percentages and includes % symbol in JSON output."
     }
   },
-  "$comment": "Generated with GOBL v0.26.0"
+  "$comment": "Generated with GOBL v0.27.0"
 }

--- a/build/schemas/org/address.json
+++ b/build/schemas/org/address.json
@@ -87,5 +87,5 @@
       "description": "Address defines a globally acceptable set of attributes that describes a postal or fiscal address."
     }
   },
-  "$comment": "Generated with GOBL v0.26.0"
+  "$comment": "Generated with GOBL v0.27.0"
 }

--- a/build/schemas/org/code.json
+++ b/build/schemas/org/code.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft/2020-12/schema",
+  "$id": "https://gobl.org/draft-0/org/code",
+  "$ref": "#/$defs/Code",
+  "$defs": {
+    "Code": {
+      "type": "string",
+      "maxLength": 6,
+      "minLength": 1,
+      "pattern": "^[A-Z0-9]{1,6}$",
+      "title": "Code",
+      "description": "Short upper-case identifier."
+    }
+  },
+  "$comment": "Generated with GOBL v0.27.0"
+}

--- a/build/schemas/org/coordinates.json
+++ b/build/schemas/org/coordinates.json
@@ -30,5 +30,5 @@
       "description": "Coordinates describes an exact geographical location in the world."
     }
   },
-  "$comment": "Generated with GOBL v0.26.0"
+  "$comment": "Generated with GOBL v0.27.0"
 }

--- a/build/schemas/org/email.json
+++ b/build/schemas/org/email.json
@@ -32,5 +32,5 @@
       "description": "Email describes the electronic mailing details."
     }
   },
-  "$comment": "Generated with GOBL v0.26.0"
+  "$comment": "Generated with GOBL v0.27.0"
 }

--- a/build/schemas/org/inbox.json
+++ b/build/schemas/org/inbox.json
@@ -11,12 +11,12 @@
           "description": "Unique ID. Useful if inbox is stored in a database."
         },
         "key": {
-          "type": "string",
+          "$ref": "https://gobl.org/draft-0/org/key",
           "title": "Key",
           "description": "Type of inbox being defined."
         },
         "role": {
-          "type": "string",
+          "$ref": "https://gobl.org/draft-0/org/key",
           "title": "Role",
           "description": "Role assigned to this inbox that may be relevant for the consumer."
         },
@@ -38,5 +38,5 @@
       "description": "Inbox is used to store data about a connection with a service that is responsible for potentially receiving copies of GOBL envelopes or other document formats defined locally."
     }
   },
-  "$comment": "Generated with GOBL v0.26.0"
+  "$comment": "Generated with GOBL v0.27.0"
 }

--- a/build/schemas/org/item.json
+++ b/build/schemas/org/item.json
@@ -84,5 +84,5 @@
       "description": "ItemCode contains a value and optional label property that means additional codes can be added to an item."
     }
   },
-  "$comment": "Generated with GOBL v0.26.0"
+  "$comment": "Generated with GOBL v0.27.0"
 }

--- a/build/schemas/org/key.json
+++ b/build/schemas/org/key.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft/2020-12/schema",
+  "$id": "https://gobl.org/draft-0/org/key",
+  "$ref": "#/$defs/Key",
+  "$defs": {
+    "Key": {
+      "type": "string",
+      "maxLength": 64,
+      "minLength": 2,
+      "pattern": "^[a-z][a-z0-9-+]*[a-z0-9]$",
+      "title": "Key",
+      "description": "Text identifier to be used instead of a code for a more verbose but readable identifier."
+    }
+  },
+  "$comment": "Generated with GOBL v0.27.0"
+}

--- a/build/schemas/org/meta.json
+++ b/build/schemas/org/meta.json
@@ -13,5 +13,5 @@
       "description": "Meta defines a structure for data about the data being defined."
     }
   },
-  "$comment": "Generated with GOBL v0.26.0"
+  "$comment": "Generated with GOBL v0.27.0"
 }

--- a/build/schemas/org/name.json
+++ b/build/schemas/org/name.json
@@ -59,5 +59,5 @@
       "description": "Name represents what a human is called."
     }
   },
-  "$comment": "Generated with GOBL v0.26.0"
+  "$comment": "Generated with GOBL v0.27.0"
 }

--- a/build/schemas/org/notes.json
+++ b/build/schemas/org/notes.json
@@ -40,5 +40,5 @@
       "description": "Notes holds an array of Note objects"
     }
   },
-  "$comment": "Generated with GOBL v0.26.0"
+  "$comment": "Generated with GOBL v0.27.0"
 }

--- a/build/schemas/org/party.json
+++ b/build/schemas/org/party.json
@@ -88,5 +88,5 @@
       "description": "Party represents a person or business entity."
     }
   },
-  "$comment": "Generated with GOBL v0.26.0"
+  "$comment": "Generated with GOBL v0.27.0"
 }

--- a/build/schemas/org/person.json
+++ b/build/schemas/org/person.json
@@ -54,5 +54,5 @@
       "description": "Person represents a human, and how to contact them electronically."
     }
   },
-  "$comment": "Generated with GOBL v0.26.0"
+  "$comment": "Generated with GOBL v0.27.0"
 }

--- a/build/schemas/org/registration.json
+++ b/build/schemas/org/registration.json
@@ -42,5 +42,5 @@
       "description": "Registration is used in countries that require additional information to be associated with a company usually related to a specific registration office."
     }
   },
-  "$comment": "Generated with GOBL v0.26.0"
+  "$comment": "Generated with GOBL v0.27.0"
 }

--- a/build/schemas/org/tax-identity.json
+++ b/build/schemas/org/tax-identity.json
@@ -43,5 +43,5 @@
       "description": "TaxIdentity stores the details required to identify an entity for tax purposes."
     }
   },
-  "$comment": "Generated with GOBL v0.26.0"
+  "$comment": "Generated with GOBL v0.27.0"
 }

--- a/build/schemas/org/telephone.json
+++ b/build/schemas/org/telephone.json
@@ -28,5 +28,5 @@
       "description": "Telephone describes what is expected for a telephone number."
     }
   },
-  "$comment": "Generated with GOBL v0.26.0"
+  "$comment": "Generated with GOBL v0.27.0"
 }

--- a/build/schemas/pay/advance.json
+++ b/build/schemas/pay/advance.json
@@ -54,5 +54,5 @@
       "description": "Advance represents a single payment that has been made already, such as a deposit on an intent to purchase, or as credit from a previous invoice which was later corrected or cancelled."
     }
   },
-  "$comment": "Generated with GOBL v0.26.0"
+  "$comment": "Generated with GOBL v0.27.0"
 }

--- a/build/schemas/pay/instructions.json
+++ b/build/schemas/pay/instructions.json
@@ -160,5 +160,5 @@
       "description": "Online provides the details required to make a payment online using a website"
     }
   },
-  "$comment": "Generated with GOBL v0.26.0"
+  "$comment": "Generated with GOBL v0.27.0"
 }

--- a/build/schemas/pay/terms.json
+++ b/build/schemas/pay/terms.json
@@ -71,5 +71,5 @@
       "description": "Terms defines when we expect the customer to pay, or have paid, for the contents of the document."
     }
   },
-  "$comment": "Generated with GOBL v0.26.0"
+  "$comment": "Generated with GOBL v0.27.0"
 }

--- a/build/schemas/tax/region.json
+++ b/build/schemas/tax/region.json
@@ -6,7 +6,7 @@
     "Category": {
       "properties": {
         "code": {
-          "type": "string",
+          "$ref": "https://gobl.org/draft-0/org/code",
           "title": "Code"
         },
         "name": {
@@ -38,6 +38,38 @@
         "rates"
       ],
       "description": "Category contains the definition of a general type of tax inside a region."
+    },
+    "Localities": {
+      "items": {
+        "$ref": "#/$defs/Locality"
+      },
+      "type": "array",
+      "description": "Localities stores an array of locality objects used to describe areas sub-divisions inside a region."
+    },
+    "Locality": {
+      "properties": {
+        "code": {
+          "type": "string",
+          "title": "Code",
+          "description": "Code"
+        },
+        "name": {
+          "$ref": "https://gobl.org/draft-0/i18n/string",
+          "title": "Name",
+          "description": "Name of the locality with local and hopefully international\ntranslations."
+        },
+        "meta": {
+          "$ref": "https://gobl.org/draft-0/org/meta",
+          "title": "Meta",
+          "description": "Any additional information"
+        }
+      },
+      "type": "object",
+      "required": [
+        "code",
+        "name"
+      ],
+      "description": "Locality represents an area inside a region, like a province or a state, which shares the basic definitions of the region, but may vary in some validation rules."
     },
     "Note": {
       "properties": {
@@ -71,7 +103,7 @@
     "Rate": {
       "properties": {
         "key": {
-          "type": "string",
+          "$ref": "https://gobl.org/draft-0/org/key",
           "title": "Key",
           "description": "Key identifies this rate within the system"
         },
@@ -144,7 +176,12 @@
         "locality": {
           "type": "string",
           "title": "Locality",
-          "description": "Locality, city, region, or similar code inside the country, if needed."
+          "description": "Locality, city, province, county, or similar code inside the country, if needed."
+        },
+        "localities": {
+          "$ref": "#/$defs/Localities",
+          "title": "Localities",
+          "description": "List of sub-localities inside a region."
         },
         "currency": {
           "type": "string",
@@ -177,7 +214,7 @@
     "Scheme": {
       "properties": {
         "key": {
-          "type": "string",
+          "$ref": "https://gobl.org/draft-0/org/key",
           "title": "Key",
           "description": "Key used to identify this scheme"
         },
@@ -193,7 +230,7 @@
         },
         "categories": {
           "items": {
-            "type": "string"
+            "$ref": "https://gobl.org/draft-0/org/code"
           },
           "type": "array",
           "title": "Category Codes",
@@ -220,5 +257,5 @@
       "description": "Schemes defines an array of scheme objects with helper functions."
     }
   },
-  "$comment": "Generated with GOBL v0.26.0"
+  "$comment": "Generated with GOBL v0.27.0"
 }

--- a/build/schemas/tax/set.json
+++ b/build/schemas/tax/set.json
@@ -6,12 +6,12 @@
     "Combo": {
       "properties": {
         "cat": {
-          "type": "string",
+          "$ref": "https://gobl.org/draft-0/org/code",
           "title": "Category",
           "description": "Tax category code from those available inside a region."
         },
         "rate": {
-          "type": "string",
+          "$ref": "https://gobl.org/draft-0/org/key",
           "title": "Rate",
           "description": "Rate within a category to apply."
         },
@@ -41,5 +41,5 @@
       "description": "Set defines a list of tax categories and their rates to be used alongside taxable items."
     }
   },
-  "$comment": "Generated with GOBL v0.26.0"
+  "$comment": "Generated with GOBL v0.27.0"
 }

--- a/build/schemas/tax/total.json
+++ b/build/schemas/tax/total.json
@@ -6,7 +6,7 @@
     "CategoryTotal": {
       "properties": {
         "code": {
-          "type": "string",
+          "$ref": "https://gobl.org/draft-0/org/code",
           "title": "Code"
         },
         "retained": {
@@ -45,7 +45,7 @@
     "RateTotal": {
       "properties": {
         "key": {
-          "type": "string",
+          "$ref": "https://gobl.org/draft-0/org/key",
           "title": "Key"
         },
         "base": {
@@ -115,5 +115,5 @@
       "description": "Total contains a set of Category Totals which in turn contain all the accumulated taxes contained in the document."
     }
   },
-  "$comment": "Generated with GOBL v0.26.0"
+  "$comment": "Generated with GOBL v0.27.0"
 }

--- a/build/schemas/uuid/uuid.json
+++ b/build/schemas/uuid/uuid.json
@@ -10,5 +10,5 @@
       "description": "Universally Unique Identifier. We only recommend using versions 1 and 4 within GoBL."
     }
   },
-  "$comment": "Generated with GOBL v0.26.0"
+  "$comment": "Generated with GOBL v0.27.0"
 }

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-ozzo/ozzo-validation/v4 v4.3.0
 	github.com/google/uuid v1.1.2
-	github.com/invopop/jsonschema v0.4.1-0.20220509222051-9cef489f4cb7
+	github.com/invopop/jsonschema v0.5.0
 	github.com/invopop/yaml v0.1.0
 	github.com/kr/pretty v0.2.0 // indirect
 	github.com/square/go-jose/v3 v3.0.0-20200630053402-0a67ce9b0693

--- a/go.sum
+++ b/go.sum
@@ -160,6 +160,8 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/invopop/jsonschema v0.4.1-0.20220509222051-9cef489f4cb7 h1:zW+nqgrkOFZr0ZybAgeJ9aV5jkIuv6rN9dWO/FTDz5o=
 github.com/invopop/jsonschema v0.4.1-0.20220509222051-9cef489f4cb7/go.mod h1:O9uiLokuu0+MGFlyiaqtWxwqJm41/+8Nj0lD7A36YH0=
+github.com/invopop/jsonschema v0.5.0 h1:6tvpBcwTGxzvx3M9f3IfzqQVyZvoH+0NRUtBcsgyfrU=
+github.com/invopop/jsonschema v0.5.0/go.mod h1:O9uiLokuu0+MGFlyiaqtWxwqJm41/+8Nj0lD7A36YH0=
 github.com/invopop/yaml v0.1.0 h1:YW3WGUoJEXYfzWBjn00zIlrw7brGVD0fUKRYDPAPhrc=
 github.com/invopop/yaml v0.1.0/go.mod h1:2XuRLgs/ouIrW3XNzuNj7J3Nvu/Dig5MXvbCEdiBN3Q=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=

--- a/l10n/l10n.go
+++ b/l10n/l10n.go
@@ -1,24 +1,31 @@
 package l10n
 
 import (
-	"errors"
 	"regexp"
+
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 )
 
-// Code is used for identifiers for specific states, cities,
-// or localities. They are limited to upper-case letters and numbers
+// Code is used for short identifiers like country or state codes.
+// They are limited to upper-case letters and numbers
 // only, and should be validated against region specific data.
 type Code string
 
-var codeFormat = regexp.MustCompile(`\A[A-Z0-9]+\z`)
+var (
+	codeFormat = regexp.MustCompile(`\A[A-Z0-9]+\z`)
+)
+
+// CodeEmpty is used for matching empty codes.
+const CodeEmpty Code = ""
 
 // Validate ensures the code is formatted correctly.
 func (c Code) Validate() error {
-	if string(c) == "" {
-		return nil
-	}
-	if !codeFormat.MatchString(string(c)) {
-		return errors.New("invalid code format")
-	}
-	return nil
+	return validation.Validate(string(c),
+		validation.Match(codeFormat),
+	)
+}
+
+// String provides string representation of code
+func (c Code) String() string {
+	return string(c)
 }

--- a/org/code.go
+++ b/org/code.go
@@ -1,26 +1,28 @@
-package tax
+package org
 
 import (
 	"regexp"
 
 	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"github.com/invopop/jsonschema"
 )
 
 // Code represents a string used to uniquely identify the data we're looking
 // at. We use "code" instead of "id", to reenforce the fact that codes should
 // be more easily set and used by humans within definitions than IDs or UUIDs.
-// Tax codes are standardised so that when validated they must contain between
+// Codes are standardised so that when validated they must contain between
 // 2 and 6 inclusive upper-case letters or numbers.
 type Code string
 
 var (
-	codeValidationRegexp = regexp.MustCompile(`^[A-Z0-9]{2,6}$`)
+	codePattern          = `^[A-Z0-9]{1,6}$`
+	codeValidationRegexp = regexp.MustCompile(codePattern)
 )
 
 // Validate ensures that the code complies with the expected rules.
 func (c Code) Validate() error {
 	return validation.Validate(string(c),
-		validation.Length(2, 6),
+		validation.Length(1, 6),
 		validation.Match(codeValidationRegexp),
 	)
 }
@@ -44,4 +46,16 @@ func (c Code) In(ary []Code) bool {
 		}
 	}
 	return false
+}
+
+// JSONSchema provides a representation of the struct for usage in Schema.
+func (Code) JSONSchema() *jsonschema.Schema {
+	return &jsonschema.Schema{
+		Type:        "string",
+		Pattern:     codePattern,
+		Title:       "Code",
+		MinLength:   1,
+		MaxLength:   6,
+		Description: "Short upper-case identifier.",
+	}
 }

--- a/org/code_test.go
+++ b/org/code_test.go
@@ -1,21 +1,21 @@
-package tax_test
+package org_test
 
 import (
 	"testing"
 
-	"github.com/invopop/gobl/tax"
+	"github.com/invopop/gobl/org"
 )
 
 func TestCodeValidation(t *testing.T) {
-	c := tax.Code("ABC")
+	c := org.Code("ABC")
 	if err := c.Validate(); err != nil {
 		t.Errorf("did not expect error: %v", err)
 	}
-	c = tax.Code("abc")
+	c = org.Code("abc")
 	if err := c.Validate(); err == nil {
 		t.Errorf("expected a validation error")
 	}
-	c = tax.Code("ab")
+	c = org.Code("ab")
 	if err := c.Validate(); err == nil {
 		t.Errorf("expected a validation error")
 	}

--- a/org/inbox.go
+++ b/org/inbox.go
@@ -1,18 +1,8 @@
 package org
 
 import (
-	"regexp"
-
 	validation "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/invopop/gobl/uuid"
-)
-
-// InboxKey determines the type of inbox data being provided. Pre-defined
-// keys are available in the regions package.
-type InboxKey string
-
-var (
-	inboxKeyValidationRegexp = regexp.MustCompile(`^[a-z][a-z0-9-]*[a-z0-9]$`)
 )
 
 // Inbox is used to store data about a connection with a service that is responsible
@@ -23,10 +13,10 @@ type Inbox struct {
 	UUID *uuid.UUID `json:"uuid,omitempty" jsonschema:"title=UUID"`
 
 	// Type of inbox being defined.
-	Key InboxKey `json:"key" jsonschema:"title=Key"`
+	Key Key `json:"key" jsonschema:"title=Key"`
 
 	// Role assigned to this inbox that may be relevant for the consumer.
-	Role InboxKey `json:"role,omitempty" jsonschema:"title=Role"`
+	Role Key `json:"role,omitempty" jsonschema:"title=Role"`
 
 	// Human name for the inbox.
 	Name string `json:"name,omitempty" jsonschema:"title=Name"`
@@ -43,17 +33,4 @@ func (i *Inbox) Validate() error {
 		validation.Field(&i.Role),
 		validation.Field(&i.Code, validation.Required),
 	)
-}
-
-// Validate ensures the key complies with the basic syntax
-// requirements.
-func (k InboxKey) Validate() error {
-	return validation.Validate(string(k),
-		validation.Match(inboxKeyValidationRegexp),
-	)
-}
-
-// String provides string representation of key
-func (k InboxKey) String() string {
-	return string(k)
 }

--- a/org/key.go
+++ b/org/key.go
@@ -1,18 +1,21 @@
-package tax
+package org
 
 import (
 	"fmt"
 	"regexp"
 
 	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"github.com/invopop/jsonschema"
 )
 
 // Key is used to define an ID or code that more closely represents
-// a human name.
+// a human name. The objective is to make it easier to define constants
+// that can be re-used more easily.
 type Key string
 
 var (
-	keyValidationRegexp = regexp.MustCompile(`^[a-z][a-z0-9-+]*[a-z0-9]$`)
+	keyPattern          = `^[a-z][a-z0-9-+]*[a-z0-9]$`
+	keyValidationRegexp = regexp.MustCompile(keyPattern)
 )
 
 // KeyEmpty is used when no key is available.
@@ -23,6 +26,7 @@ const KeyEmpty Key = ""
 func (k Key) Validate() error {
 	return validation.Validate(string(k),
 		validation.Match(keyValidationRegexp),
+		validation.Length(2, 64),
 	)
 }
 
@@ -35,4 +39,16 @@ func (k Key) String() string {
 // with a `+` symbol.
 func (k Key) With(ke Key) Key {
 	return Key(fmt.Sprintf("%s+%s", k, ke))
+}
+
+// JSONSchema provides a representation of the struct for usage in Schema.
+func (Key) JSONSchema() *jsonschema.Schema {
+	return &jsonschema.Schema{
+		Type:        "string",
+		Pattern:     keyPattern,
+		Title:       "Key",
+		MinLength:   2,
+		MaxLength:   64,
+		Description: "Text identifier to be used instead of a code for a more verbose but readable identifier.",
+	}
 }

--- a/org/meta.go
+++ b/org/meta.go
@@ -10,4 +10,4 @@ package org
 //
 // We need to always use strings for values so that meta-data is easy to convert
 // into other formats, such as protobuf which has strict type requirements.
-type Meta map[string]string
+type Meta map[Key]string

--- a/org/org.go
+++ b/org/org.go
@@ -4,6 +4,8 @@ import "github.com/invopop/gobl/schema"
 
 func init() {
 	objs := []interface{}{
+		Code(""),
+		Key(""),
 		Address{},
 		Coordinates{},
 		Item{},

--- a/regions/common/common.go
+++ b/regions/common/common.go
@@ -2,29 +2,28 @@ package common
 
 import (
 	"github.com/invopop/gobl/org"
-	"github.com/invopop/gobl/tax"
 )
 
 // Standard tax categories that may be shared between countries.
 const (
-	TaxCategoryVAT tax.Code = "VAT"
+	TaxCategoryVAT org.Code = "VAT"
 )
 
 // Most commonly used codes. Local regions may add their own rate codes.
 const (
-	TaxRateZero         tax.Key = "zero"
-	TaxRateStandard     tax.Key = "standard"
-	TaxRateReduced      tax.Key = "reduced"
-	TaxRateSuperReduced tax.Key = "super-reduced"
+	TaxRateZero         org.Key = "zero"
+	TaxRateStandard     org.Key = "standard"
+	TaxRateReduced      org.Key = "reduced"
+	TaxRateSuperReduced org.Key = "super-reduced"
 )
 
 // Standard scheme definitions
 const (
-	SchemeReverseCharge tax.Key = "reverse-charge"
-	SchemeCustomerRates tax.Key = "customer-rates"
+	SchemeReverseCharge org.Key = "reverse-charge"
+	SchemeCustomerRates org.Key = "customer-rates"
 )
 
 // Common inbox keys
 const (
-	InboxKeyPEPPOL org.InboxKey = "peppol-id"
+	InboxKeyPEPPOL org.Key = "peppol-id"
 )

--- a/regions/es/es.go
+++ b/regions/es/es.go
@@ -55,6 +55,7 @@ const (
 
 )
 
+// Locality code definitions for Spain
 const (
 	LocalityVI l10n.Code = "VI" // (01) Álava
 	LocalityAB l10n.Code = "AB" // (02) Albacete
@@ -113,12 +114,13 @@ const (
 	LocalityML l10n.Code = "ML" // (52) Melilla
 )
 
+// Custom keys used typically in meta information.
 const (
 	KeyPost org.Key = "post"
 )
 
-// TaxRegion provides the Spanish region definition
-func New() *tax.Region {
+// Region provides the Spanish region definition
+func Region() *tax.Region {
 	return &tax.Region{
 		Country:  l10n.ES,
 		Currency: "EUR",

--- a/regions/es/es.go
+++ b/regions/es/es.go
@@ -117,644 +117,646 @@ const (
 	KeyPost org.Key = "post"
 )
 
-// Region provides the Spanish region definition
-var Region = &tax.Region{
-	Country:  l10n.ES,
-	Currency: "EUR",
-	Name: i18n.String{
-		i18n.EN: "Spain",
-		i18n.ES: "España",
-	},
-	ValidateDocument: Validate,
-	Localities: tax.Localities{
-		{
-			Code: LocalityVI,
-			Name: i18n.String{i18n.ES: "Ávila"},
-			Meta: org.Meta{KeyPost: "01"},
+// TaxRegion provides the Spanish region definition
+func New() *tax.Region {
+	return &tax.Region{
+		Country:  l10n.ES,
+		Currency: "EUR",
+		Name: i18n.String{
+			i18n.EN: "Spain",
+			i18n.ES: "España",
 		},
-		{
-			Code: LocalityAB,
-			Name: i18n.String{i18n.ES: "Albacete"},
-			Meta: org.Meta{KeyPost: "02"},
-		},
-		{
-			Code: LocalityA,
-			Name: i18n.String{i18n.ES: "Alicante"},
-			Meta: org.Meta{KeyPost: "03"},
-		},
-		{
-			Code: LocalityAL,
-			Name: i18n.String{i18n.ES: "Almería"},
-			Meta: org.Meta{KeyPost: "04"},
-		},
-		{
-			Code: LocalityAV,
-			Name: i18n.String{i18n.ES: "Ávila"},
-			Meta: org.Meta{KeyPost: "05"},
-		},
-		{
-			Code: LocalityBA,
-			Name: i18n.String{i18n.ES: "Badajoz"},
-			Meta: org.Meta{KeyPost: "06"},
-		},
-		{
-			Code: LocalityPM,
-			Name: i18n.String{i18n.ES: "Baleares"},
-			Meta: org.Meta{KeyPost: "07"},
-		},
-		{
-			Code: LocalityIB,
-			Name: i18n.String{i18n.ES: "Baleares"},
-			Meta: org.Meta{KeyPost: "07"},
-		},
-		{
-			Code: LocalityB,
-			Name: i18n.String{i18n.ES: "Barcelona"},
-			Meta: org.Meta{KeyPost: "08"},
-		},
-		{
-			Code: LocalityBU,
-			Name: i18n.String{i18n.ES: "Burgos"},
-			Meta: org.Meta{KeyPost: "09"},
-		},
-		{
-			Code: LocalityCC,
-			Name: i18n.String{i18n.ES: "Cáceres"},
-			Meta: org.Meta{KeyPost: "10"},
-		},
-		{
-			Code: LocalityCA,
-			Name: i18n.String{i18n.ES: "Cadiz"},
-			Meta: org.Meta{KeyPost: "11"},
-		},
-		{
-			Code: LocalityCS,
-			Name: i18n.String{i18n.ES: "Castellón"},
-			Meta: org.Meta{KeyPost: "12"},
-		},
-		{
-			Code: LocalityCR,
-			Name: i18n.String{i18n.ES: "Ciudad Real"},
-			Meta: org.Meta{KeyPost: "13"},
-		},
-		{
-			Code: LocalityCO,
-			Name: i18n.String{i18n.ES: "Cordoba"},
-			Meta: org.Meta{KeyPost: "14"},
-		},
-		{
-			Code: LocalityC,
-			Name: i18n.String{i18n.ES: "La Coruña"},
-			Meta: org.Meta{KeyPost: "15"},
-		},
-		{
-			Code: LocalityCU,
-			Name: i18n.String{i18n.ES: "Cuenca"},
-			Meta: org.Meta{KeyPost: "16"},
-		},
-		{
-			Code: LocalityGE,
-			Name: i18n.String{i18n.ES: "Gerona"},
-			Meta: org.Meta{KeyPost: "17"},
-		},
-		{
-			Code: LocalityGI,
-			Name: i18n.String{i18n.ES: "Girona"},
-			Meta: org.Meta{KeyPost: "17"},
-		},
-		{
-			Code: LocalityGR,
-			Name: i18n.String{i18n.ES: "Granada"},
-			Meta: org.Meta{KeyPost: "18"},
-		},
-		{
-			Code: LocalityGU,
-			Name: i18n.String{i18n.ES: "Guadalajara"},
-			Meta: org.Meta{KeyPost: "19"},
-		},
-		{
-			Code: LocalitySS,
-			Name: i18n.String{i18n.ES: "Guipúzcoa"},
-			Meta: org.Meta{KeyPost: "20"},
-		},
-		{
-			Code: LocalityH,
-			Name: i18n.String{i18n.ES: "Huelva"},
-			Meta: org.Meta{KeyPost: "21"},
-		},
-		{
-			Code: LocalityHU,
-			Name: i18n.String{i18n.ES: "Huesca"},
-			Meta: org.Meta{KeyPost: "22"},
-		},
-		{
-			Code: LocalityJ,
-			Name: i18n.String{i18n.ES: "Jaén"},
-			Meta: org.Meta{KeyPost: "23"},
-		},
-		{
-			Code: LocalityLE,
-			Name: i18n.String{i18n.ES: "León"},
-			Meta: org.Meta{KeyPost: "24"},
-		},
-		{
-			Code: LocalityL,
-			Name: i18n.String{i18n.ES: "Lérida / Lleida"},
-			Meta: org.Meta{KeyPost: "25"},
-		},
-		{
-			Code: LocalityLO,
-			Name: i18n.String{i18n.ES: "La Rioja"},
-			Meta: org.Meta{KeyPost: "26"},
-		},
-		{
-			Code: LocalityLU,
-			Name: i18n.String{i18n.ES: "Lugo"},
-			Meta: org.Meta{KeyPost: "27"},
-		},
-		{
-			Code: LocalityM,
-			Name: i18n.String{i18n.ES: "Madrid"},
-			Meta: org.Meta{KeyPost: "28"},
-		},
-		{
-			Code: LocalityMA,
-			Name: i18n.String{i18n.ES: "Málaga"},
-			Meta: org.Meta{KeyPost: "29"},
-		},
-		{
-			Code: LocalityMU,
-			Name: i18n.String{i18n.ES: "Murcia"},
-			Meta: org.Meta{KeyPost: "30"},
-		},
-		{
-			Code: LocalityNA,
-			Name: i18n.String{i18n.ES: "Navarra"},
-			Meta: org.Meta{KeyPost: "31"},
-		},
-		{
-			Code: LocalityOR,
-			Name: i18n.String{i18n.ES: "Orense"},
-			Meta: org.Meta{KeyPost: "32"},
-		},
-		{
-			Code: LocalityOU,
-			Name: i18n.String{i18n.ES: "Orense"},
-			Meta: org.Meta{KeyPost: "32"},
-		},
-		{
-			Code: LocalityO,
-			Name: i18n.String{i18n.ES: "Asturias"},
-			Meta: org.Meta{KeyPost: "33"},
-		},
-		{
-			Code: LocalityP,
-			Name: i18n.String{i18n.ES: "Palencia"},
-			Meta: org.Meta{KeyPost: "34"},
-		},
-		{
-			Code: LocalityGC,
-			Name: i18n.String{i18n.ES: "Las Palmas"},
-			Meta: org.Meta{KeyPost: "35"},
-		},
-		{
-			Code: LocalityPO,
-			Name: i18n.String{i18n.ES: "Pontevedra"},
-			Meta: org.Meta{KeyPost: "36"},
-		},
-		{
-			Code: LocalitySA,
-			Name: i18n.String{i18n.ES: "Salamanca"},
-			Meta: org.Meta{KeyPost: "37"},
-		},
-		{
-			Code: LocalityTF,
-			Name: i18n.String{i18n.ES: "Santa Cruz de Tenerife"},
-			Meta: org.Meta{KeyPost: "38"},
-		},
-		{
-			Code: LocalityS,
-			Name: i18n.String{i18n.ES: "Cantabria"},
-			Meta: org.Meta{KeyPost: "39"},
-		},
-		{
-			Code: LocalitySG,
-			Name: i18n.String{i18n.ES: "Segovia"},
-			Meta: org.Meta{KeyPost: "40"},
-		},
-		{
-			Code: LocalitySE,
-			Name: i18n.String{i18n.ES: "Sevilla"},
-			Meta: org.Meta{KeyPost: "41"},
-		},
-		{
-			Code: LocalitySO,
-			Name: i18n.String{i18n.ES: "Soria"},
-			Meta: org.Meta{KeyPost: "42"},
-		},
-		{
-			Code: LocalityT,
-			Name: i18n.String{i18n.ES: "Tarragona"},
-			Meta: org.Meta{KeyPost: "43"},
-		},
-		{
-			Code: LocalityTE,
-			Name: i18n.String{i18n.ES: "Teruel"},
-			Meta: org.Meta{KeyPost: "44"},
-		},
-		{
-			Code: LocalityTO,
-			Name: i18n.String{i18n.ES: "Toledo"},
-			Meta: org.Meta{KeyPost: "45"},
-		},
-		{
-			Code: LocalityV,
-			Name: i18n.String{i18n.ES: "Valencia"},
-			Meta: org.Meta{KeyPost: "46"},
-		},
-		{
-			Code: LocalityVA,
-			Name: i18n.String{i18n.ES: "Valladolid"},
-			Meta: org.Meta{KeyPost: "47"},
-		},
-		{
-			Code: LocalityBI,
-			Name: i18n.String{i18n.ES: "Vizcaya"},
-			Meta: org.Meta{KeyPost: "48"},
-		},
-		{
-			Code: LocalityZA,
-			Name: i18n.String{i18n.ES: "Zamora"},
-			Meta: org.Meta{KeyPost: "49"},
-		},
-		{
-			Code: LocalityZ,
-			Name: i18n.String{i18n.ES: "Zaragoza"},
-			Meta: org.Meta{KeyPost: "50"},
-		},
-		{
-			Code: LocalityCE,
-			Name: i18n.String{i18n.ES: "Ceuta"},
-			Meta: org.Meta{KeyPost: "51"},
-		},
-		{
-			Code: LocalityML,
-			Name: i18n.String{i18n.ES: "Melilla"},
-			Meta: org.Meta{KeyPost: "52"},
-		},
-	},
-	Schemes: []*tax.Scheme{
-		// Reverse Charge Scheme
-		{
-			Key: common.SchemeReverseCharge,
-			Name: i18n.String{
-				i18n.EN: "Reverse Charge",
-				i18n.ES: "Inversión del sujeto pasivo",
+		ValidateDocument: Validate,
+		Localities: tax.Localities{
+			{
+				Code: LocalityVI,
+				Name: i18n.String{i18n.ES: "Ávila"},
+				Meta: org.Meta{KeyPost: "01"},
 			},
-			Categories: []org.Code{
-				common.TaxCategoryVAT,
+			{
+				Code: LocalityAB,
+				Name: i18n.String{i18n.ES: "Albacete"},
+				Meta: org.Meta{KeyPost: "02"},
 			},
-			Note: &org.Note{
-				Key:  org.NoteKeyLegal,
-				Src:  string(common.SchemeReverseCharge),
-				Text: "Reverse Charge / Inversión del sujeto pasivo.",
+			{
+				Code: LocalityA,
+				Name: i18n.String{i18n.ES: "Alicante"},
+				Meta: org.Meta{KeyPost: "03"},
+			},
+			{
+				Code: LocalityAL,
+				Name: i18n.String{i18n.ES: "Almería"},
+				Meta: org.Meta{KeyPost: "04"},
+			},
+			{
+				Code: LocalityAV,
+				Name: i18n.String{i18n.ES: "Ávila"},
+				Meta: org.Meta{KeyPost: "05"},
+			},
+			{
+				Code: LocalityBA,
+				Name: i18n.String{i18n.ES: "Badajoz"},
+				Meta: org.Meta{KeyPost: "06"},
+			},
+			{
+				Code: LocalityPM,
+				Name: i18n.String{i18n.ES: "Baleares"},
+				Meta: org.Meta{KeyPost: "07"},
+			},
+			{
+				Code: LocalityIB,
+				Name: i18n.String{i18n.ES: "Baleares"},
+				Meta: org.Meta{KeyPost: "07"},
+			},
+			{
+				Code: LocalityB,
+				Name: i18n.String{i18n.ES: "Barcelona"},
+				Meta: org.Meta{KeyPost: "08"},
+			},
+			{
+				Code: LocalityBU,
+				Name: i18n.String{i18n.ES: "Burgos"},
+				Meta: org.Meta{KeyPost: "09"},
+			},
+			{
+				Code: LocalityCC,
+				Name: i18n.String{i18n.ES: "Cáceres"},
+				Meta: org.Meta{KeyPost: "10"},
+			},
+			{
+				Code: LocalityCA,
+				Name: i18n.String{i18n.ES: "Cadiz"},
+				Meta: org.Meta{KeyPost: "11"},
+			},
+			{
+				Code: LocalityCS,
+				Name: i18n.String{i18n.ES: "Castellón"},
+				Meta: org.Meta{KeyPost: "12"},
+			},
+			{
+				Code: LocalityCR,
+				Name: i18n.String{i18n.ES: "Ciudad Real"},
+				Meta: org.Meta{KeyPost: "13"},
+			},
+			{
+				Code: LocalityCO,
+				Name: i18n.String{i18n.ES: "Cordoba"},
+				Meta: org.Meta{KeyPost: "14"},
+			},
+			{
+				Code: LocalityC,
+				Name: i18n.String{i18n.ES: "La Coruña"},
+				Meta: org.Meta{KeyPost: "15"},
+			},
+			{
+				Code: LocalityCU,
+				Name: i18n.String{i18n.ES: "Cuenca"},
+				Meta: org.Meta{KeyPost: "16"},
+			},
+			{
+				Code: LocalityGE,
+				Name: i18n.String{i18n.ES: "Gerona"},
+				Meta: org.Meta{KeyPost: "17"},
+			},
+			{
+				Code: LocalityGI,
+				Name: i18n.String{i18n.ES: "Girona"},
+				Meta: org.Meta{KeyPost: "17"},
+			},
+			{
+				Code: LocalityGR,
+				Name: i18n.String{i18n.ES: "Granada"},
+				Meta: org.Meta{KeyPost: "18"},
+			},
+			{
+				Code: LocalityGU,
+				Name: i18n.String{i18n.ES: "Guadalajara"},
+				Meta: org.Meta{KeyPost: "19"},
+			},
+			{
+				Code: LocalitySS,
+				Name: i18n.String{i18n.ES: "Guipúzcoa"},
+				Meta: org.Meta{KeyPost: "20"},
+			},
+			{
+				Code: LocalityH,
+				Name: i18n.String{i18n.ES: "Huelva"},
+				Meta: org.Meta{KeyPost: "21"},
+			},
+			{
+				Code: LocalityHU,
+				Name: i18n.String{i18n.ES: "Huesca"},
+				Meta: org.Meta{KeyPost: "22"},
+			},
+			{
+				Code: LocalityJ,
+				Name: i18n.String{i18n.ES: "Jaén"},
+				Meta: org.Meta{KeyPost: "23"},
+			},
+			{
+				Code: LocalityLE,
+				Name: i18n.String{i18n.ES: "León"},
+				Meta: org.Meta{KeyPost: "24"},
+			},
+			{
+				Code: LocalityL,
+				Name: i18n.String{i18n.ES: "Lérida / Lleida"},
+				Meta: org.Meta{KeyPost: "25"},
+			},
+			{
+				Code: LocalityLO,
+				Name: i18n.String{i18n.ES: "La Rioja"},
+				Meta: org.Meta{KeyPost: "26"},
+			},
+			{
+				Code: LocalityLU,
+				Name: i18n.String{i18n.ES: "Lugo"},
+				Meta: org.Meta{KeyPost: "27"},
+			},
+			{
+				Code: LocalityM,
+				Name: i18n.String{i18n.ES: "Madrid"},
+				Meta: org.Meta{KeyPost: "28"},
+			},
+			{
+				Code: LocalityMA,
+				Name: i18n.String{i18n.ES: "Málaga"},
+				Meta: org.Meta{KeyPost: "29"},
+			},
+			{
+				Code: LocalityMU,
+				Name: i18n.String{i18n.ES: "Murcia"},
+				Meta: org.Meta{KeyPost: "30"},
+			},
+			{
+				Code: LocalityNA,
+				Name: i18n.String{i18n.ES: "Navarra"},
+				Meta: org.Meta{KeyPost: "31"},
+			},
+			{
+				Code: LocalityOR,
+				Name: i18n.String{i18n.ES: "Orense"},
+				Meta: org.Meta{KeyPost: "32"},
+			},
+			{
+				Code: LocalityOU,
+				Name: i18n.String{i18n.ES: "Orense"},
+				Meta: org.Meta{KeyPost: "32"},
+			},
+			{
+				Code: LocalityO,
+				Name: i18n.String{i18n.ES: "Asturias"},
+				Meta: org.Meta{KeyPost: "33"},
+			},
+			{
+				Code: LocalityP,
+				Name: i18n.String{i18n.ES: "Palencia"},
+				Meta: org.Meta{KeyPost: "34"},
+			},
+			{
+				Code: LocalityGC,
+				Name: i18n.String{i18n.ES: "Las Palmas"},
+				Meta: org.Meta{KeyPost: "35"},
+			},
+			{
+				Code: LocalityPO,
+				Name: i18n.String{i18n.ES: "Pontevedra"},
+				Meta: org.Meta{KeyPost: "36"},
+			},
+			{
+				Code: LocalitySA,
+				Name: i18n.String{i18n.ES: "Salamanca"},
+				Meta: org.Meta{KeyPost: "37"},
+			},
+			{
+				Code: LocalityTF,
+				Name: i18n.String{i18n.ES: "Santa Cruz de Tenerife"},
+				Meta: org.Meta{KeyPost: "38"},
+			},
+			{
+				Code: LocalityS,
+				Name: i18n.String{i18n.ES: "Cantabria"},
+				Meta: org.Meta{KeyPost: "39"},
+			},
+			{
+				Code: LocalitySG,
+				Name: i18n.String{i18n.ES: "Segovia"},
+				Meta: org.Meta{KeyPost: "40"},
+			},
+			{
+				Code: LocalitySE,
+				Name: i18n.String{i18n.ES: "Sevilla"},
+				Meta: org.Meta{KeyPost: "41"},
+			},
+			{
+				Code: LocalitySO,
+				Name: i18n.String{i18n.ES: "Soria"},
+				Meta: org.Meta{KeyPost: "42"},
+			},
+			{
+				Code: LocalityT,
+				Name: i18n.String{i18n.ES: "Tarragona"},
+				Meta: org.Meta{KeyPost: "43"},
+			},
+			{
+				Code: LocalityTE,
+				Name: i18n.String{i18n.ES: "Teruel"},
+				Meta: org.Meta{KeyPost: "44"},
+			},
+			{
+				Code: LocalityTO,
+				Name: i18n.String{i18n.ES: "Toledo"},
+				Meta: org.Meta{KeyPost: "45"},
+			},
+			{
+				Code: LocalityV,
+				Name: i18n.String{i18n.ES: "Valencia"},
+				Meta: org.Meta{KeyPost: "46"},
+			},
+			{
+				Code: LocalityVA,
+				Name: i18n.String{i18n.ES: "Valladolid"},
+				Meta: org.Meta{KeyPost: "47"},
+			},
+			{
+				Code: LocalityBI,
+				Name: i18n.String{i18n.ES: "Vizcaya"},
+				Meta: org.Meta{KeyPost: "48"},
+			},
+			{
+				Code: LocalityZA,
+				Name: i18n.String{i18n.ES: "Zamora"},
+				Meta: org.Meta{KeyPost: "49"},
+			},
+			{
+				Code: LocalityZ,
+				Name: i18n.String{i18n.ES: "Zaragoza"},
+				Meta: org.Meta{KeyPost: "50"},
+			},
+			{
+				Code: LocalityCE,
+				Name: i18n.String{i18n.ES: "Ceuta"},
+				Meta: org.Meta{KeyPost: "51"},
+			},
+			{
+				Code: LocalityML,
+				Name: i18n.String{i18n.ES: "Melilla"},
+				Meta: org.Meta{KeyPost: "52"},
 			},
 		},
-		// Customer Rates Scheme (digital goods)
-		{
-			Key: common.SchemeCustomerRates,
-			Name: i18n.String{
-				i18n.EN: "Customer Country Rates",
-				i18n.ES: "Tasas del País del Cliente",
-			},
-			Description: i18n.String{
-				i18n.EN: "Use the customers country to determine tax rates.",
-			},
-		},
-		// Simplified Regime
-		{
-			Key: SchemeSimplified,
-			Name: i18n.String{
-				i18n.EN: "Simplified tax scheme",
-				i18n.ES: "Contribuyente en régimen simplificado",
-			},
-			Note: &org.Note{
-				Key:  org.NoteKeyLegal,
-				Src:  string(SchemeSimplified),
-				Text: "Factura expedida por contibuyente en régimen simplificado.",
-			},
-		},
-		// Customer issued invoices
-		{
-			Key: SchemeCustomerIssued,
-			Name: i18n.String{
-				i18n.EN: "Customer issued invoice",
-				i18n.ES: "Facturación por el destinatario",
-			},
-			Note: &org.Note{
-				Key:  org.NoteKeyLegal,
-				Src:  string(SchemeCustomerIssued),
-				Text: "Facturación por el destinatario.",
-			},
-		},
-		// Travel agency
-		{
-			Key: SchemeTravelAgency,
-			Name: i18n.String{
-				i18n.EN: "Special scheme for travel agencies",
-				i18n.ES: "Régimen especial de las agencias de viajes",
-			},
-			Note: &org.Note{
-				Key:  org.NoteKeyLegal,
-				Src:  string(SchemeTravelAgency),
-				Text: "Régimen especial de las agencias de viajes.",
-			},
-		},
-		// Secondhand stuff
-		{
-			Key: SchemeSecondHandGoods,
-			Name: i18n.String{
-				i18n.EN: "Special scheme for second-hand goods",
-				i18n.ES: "Régimen especial de los bienes usados",
-			},
-			Note: &org.Note{
-				Key:  org.NoteKeyLegal,
-				Src:  string(SchemeSecondHandGoods),
-				Text: "Régimen especial de los bienes usados.",
-			},
-		},
-		// Art
-		{
-			Key: SchemeArt,
-			Name: i18n.String{
-				i18n.EN: "Special scheme of works of art",
-				i18n.ES: "Régimen especial de los objetos de arte",
-			},
-			Note: &org.Note{
-				Key:  org.NoteKeyLegal,
-				Src:  string(SchemeArt),
-				Text: "Régimen especial de los objetos de arte.",
-			},
-		},
-		// Antiques
-		{
-			Key: SchemeAntiques,
-			Name: i18n.String{
-				i18n.EN: "Special scheme of antiques and collectables",
-				i18n.ES: "Régimen especial de las antigüedades y objetos de colección",
-			},
-			Note: &org.Note{
-				Key:  org.NoteKeyLegal,
-				Src:  string(SchemeAntiques),
-				Text: "Régimen especial de las antigüedades y objetos de colección.",
-			},
-		},
-		// Special Regime of "Cash Criteria"
-		{
-			Key: SchemeCashBasis,
-			Name: i18n.String{
-				i18n.EN: "Special scheme on cash basis",
-				i18n.ES: "Régimen especial del criterio de caja",
-			},
-			Note: &org.Note{
-				Key:  org.NoteKeyLegal,
-				Src:  string(SchemeCashBasis),
-				Text: "Régimen especial del criterio de caja.",
-			},
-		},
-	},
-	Categories: []*tax.Category{
-		//
-		// VAT
-		//
-		{
-			Code: common.TaxCategoryVAT,
-			Name: i18n.String{
-				i18n.EN: "VAT",
-				i18n.ES: "IVA",
-			},
-			Desc: i18n.String{
-				i18n.EN: "Value Added Tax",
-				i18n.ES: "Impuesto sobre el Valor Añadido",
-			},
-			Retained: false,
-			Rates: []*tax.Rate{
-				{
-					Key: common.TaxRateZero,
-					Name: i18n.String{
-						i18n.EN: "Zero Rate",
-						i18n.ES: "Tipo Zero",
-					},
-					Values: []*tax.RateValue{
-						{
-							Percent: num.MakePercentage(0, 3),
-						},
-					},
+		Schemes: []*tax.Scheme{
+			// Reverse Charge Scheme
+			{
+				Key: common.SchemeReverseCharge,
+				Name: i18n.String{
+					i18n.EN: "Reverse Charge",
+					i18n.ES: "Inversión del sujeto pasivo",
 				},
-				{
-					Key: common.TaxRateStandard,
-					Name: i18n.String{
-						i18n.EN: "Standard Rate",
-						i18n.ES: "Tipo General",
-					},
-					Values: []*tax.RateValue{
-						{
-							Since:   cal.NewDate(2012, 9, 1),
-							Percent: num.MakePercentage(210, 3),
-						},
-						{
-							Since:   cal.NewDate(2010, 7, 1),
-							Percent: num.MakePercentage(180, 3),
-						},
-						{
-							Since:   cal.NewDate(1995, 1, 1),
-							Percent: num.MakePercentage(160, 3),
-						},
-						{
-							Since:   cal.NewDate(1993, 1, 1),
-							Percent: num.MakePercentage(150, 3),
-						},
-					},
+				Categories: []org.Code{
+					common.TaxCategoryVAT,
 				},
-				{
-					Key: common.TaxRateStandard.With(TaxRateEquivalence),
-					Name: i18n.String{
-						i18n.EN: "Standard Rate + Equivalence Surcharge",
-						i18n.ES: "Tipo General + Recargo de Equivalencia",
-					},
-					Values: []*tax.RateValue{
-						{
-							Since:     cal.NewDate(2012, 9, 1),
-							Percent:   num.MakePercentage(210, 3),
-							Surcharge: num.NewPercentage(52, 3),
-						},
-						{
-							Since:     cal.NewDate(2010, 7, 1),
-							Percent:   num.MakePercentage(180, 3),
-							Surcharge: num.NewPercentage(40, 3),
-						},
-					},
+				Note: &org.Note{
+					Key:  org.NoteKeyLegal,
+					Src:  string(common.SchemeReverseCharge),
+					Text: "Reverse Charge / Inversión del sujeto pasivo.",
 				},
-				{
-					Key: common.TaxRateReduced,
-					Name: i18n.String{
-						i18n.EN: "Reduced Rate",
-						i18n.ES: "Tipo Reducido",
-					},
-					Values: []*tax.RateValue{
-						{
-							Since:   cal.NewDate(2012, 9, 1),
-							Percent: num.MakePercentage(100, 3),
-						},
-						{
-							Since:   cal.NewDate(2010, 7, 1),
-							Percent: num.MakePercentage(80, 3),
-						},
-						{
-							Since:   cal.NewDate(1995, 1, 1),
-							Percent: num.MakePercentage(70, 3),
-						},
-						{
-							Since:   cal.NewDate(1993, 1, 1),
-							Percent: num.MakePercentage(60, 3),
-						},
-					},
+			},
+			// Customer Rates Scheme (digital goods)
+			{
+				Key: common.SchemeCustomerRates,
+				Name: i18n.String{
+					i18n.EN: "Customer Country Rates",
+					i18n.ES: "Tasas del País del Cliente",
 				},
-				{
-					Key: common.TaxRateReduced.With(TaxRateEquivalence),
-					Name: i18n.String{
-						i18n.EN: "Reduced Rate + Equivalence Surcharge",
-						i18n.ES: "Tipo Reducido + Recargo de Equivalencia",
-					},
-					Values: []*tax.RateValue{
-						{
-							Since:     cal.NewDate(2012, 9, 1),
-							Percent:   num.MakePercentage(100, 3),
-							Surcharge: num.NewPercentage(14, 3),
-						},
-						{
-							Since:     cal.NewDate(2010, 7, 1),
-							Percent:   num.MakePercentage(80, 3),
-							Surcharge: num.NewPercentage(10, 3),
-						},
-					},
+				Description: i18n.String{
+					i18n.EN: "Use the customers country to determine tax rates.",
 				},
-				{
-					Key: common.TaxRateSuperReduced,
-					Name: i18n.String{
-						i18n.EN: "Super-Reduced Rate",
-						i18n.ES: "Tipo Superreducido",
-					},
-					Values: []*tax.RateValue{
-						{
-							Since:   cal.NewDate(1995, 1, 1),
-							Percent: num.MakePercentage(40, 3),
-						},
-						{
-							Since:   cal.NewDate(1993, 1, 1),
-							Percent: num.MakePercentage(30, 3),
-						},
-					},
+			},
+			// Simplified Regime
+			{
+				Key: SchemeSimplified,
+				Name: i18n.String{
+					i18n.EN: "Simplified tax scheme",
+					i18n.ES: "Contribuyente en régimen simplificado",
 				},
-				{
-					Key: common.TaxRateSuperReduced.With(TaxRateEquivalence),
-					Name: i18n.String{
-						i18n.EN: "Super-Reduced Rate + Equivalence Surcharge",
-						i18n.ES: "Tipo Superreducido + Recargo de Equivalencia",
-					},
-					Values: []*tax.RateValue{
-						{
-							Since:     cal.NewDate(1995, 1, 1),
-							Percent:   num.MakePercentage(40, 3),
-							Surcharge: num.NewPercentage(5, 3),
-						},
-					},
+				Note: &org.Note{
+					Key:  org.NoteKeyLegal,
+					Src:  string(SchemeSimplified),
+					Text: "Factura expedida por contibuyente en régimen simplificado.",
+				},
+			},
+			// Customer issued invoices
+			{
+				Key: SchemeCustomerIssued,
+				Name: i18n.String{
+					i18n.EN: "Customer issued invoice",
+					i18n.ES: "Facturación por el destinatario",
+				},
+				Note: &org.Note{
+					Key:  org.NoteKeyLegal,
+					Src:  string(SchemeCustomerIssued),
+					Text: "Facturación por el destinatario.",
+				},
+			},
+			// Travel agency
+			{
+				Key: SchemeTravelAgency,
+				Name: i18n.String{
+					i18n.EN: "Special scheme for travel agencies",
+					i18n.ES: "Régimen especial de las agencias de viajes",
+				},
+				Note: &org.Note{
+					Key:  org.NoteKeyLegal,
+					Src:  string(SchemeTravelAgency),
+					Text: "Régimen especial de las agencias de viajes.",
+				},
+			},
+			// Secondhand stuff
+			{
+				Key: SchemeSecondHandGoods,
+				Name: i18n.String{
+					i18n.EN: "Special scheme for second-hand goods",
+					i18n.ES: "Régimen especial de los bienes usados",
+				},
+				Note: &org.Note{
+					Key:  org.NoteKeyLegal,
+					Src:  string(SchemeSecondHandGoods),
+					Text: "Régimen especial de los bienes usados.",
+				},
+			},
+			// Art
+			{
+				Key: SchemeArt,
+				Name: i18n.String{
+					i18n.EN: "Special scheme of works of art",
+					i18n.ES: "Régimen especial de los objetos de arte",
+				},
+				Note: &org.Note{
+					Key:  org.NoteKeyLegal,
+					Src:  string(SchemeArt),
+					Text: "Régimen especial de los objetos de arte.",
+				},
+			},
+			// Antiques
+			{
+				Key: SchemeAntiques,
+				Name: i18n.String{
+					i18n.EN: "Special scheme of antiques and collectables",
+					i18n.ES: "Régimen especial de las antigüedades y objetos de colección",
+				},
+				Note: &org.Note{
+					Key:  org.NoteKeyLegal,
+					Src:  string(SchemeAntiques),
+					Text: "Régimen especial de las antigüedades y objetos de colección.",
+				},
+			},
+			// Special Regime of "Cash Criteria"
+			{
+				Key: SchemeCashBasis,
+				Name: i18n.String{
+					i18n.EN: "Special scheme on cash basis",
+					i18n.ES: "Régimen especial del criterio de caja",
+				},
+				Note: &org.Note{
+					Key:  org.NoteKeyLegal,
+					Src:  string(SchemeCashBasis),
+					Text: "Régimen especial del criterio de caja.",
 				},
 			},
 		},
+		Categories: []*tax.Category{
+			//
+			// VAT
+			//
+			{
+				Code: common.TaxCategoryVAT,
+				Name: i18n.String{
+					i18n.EN: "VAT",
+					i18n.ES: "IVA",
+				},
+				Desc: i18n.String{
+					i18n.EN: "Value Added Tax",
+					i18n.ES: "Impuesto sobre el Valor Añadido",
+				},
+				Retained: false,
+				Rates: []*tax.Rate{
+					{
+						Key: common.TaxRateZero,
+						Name: i18n.String{
+							i18n.EN: "Zero Rate",
+							i18n.ES: "Tipo Zero",
+						},
+						Values: []*tax.RateValue{
+							{
+								Percent: num.MakePercentage(0, 3),
+							},
+						},
+					},
+					{
+						Key: common.TaxRateStandard,
+						Name: i18n.String{
+							i18n.EN: "Standard Rate",
+							i18n.ES: "Tipo General",
+						},
+						Values: []*tax.RateValue{
+							{
+								Since:   cal.NewDate(2012, 9, 1),
+								Percent: num.MakePercentage(210, 3),
+							},
+							{
+								Since:   cal.NewDate(2010, 7, 1),
+								Percent: num.MakePercentage(180, 3),
+							},
+							{
+								Since:   cal.NewDate(1995, 1, 1),
+								Percent: num.MakePercentage(160, 3),
+							},
+							{
+								Since:   cal.NewDate(1993, 1, 1),
+								Percent: num.MakePercentage(150, 3),
+							},
+						},
+					},
+					{
+						Key: common.TaxRateStandard.With(TaxRateEquivalence),
+						Name: i18n.String{
+							i18n.EN: "Standard Rate + Equivalence Surcharge",
+							i18n.ES: "Tipo General + Recargo de Equivalencia",
+						},
+						Values: []*tax.RateValue{
+							{
+								Since:     cal.NewDate(2012, 9, 1),
+								Percent:   num.MakePercentage(210, 3),
+								Surcharge: num.NewPercentage(52, 3),
+							},
+							{
+								Since:     cal.NewDate(2010, 7, 1),
+								Percent:   num.MakePercentage(180, 3),
+								Surcharge: num.NewPercentage(40, 3),
+							},
+						},
+					},
+					{
+						Key: common.TaxRateReduced,
+						Name: i18n.String{
+							i18n.EN: "Reduced Rate",
+							i18n.ES: "Tipo Reducido",
+						},
+						Values: []*tax.RateValue{
+							{
+								Since:   cal.NewDate(2012, 9, 1),
+								Percent: num.MakePercentage(100, 3),
+							},
+							{
+								Since:   cal.NewDate(2010, 7, 1),
+								Percent: num.MakePercentage(80, 3),
+							},
+							{
+								Since:   cal.NewDate(1995, 1, 1),
+								Percent: num.MakePercentage(70, 3),
+							},
+							{
+								Since:   cal.NewDate(1993, 1, 1),
+								Percent: num.MakePercentage(60, 3),
+							},
+						},
+					},
+					{
+						Key: common.TaxRateReduced.With(TaxRateEquivalence),
+						Name: i18n.String{
+							i18n.EN: "Reduced Rate + Equivalence Surcharge",
+							i18n.ES: "Tipo Reducido + Recargo de Equivalencia",
+						},
+						Values: []*tax.RateValue{
+							{
+								Since:     cal.NewDate(2012, 9, 1),
+								Percent:   num.MakePercentage(100, 3),
+								Surcharge: num.NewPercentage(14, 3),
+							},
+							{
+								Since:     cal.NewDate(2010, 7, 1),
+								Percent:   num.MakePercentage(80, 3),
+								Surcharge: num.NewPercentage(10, 3),
+							},
+						},
+					},
+					{
+						Key: common.TaxRateSuperReduced,
+						Name: i18n.String{
+							i18n.EN: "Super-Reduced Rate",
+							i18n.ES: "Tipo Superreducido",
+						},
+						Values: []*tax.RateValue{
+							{
+								Since:   cal.NewDate(1995, 1, 1),
+								Percent: num.MakePercentage(40, 3),
+							},
+							{
+								Since:   cal.NewDate(1993, 1, 1),
+								Percent: num.MakePercentage(30, 3),
+							},
+						},
+					},
+					{
+						Key: common.TaxRateSuperReduced.With(TaxRateEquivalence),
+						Name: i18n.String{
+							i18n.EN: "Super-Reduced Rate + Equivalence Surcharge",
+							i18n.ES: "Tipo Superreducido + Recargo de Equivalencia",
+						},
+						Values: []*tax.RateValue{
+							{
+								Since:     cal.NewDate(1995, 1, 1),
+								Percent:   num.MakePercentage(40, 3),
+								Surcharge: num.NewPercentage(5, 3),
+							},
+						},
+					},
+				},
+			},
 
-		//
-		// IRPF
-		//
-		{
-			Code:     TaxCategoryIRPF,
-			Retained: true,
-			Name: i18n.String{
-				i18n.EN: "IRPF",
-				i18n.ES: "IRPF",
-			},
-			Desc: i18n.String{
-				i18n.EN: "Personal income tax.",
-				i18n.ES: "Impuesto sobre la renta de las personas físicas.",
-			},
-			Rates: []*tax.Rate{
-				{
-					Key: TaxRatePro,
-					Name: i18n.String{
-						i18n.EN: "Professional Rate",
-						i18n.ES: "Professionales",
-					},
-					Values: []*tax.RateValue{
-						{
-							Since:   cal.NewDate(2015, 7, 12),
-							Percent: num.MakePercentage(150, 3),
-						},
-						{
-							Since:   cal.NewDate(2015, 1, 1),
-							Percent: num.MakePercentage(190, 3),
-						},
-						{
-							Since:   cal.NewDate(2012, 9, 1),
-							Percent: num.MakePercentage(210, 3),
-						},
-						{
-							Since:   cal.NewDate(2007, 1, 1),
-							Percent: num.MakePercentage(150, 3),
-						},
-					},
+			//
+			// IRPF
+			//
+			{
+				Code:     TaxCategoryIRPF,
+				Retained: true,
+				Name: i18n.String{
+					i18n.EN: "IRPF",
+					i18n.ES: "IRPF",
 				},
-				{
-					Key: TaxRateProStart,
-					Name: i18n.String{
-						i18n.EN: "Professional Starting Rate",
-						i18n.ES: "Professionales Inicio",
-					},
-					Values: []*tax.RateValue{
-						{
-							Since:   cal.NewDate(2007, 1, 1),
-							Percent: num.MakePercentage(70, 3),
+				Desc: i18n.String{
+					i18n.EN: "Personal income tax.",
+					i18n.ES: "Impuesto sobre la renta de las personas físicas.",
+				},
+				Rates: []*tax.Rate{
+					{
+						Key: TaxRatePro,
+						Name: i18n.String{
+							i18n.EN: "Professional Rate",
+							i18n.ES: "Professionales",
+						},
+						Values: []*tax.RateValue{
+							{
+								Since:   cal.NewDate(2015, 7, 12),
+								Percent: num.MakePercentage(150, 3),
+							},
+							{
+								Since:   cal.NewDate(2015, 1, 1),
+								Percent: num.MakePercentage(190, 3),
+							},
+							{
+								Since:   cal.NewDate(2012, 9, 1),
+								Percent: num.MakePercentage(210, 3),
+							},
+							{
+								Since:   cal.NewDate(2007, 1, 1),
+								Percent: num.MakePercentage(150, 3),
+							},
 						},
 					},
-				},
-				{
-					Key: TaxRateCapital,
-					Name: i18n.String{
-						i18n.EN: "Rental or Interest Capital",
-						i18n.ES: "Alquileres o Intereses de Capital",
-					},
-					Values: []*tax.RateValue{
-						{
-							Since:   cal.NewDate(2007, 1, 1),
-							Percent: num.MakePercentage(190, 3),
+					{
+						Key: TaxRateProStart,
+						Name: i18n.String{
+							i18n.EN: "Professional Starting Rate",
+							i18n.ES: "Professionales Inicio",
+						},
+						Values: []*tax.RateValue{
+							{
+								Since:   cal.NewDate(2007, 1, 1),
+								Percent: num.MakePercentage(70, 3),
+							},
 						},
 					},
-				},
-				{
-					Key: TaxRateModules,
-					Name: i18n.String{
-						i18n.EN: "Modules Rate",
-						i18n.ES: "Tipo Modulos",
+					{
+						Key: TaxRateCapital,
+						Name: i18n.String{
+							i18n.EN: "Rental or Interest Capital",
+							i18n.ES: "Alquileres o Intereses de Capital",
+						},
+						Values: []*tax.RateValue{
+							{
+								Since:   cal.NewDate(2007, 1, 1),
+								Percent: num.MakePercentage(190, 3),
+							},
+						},
 					},
-					Values: []*tax.RateValue{
-						{
-							Since:   cal.NewDate(2007, 1, 1),
-							Percent: num.MakePercentage(10, 3),
+					{
+						Key: TaxRateModules,
+						Name: i18n.String{
+							i18n.EN: "Modules Rate",
+							i18n.ES: "Tipo Modulos",
+						},
+						Values: []*tax.RateValue{
+							{
+								Since:   cal.NewDate(2007, 1, 1),
+								Percent: num.MakePercentage(10, 3),
+							},
 						},
 					},
 				},
 			},
 		},
-	},
+	}
 }
 
 // Validate checks the document type and determines if it can be validated.

--- a/regions/es/es.go
+++ b/regions/es/es.go
@@ -13,411 +13,748 @@ import (
 
 // Local tax category definitions which are not considered standard.
 const (
-	TaxCategoryIRPF tax.Code = "IRPF"
-	TaxCategoryIGIC tax.Code = "IGIC"
-	TaxCategoryIPSI tax.Code = "IPSI"
+	TaxCategoryIRPF org.Code = "IRPF"
+	TaxCategoryIGIC org.Code = "IGIC"
+	TaxCategoryIPSI org.Code = "IPSI"
 )
 
 // Specific tax rate codes.
 const (
 	// IRPF non-standard Rates (usually for self-employed)
-	TaxRatePro                tax.Key = "pro"                 // Professional Services
-	TaxRateProStart           tax.Key = "pro-start"           // Professionals, first 2 years
-	TaxRateModules            tax.Key = "modules"             // Module system
-	TaxRateAgriculture        tax.Key = "agriculture"         // Agricultural
-	TaxRateAgricultureSpecial tax.Key = "agriculture-special" // Agricultural special
-	TaxRateCapital            tax.Key = "capital"             // Rental or Interest
+	TaxRatePro                org.Key = "pro"                 // Professional Services
+	TaxRateProStart           org.Key = "pro-start"           // Professionals, first 2 years
+	TaxRateModules            org.Key = "modules"             // Module system
+	TaxRateAgriculture        org.Key = "agriculture"         // Agricultural
+	TaxRateAgricultureSpecial org.Key = "agriculture-special" // Agricultural special
+	TaxRateCapital            org.Key = "capital"             // Rental or Interest
 
 	// Special tax rate surcharge extension
-	TaxRateEquivalence tax.Key = "eqs"
+	TaxRateEquivalence org.Key = "eqs"
 )
 
 // Scheme key definitions
 const (
-	SchemeSimplified      tax.Key = "simplified"
-	SchemeCustomerIssued  tax.Key = "customer-issued"
-	SchemeTravelAgency    tax.Key = "travel-agency"
-	SchemeSecondHandGoods tax.Key = "second-hand-goods"
-	SchemeArt             tax.Key = "art"
-	SchemeAntiques        tax.Key = "antiques"
-	SchemeCashBasis       tax.Key = "cash-basis"
+	SchemeSimplified      org.Key = "simplified"
+	SchemeCustomerIssued  org.Key = "customer-issued"
+	SchemeTravelAgency    org.Key = "travel-agency"
+	SchemeSecondHandGoods org.Key = "second-hand-goods"
+	SchemeArt             org.Key = "art"
+	SchemeAntiques        org.Key = "antiques"
+	SchemeCashBasis       org.Key = "cash-basis"
 )
 
 // Inbox key and role definitions
 const (
-	InboxKeyFACE org.InboxKey = "face"
+	InboxKeyFACE org.Key = "face"
 
 	// Main roles defined in FACE
-	InboxRoleFiscal    org.InboxKey = "fiscal"    // Fiscal / 01
-	InboxRoleRecipient org.InboxKey = "recipient" // Receptor / 02
-	InboxRolePayer     org.InboxKey = "payer"     // Pagador / 03
-	InboxRoleCustomer  org.InboxKey = "customer"  // Comprador / 04
+	InboxRoleFiscal    org.Key = "fiscal"    // Fiscal / 01
+	InboxRoleRecipient org.Key = "recipient" // Receptor / 02
+	InboxRolePayer     org.Key = "payer"     // Pagador / 03
+	InboxRoleCustomer  org.Key = "customer"  // Comprador / 04
 
 )
 
-// New provides the Spanish region definition
-func New() *tax.Region {
-	return &tax.Region{
-		Country:  l10n.ES,
-		Currency: "EUR",
-		Name: i18n.String{
-			i18n.EN: "Spain",
-			i18n.ES: "España",
-		},
-		ValidateDocument: Validate,
-		Schemes: []*tax.Scheme{
-			// Reverse Charge Scheme
-			{
-				Key: common.SchemeReverseCharge,
-				Name: i18n.String{
-					i18n.EN: "Reverse Charge",
-					i18n.ES: "Inversión del sujeto pasivo",
-				},
-				Categories: []tax.Code{
-					common.TaxCategoryVAT,
-				},
-				Note: &org.Note{
-					Key:  org.NoteKeyLegal,
-					Src:  string(common.SchemeReverseCharge),
-					Text: "Reverse Charge / Inversión del sujeto pasivo.",
-				},
-			},
-			// Customer Rates Scheme (digital goods)
-			{
-				Key: common.SchemeCustomerRates,
-				Name: i18n.String{
-					i18n.EN: "Customer Country Rates",
-					i18n.ES: "Tasas del País del Cliente",
-				},
-				Description: i18n.String{
-					i18n.EN: "Use the customers country to determine tax rates.",
-				},
-			},
-			// Simplified Regime
-			{
-				Key: SchemeSimplified,
-				Name: i18n.String{
-					i18n.EN: "Simplified tax scheme",
-					i18n.ES: "Contribuyente en régimen simplificado",
-				},
-				Note: &org.Note{
-					Key:  org.NoteKeyLegal,
-					Src:  string(SchemeSimplified),
-					Text: "Factura expedida por contibuyente en régimen simplificado.",
-				},
-			},
-			// Customer issued invoices
-			{
-				Key: SchemeCustomerIssued,
-				Name: i18n.String{
-					i18n.EN: "Customer issued invoice",
-					i18n.ES: "Facturación por el destinatario",
-				},
-				Note: &org.Note{
-					Key:  org.NoteKeyLegal,
-					Src:  string(SchemeCustomerIssued),
-					Text: "Facturación por el destinatario.",
-				},
-			},
-			// Travel agency
-			{
-				Key: SchemeTravelAgency,
-				Name: i18n.String{
-					i18n.EN: "Special scheme for travel agencies",
-					i18n.ES: "Régimen especial de las agencias de viajes",
-				},
-				Note: &org.Note{
-					Key:  org.NoteKeyLegal,
-					Src:  string(SchemeTravelAgency),
-					Text: "Régimen especial de las agencias de viajes.",
-				},
-			},
-			// Secondhand stuff
-			{
-				Key: SchemeSecondHandGoods,
-				Name: i18n.String{
-					i18n.EN: "Special scheme for second-hand goods",
-					i18n.ES: "Régimen especial de los bienes usados",
-				},
-				Note: &org.Note{
-					Key:  org.NoteKeyLegal,
-					Src:  string(SchemeSecondHandGoods),
-					Text: "Régimen especial de los bienes usados.",
-				},
-			},
-			// Art
-			{
-				Key: SchemeArt,
-				Name: i18n.String{
-					i18n.EN: "Special scheme of works of art",
-					i18n.ES: "Régimen especial de los objetos de arte",
-				},
-				Note: &org.Note{
-					Key:  org.NoteKeyLegal,
-					Src:  string(SchemeArt),
-					Text: "Régimen especial de los objetos de arte.",
-				},
-			},
-			// Antiques
-			{
-				Key: SchemeAntiques,
-				Name: i18n.String{
-					i18n.EN: "Special scheme of antiques and collectables",
-					i18n.ES: "Régimen especial de las antigüedades y objetos de colección",
-				},
-				Note: &org.Note{
-					Key:  org.NoteKeyLegal,
-					Src:  string(SchemeAntiques),
-					Text: "Régimen especial de las antigüedades y objetos de colección.",
-				},
-			},
-			// Special Regime of "Cash Criteria"
-			{
-				Key: SchemeCashBasis,
-				Name: i18n.String{
-					i18n.EN: "Special scheme on cash basis",
-					i18n.ES: "Régimen especial del criterio de caja",
-				},
-				Note: &org.Note{
-					Key:  org.NoteKeyLegal,
-					Src:  string(SchemeCashBasis),
-					Text: "Régimen especial del criterio de caja.",
-				},
-			},
-		},
-		Categories: []*tax.Category{
-			//
-			// VAT
-			//
-			{
-				Code: common.TaxCategoryVAT,
-				Name: i18n.String{
-					i18n.EN: "VAT",
-					i18n.ES: "IVA",
-				},
-				Desc: i18n.String{
-					i18n.EN: "Value Added Tax",
-					i18n.ES: "Impuesto sobre el Valor Añadido",
-				},
-				Retained: false,
-				Rates: []*tax.Rate{
-					{
-						Key: common.TaxRateZero,
-						Name: i18n.String{
-							i18n.EN: "Zero Rate",
-							i18n.ES: "Tipo Zero",
-						},
-						Values: []*tax.RateValue{
-							{
-								Percent: num.MakePercentage(0, 3),
-							},
-						},
-					},
-					{
-						Key: common.TaxRateStandard,
-						Name: i18n.String{
-							i18n.EN: "Standard Rate",
-							i18n.ES: "Tipo General",
-						},
-						Values: []*tax.RateValue{
-							{
-								Since:   cal.NewDate(2012, 9, 1),
-								Percent: num.MakePercentage(210, 3),
-							},
-							{
-								Since:   cal.NewDate(2010, 7, 1),
-								Percent: num.MakePercentage(180, 3),
-							},
-							{
-								Since:   cal.NewDate(1995, 1, 1),
-								Percent: num.MakePercentage(160, 3),
-							},
-							{
-								Since:   cal.NewDate(1993, 1, 1),
-								Percent: num.MakePercentage(150, 3),
-							},
-						},
-					},
-					{
-						Key: common.TaxRateStandard.With(TaxRateEquivalence),
-						Name: i18n.String{
-							i18n.EN: "Standard Rate + Equivalence Surcharge",
-							i18n.ES: "Tipo General + Recargo de Equivalencia",
-						},
-						Values: []*tax.RateValue{
-							{
-								Since:     cal.NewDate(2012, 9, 1),
-								Percent:   num.MakePercentage(210, 3),
-								Surcharge: num.NewPercentage(52, 3),
-							},
-							{
-								Since:     cal.NewDate(2010, 7, 1),
-								Percent:   num.MakePercentage(180, 3),
-								Surcharge: num.NewPercentage(40, 3),
-							},
-						},
-					},
-					{
-						Key: common.TaxRateReduced,
-						Name: i18n.String{
-							i18n.EN: "Reduced Rate",
-							i18n.ES: "Tipo Reducido",
-						},
-						Values: []*tax.RateValue{
-							{
-								Since:   cal.NewDate(2012, 9, 1),
-								Percent: num.MakePercentage(100, 3),
-							},
-							{
-								Since:   cal.NewDate(2010, 7, 1),
-								Percent: num.MakePercentage(80, 3),
-							},
-							{
-								Since:   cal.NewDate(1995, 1, 1),
-								Percent: num.MakePercentage(70, 3),
-							},
-							{
-								Since:   cal.NewDate(1993, 1, 1),
-								Percent: num.MakePercentage(60, 3),
-							},
-						},
-					},
-					{
-						Key: common.TaxRateReduced.With(TaxRateEquivalence),
-						Name: i18n.String{
-							i18n.EN: "Reduced Rate + Equivalence Surcharge",
-							i18n.ES: "Tipo Reducido + Recargo de Equivalencia",
-						},
-						Values: []*tax.RateValue{
-							{
-								Since:     cal.NewDate(2012, 9, 1),
-								Percent:   num.MakePercentage(100, 3),
-								Surcharge: num.NewPercentage(14, 3),
-							},
-							{
-								Since:     cal.NewDate(2010, 7, 1),
-								Percent:   num.MakePercentage(80, 3),
-								Surcharge: num.NewPercentage(10, 3),
-							},
-						},
-					},
-					{
-						Key: common.TaxRateSuperReduced,
-						Name: i18n.String{
-							i18n.EN: "Super-Reduced Rate",
-							i18n.ES: "Tipo Superreducido",
-						},
-						Values: []*tax.RateValue{
-							{
-								Since:   cal.NewDate(1995, 1, 1),
-								Percent: num.MakePercentage(40, 3),
-							},
-							{
-								Since:   cal.NewDate(1993, 1, 1),
-								Percent: num.MakePercentage(30, 3),
-							},
-						},
-					},
-					{
-						Key: common.TaxRateSuperReduced.With(TaxRateEquivalence),
-						Name: i18n.String{
-							i18n.EN: "Super-Reduced Rate + Equivalence Surcharge",
-							i18n.ES: "Tipo Superreducido + Recargo de Equivalencia",
-						},
-						Values: []*tax.RateValue{
-							{
-								Since:     cal.NewDate(1995, 1, 1),
-								Percent:   num.MakePercentage(40, 3),
-								Surcharge: num.NewPercentage(5, 3),
-							},
-						},
-					},
-				},
-			},
+const (
+	LocalityVI l10n.Code = "VI" // (01) Álava
+	LocalityAB l10n.Code = "AB" // (02) Albacete
+	LocalityA  l10n.Code = "A"  // (03) Alicante
+	LocalityAL l10n.Code = "AL" // (04) Almería
+	LocalityAV l10n.Code = "AV" // (05) Ávila
+	LocalityBA l10n.Code = "BA" // (06) Badajoz
+	LocalityPM l10n.Code = "PM" // (07) Baleares
+	LocalityIB l10n.Code = "IB" // (07) Baleares
+	LocalityB  l10n.Code = "B"  // (08) Barcelona
+	LocalityBU l10n.Code = "BU" // (09) Burgos
+	LocalityCC l10n.Code = "CC" // (10) Cáceres
+	LocalityCA l10n.Code = "CA" // (11) Cádiz
+	LocalityCS l10n.Code = "CS" // (12) Castellon
+	LocalityCR l10n.Code = "CR" // (13) Ciudad Real
+	LocalityCO l10n.Code = "CO" // (14) Cordoba
+	LocalityC  l10n.Code = "C"  // (15) La Coruña
+	LocalityCU l10n.Code = "CU" // (16) Cuenca
+	LocalityGE l10n.Code = "GE" // (17) Gerona
+	LocalityGI l10n.Code = "GI" // (17) Girona
+	LocalityGR l10n.Code = "GR" // (18) Granada
+	LocalityGU l10n.Code = "GU" // (19) Guadalajara
+	LocalitySS l10n.Code = "SS" // (20) Guipúzcoa
+	LocalityH  l10n.Code = "H"  // (21) Huelva
+	LocalityHU l10n.Code = "HU" // (22) Huesca
+	LocalityJ  l10n.Code = "J"  // (23) Jaén
+	LocalityLE l10n.Code = "LE" // (24) León
+	LocalityL  l10n.Code = "L"  // (25) Lérida / Lleida
+	LocalityLO l10n.Code = "LO" // (26) La Rioja
+	LocalityLU l10n.Code = "LU" // (27) Lugo
+	LocalityM  l10n.Code = "M"  // (28) Madrid
+	LocalityMA l10n.Code = "MA" // (29) Málaga
+	LocalityMU l10n.Code = "MU" // (30) Murcia
+	LocalityNA l10n.Code = "NA" // (31) Navarra
+	LocalityOR l10n.Code = "OR" // (32) Orense
+	LocalityOU l10n.Code = "OU" // (32) Orense
+	LocalityO  l10n.Code = "O"  // (33) Asturias
+	LocalityP  l10n.Code = "P"  // (34) Palencia
+	LocalityGC l10n.Code = "GC" // (35) Las Palmas
+	LocalityPO l10n.Code = "PO" // (36) Pontevedra
+	LocalitySA l10n.Code = "SA" // (37) Salamanca
+	LocalityTF l10n.Code = "TF" // (38) Santa Cruz de Tenerife
+	LocalityS  l10n.Code = "S"  // (39) Cantabria
+	LocalitySG l10n.Code = "SG" // (40) Segovia
+	LocalitySE l10n.Code = "SE" // (41) Sevilla
+	LocalitySO l10n.Code = "SO" // (42) Soria
+	LocalityT  l10n.Code = "T"  // (43) Tarragona
+	LocalityTE l10n.Code = "TE" // (44) Teruel
+	LocalityTO l10n.Code = "TO" // (45) Toledo
+	LocalityV  l10n.Code = "V"  // (46) Valencia
+	LocalityVA l10n.Code = "VA" // (47) Valladolid
+	LocalityBI l10n.Code = "BI" // (48) Vizcaya
+	LocalityZA l10n.Code = "ZA" // (49) Zamora
+	LocalityZ  l10n.Code = "Z"  // (50) Zaragoza
+	LocalityCE l10n.Code = "CE" // (51) Ceuta
+	LocalityML l10n.Code = "ML" // (52) Melilla
+)
 
-			//
-			// IRPF
-			//
-			{
-				Code:     TaxCategoryIRPF,
-				Retained: true,
-				Name: i18n.String{
-					i18n.EN: "IRPF",
-					i18n.ES: "IRPF",
+const (
+	KeyPost org.Key = "post"
+)
+
+// Region provides the Spanish region definition
+var Region = &tax.Region{
+	Country:  l10n.ES,
+	Currency: "EUR",
+	Name: i18n.String{
+		i18n.EN: "Spain",
+		i18n.ES: "España",
+	},
+	ValidateDocument: Validate,
+	Localities: tax.Localities{
+		{
+			Code: LocalityVI,
+			Name: i18n.String{i18n.ES: "Ávila"},
+			Meta: org.Meta{KeyPost: "01"},
+		},
+		{
+			Code: LocalityAB,
+			Name: i18n.String{i18n.ES: "Albacete"},
+			Meta: org.Meta{KeyPost: "02"},
+		},
+		{
+			Code: LocalityA,
+			Name: i18n.String{i18n.ES: "Alicante"},
+			Meta: org.Meta{KeyPost: "03"},
+		},
+		{
+			Code: LocalityAL,
+			Name: i18n.String{i18n.ES: "Almería"},
+			Meta: org.Meta{KeyPost: "04"},
+		},
+		{
+			Code: LocalityAV,
+			Name: i18n.String{i18n.ES: "Ávila"},
+			Meta: org.Meta{KeyPost: "05"},
+		},
+		{
+			Code: LocalityBA,
+			Name: i18n.String{i18n.ES: "Badajoz"},
+			Meta: org.Meta{KeyPost: "06"},
+		},
+		{
+			Code: LocalityPM,
+			Name: i18n.String{i18n.ES: "Baleares"},
+			Meta: org.Meta{KeyPost: "07"},
+		},
+		{
+			Code: LocalityIB,
+			Name: i18n.String{i18n.ES: "Baleares"},
+			Meta: org.Meta{KeyPost: "07"},
+		},
+		{
+			Code: LocalityB,
+			Name: i18n.String{i18n.ES: "Barcelona"},
+			Meta: org.Meta{KeyPost: "08"},
+		},
+		{
+			Code: LocalityBU,
+			Name: i18n.String{i18n.ES: "Burgos"},
+			Meta: org.Meta{KeyPost: "09"},
+		},
+		{
+			Code: LocalityCC,
+			Name: i18n.String{i18n.ES: "Cáceres"},
+			Meta: org.Meta{KeyPost: "10"},
+		},
+		{
+			Code: LocalityCA,
+			Name: i18n.String{i18n.ES: "Cadiz"},
+			Meta: org.Meta{KeyPost: "11"},
+		},
+		{
+			Code: LocalityCS,
+			Name: i18n.String{i18n.ES: "Castellón"},
+			Meta: org.Meta{KeyPost: "12"},
+		},
+		{
+			Code: LocalityCR,
+			Name: i18n.String{i18n.ES: "Ciudad Real"},
+			Meta: org.Meta{KeyPost: "13"},
+		},
+		{
+			Code: LocalityCO,
+			Name: i18n.String{i18n.ES: "Cordoba"},
+			Meta: org.Meta{KeyPost: "14"},
+		},
+		{
+			Code: LocalityC,
+			Name: i18n.String{i18n.ES: "La Coruña"},
+			Meta: org.Meta{KeyPost: "15"},
+		},
+		{
+			Code: LocalityCU,
+			Name: i18n.String{i18n.ES: "Cuenca"},
+			Meta: org.Meta{KeyPost: "16"},
+		},
+		{
+			Code: LocalityGE,
+			Name: i18n.String{i18n.ES: "Gerona"},
+			Meta: org.Meta{KeyPost: "17"},
+		},
+		{
+			Code: LocalityGI,
+			Name: i18n.String{i18n.ES: "Girona"},
+			Meta: org.Meta{KeyPost: "17"},
+		},
+		{
+			Code: LocalityGR,
+			Name: i18n.String{i18n.ES: "Granada"},
+			Meta: org.Meta{KeyPost: "18"},
+		},
+		{
+			Code: LocalityGU,
+			Name: i18n.String{i18n.ES: "Guadalajara"},
+			Meta: org.Meta{KeyPost: "19"},
+		},
+		{
+			Code: LocalitySS,
+			Name: i18n.String{i18n.ES: "Guipúzcoa"},
+			Meta: org.Meta{KeyPost: "20"},
+		},
+		{
+			Code: LocalityH,
+			Name: i18n.String{i18n.ES: "Huelva"},
+			Meta: org.Meta{KeyPost: "21"},
+		},
+		{
+			Code: LocalityHU,
+			Name: i18n.String{i18n.ES: "Huesca"},
+			Meta: org.Meta{KeyPost: "22"},
+		},
+		{
+			Code: LocalityJ,
+			Name: i18n.String{i18n.ES: "Jaén"},
+			Meta: org.Meta{KeyPost: "23"},
+		},
+		{
+			Code: LocalityLE,
+			Name: i18n.String{i18n.ES: "León"},
+			Meta: org.Meta{KeyPost: "24"},
+		},
+		{
+			Code: LocalityL,
+			Name: i18n.String{i18n.ES: "Lérida / Lleida"},
+			Meta: org.Meta{KeyPost: "25"},
+		},
+		{
+			Code: LocalityLO,
+			Name: i18n.String{i18n.ES: "La Rioja"},
+			Meta: org.Meta{KeyPost: "26"},
+		},
+		{
+			Code: LocalityLU,
+			Name: i18n.String{i18n.ES: "Lugo"},
+			Meta: org.Meta{KeyPost: "27"},
+		},
+		{
+			Code: LocalityM,
+			Name: i18n.String{i18n.ES: "Madrid"},
+			Meta: org.Meta{KeyPost: "28"},
+		},
+		{
+			Code: LocalityMA,
+			Name: i18n.String{i18n.ES: "Málaga"},
+			Meta: org.Meta{KeyPost: "29"},
+		},
+		{
+			Code: LocalityMU,
+			Name: i18n.String{i18n.ES: "Murcia"},
+			Meta: org.Meta{KeyPost: "30"},
+		},
+		{
+			Code: LocalityNA,
+			Name: i18n.String{i18n.ES: "Navarra"},
+			Meta: org.Meta{KeyPost: "31"},
+		},
+		{
+			Code: LocalityOR,
+			Name: i18n.String{i18n.ES: "Orense"},
+			Meta: org.Meta{KeyPost: "32"},
+		},
+		{
+			Code: LocalityOU,
+			Name: i18n.String{i18n.ES: "Orense"},
+			Meta: org.Meta{KeyPost: "32"},
+		},
+		{
+			Code: LocalityO,
+			Name: i18n.String{i18n.ES: "Asturias"},
+			Meta: org.Meta{KeyPost: "33"},
+		},
+		{
+			Code: LocalityP,
+			Name: i18n.String{i18n.ES: "Palencia"},
+			Meta: org.Meta{KeyPost: "34"},
+		},
+		{
+			Code: LocalityGC,
+			Name: i18n.String{i18n.ES: "Las Palmas"},
+			Meta: org.Meta{KeyPost: "35"},
+		},
+		{
+			Code: LocalityPO,
+			Name: i18n.String{i18n.ES: "Pontevedra"},
+			Meta: org.Meta{KeyPost: "36"},
+		},
+		{
+			Code: LocalitySA,
+			Name: i18n.String{i18n.ES: "Salamanca"},
+			Meta: org.Meta{KeyPost: "37"},
+		},
+		{
+			Code: LocalityTF,
+			Name: i18n.String{i18n.ES: "Santa Cruz de Tenerife"},
+			Meta: org.Meta{KeyPost: "38"},
+		},
+		{
+			Code: LocalityS,
+			Name: i18n.String{i18n.ES: "Cantabria"},
+			Meta: org.Meta{KeyPost: "39"},
+		},
+		{
+			Code: LocalitySG,
+			Name: i18n.String{i18n.ES: "Segovia"},
+			Meta: org.Meta{KeyPost: "40"},
+		},
+		{
+			Code: LocalitySE,
+			Name: i18n.String{i18n.ES: "Sevilla"},
+			Meta: org.Meta{KeyPost: "41"},
+		},
+		{
+			Code: LocalitySO,
+			Name: i18n.String{i18n.ES: "Soria"},
+			Meta: org.Meta{KeyPost: "42"},
+		},
+		{
+			Code: LocalityT,
+			Name: i18n.String{i18n.ES: "Tarragona"},
+			Meta: org.Meta{KeyPost: "43"},
+		},
+		{
+			Code: LocalityTE,
+			Name: i18n.String{i18n.ES: "Teruel"},
+			Meta: org.Meta{KeyPost: "44"},
+		},
+		{
+			Code: LocalityTO,
+			Name: i18n.String{i18n.ES: "Toledo"},
+			Meta: org.Meta{KeyPost: "45"},
+		},
+		{
+			Code: LocalityV,
+			Name: i18n.String{i18n.ES: "Valencia"},
+			Meta: org.Meta{KeyPost: "46"},
+		},
+		{
+			Code: LocalityVA,
+			Name: i18n.String{i18n.ES: "Valladolid"},
+			Meta: org.Meta{KeyPost: "47"},
+		},
+		{
+			Code: LocalityBI,
+			Name: i18n.String{i18n.ES: "Vizcaya"},
+			Meta: org.Meta{KeyPost: "48"},
+		},
+		{
+			Code: LocalityZA,
+			Name: i18n.String{i18n.ES: "Zamora"},
+			Meta: org.Meta{KeyPost: "49"},
+		},
+		{
+			Code: LocalityZ,
+			Name: i18n.String{i18n.ES: "Zaragoza"},
+			Meta: org.Meta{KeyPost: "50"},
+		},
+		{
+			Code: LocalityCE,
+			Name: i18n.String{i18n.ES: "Ceuta"},
+			Meta: org.Meta{KeyPost: "51"},
+		},
+		{
+			Code: LocalityML,
+			Name: i18n.String{i18n.ES: "Melilla"},
+			Meta: org.Meta{KeyPost: "52"},
+		},
+	},
+	Schemes: []*tax.Scheme{
+		// Reverse Charge Scheme
+		{
+			Key: common.SchemeReverseCharge,
+			Name: i18n.String{
+				i18n.EN: "Reverse Charge",
+				i18n.ES: "Inversión del sujeto pasivo",
+			},
+			Categories: []org.Code{
+				common.TaxCategoryVAT,
+			},
+			Note: &org.Note{
+				Key:  org.NoteKeyLegal,
+				Src:  string(common.SchemeReverseCharge),
+				Text: "Reverse Charge / Inversión del sujeto pasivo.",
+			},
+		},
+		// Customer Rates Scheme (digital goods)
+		{
+			Key: common.SchemeCustomerRates,
+			Name: i18n.String{
+				i18n.EN: "Customer Country Rates",
+				i18n.ES: "Tasas del País del Cliente",
+			},
+			Description: i18n.String{
+				i18n.EN: "Use the customers country to determine tax rates.",
+			},
+		},
+		// Simplified Regime
+		{
+			Key: SchemeSimplified,
+			Name: i18n.String{
+				i18n.EN: "Simplified tax scheme",
+				i18n.ES: "Contribuyente en régimen simplificado",
+			},
+			Note: &org.Note{
+				Key:  org.NoteKeyLegal,
+				Src:  string(SchemeSimplified),
+				Text: "Factura expedida por contibuyente en régimen simplificado.",
+			},
+		},
+		// Customer issued invoices
+		{
+			Key: SchemeCustomerIssued,
+			Name: i18n.String{
+				i18n.EN: "Customer issued invoice",
+				i18n.ES: "Facturación por el destinatario",
+			},
+			Note: &org.Note{
+				Key:  org.NoteKeyLegal,
+				Src:  string(SchemeCustomerIssued),
+				Text: "Facturación por el destinatario.",
+			},
+		},
+		// Travel agency
+		{
+			Key: SchemeTravelAgency,
+			Name: i18n.String{
+				i18n.EN: "Special scheme for travel agencies",
+				i18n.ES: "Régimen especial de las agencias de viajes",
+			},
+			Note: &org.Note{
+				Key:  org.NoteKeyLegal,
+				Src:  string(SchemeTravelAgency),
+				Text: "Régimen especial de las agencias de viajes.",
+			},
+		},
+		// Secondhand stuff
+		{
+			Key: SchemeSecondHandGoods,
+			Name: i18n.String{
+				i18n.EN: "Special scheme for second-hand goods",
+				i18n.ES: "Régimen especial de los bienes usados",
+			},
+			Note: &org.Note{
+				Key:  org.NoteKeyLegal,
+				Src:  string(SchemeSecondHandGoods),
+				Text: "Régimen especial de los bienes usados.",
+			},
+		},
+		// Art
+		{
+			Key: SchemeArt,
+			Name: i18n.String{
+				i18n.EN: "Special scheme of works of art",
+				i18n.ES: "Régimen especial de los objetos de arte",
+			},
+			Note: &org.Note{
+				Key:  org.NoteKeyLegal,
+				Src:  string(SchemeArt),
+				Text: "Régimen especial de los objetos de arte.",
+			},
+		},
+		// Antiques
+		{
+			Key: SchemeAntiques,
+			Name: i18n.String{
+				i18n.EN: "Special scheme of antiques and collectables",
+				i18n.ES: "Régimen especial de las antigüedades y objetos de colección",
+			},
+			Note: &org.Note{
+				Key:  org.NoteKeyLegal,
+				Src:  string(SchemeAntiques),
+				Text: "Régimen especial de las antigüedades y objetos de colección.",
+			},
+		},
+		// Special Regime of "Cash Criteria"
+		{
+			Key: SchemeCashBasis,
+			Name: i18n.String{
+				i18n.EN: "Special scheme on cash basis",
+				i18n.ES: "Régimen especial del criterio de caja",
+			},
+			Note: &org.Note{
+				Key:  org.NoteKeyLegal,
+				Src:  string(SchemeCashBasis),
+				Text: "Régimen especial del criterio de caja.",
+			},
+		},
+	},
+	Categories: []*tax.Category{
+		//
+		// VAT
+		//
+		{
+			Code: common.TaxCategoryVAT,
+			Name: i18n.String{
+				i18n.EN: "VAT",
+				i18n.ES: "IVA",
+			},
+			Desc: i18n.String{
+				i18n.EN: "Value Added Tax",
+				i18n.ES: "Impuesto sobre el Valor Añadido",
+			},
+			Retained: false,
+			Rates: []*tax.Rate{
+				{
+					Key: common.TaxRateZero,
+					Name: i18n.String{
+						i18n.EN: "Zero Rate",
+						i18n.ES: "Tipo Zero",
+					},
+					Values: []*tax.RateValue{
+						{
+							Percent: num.MakePercentage(0, 3),
+						},
+					},
 				},
-				Desc: i18n.String{
-					i18n.EN: "Personal income tax.",
-					i18n.ES: "Impuesto sobre la renta de las personas físicas.",
+				{
+					Key: common.TaxRateStandard,
+					Name: i18n.String{
+						i18n.EN: "Standard Rate",
+						i18n.ES: "Tipo General",
+					},
+					Values: []*tax.RateValue{
+						{
+							Since:   cal.NewDate(2012, 9, 1),
+							Percent: num.MakePercentage(210, 3),
+						},
+						{
+							Since:   cal.NewDate(2010, 7, 1),
+							Percent: num.MakePercentage(180, 3),
+						},
+						{
+							Since:   cal.NewDate(1995, 1, 1),
+							Percent: num.MakePercentage(160, 3),
+						},
+						{
+							Since:   cal.NewDate(1993, 1, 1),
+							Percent: num.MakePercentage(150, 3),
+						},
+					},
 				},
-				Rates: []*tax.Rate{
-					{
-						Key: TaxRatePro,
-						Name: i18n.String{
-							i18n.EN: "Professional Rate",
-							i18n.ES: "Professionales",
+				{
+					Key: common.TaxRateStandard.With(TaxRateEquivalence),
+					Name: i18n.String{
+						i18n.EN: "Standard Rate + Equivalence Surcharge",
+						i18n.ES: "Tipo General + Recargo de Equivalencia",
+					},
+					Values: []*tax.RateValue{
+						{
+							Since:     cal.NewDate(2012, 9, 1),
+							Percent:   num.MakePercentage(210, 3),
+							Surcharge: num.NewPercentage(52, 3),
 						},
-						Values: []*tax.RateValue{
-							{
-								Since:   cal.NewDate(2015, 7, 12),
-								Percent: num.MakePercentage(150, 3),
-							},
-							{
-								Since:   cal.NewDate(2015, 1, 1),
-								Percent: num.MakePercentage(190, 3),
-							},
-							{
-								Since:   cal.NewDate(2012, 9, 1),
-								Percent: num.MakePercentage(210, 3),
-							},
-							{
-								Since:   cal.NewDate(2007, 1, 1),
-								Percent: num.MakePercentage(150, 3),
-							},
+						{
+							Since:     cal.NewDate(2010, 7, 1),
+							Percent:   num.MakePercentage(180, 3),
+							Surcharge: num.NewPercentage(40, 3),
 						},
 					},
-					{
-						Key: TaxRateProStart,
-						Name: i18n.String{
-							i18n.EN: "Professional Starting Rate",
-							i18n.ES: "Professionales Inicio",
+				},
+				{
+					Key: common.TaxRateReduced,
+					Name: i18n.String{
+						i18n.EN: "Reduced Rate",
+						i18n.ES: "Tipo Reducido",
+					},
+					Values: []*tax.RateValue{
+						{
+							Since:   cal.NewDate(2012, 9, 1),
+							Percent: num.MakePercentage(100, 3),
 						},
-						Values: []*tax.RateValue{
-							{
-								Since:   cal.NewDate(2007, 1, 1),
-								Percent: num.MakePercentage(70, 3),
-							},
+						{
+							Since:   cal.NewDate(2010, 7, 1),
+							Percent: num.MakePercentage(80, 3),
+						},
+						{
+							Since:   cal.NewDate(1995, 1, 1),
+							Percent: num.MakePercentage(70, 3),
+						},
+						{
+							Since:   cal.NewDate(1993, 1, 1),
+							Percent: num.MakePercentage(60, 3),
 						},
 					},
-					{
-						Key: TaxRateCapital,
-						Name: i18n.String{
-							i18n.EN: "Rental or Interest Capital",
-							i18n.ES: "Alquileres o Intereses de Capital",
+				},
+				{
+					Key: common.TaxRateReduced.With(TaxRateEquivalence),
+					Name: i18n.String{
+						i18n.EN: "Reduced Rate + Equivalence Surcharge",
+						i18n.ES: "Tipo Reducido + Recargo de Equivalencia",
+					},
+					Values: []*tax.RateValue{
+						{
+							Since:     cal.NewDate(2012, 9, 1),
+							Percent:   num.MakePercentage(100, 3),
+							Surcharge: num.NewPercentage(14, 3),
 						},
-						Values: []*tax.RateValue{
-							{
-								Since:   cal.NewDate(2007, 1, 1),
-								Percent: num.MakePercentage(190, 3),
-							},
+						{
+							Since:     cal.NewDate(2010, 7, 1),
+							Percent:   num.MakePercentage(80, 3),
+							Surcharge: num.NewPercentage(10, 3),
 						},
 					},
-					{
-						Key: TaxRateModules,
-						Name: i18n.String{
-							i18n.EN: "Modules Rate",
-							i18n.ES: "Tipo Modulos",
+				},
+				{
+					Key: common.TaxRateSuperReduced,
+					Name: i18n.String{
+						i18n.EN: "Super-Reduced Rate",
+						i18n.ES: "Tipo Superreducido",
+					},
+					Values: []*tax.RateValue{
+						{
+							Since:   cal.NewDate(1995, 1, 1),
+							Percent: num.MakePercentage(40, 3),
 						},
-						Values: []*tax.RateValue{
-							{
-								Since:   cal.NewDate(2007, 1, 1),
-								Percent: num.MakePercentage(10, 3),
-							},
+						{
+							Since:   cal.NewDate(1993, 1, 1),
+							Percent: num.MakePercentage(30, 3),
+						},
+					},
+				},
+				{
+					Key: common.TaxRateSuperReduced.With(TaxRateEquivalence),
+					Name: i18n.String{
+						i18n.EN: "Super-Reduced Rate + Equivalence Surcharge",
+						i18n.ES: "Tipo Superreducido + Recargo de Equivalencia",
+					},
+					Values: []*tax.RateValue{
+						{
+							Since:     cal.NewDate(1995, 1, 1),
+							Percent:   num.MakePercentage(40, 3),
+							Surcharge: num.NewPercentage(5, 3),
 						},
 					},
 				},
 			},
 		},
-	}
+
+		//
+		// IRPF
+		//
+		{
+			Code:     TaxCategoryIRPF,
+			Retained: true,
+			Name: i18n.String{
+				i18n.EN: "IRPF",
+				i18n.ES: "IRPF",
+			},
+			Desc: i18n.String{
+				i18n.EN: "Personal income tax.",
+				i18n.ES: "Impuesto sobre la renta de las personas físicas.",
+			},
+			Rates: []*tax.Rate{
+				{
+					Key: TaxRatePro,
+					Name: i18n.String{
+						i18n.EN: "Professional Rate",
+						i18n.ES: "Professionales",
+					},
+					Values: []*tax.RateValue{
+						{
+							Since:   cal.NewDate(2015, 7, 12),
+							Percent: num.MakePercentage(150, 3),
+						},
+						{
+							Since:   cal.NewDate(2015, 1, 1),
+							Percent: num.MakePercentage(190, 3),
+						},
+						{
+							Since:   cal.NewDate(2012, 9, 1),
+							Percent: num.MakePercentage(210, 3),
+						},
+						{
+							Since:   cal.NewDate(2007, 1, 1),
+							Percent: num.MakePercentage(150, 3),
+						},
+					},
+				},
+				{
+					Key: TaxRateProStart,
+					Name: i18n.String{
+						i18n.EN: "Professional Starting Rate",
+						i18n.ES: "Professionales Inicio",
+					},
+					Values: []*tax.RateValue{
+						{
+							Since:   cal.NewDate(2007, 1, 1),
+							Percent: num.MakePercentage(70, 3),
+						},
+					},
+				},
+				{
+					Key: TaxRateCapital,
+					Name: i18n.String{
+						i18n.EN: "Rental or Interest Capital",
+						i18n.ES: "Alquileres o Intereses de Capital",
+					},
+					Values: []*tax.RateValue{
+						{
+							Since:   cal.NewDate(2007, 1, 1),
+							Percent: num.MakePercentage(190, 3),
+						},
+					},
+				},
+				{
+					Key: TaxRateModules,
+					Name: i18n.String{
+						i18n.EN: "Modules Rate",
+						i18n.ES: "Tipo Modulos",
+					},
+					Values: []*tax.RateValue{
+						{
+							Since:   cal.NewDate(2007, 1, 1),
+							Percent: num.MakePercentage(10, 3),
+						},
+					},
+				},
+			},
+		},
+	},
 }
 
 // Validate checks the document type and determines if it can be validated.

--- a/regions/es/es_test.go
+++ b/regions/es/es_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestTaxRegion(t *testing.T) {
-	if err := es.New().Validate(); err != nil {
+	if err := es.Region().Validate(); err != nil {
 		t.Errorf("Validation on tax def failed: %v", err.Error())
 	}
 }

--- a/regions/es/es_test.go
+++ b/regions/es/es_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestTaxRegion(t *testing.T) {
-	if err := es.Region.Validate(); err != nil {
+	if err := es.New().Validate(); err != nil {
 		t.Errorf("Validation on tax def failed: %v", err.Error())
 	}
 }

--- a/regions/es/es_test.go
+++ b/regions/es/es_test.go
@@ -7,8 +7,7 @@ import (
 )
 
 func TestTaxRegion(t *testing.T) {
-	tr := es.New()
-	if err := tr.Validate(); err != nil {
+	if err := es.Region.Validate(); err != nil {
 		t.Errorf("Validation on tax def failed: %v", err.Error())
 	}
 }

--- a/regions/fr/fr.go
+++ b/regions/fr/fr.go
@@ -9,8 +9,8 @@ import (
 	"github.com/invopop/gobl/tax"
 )
 
-// New provides the tax region definition
-func New() *tax.Region {
+// Region provides the tax region definition
+func Region() *tax.Region {
 	return &tax.Region{
 		Country:  l10n.FR,
 		Currency: "EUR",

--- a/regions/gb/gb.go
+++ b/regions/gb/gb.go
@@ -10,8 +10,8 @@ import (
 	"github.com/invopop/gobl/tax"
 )
 
-// New provides the tax region definition
-func New() *tax.Region {
+// Region provides the tax region definition
+func Region() *tax.Region {
 	return &tax.Region{
 		Country:  l10n.GB,
 		Currency: "GBP",

--- a/regions/nl/nl.go
+++ b/regions/nl/nl.go
@@ -9,8 +9,8 @@ import (
 	"github.com/invopop/gobl/tax"
 )
 
-// New provides the Dutch region definition
-func New() *tax.Region {
+// Region provides the Dutch region definition
+func Region() *tax.Region {
 	return &tax.Region{
 		Country:  l10n.NL,
 		Currency: "EUR",

--- a/regions/nl/nl_test.go
+++ b/regions/nl/nl_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestTaxRegion(t *testing.T) {
-	tr := nl.New()
+	tr := nl.Region()
 	if err := tr.Validate(); err != nil {
 		t.Errorf("Validation on tax def failed: %v", err.Error())
 	}

--- a/regions/regions.go
+++ b/regions/regions.go
@@ -9,7 +9,7 @@ import (
 )
 
 func init() {
-	tax.RegisterRegion(es.Region)
+	tax.RegisterRegion(es.New())
 	tax.RegisterRegion(fr.New())
 	tax.RegisterRegion(gb.New())
 	tax.RegisterRegion(nl.New())

--- a/regions/regions.go
+++ b/regions/regions.go
@@ -9,8 +9,8 @@ import (
 )
 
 func init() {
-	tax.RegisterRegion(es.New())
-	tax.RegisterRegion(fr.New())
-	tax.RegisterRegion(gb.New())
-	tax.RegisterRegion(nl.New())
+	tax.RegisterRegion(es.Region())
+	tax.RegisterRegion(fr.Region())
+	tax.RegisterRegion(gb.Region())
+	tax.RegisterRegion(nl.Region())
 }

--- a/regions/regions.go
+++ b/regions/regions.go
@@ -9,7 +9,7 @@ import (
 )
 
 func init() {
-	tax.RegisterRegion(es.New())
+	tax.RegisterRegion(es.Region)
 	tax.RegisterRegion(fr.New())
 	tax.RegisterRegion(gb.New())
 	tax.RegisterRegion(nl.New())

--- a/tax/errors.go
+++ b/tax/errors.go
@@ -1,11 +1,15 @@
 package tax
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/invopop/gobl/org"
+)
 
 // Error is a general wrapper around tax errors produced during run
 // time, typically during calculations. Not to be confused with errors
 // produced from definition validation.
-type Error Key
+type Error org.Key
 
 // Standard list of tax errors
 const (

--- a/tax/region.go
+++ b/tax/region.go
@@ -9,6 +9,7 @@ import (
 	"github.com/invopop/gobl/i18n"
 	"github.com/invopop/gobl/l10n"
 	"github.com/invopop/gobl/num"
+	"github.com/invopop/gobl/org"
 )
 
 // Region defines the holding structure for a regions categories and subsequent
@@ -19,8 +20,11 @@ type Region struct {
 
 	// Country code for the region
 	Country l10n.Code `json:"country" jsonschema:"title=Code"`
-	// Locality, city, region, or similar code inside the country, if needed.
+	// Locality, city, province, county, or similar code inside the country, if needed.
 	Locality l10n.Code `json:"locality,omitempty" jsonschema:"title=Locality"`
+
+	// List of sub-localities inside a region.
+	Localities Localities `json:"localities,omitempty" jsonschema:"title=Localities"`
 
 	// Currency used by the region for tax purposes.
 	Currency currency.Code `json:"currency" jsonschema:"title=Currency"`
@@ -35,9 +39,26 @@ type Region struct {
 	ValidateDocument func(doc interface{}) error `json:"-"`
 }
 
+// Localities stores an array of locality objects used to describe areas
+// sub-divisions inside a region.
+type Localities []Locality
+
+// Locality represents an area inside a region, like a province
+// or a state, which shares the basic definitions of the region, but
+// may vary in some validation rules.
+type Locality struct {
+	// Code
+	Code l10n.Code `json:"code" jsonschema:"title=Code"`
+	// Name of the locality with local and hopefully international
+	// translations.
+	Name i18n.String `json:"name" jsonschema:"title=Name"`
+	// Any additional information
+	Meta org.Meta `json:"meta,omitempty" jsonschema:"title=Meta"`
+}
+
 // Category contains the definition of a general type of tax inside a region.
 type Category struct {
-	Code Code        `json:"code" jsonschema:"title=Code"`
+	Code org.Code    `json:"code" jsonschema:"title=Code"`
 	Name i18n.String `json:"name" jsonschema:"title=Name"`
 	Desc i18n.String `json:"desc,omitempty" jsonschema:"title=Description"`
 
@@ -54,7 +75,7 @@ type Category struct {
 // Rate defines a single rate inside a category
 type Rate struct {
 	// Key identifies this rate within the system
-	Key Key `json:"key" jsonschema:"title=Key"`
+	Key org.Key `json:"key" jsonschema:"title=Key"`
 
 	Name i18n.String `json:"name" jsonschema:"title=Name"`
 	Desc i18n.String `json:"desc,omitempty" jsonschema:"title=Description"`
@@ -148,7 +169,7 @@ func checkRateValuesOrder(list interface{}) error {
 }
 
 // Category provides the requested category by its code.
-func (r *Region) Category(code Code) *Category {
+func (r *Region) Category(code org.Code) *Category {
 	for _, c := range r.Categories {
 		if c.Code == code {
 			return c
@@ -159,7 +180,7 @@ func (r *Region) Category(code Code) *Category {
 
 // Rate provides the rate definition with a matching key for
 // the category.
-func (c *Category) Rate(key Key) *Rate {
+func (c *Category) Rate(key org.Key) *Rate {
 	for _, r := range c.Rates {
 		if r.Key == key {
 			return r

--- a/tax/schemes.go
+++ b/tax/schemes.go
@@ -9,13 +9,13 @@ import (
 type Schemes []*Scheme
 
 // SchemeKeys stores a list of keys that makes it easier to perform matches.
-type SchemeKeys []Key
+type SchemeKeys []org.Key
 
 // Scheme contains the definition of a scheme that belongs to a region and can be used
 // to simplify validation processes for document contents.
 type Scheme struct {
 	// Key used to identify this scheme
-	Key Key `json:"key" jsonschema:"title=Key"`
+	Key org.Key `json:"key" jsonschema:"title=Key"`
 
 	// Name of this scheme.
 	Name i18n.String `json:"name" jsonschema:"title=Name"`
@@ -24,7 +24,7 @@ type Scheme struct {
 
 	// List of tax category codes that can be used when this scheme is
 	// applied.
-	Categories []Code `json:"categories,omitempty" jsonschema:"title=Category Codes"`
+	Categories []org.Code `json:"categories,omitempty" jsonschema:"title=Category Codes"`
 
 	// Notes defines messages that should be added to a document
 	// when this scheme is used.
@@ -32,7 +32,7 @@ type Scheme struct {
 }
 
 // ForKey finds the scheme with a matching key.
-func (ss Schemes) ForKey(key Key) *Scheme {
+func (ss Schemes) ForKey(key org.Key) *Scheme {
 	for _, s := range ss {
 		if s.Key == key {
 			return s
@@ -43,7 +43,7 @@ func (ss Schemes) ForKey(key Key) *Scheme {
 
 // Contains returns true if the list of keys contains a match for the provided
 // key.
-func (sk SchemeKeys) Contains(key Key) bool {
+func (sk SchemeKeys) Contains(key org.Key) bool {
 	for _, v := range sk {
 		if key == v {
 			return true

--- a/tax/set.go
+++ b/tax/set.go
@@ -6,6 +6,7 @@ import (
 	validation "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/invopop/gobl/cal"
 	"github.com/invopop/gobl/num"
+	"github.com/invopop/gobl/org"
 )
 
 // Set defines a list of tax categories and their rates to be used alongside taxable items.
@@ -16,9 +17,9 @@ type Set []*Combo
 // during calculation.
 type Combo struct {
 	// Tax category code from those available inside a region.
-	Category Code `json:"cat" jsonschema:"title=Category"`
+	Category org.Code `json:"cat" jsonschema:"title=Category"`
 	// Rate within a category to apply.
-	Rate Key `json:"rate,omitempty" jsonschema:"title=Rate"`
+	Rate org.Key `json:"rate,omitempty" jsonschema:"title=Rate"`
 	// Percent defines the percentage set manually or determined from the rate key.
 	Percent num.Percentage `json:"percent" jsonschema:"title=Percent"`
 	// Some countries require an additional surcharge.
@@ -45,7 +46,7 @@ func (c *Combo) prepare(r *Region, date cal.Date) error {
 		return ErrInvalidCategory.WithMessage("'%s' not in region", c.Category.String())
 	}
 
-	if c.Rate != KeyEmpty {
+	if c.Rate != org.KeyEmpty {
 		rate := c.category.Rate(c.Rate)
 		if rate == nil {
 			return ErrInvalidRate.WithMessage("'%s' not in category '%s'", c.Rate.String(), c.Category.String())
@@ -68,7 +69,7 @@ func (c *Combo) prepare(r *Region, date cal.Date) error {
 
 // Validate ensures the set of tax combos looks correct
 func (s Set) Validate() error {
-	combos := make(map[Code]Key)
+	combos := make(map[org.Code]org.Key)
 	for i, c := range s {
 		if _, ok := combos[c.Category]; ok {
 			return fmt.Errorf("%d: category %v is duplicated", i, c.Category)
@@ -100,7 +101,7 @@ func (s Set) Equals(s2 Set) bool {
 }
 
 // Get the Rate key for the given category
-func (s Set) Get(cat Code) *Combo {
+func (s Set) Get(cat org.Code) *Combo {
 	for _, c := range s {
 		if c.Category == cat {
 			return c
@@ -110,7 +111,7 @@ func (s Set) Get(cat Code) *Combo {
 }
 
 // Rate returns the rate from the matching category, if set.
-func (s Set) Rate(cat Code) Key {
+func (s Set) Rate(cat org.Code) org.Key {
 	for _, c := range s {
 		if c.Category == cat {
 			return c.Rate

--- a/tax/set_test.go
+++ b/tax/set_test.go
@@ -3,6 +3,7 @@ package tax_test
 import (
 	"testing"
 
+	"github.com/invopop/gobl/org"
 	"github.com/invopop/gobl/tax"
 	"github.com/stretchr/testify/assert"
 )
@@ -159,8 +160,8 @@ func TestSetRate(t *testing.T) {
 			Rate:     "pro",
 		},
 	}
-	assert.Equal(t, s.Rate("VAT"), tax.Key("standard"))
-	assert.Equal(t, s.Rate("IRPF"), tax.Key("pro"))
+	assert.Equal(t, s.Rate("VAT"), org.Key("standard"))
+	assert.Equal(t, s.Rate("IRPF"), org.Key("pro"))
 	assert.Empty(t, s.Rate("FOO"))
 }
 
@@ -175,6 +176,6 @@ func TestSetGet(t *testing.T) {
 			Rate:     "pro",
 		},
 	}
-	assert.NotNil(t, s.Get(tax.Code("VAT")))
-	assert.Nil(t, s.Get(tax.Code("FOO")))
+	assert.NotNil(t, s.Get(org.Code("VAT")))
+	assert.Nil(t, s.Get(org.Code("FOO")))
 }

--- a/tax/totals.go
+++ b/tax/totals.go
@@ -3,11 +3,12 @@ package tax
 import (
 	"github.com/invopop/gobl/cal"
 	"github.com/invopop/gobl/num"
+	"github.com/invopop/gobl/org"
 )
 
 // CategoryTotal groups together all rates inside a given category.
 type CategoryTotal struct {
-	Code      Code         `json:"code" jsonschema:"title=Code"`
+	Code      org.Code     `json:"code" jsonschema:"title=Code"`
 	Retained  bool         `json:"retained,omitempty" jsonschema:"title=Retained"`
 	Rates     []*RateTotal `json:"rates" jsonschema:"title=Rates"`
 	Base      num.Amount   `json:"base" jsonschema:"title=Base"`
@@ -19,7 +20,7 @@ type CategoryTotal struct {
 // a matching category and rate. The Key is optional as we may be using
 // the percentage to group rates.
 type RateTotal struct {
-	Key     Key            `json:"key,omitempty" jsonschema:"title=Key"`
+	Key     org.Key        `json:"key,omitempty" jsonschema:"title=Key"`
 	Base    num.Amount     `json:"base" jsonschema:"title=Base"`
 	Percent num.Percentage `json:"percent" jsonschema:"title=Percent"`
 	// Total amount of rate, excluding surcharges
@@ -86,7 +87,7 @@ func newRateTotal(c *Combo, zero num.Amount) *RateTotal {
 }
 
 // Category provides the category total for the matching code.
-func (t *Total) Category(code Code) *CategoryTotal {
+func (t *Total) Category(code org.Code) *CategoryTotal {
 	for _, ct := range t.Categories {
 		if ct.Code == code {
 			return ct
@@ -96,7 +97,7 @@ func (t *Total) Category(code Code) *CategoryTotal {
 }
 
 // Calculate figures out the total taxes for the set of `TaxableLine`s provided.
-func (t *Total) Calculate(reg *Region, lines []TaxableLine, taxIncluded Code, date cal.Date, zero num.Amount) error {
+func (t *Total) Calculate(reg *Region, lines []TaxableLine, taxIncluded org.Code, date cal.Date, zero num.Amount) error {
 	if reg == nil {
 		return ErrMissingRegion
 	}
@@ -232,7 +233,7 @@ type taxLine struct {
 	taxes Set
 }
 
-func (tl *taxLine) rateForCategory(code Code) Key {
+func (tl *taxLine) rateForCategory(code org.Code) org.Key {
 	return tl.taxes.Rate(code)
 }
 

--- a/tax/totals_test.go
+++ b/tax/totals_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/invopop/gobl/cal"
 	"github.com/invopop/gobl/num"
+	"github.com/invopop/gobl/org"
 	"github.com/invopop/gobl/regions/common"
 	"github.com/invopop/gobl/regions/es"
 	"github.com/invopop/gobl/tax"
@@ -27,14 +28,14 @@ func (tl *taxableLine) GetTotal() num.Amount {
 }
 
 func TestTotalCalculate(t *testing.T) {
-	spain := es.New()
+	spain := es.Region
 	date := cal.MakeDate(2022, 01, 24)
 	zero := num.MakeAmount(0, 2)
 	var tests = []struct {
 		desc        string
 		lines       []tax.TaxableLine
 		date        *cal.Date
-		taxIncluded tax.Code
+		taxIncluded org.Code
 		want        *tax.Total
 		err         error
 		errContent  string
@@ -589,7 +590,7 @@ func TestTotalCalculate(t *testing.T) {
 				&taxableLine{
 					taxes: tax.Set{
 						{
-							Category: tax.Code("FOO"),
+							Category: org.Code("FOO"),
 							Rate:     common.TaxRateStandard,
 						},
 					},

--- a/tax/totals_test.go
+++ b/tax/totals_test.go
@@ -28,7 +28,7 @@ func (tl *taxableLine) GetTotal() num.Amount {
 }
 
 func TestTotalCalculate(t *testing.T) {
-	spain := es.New()
+	spain := es.Region()
 	date := cal.MakeDate(2022, 01, 24)
 	zero := num.MakeAmount(0, 2)
 	var tests = []struct {

--- a/tax/totals_test.go
+++ b/tax/totals_test.go
@@ -28,7 +28,7 @@ func (tl *taxableLine) GetTotal() num.Amount {
 }
 
 func TestTotalCalculate(t *testing.T) {
-	spain := es.Region
+	spain := es.New()
 	date := cal.MakeDate(2022, 01, 24)
 	zero := num.MakeAmount(0, 2)
 	var tests = []struct {

--- a/version.go
+++ b/version.go
@@ -8,7 +8,7 @@ import (
 type Version string
 
 // VERSION is the current version of the GOBL library.
-const VERSION Version = "v0.26.2"
+const VERSION Version = "v0.27.0"
 
 // Semver parses and returns semver
 func (v Version) Semver() *semver.Version {

--- a/version.go
+++ b/version.go
@@ -8,7 +8,7 @@ import (
 type Version string
 
 // VERSION is the current version of the GOBL library.
-const VERSION Version = "v0.26.1"
+const VERSION Version = "v0.27.0"
 
 // Semver parses and returns semver
 func (v Version) Semver() *semver.Version {


### PR DESCRIPTION
* Main objective was to add pre-defined "localities" to region definitions, specifically for Spain whereby some provinces have specific local requirements. This is specifically needed for the TicketBAI integration.
* Ended up refactoring the Code and Key types which had been duplicated a few times into a single `org.Code` and `org.Key` ready to be used throughout the project.
* Modified the `org.Meta` map to require an `org.Key`, thus forcing all meta fields to comply with basic key formats.