### PR TITLE
Preceding stamps

### DIFF
--- a/bill/preceding.go
+++ b/bill/preceding.go
@@ -26,6 +26,8 @@ type Preceding struct {
 	Corrections []CorrectionKey `json:"corrections,omitempty" jsonschema:"title=Corrections"`
 	// How has the previous invoice been corrected?
 	CorrectionMethod CorrectionMethodKey `json:"correction_method,omitempty" jsonschema:"title=Correction Method"`
+	// Seals of approval from other organisations.
+	Stamps []*org.Stamp `json:"stamps,omitempty" jsonschema:"title=Stamps"`
 	// Additional details regarding preceding invoice
 	Notes string `json:"notes,omitempty" jsonschema:"title=Notes"`
 	// Additional semi-structured data that may be useful in specific regions
@@ -42,6 +44,7 @@ func (p *Preceding) Validate() error {
 		validation.Field(&p.Period),
 		validation.Field(&p.Corrections, validation.Each(isValidCorrectionKey)),
 		validation.Field(&p.CorrectionMethod, isValidCorrectionMethodKey),
+		validation.Field(&p.Stamps),
 		validation.Field(&p.Meta),
 	)
 }
@@ -133,6 +136,7 @@ func validCorrectionKeys() []interface{} {
 // Defined list of correction methods
 const (
 	CompleteCorrectionMethodKey   CorrectionMethodKey = "complete"   // everything has changed
+	RevokedCorrectionMethodKey    CorrectionMethodKey = "revoked"    // previous document has been completely cancelled
 	PartialCorrectionMethodKey    CorrectionMethodKey = "partial"    // only differences corrected
 	DiscountCorrectionMethodKey   CorrectionMethodKey = "discount"   // deducted from future invoices
 	AuthorizedCorrectionMethodKey CorrectionMethodKey = "authorized" // Permitted by tax agency
@@ -150,6 +154,7 @@ type CorrectionMethodKeyDef struct {
 // purposes.
 var CorrectionMethodKeyDefinitions = []CorrectionMethodKeyDef{
 	{CompleteCorrectionMethodKey, "Everything has changed, this document replaces the previous one."},
+	{RevokedCorrectionMethodKey, "Previous document has been completely revoked."},
 	{PartialCorrectionMethodKey, "Only differences corrected."},
 	{DiscountCorrectionMethodKey, "Deducted from future invoices."},
 	{AuthorizedCorrectionMethodKey, "Permitted by tax agency."},

--- a/header.go
+++ b/header.go
@@ -17,7 +17,7 @@ type Header struct {
 	Digest *dsig.Digest `json:"dig" jsonschema:"title=Digest"`
 
 	// Seals of approval from other organisations.
-	Stamps []*Stamp `json:"stamps,omitempty" jsonschema:"title=Stamps"`
+	Stamps []*org.Stamp `json:"stamps,omitempty" jsonschema:"title=Stamps"`
 
 	// Set of labels that describe but have no influence on the data.
 	Tags []string `json:"tags,omitempty" jsonschema:"title=Tags"`
@@ -40,19 +40,11 @@ func NewHeader() *Header {
 	return h
 }
 
-// Stamp defines an official seal of approval from a third party like a governmental agency
-// or intermediary and should thus be included in any official envelopes.
-type Stamp struct {
-	// Identity of the agency used to create the stamp usually defined by each region.
-	Provider org.Key `json:"prv" jsonschema:"title=Provider"`
-	// The serialized stamp value generated for or by the external agency
-	Value string `json:"val" jsonschema:"title=Value"`
-}
-
 // Validate checks that the header contains the basic information we need to function.
 func (h *Header) Validate() error {
 	return validation.ValidateStruct(h,
 		validation.Field(&h.UUID, validation.Required, uuid.IsV1),
 		validation.Field(&h.Digest, validation.Required),
+		validation.Field(&h.Stamps),
 	)
 }

--- a/header_test.go
+++ b/header_test.go
@@ -16,5 +16,5 @@ func TestNewHeader(t *testing.T) {
 		h.Meta["foo"] = "bar"
 		h.Tags = append(h.Tags, "foo")
 		h.Stamps = append(h.Stamps, &org.Stamp{})
-	})
+	}, "header and meta hash should have been initialized")
 }

--- a/header_test.go
+++ b/header_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/invopop/gobl"
+	"github.com/invopop/gobl/org"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -14,6 +15,6 @@ func TestNewHeader(t *testing.T) {
 	assert.NotPanics(t, func() {
 		h.Meta["foo"] = "bar"
 		h.Tags = append(h.Tags, "foo")
-		h.Stamps = append(h.Stamps, &gobl.Stamp{})
+		h.Stamps = append(h.Stamps, &org.Stamp{})
 	})
 }

--- a/org/stamps.go
+++ b/org/stamps.go
@@ -1,0 +1,20 @@
+package org
+
+import validation "github.com/go-ozzo/ozzo-validation/v4"
+
+// Stamp defines an official seal of approval from a third party like a governmental agency
+// or intermediary and should thus be included in any official envelopes.
+type Stamp struct {
+	// Identity of the agency used to create the stamp usually defined by each region.
+	Provider Key `json:"prv" jsonschema:"title=Provider"`
+	// The serialized stamp value generated for or by the external agency
+	Value string `json:"val" jsonschema:"title=Value"`
+}
+
+// Validate checks that the header contains the basic information we need to function.
+func (s *Stamp) Validate() error {
+	return validation.ValidateStruct(s,
+		validation.Field(&s.Provider, validation.Required),
+		validation.Field(&s.Value, validation.Required),
+	)
+}


### PR DESCRIPTION
* Moving `Stamp` from header to `org` package so it can be re-used.
* Adding stamps to bill.Preceding
* Adding new use-case for "revoked" correction method.