### PR TITLE
Removing array types for simpler references

### DIFF
--- a/bill/charges.go
+++ b/bill/charges.go
@@ -30,9 +30,6 @@ func (lc *LineCharge) Validate() error {
 	)
 }
 
-// Charges represents an array of charge objects
-type Charges []*Charge
-
 // Charge represents a surchange applied to the complete document
 // independent from the individual lines.
 type Charge struct {

--- a/bill/discounts.go
+++ b/bill/discounts.go
@@ -30,9 +30,6 @@ func (ld *LineDiscount) Validate() error {
 	)
 }
 
-// Discounts represents an array of discounts.
-type Discounts []*Discount
-
 // Discount represents an allowance applied to the complete document
 // independent from the individual lines. These have more in common with
 // Invoice Lines than anything else, as each discount must have the

--- a/bill/invoice.go
+++ b/bill/invoice.go
@@ -53,13 +53,13 @@ type Invoice struct {
 	Customer *org.Party `json:"customer,omitempty" jsonschema:"title=Customer"`
 
 	// List of invoice lines representing each of the items sold to the customer.
-	Lines Lines `json:"lines,omitempty" jsonschema:"title=Lines"`
+	Lines []*Line `json:"lines,omitempty" jsonschema:"title=Lines"`
 	// Discounts or allowances applied to the complete invoice
-	Discounts Discounts `json:"discounts,omitempty" jsonschema:"title=Discounts"`
+	Discounts []*Discount `json:"discounts,omitempty" jsonschema:"title=Discounts"`
 	// Charges or surcharges applied to the complete invoice
-	Charges Charges `json:"charges,omitempty" jsonschema:"title=Charges"`
+	Charges []*Charge `json:"charges,omitempty" jsonschema:"title=Charges"`
 	// Expenses paid for by the supplier but invoiced directly to the customer.
-	Outlays Outlays `json:"outlays,omitempty" jsonschema:"title=Outlays"`
+	Outlays []*Outlay `json:"outlays,omitempty" jsonschema:"title=Outlays"`
 
 	Ordering *Ordering `json:"ordering,omitempty" jsonschema:"title=Ordering Details"`
 	Payment  *Payment  `json:"payment,omitempty" jsonschema:"title=Payment Details"`
@@ -75,7 +75,7 @@ type Invoice struct {
 
 	// Unstructured information that is relevant to the invoice, such as correction or additional
 	// legal details.
-	Notes org.Notes `json:"notes,omitempty" jsonschema:"title=Notes"`
+	Notes []*org.Note `json:"notes,omitempty" jsonschema:"title=Notes"`
 	// Additional semi-structured data that doesn't fit into the body of the invoice.
 	Meta org.Meta `json:"meta,omitempty" jsonschema:"title=Meta"`
 }
@@ -222,19 +222,19 @@ func (inv *Invoice) RemoveIncludedTaxes(accuracy uint32) *Invoice {
 	}
 
 	i2 := *inv
-	i2.Lines = make(Lines, len(inv.Lines))
+	i2.Lines = make([]*Line, len(inv.Lines))
 	for i, l := range inv.Lines {
 		i2.Lines[i] = l.removeIncludedTaxes(inv.Tax.PricesInclude, accuracy)
 	}
 
 	if len(inv.Discounts) > 0 {
-		i2.Discounts = make(Discounts, len(inv.Discounts))
+		i2.Discounts = make([]*Discount, len(inv.Discounts))
 		for i, l := range inv.Discounts {
 			i2.Discounts[i] = l.removeIncludedTaxes(inv.Tax.PricesInclude, accuracy)
 		}
 	}
 	if len(i2.Charges) > 0 {
-		i2.Charges = make(Charges, len(inv.Charges))
+		i2.Charges = make([]*Charge, len(inv.Charges))
 		for i, l := range inv.Charges {
 			i2.Charges[i] = l.removeIncludedTaxes(inv.Tax.PricesInclude, accuracy)
 		}

--- a/bill/invoice_test.go
+++ b/bill/invoice_test.go
@@ -35,7 +35,7 @@ func TestRemoveIncludedTax(t *testing.T) {
 			},
 		},
 		IssueDate: cal.MakeDate(2022, 6, 13),
-		Lines: bill.Lines{
+		Lines: []*bill.Line{
 			{
 				Quantity: num.MakeAmount(10, 0),
 				Item: &org.Item{
@@ -92,7 +92,7 @@ func TestCalculate(t *testing.T) {
 			},
 		},
 		IssueDate: cal.MakeDate(2022, 6, 13),
-		Lines: bill.Lines{
+		Lines: []*bill.Line{
 			{
 				Quantity: num.MakeAmount(10, 0),
 				Item: &org.Item{

--- a/bill/line.go
+++ b/bill/line.go
@@ -8,9 +8,6 @@ import (
 	"github.com/invopop/gobl/uuid"
 )
 
-// Lines holds an array of Line objects.
-type Lines []*Line
-
 // Line is a single row in an invoice.
 type Line struct {
 	// Unique identifier for this line
@@ -33,7 +30,7 @@ type Line struct {
 	Total num.Amount `json:"total" jsonschema:"title=Total"  jsonschema_extras:"calculated=true"`
 	// Set of specific notes for this line that may be required for
 	// clarification.
-	Notes org.Notes `json:"notes,omitempty" jsonschema:"title=Notes"`
+	Notes []*org.Note `json:"notes,omitempty" jsonschema:"title=Notes"`
 }
 
 // GetTaxes responds with the array of tax rates applied to this line.

--- a/bill/outlay.go
+++ b/bill/outlay.go
@@ -8,9 +8,6 @@ import (
 	"github.com/invopop/gobl/uuid"
 )
 
-// Outlays holds an array of Outlay objects used inside a billing document.
-type Outlays []*Outlay
-
 // Outlay represents a reimbursable expense that was paid for by the supplier and invoiced separately
 // by the third party directly to the customer.
 // Most suppliers will want to include the expenses of their providers as part of their

--- a/build/schemas/bill/invoice.json
+++ b/build/schemas/bill/invoice.json
@@ -72,13 +72,6 @@
       ],
       "description": "Charge represents a surchange applied to the complete document independent from the individual lines."
     },
-    "Charges": {
-      "items": {
-        "$ref": "#/$defs/Charge"
-      },
-      "type": "array",
-      "description": "Charges represents an array of charge objects"
-    },
     "Delivery": {
       "properties": {
         "receiver": {
@@ -167,13 +160,6 @@
       ],
       "description": "Discount represents an allowance applied to the complete document independent from the individual lines."
     },
-    "Discounts": {
-      "items": {
-        "$ref": "#/$defs/Discount"
-      },
-      "type": "array",
-      "description": "Discounts represents an array of discounts."
-    },
     "ExchangeRates": {
       "items": {
         "$ref": "https://gobl.org/draft-0/currency/exchange-rate"
@@ -249,22 +235,34 @@
           "description": "Legal entity receiving the goods or services, may be empty in certain circumstances such as simplified invoices."
         },
         "lines": {
-          "$ref": "#/$defs/Lines",
+          "items": {
+            "$ref": "#/$defs/Line"
+          },
+          "type": "array",
           "title": "Lines",
           "description": "List of invoice lines representing each of the items sold to the customer."
         },
         "discounts": {
-          "$ref": "#/$defs/Discounts",
+          "items": {
+            "$ref": "#/$defs/Discount"
+          },
+          "type": "array",
           "title": "Discounts",
           "description": "Discounts or allowances applied to the complete invoice"
         },
         "charges": {
-          "$ref": "#/$defs/Charges",
+          "items": {
+            "$ref": "#/$defs/Charge"
+          },
+          "type": "array",
           "title": "Charges",
           "description": "Charges or surcharges applied to the complete invoice"
         },
         "outlays": {
-          "$ref": "#/$defs/Outlays",
+          "items": {
+            "$ref": "#/$defs/Outlay"
+          },
+          "type": "array",
           "title": "Outlays",
           "description": "Expenses paid for by the supplier but invoiced directly to the customer."
         },
@@ -287,7 +285,10 @@
           "calculated": true
         },
         "notes": {
-          "$ref": "https://gobl.org/draft-0/org/notes",
+          "items": {
+            "$ref": "https://gobl.org/draft-0/org/note"
+          },
+          "type": "array",
           "title": "Notes",
           "description": "Unstructured information that is relevant to the invoice, such as correction or additional\nlegal details."
         },
@@ -399,7 +400,10 @@
           "calculated": true
         },
         "notes": {
-          "$ref": "https://gobl.org/draft-0/org/notes",
+          "items": {
+            "$ref": "https://gobl.org/draft-0/org/note"
+          },
+          "type": "array",
           "title": "Notes",
           "description": "Set of specific notes for this line that may be required for\nclarification."
         }
@@ -474,13 +478,6 @@
       ],
       "description": "LineDiscount represents an amount deducted from the line, and will be applied before taxes."
     },
-    "Lines": {
-      "items": {
-        "$ref": "#/$defs/Line"
-      },
-      "type": "array",
-      "description": "Lines holds an array of Line objects."
-    },
     "Ordering": {
       "properties": {
         "seller": {
@@ -543,13 +540,6 @@
         "amount"
       ],
       "description": "Outlay represents a reimbursable expense that was paid for by the supplier and invoiced separately by the third party directly to the customer."
-    },
-    "Outlays": {
-      "items": {
-        "$ref": "#/$defs/Outlay"
-      },
-      "type": "array",
-      "description": "Outlays holds an array of Outlay objects used inside a billing document."
     },
     "Payment": {
       "properties": {
@@ -736,5 +726,5 @@
       "description": "Totals contains the summaries of all calculations for the invoice."
     }
   },
-  "$comment": "Generated with GOBL v0.30.2"
+  "$comment": "Generated with GOBL v0.30.4"
 }

--- a/build/schemas/cal/date.json
+++ b/build/schemas/cal/date.json
@@ -10,5 +10,5 @@
       "description": "Civil date in simplified ISO format, like 2021-05-26"
     }
   },
-  "$comment": "Generated with GOBL v0.30.2"
+  "$comment": "Generated with GOBL v0.30.4"
 }

--- a/build/schemas/cal/period.json
+++ b/build/schemas/cal/period.json
@@ -20,5 +20,5 @@
       "description": "Period represents two dates with a start and finish."
     }
   },
