### PR TITLE
Use alternative CO tax name

### DIFF
--- a/build/data/tax/CO.json
+++ b/build/data/tax/CO.json
@@ -408,7 +408,7 @@
     {
       "code": "RR",
       "name": {
-        "es": "ReteRenta"
+        "es": "Retefuente"
       },
       "desc": {
         "es": "Retención en la fuente por el Impuesto de la Renta"

--- a/regions/co/co.go
+++ b/regions/co/co.go
@@ -204,7 +204,7 @@ func Region() *tax.Region {
 			{
 				Code: TaxCategoryReteRenta,
 				Name: i18n.String{
-					i18n.ES: "ReteRenta",
+					i18n.ES: "Retefuente",
 				},
 				Desc: i18n.String{
 					i18n.ES: "Retención en la fuente por el Impuesto de la Renta",


### PR DESCRIPTION
* Apparently, the ReteRenta tax is commonly known as "Retefuente". This is how the DIAN itself calls it in their own PDF invoice representations.