### PR TITLE
Preceding now array, fixed key listings in schema

### DIFF
--- a/bill/invoice.go
+++ b/bill/invoice.go
@@ -36,9 +36,9 @@ type Invoice struct {
 	// Special tax configuration for billing.
 	Tax *Tax `json:"tax,omitempty" jsonschema:"title=Tax"`
 
-	// Key information regarding a previous invoice and potentially details as to why it
-	// was corrected.
-	Preceding *Preceding `json:"preceding,omitempty" jsonschema:"title=Preceding Details"`
+	// Key information regarding previous invoices and potentially details as to why they
+	// were corrected.
+	Preceding []*Preceding `json:"preceding,omitempty" jsonschema:"title=Preceding Details"`
 
 	// When the invoice was created.
 	IssueDate cal.Date `json:"issue_date" jsonschema:"title=Issue Date"`

--- a/bill/preceding.go
+++ b/bill/preceding.go
@@ -1,12 +1,11 @@
 package bill
 
 import (
-	"errors"
-
 	validation "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/invopop/gobl/cal"
 	"github.com/invopop/gobl/org"
 	"github.com/invopop/gobl/uuid"
+	"github.com/invopop/jsonschema"
 )
 
 // Preceding allows for information to be provided about a previous invoice that this one
@@ -15,13 +14,13 @@ import (
 type Preceding struct {
 	// Preceding document's UUID if available can be useful for tracing.
 	UUID *uuid.UUID `json:"uuid,omitempty" jsonschema:"title=UUID"`
-	// Identity code of the previous invoice.
-	Code string `json:"code" jsonschema:"title=Code"`
-	// Additional identification details
+	// Series identification code
 	Series string `json:"series,omitempty" jsonschema:"title=Series"`
-	// When the preceding invoice was issued.
+	// Code of the previous document.
+	Code string `json:"code" jsonschema:"title=Code"`
+	// The issue date if the previous document.
 	IssueDate cal.Date `json:"issue_date" jsonschema:"title=Issue Date"`
-	// Tax period in which the previous invoice has an effect.
+	// Tax period in which the previous invoice had an effect.
 	Period *cal.Period `json:"period,omitempty" jsonschema:"title=Period"`
 	// Specific codes for the corrections made.
 	Corrections []CorrectionKey `json:"corrections,omitempty" jsonschema:"title=Corrections"`
@@ -37,18 +36,19 @@ type Preceding struct {
 func (p *Preceding) Validate() error {
 	return validation.ValidateStruct(p,
 		validation.Field(&p.UUID),
+		validation.Field(&p.Series),
 		validation.Field(&p.Code, validation.Required),
 		validation.Field(&p.IssueDate, cal.DateNotZero()),
 		validation.Field(&p.Period),
-		validation.Field(&p.Corrections),
-		validation.Field(&p.CorrectionMethod),
+		validation.Field(&p.Corrections, validation.Each(isValidCorrectionKey)),
+		validation.Field(&p.CorrectionMethod, isValidCorrectionMethodKey),
 		validation.Field(&p.Meta),
 	)
 }
 
 // CorrectionKey helps identify from a set of reasons why this correction
 // is happening
-type CorrectionKey string
+type CorrectionKey org.Key
 
 // CorrectionMethodKey identifies that type of correction being applied.
 type CorrectionMethodKey string
@@ -82,43 +82,52 @@ const (
 	InsolvencyCorrectionKey      CorrectionKey = "insolvency"   // the customer is insolvent and cannot pay
 )
 
-// CorrectionKeyList provides a fixed list of all the correction
-// codes that are currently supported by GOBL.
-var CorrectionKeyList = []CorrectionKey{
-	CodeCorrectionKey,
-	SeriesCorrectionKey,
-	IssueDateCorrectionKey,
-	SupplierCorrectionKey,
-	CustomerCorrectionKey,
-	SupplierNameCorrectionKey,
-	CustomerNameCorrectionKey,
-	SupplierTaxIDCorrectionKey,
-	CustomerTaxIDCorrectionKey,
-	SupplierAddressCorrectionKey,
-	CustomerAddressCorrectionKey,
-	LineCorrectionKey,
-	PeriodCorrectionKey,
-	TypeCorrectionKey,
-	LegalDetailsCorrectionKey,
-	TaxRateCorrectionKey,
-	TaxAmountCorrectionKey,
-	TaxBaseCorrectionKey,
-	TaxCorrectionKey,
-	TaxRetainedCorrectionKey,
-	RefundCorrectionKey,
-	DiscountCorrectionKey,
-	JudicialCorrectionKey,
-	InsolvencyCorrectionKey,
+// CorrectionKeyDef holds a definition of a correction key with it's
+// description.
+type CorrectionKeyDef struct {
+	// Key being defined
+	Key CorrectionKey `json:"key" jsonschema:"title=Key"`
+	// Description of the key and how it should be used.
+	Description string `json:"description" jsonschema:"title=Description"`
 }
 
-// Validate ensures the correction code is part of the accepted list
-func (cc CorrectionKey) Validate() error {
-	for _, code := range CorrectionKeyList {
-		if code == cc {
-			return nil
-		}
+// CorrectionKeyList provides a fixed list of all the correction
+// codes that are currently supported by GOBL.
+var CorrectionKeyDefinitions = []CorrectionKeyDef{
+	{CodeCorrectionKey, "Code has changed."},
+	{SeriesCorrectionKey, "Series has changed."},
+	{IssueDateCorrectionKey, "Issue date was modified."},
+	{SupplierCorrectionKey, "Supplier details were changed."},
+	{CustomerCorrectionKey, "Customer details were changed."},
+	{SupplierNameCorrectionKey, "Supplier name was changed."},
+	{CustomerNameCorrectionKey, "Customer name was changed."},
+	{SupplierTaxIDCorrectionKey, "Supplier Tax ID was changed."},
+	{CustomerTaxIDCorrectionKey, "Customer Tax ID was changed."},
+	{SupplierAddressCorrectionKey, "Supplier address was modified."},
+	{CustomerAddressCorrectionKey, "Customer address was modified."},
+	{LineCorrectionKey, "Line details were corrected."},
+	{PeriodCorrectionKey, "Period was changed."},
+	{TypeCorrectionKey, "Type of document was corrected."},
+	{LegalDetailsCorrectionKey, "Legal details were corrected."},
+	{TaxRateCorrectionKey, "Tax rates were modified."},
+	{TaxAmountCorrectionKey, "Tax amount was corrected."},
+	{TaxBaseCorrectionKey, "Taxable base was corrected."},
+	{TaxCorrectionKey, "General issue with tax calculations."},
+	{TaxRetainedCorrectionKey, "Error in retained tax calculations/"},
+	{RefundCorrectionKey, "Goods or materials have been returned to supplier."},
+	{DiscountCorrectionKey, "New discounts or rebates added."},
+	{JudicialCorrectionKey, "Court ruling or administrative decision."},
+	{InsolvencyCorrectionKey, "The customer is insolvent and cannot pay."},
+}
+
+var isValidCorrectionKey = validation.In(validCorrectionKeys()...)
+
+func validCorrectionKeys() []interface{} {
+	list := make([]interface{}, len(CorrectionKeyDefinitions))
+	for i, v := range CorrectionKeyDefinitions {
+		list[i] = v.Key
 	}
-	return errors.New("invalid")
+	return list
 }
 
 // Defined list of correction methods
@@ -129,21 +138,51 @@ const (
 	AuthorizedCorrectionMethodKey CorrectionMethodKey = "authorized" // Permitted by tax agency
 )
 
-// CorrectionMethodKeyList provides a fixed list of codes for validation
-// purposes.
-var CorrectionMethodKeyList = []CorrectionMethodKey{
-	CompleteCorrectionMethodKey,
-	PartialCorrectionMethodKey,
-	DiscountCorrectionMethodKey,
-	AuthorizedCorrectionMethodKey,
+// CorrectionMethodKeyDef defines the fields used to describe each correction method.
+type CorrectionMethodKeyDef struct {
+	// Key being defined
+	Key CorrectionMethodKey `json:"key" jsonschema:"title=Key"`
+	// Description of the key and how it should be used.
+	Description string `json:"description" jsonschema:"title=Description"`
 }
 
-// Validate ensures the correction code is part of the accepted list
-func (cc CorrectionMethodKey) Validate() error {
-	for _, code := range CorrectionMethodKeyList {
-		if code == cc {
-			return nil
+// CorrectionMethodKeyList provides a fixed list of codes for validation
+// purposes.
+var CorrectionMethodKeyDefinitions = []CorrectionMethodKeyDef{
+	{CompleteCorrectionMethodKey, "Everything has changed, this document replaces the previous one."},
+	{PartialCorrectionMethodKey, "Only differences corrected."},
+	{DiscountCorrectionMethodKey, "Deducted from future invoices."},
+	{AuthorizedCorrectionMethodKey, "Permitted by tax agency."},
+}
+
+var isValidCorrectionMethodKey = validation.In(validCorrectionMethodKeys()...)
+
+func validCorrectionMethodKeys() []interface{} {
+	list := make([]interface{}, len(CorrectionMethodKeyDefinitions))
+	for i, v := range CorrectionMethodKeyDefinitions {
+		list[i] = v.Key
+	}
+	return list
+}
+
+// JSONSchemaExtend provides additional details to the schema.
+func (CorrectionKey) JSONSchemaExtend(s *jsonschema.Schema) {
+	s.AnyOf = make([]*jsonschema.Schema, len(CorrectionKeyDefinitions))
+	for i, v := range CorrectionKeyDefinitions {
+		s.AnyOf[i] = &jsonschema.Schema{
+			Const:       v.Key,
+			Description: v.Description,
 		}
 	}
-	return errors.New("invalid")
+}
+
+// JSONSchemaExtend provides additional details to the schema.
+func (CorrectionMethodKey) JSONSchemaExtend(s *jsonschema.Schema) {
+	s.AnyOf = make([]*jsonschema.Schema, len(CorrectionMethodKeyDefinitions))
+	for i, v := range CorrectionMethodKeyDefinitions {
+		s.AnyOf[i] = &jsonschema.Schema{
+			Const:       v.Key,
+			Description: v.Description,
+		}
+	}
 }

--- a/bill/preceding.go
+++ b/bill/preceding.go
@@ -91,7 +91,7 @@ type CorrectionKeyDef struct {
 	Description string `json:"description" jsonschema:"title=Description"`
 }
 
-// CorrectionKeyList provides a fixed list of all the correction
+// CorrectionKeyDefinitions provides a fixed list of all the correction
 // codes that are currently supported by GOBL.
 var CorrectionKeyDefinitions = []CorrectionKeyDef{
 	{CodeCorrectionKey, "Code has changed."},
@@ -146,7 +146,7 @@ type CorrectionMethodKeyDef struct {
 	Description string `json:"description" jsonschema:"title=Description"`
 }
 
-// CorrectionMethodKeyList provides a fixed list of codes for validation
+// CorrectionMethodKeyDefinitions provides a fixed list of codes for validation
 // purposes.
 var CorrectionMethodKeyDefinitions = []CorrectionMethodKeyDef{
 	{CompleteCorrectionMethodKey, "Everything has changed, this document replaces the previous one."},

--- a/bill/preceding_test.go
+++ b/bill/preceding_test.go
@@ -1,0 +1,20 @@
+package bill_test
+
+import (
+	"testing"
+
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/cal"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrecedingValidation(t *testing.T) {
+	p := new(bill.Preceding)
+	p.Code = "FOO"
+	p.IssueDate = cal.MakeDate(2022, 11, 6)
+	p.Corrections = []bill.CorrectionKey{bill.CodeCorrectionKey, bill.LineCorrectionKey}
+	p.CorrectionMethod = bill.CompleteCorrectionMethodKey
+
+	err := p.Validate()
+	assert.NoError(t, err)
+}

--- a/build/schemas/bill/invoice.json
+++ b/build/schemas/bill/invoice.json
@@ -205,9 +205,12 @@
           "description": "Special tax configuration for billing."
         },
         "preceding": {
-          "$ref": "#/$defs/Preceding",
+          "items": {
+            "$ref": "#/$defs/Preceding"
+          },
+          "type": "array",
           "title": "Preceding Details",
-          "description": "Key information regarding a previous invoice and potentially details as to why it\nwas corrected."
+          "description": "Key information regarding previous invoices and potentially details as to why they\nwere corrected."
         },
         "issue_date": {
           "$ref": "https://gobl.org/draft-0/cal/date",
@@ -574,28 +577,126 @@
           "title": "UUID",
           "description": "Preceding document's UUID if available can be useful for tracing."
         },
-        "code": {
-          "type": "string",
-          "title": "Code",
-          "description": "Identity code of the previous invoice."
-        },
         "series": {
           "type": "string",
           "title": "Series",
-          "description": "Additional identification details"
+          "description": "Series identification code"
+        },
+        "code": {
+          "type": "string",
+          "title": "Code",
+          "description": "Code of the previous document."
         },
         "issue_date": {
           "$ref": "https://gobl.org/draft-0/cal/date",
           "title": "Issue Date",
-          "description": "When the preceding invoice was issued."
+          "description": "The issue date if the previous document."
         },
         "period": {
           "$ref": "https://gobl.org/draft-0/cal/period",
           "title": "Period",
-          "description": "Tax period in which the previous invoice has an effect."
+          "description": "Tax period in which the previous invoice had an effect."
         },
         "corrections": {
           "items": {
+            "anyOf": [
+              {
+                "const": "code",
+                "description": "Code has changed."
+              },
+              {
+                "const": "series",
+                "description": "Series has changed."
+              },
+              {
+                "const": "issue-date",
+                "description": "Issue date was modified."
+              },
+              {
+                "const": "supplier",
+                "description": "Supplier details were changed."
+              },
+              {
+                "const": "customer",
+                "description": "Customer details were changed."
+              },
+              {
+                "const": "supplier-name",
+                "description": "Supplier name was changed."
+              },
+              {
+                "const": "customer-name",
+                "description": "Customer name was changed."
+              },
+              {
+                "const": "supplier-tax-id",
+                "description": "Supplier Tax ID was changed."
+              },
+              {
+                "const": "customer-tax-id",
+                "description": "Customer Tax ID was changed."
+              },
+              {
+                "const": "supplier-addr",
+                "description": "Supplier address was modified."
+              },
+              {
+                "const": "customer-addr",
+                "description": "Customer address was modified."
+              },
+              {
+                "const": "line",
+                "description": "Line details were corrected."
+              },
+              {
+                "const": "period",
+                "description": "Period was changed."
+              },
+              {
+                "const": "type",
+                "description": "Type of document was corrected."
+              },
+              {
+                "const": "legal-details",
+                "description": "Legal details were corrected."
+              },
+              {
+                "const": "tax-rate",
+                "description": "Tax rates were modified."
+              },
+              {
+                "const": "tax-amount",
+                "description": "Tax amount was corrected."
+              },
+              {
+                "const": "tax-base",
+                "description": "Taxable base was corrected."
+              },
+              {
+                "const": "tax",
+                "description": "General issue with tax calculations."
+              },
+              {
+                "const": "tax-retained",
+                "description": "Error in retained tax calculations/"
+              },
+              {
+                "const": "refund",
+                "description": "Goods or materials have been returned to supplier."
+              },
+              {
+                "const": "discount",
+                "description": "New discounts or rebates added."
+              },
+              {
+                "const": "judicial",
+                "description": "Court ruling or administrative decision."
+              },
+              {
+                "const": "insolvency",
+                "description": "The customer is insolvent and cannot pay."
+              }
+            ],
             "type": "string"
           },
           "type": "array",
@@ -603,6 +704,24 @@
           "description": "Specific codes for the corrections made."
         },
         "correction_method": {
+          "anyOf": [
+            {
+              "const": "complete",
+              "description": "Everything has changed, this document replaces the previous one."
+            },
+            {
+              "const": "partial",
+              "description": "Only differences corrected."
+            },
+            {
+              "const": "discount",
+              "description": "Deducted from future invoices."
+            },
+            {
+              "const": "authorized",
+              "description": "Permitted by tax agency."
+            }
+          ],
           "type": "string",
           "title": "Correction Method",
           "description": "How has the previous invoice been corrected?"

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-ozzo/ozzo-validation/v4 v4.3.0
 	github.com/google/uuid v1.1.2
-	github.com/invopop/jsonschema v0.6.1-0.20220804171514-4a807f958afc
+	github.com/invopop/jsonschema v0.7.0
 	github.com/invopop/yaml v0.1.0
 	github.com/kr/pretty v0.2.0 // indirect
 	github.com/square/go-jose/v3 v3.0.0-20200630053402-0a67ce9b0693

--- a/go.sum
+++ b/go.sum
@@ -166,6 +166,8 @@ github.com/invopop/jsonschema v0.6.0 h1:8e+xY8ZEn8gDHUYylSlLHy22P+SLeIRIHv3nM3hC
 github.com/invopop/jsonschema v0.6.0/go.mod h1:O9uiLokuu0+MGFlyiaqtWxwqJm41/+8Nj0lD7A36YH0=
 github.com/invopop/jsonschema v0.6.1-0.20220804171514-4a807f958afc h1:oahLky411E49pZs591QDuPE4gbofMkw4SNT0xOPU6ZA=
 github.com/invopop/jsonschema v0.6.1-0.20220804171514-4a807f958afc/go.mod h1:O9uiLokuu0+MGFlyiaqtWxwqJm41/+8Nj0lD7A36YH0=
+github.com/invopop/jsonschema v0.7.0 h1:2vgQcBz1n256N+FpX3Jq7Y17AjYt46Ig3zIWyy770So=
+github.com/invopop/jsonschema v0.7.0/go.mod h1:O9uiLokuu0+MGFlyiaqtWxwqJm41/+8Nj0lD7A36YH0=
 github.com/invopop/yaml v0.1.0 h1:YW3WGUoJEXYfzWBjn00zIlrw7brGVD0fUKRYDPAPhrc=
 github.com/invopop/yaml v0.1.0/go.mod h1:2XuRLgs/ouIrW3XNzuNj7J3Nvu/Dig5MXvbCEdiBN3Q=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=

--- a/pay/instructions.go
+++ b/pay/instructions.go
@@ -27,11 +27,11 @@ const (
 // that can be accepted by GOBL.
 type MethodKeyDef struct {
 	// Key being described
-	Key MethodKey `json:"key" jsonschema:"Key"`
+	Key MethodKey `json:"key" jsonschema:"title=Key"`
 	// Details about the meaning of the key
-	Description string `json:"description" jsonschema:"Description"`
+	Description string `json:"description" jsonschema:"title=Description"`
 	// UNTDID 4461 Equivalent Code
-	UNTDID4461 org.Code `json:"untdid4461" jsonschema:"UNTDID 4461 Code"`
+	UNTDID4461 org.Code `json:"untdid4461" jsonschema:"title=UNTDID 4461 Code"`
 }
 
 // MethodKeyDefinitions includes all the payment method keys that


### PR DESCRIPTION
* Bill Invoice `preceding` property now changed to an array in case there are multiple preceding invoices to be modified.
* Upgraded to latest JSON Schema generator
* Correction key options now included in schema.