-  "$comment": "Generated with GOBL v0.30.2"
+  "$comment": "Generated with GOBL v0.30.4"
 }

--- a/build/schemas/currency/code.json
+++ b/build/schemas/currency/code.json
@@ -675,5 +675,5 @@
       "description": "ISO Currency Code"
     }
   },
-  "$comment": "Generated with GOBL v0.30.2"
+  "$comment": "Generated with GOBL v0.30.4"
 }

--- a/build/schemas/currency/exchange-rate.json
+++ b/build/schemas/currency/exchange-rate.json
@@ -24,5 +24,5 @@
       "description": "ExchangeRate contains data on the rate to be used when converting amounts from the document's base currency to whatever is defined."
     }
   },
-  "$comment": "Generated with GOBL v0.30.2"
+  "$comment": "Generated with GOBL v0.30.4"
 }

--- a/build/schemas/dsig/digest.json
+++ b/build/schemas/dsig/digest.json
@@ -24,5 +24,5 @@
       "description": "Digest defines a structure to hold a digest value including the algorithm used to generate it."
     }
   },
-  "$comment": "Generated with GOBL v0.30.2"
+  "$comment": "Generated with GOBL v0.30.4"
 }

--- a/build/schemas/dsig/signature.json
+++ b/build/schemas/dsig/signature.json
@@ -9,5 +9,5 @@
       "description": "JSON Web Signature in compact form."
     }
   },
