### PR TITLE
Adding regional Spanish taxes

### DIFF
--- a/bill/invoice.go
+++ b/bill/invoice.go
@@ -65,8 +65,8 @@ type Invoice struct {
 	Payment  *Payment  `json:"payment,omitempty" jsonschema:"title=Payment Details"`
 	Delivery *Delivery `json:"delivery,omitempty" jsonschema:"title=Delivery Details"`
 
-	// Summary of all the invoice totals, including taxes.
-	Totals *Totals `json:"totals" jsonschema:"title=Totals"`
+	// Summary of all the invoice totals, including taxes (calculated).
+	Totals *Totals `json:"totals" jsonschema:"title=Totals" jsonschema_extras:"calculated=true"`
 
 	// The EN 16931-1:2017 standard recognises a need to be able to attach additional
 	// documents to an invoice. We don't support this yet, but this is where

--- a/build/data/tax/ES.json
+++ b/build/data/tax/ES.json
@@ -760,6 +760,67 @@
       ]
     },
     {
+      "code": "IGIC",
+      "name": {
+        "en": "IGIC",
+        "es": "IGIC"
+      },
+      "desc": {
+        "en": "Canary Island General Indirect Tax",
+        "es": "Impuesto General Indirecto Canario"
+      },
+      "rates": [
+        {
+          "key": "zero",
+          "name": {
+            "en": "Zero Rate",
+            "es": "Tipo Zero"
+          },
+          "values": [
+            {
+              "percent": "0.0%"
+            }
+          ]
+        },
+        {
+          "key": "standard",
+          "name": {
+            "en": "Standard Rate",
+            "es": "Tipo General"
+          },
+          "values": [
+            {
+              "percent": "7.0%"
+            }
+          ]
+        },
+        {
+          "key": "reduced",
+          "name": {
+            "en": "Reduced Rate",
+            "es": "Tipo Reducido"
+          },
+          "values": [
+            {
+              "percent": "3.0%"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "code": "IPSI",
+      "name": {
+        "en": "IPSI",
+        "es": "IPSI"
+      },
+      "desc": {
+        "en": "Production, Services, and Import Tax",
+        "es": "Impuesto sobre la Producción, los Servicios y la Importación"
+      },
+      "rates": []
+    },
+    {
       "code": "IRPF",
       "name": {
         "en": "IRPF",

--- a/build/schemas/bill/invoice.json
+++ b/build/schemas/bill/invoice.json
@@ -283,7 +283,8 @@
         "totals": {
           "$ref": "#/$defs/Totals",
           "title": "Totals",
-          "description": "Summary of all the invoice totals, including taxes."
+          "description": "Summary of all the invoice totals, including taxes (calculated).",
+          "calculated": true
         },
         "notes": {
           "$ref": "https://gobl.org/draft-0/org/notes",

--- a/regions/es/es.go
+++ b/regions/es/es.go
@@ -540,7 +540,8 @@ func Region() *tax.Region {
 			// VAT
 			//
 			{
-				Code: common.TaxCategoryVAT,
+				Code:     common.TaxCategoryVAT,
+				Retained: false,
 				Name: i18n.String{
 					i18n.EN: "VAT",
 					i18n.ES: "IVA",
@@ -549,7 +550,6 @@ func Region() *tax.Region {
 					i18n.EN: "Value Added Tax",
 					i18n.ES: "Impuesto sobre el Valor Añadido",
 				},
-				Retained: false,
 				Rates: []*tax.Rate{
 					{
 						Key: common.TaxRateZero,
@@ -683,6 +683,81 @@ func Region() *tax.Region {
 						},
 					},
 				},
+			},
+
+			//
+			// IGIC
+			//
+			{
+				Code:     TaxCategoryIGIC,
+				Retained: false,
+				Name: i18n.String{
+					i18n.EN: "IGIC",
+					i18n.ES: "IGIC",
+				},
+				Desc: i18n.String{
+					i18n.EN: "Canary Island General Indirect Tax",
+					i18n.ES: "Impuesto General Indirecto Canario",
+				},
+				// This is a subset of the possible rates.
+				Rates: []*tax.Rate{
+					{
+						Key: common.TaxRateZero,
+						Name: i18n.String{
+							i18n.EN: "Zero Rate",
+							i18n.ES: "Tipo Zero",
+						},
+						Values: []*tax.RateValue{
+							{
+								Percent: num.MakePercentage(0, 3),
+							},
+						},
+					},
+					{
+						Key: common.TaxRateStandard,
+						Name: i18n.String{
+							i18n.EN: "Standard Rate",
+							i18n.ES: "Tipo General",
+						},
+						Values: []*tax.RateValue{
+							{
+								Percent: num.MakePercentage(70, 3),
+							},
+						},
+					},
+					{
+						Key: common.TaxRateReduced,
+						Name: i18n.String{
+							i18n.EN: "Reduced Rate",
+							i18n.ES: "Tipo Reducido",
+						},
+						Values: []*tax.RateValue{
+							{
+								Percent: num.MakePercentage(30, 3),
+							},
+						},
+					},
+				},
+			},
+
+			//
+			// IPSI
+			//
+			{
+				Code:     TaxCategoryIPSI,
+				Retained: false,
+				Name: i18n.String{
+					i18n.EN: "IPSI",
+					i18n.ES: "IPSI",
+				},
+				Desc: i18n.String{
+					i18n.EN: "Production, Services, and Import Tax",
+					i18n.ES: "Impuesto sobre la Producción, los Servicios y la Importación",
+				},
+				// IPSI rates are complex and don't align well regular rates. Users are
+				// recommended to include whatever percentage applies to their situation
+				// directly in the invoice.
+				Rates: []*tax.Rate{},
 			},
 
 			//

--- a/tax/region.go
+++ b/tax/region.go
@@ -135,7 +135,7 @@ func (c *Category) Validate() error {
 	err := validation.ValidateStruct(c,
 		validation.Field(&c.Code, validation.Required),
 		validation.Field(&c.Name, validation.Required),
-		validation.Field(&c.Rates, validation.Required),
+		validation.Field(&c.Rates),
 	)
 	return err
 }


### PR DESCRIPTION
* Adding IGIC and IPSI tax categories for Spain, which were missing.
* Also adding that the Invoice Totals are calculated (was missing from previous PRs for some reason)