### PR TITLE
Fix nl tax code

### DIFF
--- a/regions/nl/tax_code.go
+++ b/regions/nl/tax_code.go
@@ -98,8 +98,7 @@ func mod11(num int64) int64 {
 func checkMod97(code string) bool {
 	// Convert ASCII numbers and letters to integers
 	set := make([]int, len(code))
-	for i, v := range code {
-		char := rune(v)
+	for i, char := range code {
 		if char >= 48 && char <= 57 { // 0 -- 9
 			set[i] = int(char - 48)
 		} else { // assume letters

--- a/regions/nl/tax_code.go
+++ b/regions/nl/tax_code.go
@@ -73,7 +73,7 @@ func validateDigits(code, check string) error {
 	sum := mod11(num)
 
 	// changes in 2020 mean that NL VAT numbers have a different check
-	// digit and should be checked with Mod 97 (like IBAN).
+	// digit and should be checked with Mod 97 (like an IBAN).
 	if sum != ck && !checkMod97("NL"+code+"B"+check) {
 		return errors.New("checksum mismatch")
 	}
@@ -96,7 +96,7 @@ func mod11(num int64) int64 {
 }
 
 func checkMod97(code string) bool {
-	// Convert any ASCII letters to numbers
+	// Convert ASCII numbers and letters to integers
 	set := make([]int, len(code))
 	for i, v := range code {
 		char := rune(v)
@@ -107,7 +107,7 @@ func checkMod97(code string) bool {
 		}
 	}
 
-	// Add up all the numbers
+	// Concatenate all the numbers into a single integer
 	var r int
 	for _, c := range set {
 		r = r * 10
@@ -117,6 +117,5 @@ func checkMod97(code string) bool {
 		r = r + c
 	}
 
-	// Now check modulus to see if 1
 	return (r % 97) == 1
 }

--- a/regions/nl/tax_code_test.go
+++ b/regions/nl/tax_code_test.go
@@ -57,7 +57,11 @@ func TestValidateTaxIdentity(t *testing.T) {
 		},
 		{
 			name: "valid",
-			code: "000099995B57",
+			code: "000099998B57",
+		},
+		{
+			name: "valid 2",
+			code: "808661863B01",
 		},
 		{
 			name: "not normalized",

--- a/version.go
+++ b/version.go
@@ -8,7 +8,7 @@ import (
 type Version string
 
 // VERSION is the current version of the GOBL library.
-const VERSION Version = "v0.29.1"
+const VERSION Version = "v0.29.2"
 
 // Semver parses and returns semver
 func (v Version) Semver() *semver.Version {


### PR DESCRIPTION
* Discovered that the NL tax code validation was not working for all examples (as far as I can gather) from a change in 2020 that meant codes need to be checked using either a mod11 or mod97 algorithm. We only had mod11.