-  "$comment": "Generated with GOBL v0.30.2"
+  "$comment": "Generated with GOBL v0.30.4"
 }

--- a/build/schemas/envelope.json
+++ b/build/schemas/envelope.json
@@ -114,5 +114,5 @@
       "description": "Stamp defines an official seal of approval from a third party like a governmental agency or intermediary and should thus be included in any official envelopes."
     }
   },
-  "$comment": "Generated with GOBL v0.30.2"
+  "$comment": "Generated with GOBL v0.30.4"
 }

--- a/build/schemas/i18n/string.json
+++ b/build/schemas/i18n/string.json
@@ -15,5 +15,5 @@
       "description": "Map of 2-Letter language codes to their translations."
     }
   },
-  "$comment": "Generated with GOBL v0.30.2"
+  "$comment": "Generated with GOBL v0.30.4"
 }

--- a/build/schemas/l10n/code.json
+++ b/build/schemas/l10n/code.json
@@ -10,5 +10,5 @@
       "description": "Code is used for short identifies like country or state codes."
     }
   },
-  "$comment": "Generated with GOBL v0.30.2"
+  "$comment": "Generated with GOBL v0.30.4"
 }

--- a/build/schemas/l10n/country-code.json
+++ b/build/schemas/l10n/country-code.json
@@ -1006,5 +1006,5 @@
       "title": "Country Code"
     }
   },
-  "$comment": "Generated with GOBL v0.30.2"
+  "$comment": "Generated with GOBL v0.30.4"
 }

--- a/build/schemas/note/message.json
+++ b/build/schemas/note/message.json
@@ -28,5 +28,5 @@
       "description": "Message represents the minimum possible contents for a GoBL document type."
     }
   },
-  "$comment": "Generated with GOBL v0.30.2"
+  "$comment": "Generated with GOBL v0.30.4"
 }

--- a/build/schemas/num/amount.json
+++ b/build/schemas/num/amount.json
@@ -10,5 +10,5 @@
       "description": "Quantity with optional decimal places that determine accuracy."
     }
   },
-  "$comment": "Generated with GOBL v0.30.2"
+  "$comment": "Generated with GOBL v0.30.4"
 }

--- a/build/schemas/num/percentage.json
+++ b/build/schemas/num/percentage.json
@@ -10,5 +10,5 @@
       "description": "Similar to an Amount, but designed for percentages and includes % symbol in JSON output."
     }
   },
-  "$comment": "Generated with GOBL v0.30.2"
+  "$comment": "Generated with GOBL v0.30.4"
 }

--- a/build/schemas/org/address.json
+++ b/build/schemas/org/address.json
@@ -89,5 +89,5 @@
       "description": "Address defines a globally acceptable set of attributes that describes a postal or fiscal address."
     }
   },
-  "$comment": "Generated with GOBL v0.30.2"
+  "$comment": "Generated with GOBL v0.30.4"
 }

--- a/build/schemas/org/code.json
+++ b/build/schemas/org/code.json
@@ -12,5 +12,5 @@
       "description": "Short upper-case identifier."
     }
   },
-  "$comment": "Generated with GOBL v0.30.2"
+  "$comment": "Generated with GOBL v0.30.4"
 }

--- a/build/schemas/org/coordinates.json
+++ b/build/schemas/org/coordinates.json
@@ -30,5 +30,5 @@
       "description": "Coordinates describes an exact geographical location in the world."
     }
   },
-  "$comment": "Generated with GOBL v0.30.2"
+  "$comment": "Generated with GOBL v0.30.4"
 }

--- a/build/schemas/org/email.json
+++ b/build/schemas/org/email.json
@@ -32,5 +32,5 @@
       "description": "Email describes the electronic mailing details."
     }
   },
-  "$comment": "Generated with GOBL v0.30.2"
+  "$comment": "Generated with GOBL v0.30.4"
 }

--- a/build/schemas/org/inbox.json
+++ b/build/schemas/org/inbox.json
@@ -38,5 +38,5 @@
       "description": "Inbox is used to store data about a connection with a service that is responsible for potentially receiving copies of GOBL envelopes or other document formats defined locally."
     }
   },
-  "$comment": "Generated with GOBL v0.30.2"
+  "$comment": "Generated with GOBL v0.30.4"
 }

--- a/build/schemas/org/item.json
+++ b/build/schemas/org/item.json
@@ -84,5 +84,5 @@
       "description": "ItemCode contains a value and optional label property that means additional codes can be added to an item."
     }
   },
-  "$comment": "Generated with GOBL v0.30.2"
+  "$comment": "Generated with GOBL v0.30.4"
 }

--- a/build/schemas/org/key.json
+++ b/build/schemas/org/key.json
@@ -12,5 +12,5 @@
       "description": "Text identifier to be used instead of a code for a more verbose but readable identifier."
     }
   },
-  "$comment": "Generated with GOBL v0.30.2"
+  "$comment": "Generated with GOBL v0.30.4"
 }

--- a/build/schemas/org/meta.json
+++ b/build/schemas/org/meta.json
@@ -13,5 +13,5 @@
       "description": "Meta defines a structure for data about the data being defined."
     }
   },
-  "$comment": "Generated with GOBL v0.30.2"
+  "$comment": "Generated with GOBL v0.30.4"
 }

--- a/build/schemas/org/name.json
+++ b/build/schemas/org/name.json
@@ -59,5 +59,5 @@
       "description": "Name represents what a human is called."
     }
   },
-  "$comment": "Generated with GOBL v0.30.2"
+  "$comment": "Generated with GOBL v0.30.4"
 }

--- a/build/schemas/org/note.json
+++ b/build/schemas/org/note.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://gobl.org/draft-0/org/notes",
-  "$ref": "#/$defs/Notes",
+  "$id": "https://gobl.org/draft-0/org/note",
+  "$ref": "#/$defs/Note",
   "$defs": {
     "Note": {
       "properties": {
@@ -138,14 +138,7 @@
       "type": "string",
       "title": "Note Key",
       "description": "NoteKey identifies the type of note being edited"
-    },
-    "Notes": {
-      "items": {
-        "$ref": "#/$defs/Note"
-      },
-      "type": "array",
-      "description": "Notes holds an array of Note objects"
     }
   },
-  "$comment": "Generated with GOBL v0.30.2"
+  "$comment": "Generated with GOBL v0.30.4"
 }

--- a/build/schemas/org/party.json
+++ b/build/schemas/org/party.json
@@ -88,5 +88,5 @@
       "description": "Party represents a person or business entity."
     }
   },
-  "$comment": "Generated with GOBL v0.30.2"
+  "$comment": "Generated with GOBL v0.30.4"
 }

--- a/build/schemas/org/person.json
+++ b/build/schemas/org/person.json
@@ -54,5 +54,5 @@
       "description": "Person represents a human, and how to contact them electronically."
     }
   },
-  "$comment": "Generated with GOBL v0.30.2"
+  "$comment": "Generated with GOBL v0.30.4"
 }

--- a/build/schemas/org/registration.json
+++ b/build/schemas/org/registration.json
@@ -42,5 +42,5 @@
       "description": "Registration is used in countries that require additional information to be associated with a company usually related to a specific registration office."
     }
   },
-  "$comment": "Generated with GOBL v0.30.2"
+  "$comment": "Generated with GOBL v0.30.4"
 }

--- a/build/schemas/org/tax-identity.json
+++ b/build/schemas/org/tax-identity.json
@@ -70,5 +70,5 @@
       "description": "TaxIdentity stores the details required to identify an entity for tax purposes."
     }
   },
-  "$comment": "Generated with GOBL v0.30.2"
+  "$comment": "Generated with GOBL v0.30.4"
 }

--- a/build/schemas/org/telephone.json
+++ b/build/schemas/org/telephone.json
@@ -28,5 +28,5 @@
       "description": "Telephone describes what is expected for a telephone number."
     }
   },
-  "$comment": "Generated with GOBL v0.30.2"
+  "$comment": "Generated with GOBL v0.30.4"
 }

--- a/build/schemas/org/unit.json
+++ b/build/schemas/org/unit.json
@@ -207,5 +207,5 @@
       "description": "Unit describes how the quantity of the product should be interpreted."
     }
   },
-  "$comment": "Generated with GOBL v0.30.2"
+  "$comment": "Generated with GOBL v0.30.4"
 }

--- a/build/schemas/pay/advance.json
+++ b/build/schemas/pay/advance.json
@@ -54,5 +54,5 @@
       "description": "Advance represents a single payment that has been made already, such as a deposit on an intent to purchase, or as credit from a previous invoice which was later corrected or cancelled."
     }
   },
-  "$comment": "Generated with GOBL v0.30.2"
+  "$comment": "Generated with GOBL v0.30.4"
 }

--- a/build/schemas/pay/instructions.json
+++ b/build/schemas/pay/instructions.json
@@ -190,5 +190,5 @@
       "description": "Online provides the details required to make a payment online using a website"
     }
   },
-  "$comment": "Generated with GOBL v0.30.2"
+  "$comment": "Generated with GOBL v0.30.4"
 }

--- a/build/schemas/pay/terms.json
+++ b/build/schemas/pay/terms.json
@@ -118,5 +118,5 @@
       "description": "Terms defines when we expect the customer to pay, or have paid, for the contents of the document."
     }
   },
-  "$comment": "Generated with GOBL v0.30.2"
+  "$comment": "Generated with GOBL v0.30.4"
 }

--- a/build/schemas/tax/region.json
+++ b/build/schemas/tax/region.json
@@ -71,142 +71,6 @@
       ],
       "description": "Locality represents an area inside a region, like a province or a state, which shares the basic definitions of the region, but may vary in some validation rules."
     },
-    "Note": {
-      "properties": {
-        "key": {
-          "$ref": "#/$defs/NoteKey",
-          "title": "Key",
-          "description": "Key specifying subject of the text"
-        },
-        "code": {
-          "type": "string",
-          "title": "Code",
-          "description": "Code used for additional data that may be required to identify the note."
-        },
-        "src": {
-          "type": "string",
-          "title": "Source",
-          "description": "Source of this note, especially useful when auto-generated."
-        },
-        "text": {
-          "type": "string",
-          "title": "Text",
-          "description": "The contents of the note"
-        }
-      },
-      "type": "object",
-      "required": [
-        "text"
-      ],
-      "description": "Note represents a free text of additional information that may be added to a document."
-    },
-    "NoteKey": {
-      "oneOf": [
-        {
-          "const": "goods",
-          "description": "Goods Description"
-        },
-        {
-          "const": "payment",
-          "description": "Terms of Payment"
-        },
-        {
-          "const": "legal",
-          "description": "Legal or regulatory information"
-        },
-        {
-          "const": "dangerous-goods",
-          "description": "Dangerous goods additional information"
-        },
-        {
-          "const": "ack",
-          "description": "Acknowledgement Description"
-        },
-        {
-          "const": "rate",
-          "description": "Rate additional information"
-        },
-        {
-          "const": "reason",
-          "description": "Reason"
-        },
-        {
-          "const": "dispute",
-          "description": "Dispute"
-        },
-        {
-          "const": "customer",
-          "description": "Customer remarks"
-        },
-        {
-          "const": "glossary",
-          "description": "Glossary"
-        },
-        {
-          "const": "customs",
-          "description": "Customs declaration information"
-        },
-        {
-          "const": "general",
-          "description": "General information"
-        },
-        {
-          "const": "handling",
-          "description": "Handling instructions"
-        },
-        {
-          "const": "packaging",
-          "description": "Packaging information"
-        },
-        {
-          "const": "loading",
-          "description": "Loading instructions"
-        },
-        {
-          "const": "price",
-          "description": "Price conditions"
-        },
-        {
-          "const": "priority",
-          "description": "Priority information"
-        },
-        {
-          "const": "regulatory",
-          "description": "Regulatory information"
-        },
-        {
-          "const": "safety",
-          "description": "Safety instructions"
-        },
-        {
-          "const": "ship-line",
-          "description": "Ship line"
-        },
-        {
-          "const": "supplier",
-          "description": "Supplier remarks"
-        },
-        {
-          "const": "transport",
-          "description": "Transportation information"
-        },
-        {
-          "const": "delivery",
-          "description": "Delivery information"
-        },
-        {
-          "const": "quarantine",
-          "description": "Quarantine information"
-        },
-        {
-          "const": "tax",
-          "description": "Tax declaration"
-        }
-      ],
-      "type": "string",
-      "title": "Note Key",
-      "description": "NoteKey identifies the type of note being edited"
-    },
     "Rate": {
       "properties": {
         "key": {
@@ -344,7 +208,7 @@
           "description": "List of tax category codes that can be used when this scheme is\napplied."
         },
         "note": {
-          "$ref": "#/$defs/Note",
+          "$ref": "https://gobl.org/draft-0/org/note",
           "title": "Note",
           "description": "Notes defines messages that should be added to a document\nwhen this scheme is used."
         }
@@ -364,5 +228,5 @@
       "description": "Schemes defines an array of scheme objects with helper functions."
     }
   },
-  "$comment": "Generated with GOBL v0.30.2"
+  "$comment": "Generated with GOBL v0.30.4"
 }

--- a/build/schemas/tax/set.json
+++ b/build/schemas/tax/set.json
@@ -43,5 +43,5 @@
       "description": "Set defines a list of tax categories and their rates to be used alongside taxable items."
     }
   },
-  "$comment": "Generated with GOBL v0.30.2"
+  "$comment": "Generated with GOBL v0.30.4"
 }

--- a/build/schemas/tax/total.json
+++ b/build/schemas/tax/total.json
@@ -115,5 +115,5 @@
       "description": "Total contains a set of Category Totals which in turn contain all the accumulated taxes contained in the document."
     }
   },
-  "$comment": "Generated with GOBL v0.30.2"
+  "$comment": "Generated with GOBL v0.30.4"
 }

--- a/build/schemas/uuid/uuid.json
+++ b/build/schemas/uuid/uuid.json
@@ -10,5 +10,5 @@
       "description": "Universally Unique Identifier. We only recommend using versions 1 and 4 within GOBL."
     }
   },
-  "$comment": "Generated with GOBL v0.30.2"
+  "$comment": "Generated with GOBL v0.30.4"
 }

--- a/org/notes.go
+++ b/org/notes.go
@@ -207,7 +207,7 @@ var NoteKeyDefinitions = []DefNoteKey{
 }
 
 // Notes holds an array of Note objects
-type Notes []*Note
+// type Notes []*Note
 
 // Note represents a free text of additional information that may be
 // added to a document.

--- a/org/org.go
+++ b/org/org.go
@@ -18,7 +18,7 @@ func init() {
 		Registration{},
 		TaxIdentity{},
 		Meta{},
-		Notes{},
+		Note{},
 		Inbox{},
 	)
 }

--- a/tax/schemes.go
+++ b/tax/schemes.go
@@ -26,7 +26,7 @@ type Scheme struct {
 	// applied.
 	Categories []org.Code `json:"categories,omitempty" jsonschema:"title=Category Codes"`
 
-	// Notes defines messages that should be added to a document
+	// Note defines a message that should be added to a document
 	// when this scheme is used.
 	Note *org.Note `json:"note,omitempty" jsonschema:"title=Note"`
 }

--- a/version.go
+++ b/version.go
@@ -8,7 +8,7 @@ import (
 type Version string
 
 // VERSION is the current version of the GOBL library.
-const VERSION Version = "v0.30.3"
+const VERSION Version = "v0.30.4"
 
 // Semver parses and returns semver
 func (v Version) Semver() *semver.Version {


### PR DESCRIPTION
* Relatively simple change to remove simple array types and instead use regular arrays.
* Fixes an issue whereby the complete notes were duplicated between the `org` and `tax` packages.