### PR TITLE
Image support for org party and person

### DIFF
--- a/build/schemas/org/image.json
+++ b/build/schemas/org/image.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://gobl.org/draft-0/org/image",
+  "$ref": "#/$defs/Image",
+  "$defs": {
+    "Image": {
+      "properties": {
+        "uuid": {
+          "$ref": "https://gobl.org/draft-0/uuid/uuid",
+          "title": "UUID",
+          "description": "Unique ID of the image"
+        },
+        "label": {
+          "type": "string",
+          "title": "Label",
+          "description": "Label to help identify the image."
+        },
+        "url": {
+          "type": "string",
+          "title": "URL",
+          "description": "URL of the image"
+        },
+        "data": {
+          "type": "string",
+          "contentEncoding": "base64",
+          "title": "Data",
+          "description": "As an alternative to the URL and only when the source data is small,\nlike an SVG, the raw data may be provided using Base64 encoding."
+        },
+        "mime": {
+          "type": "string",
+          "title": "MIME",
+          "description": "Format of the image."
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Details of what the image represents."
+        },
+        "alt": {
+          "type": "string",
+          "title": "Alt",
+          "description": "Alternative text if the image cannot be shown."
+        },
+        "height": {
+          "type": "integer",
+          "title": "Height",
+          "description": "Height of the image in pixels."
+        },
+        "width": {
+          "type": "integer",
+          "title": "Width",
+          "description": "Width of the image in pixels."
+        },
+        "digest": {
+          "$ref": "https://gobl.org/draft-0/dsig/digest",
+          "title": "Digest",
+          "description": "Digest can be used to ensure the image contained at the URL\nis the same one as originally intended."
+        }
+      },
+      "type": "object",
+      "description": "Image describes a logo or photo that represents an entity."
+    }
+  },
+  "$comment": "Generated with GOBL v0.34.1"
+}

--- a/build/schemas/org/party.json
+++ b/build/schemas/org/party.json
@@ -83,6 +83,14 @@
           "title": "Registration",
           "description": "Additional registration details about the company that may need to be included in a document."
         },
+        "logos": {
+          "items": {
+            "$ref": "https://gobl.org/draft-0/org/image"
+          },
+          "type": "array",
+          "title": "Logos",
+          "description": "Images that can be used to identify the party visually."
+        },
         "meta": {
           "$ref": "https://gobl.org/draft-0/cbc/meta",
           "title": "Meta",

--- a/build/schemas/org/person.json
+++ b/build/schemas/org/person.json
@@ -41,6 +41,14 @@
           "title": "Telephone Numbers",
           "description": "Regular phone or mobile numbers"
         },
+        "avatars": {
+          "items": {
+            "$ref": "https://gobl.org/draft-0/org/image"
+          },
+          "type": "array",
+          "title": "Avatars",
+          "description": "Avatars provider links to images or photos or the person."
+        },
         "meta": {
           "$ref": "https://gobl.org/draft-0/cbc/meta",
           "title": "Meta",

--- a/build/schemas/tax/regime.json
+++ b/build/schemas/tax/regime.json
@@ -60,7 +60,7 @@
           },
           "type": "array",
           "title": "Values",
-          "description": "Values contains a list of Value objects that contain the\ncurrent and historical percentage values for the rate;\norder is important, newer values should come before\nolder values."
+          "description": "Values contains a list of Value objects that contain the\ncurrent and historical percentage values for the rate and\nadditional filters.\nOrder is important, newer values should come before\nolder values."
         }
       },
       "type": "object",
@@ -73,6 +73,14 @@
     },
     "RateValue": {
       "properties": {
+        "zones": {
+          "items": {
+            "$ref": "https://gobl.org/draft-0/l10n/code"
+          },
+          "type": "array",
+          "title": "Zones",
+          "description": "Only use this value if one of the zones matches."
+        },
         "since": {
           "$ref": "https://gobl.org/draft-0/cal/date",
           "title": "Since",

--- a/org/image.go
+++ b/org/image.go
@@ -16,7 +16,10 @@ type Image struct {
 	// Label to help identify the image.
 	Label string `json:"label,omitempty" jsonschema:"title=Label"`
 	// URL of the image
-	URL string `json:"url" jsonschema:"title=URL"`
+	URL string `json:"url,omitempty" jsonschema:"title=URL"`
+	// As an alternative to the URL and only when the source data is small,
+	// like an SVG, the raw data may be provided using Base64 encoding.
+	Data []byte `json:"data,omitempty" jsonschema:"title=Data"`
 	// Format of the image.
 	MIME string `json:"mime,omitempty" jsonschema:"title=MIME"`
 	// Details of what the image represents.
@@ -36,7 +39,7 @@ type Image struct {
 func (i *Image) Validate() error {
 	return validation.ValidateStruct(i,
 		validation.Field(&i.UUID),
-		validation.Field(&i.URL, validation.Required, is.URL),
+		validation.Field(&i.URL, is.URL),
 		validation.Field(&i.Height, validation.Min(1), validation.Max(2048)),
 		validation.Field(&i.Width, validation.Min(1), validation.Max(2048)),
 		validation.Field(&i.Digest),

--- a/org/image.go
+++ b/org/image.go
@@ -1,0 +1,44 @@
+package org
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"github.com/go-ozzo/ozzo-validation/v4/is"
+	"github.com/invopop/gobl/dsig"
+	"github.com/invopop/gobl/uuid"
+)
+
+// Image describes a logo or photo that represents an entity. Most
+// details except the URL are optional, but are potentially useful
+// for validation if that's a requirement for the use case.
+type Image struct {
+	// Unique ID of the image
+	UUID *uuid.UUID `json:"uuid,omitempty" jsonschema:"title=UUID"`
+	// Label to help identify the image.
+	Label string `json:"label,omitempty" jsonschema:"title=Label"`
+	// URL of the image
+	URL string `json:"url" jsonschema:"title=URL"`
+	// Format of the image.
+	MIME string `json:"mime,omitempty" jsonschema:"title=MIME"`
+	// Details of what the image represents.
+	Description string `json:"description,omitempty" jsonschema:"title=Description"`
+	// Alternative text if the image cannot be shown.
+	Alt string `json:"alt,omitempty" jsonschema:"title=Alt"`
+	// Height of the image in pixels.
+	Height int32 `json:"height,omitempty" jsonschema:"title=Height"`
+	// Width of the image in pixels.
+	Width int32 `json:"width,omitempty" jsonschema:"title=Width"`
+	// Digest can be used to ensure the image contained at the URL
+	// is the same one as originally intended.
+	Digest *dsig.Digest `json:"digest,omitempty" jsonschema:"title=Digest"`
+}
+
+// Validate ensures the details on the image look okay.
+func (i *Image) Validate() error {
+	return validation.ValidateStruct(i,
+		validation.Field(&i.UUID),
+		validation.Field(&i.URL, validation.Required, is.URL),
+		validation.Field(&i.Height, validation.Min(1), validation.Max(2048)),
+		validation.Field(&i.Width, validation.Min(1), validation.Max(2048)),
+		validation.Field(&i.Digest),
+	)
+}

--- a/org/org.go
+++ b/org/org.go
@@ -15,5 +15,6 @@ func init() {
 		Telephone{},
 		Registration{},
 		Inbox{},
+		Image{},
 	)
 }

--- a/org/party.go
+++ b/org/party.go
@@ -35,6 +35,8 @@ type Party struct {
 	Telephones []*Telephone `json:"telephones,omitempty" jsonschema:"title=Telephone Numbers"`
 	// Additional registration details about the company that may need to be included in a document.
 	Registration *Registration `json:"registration,omitempty" jsonschema:"title=Registration"`
+	// Images that can be used to identify the party visually.
+	Logos []*Image `json:"logos,omitempty" jsonschema:"title=Logos"`
 	// Any additional semi-structured information that does not fit into the rest of the party.
 	Meta cbc.Meta `json:"meta,omitempty" jsonschema:"title=Meta"`
 }
@@ -53,6 +55,8 @@ type Person struct {
 	Emails []*Email `json:"emails,omitempty" jsonschema:"title=Email Addresses"`
 	// Regular phone or mobile numbers
 	Telephones []*Telephone `json:"telephones,omitempty" jsonschema:"title=Telephone Numbers"`
+	// Avatars provider links to images or photos or the person.
+	Avatars []*Image `json:"avatars,omitempty" jsonschema:"title=Avatars"`
 	// Data about the data.
 	Meta cbc.Meta `json:"meta,omitempty" jsonschema:"title=Meta"`
 }
@@ -151,6 +155,7 @@ func (p *Party) Validate() error {
 		validation.Field(&p.People),
 		validation.Field(&p.Emails),
 		validation.Field(&p.Telephones),
+		validation.Field(&p.Logos),
 		validation.Field(&p.Websites),
 	)
 }


### PR DESCRIPTION
Use-Case: be able to include details about a logo so that companies who issue invoices on behalf of others can include images in PDF output, etc.

* First approximation for adding an "Image" structure to the `org` package.
* Added `logos` to `Party`.
* Added `avatars` to `Person`.

The objective of this PR is to add support for being to include company logo details inside the original GOBL. The logo provided for a party can then be used inside PDFs or other output formats instead of the configuration of a provider.

There may be an argument for being able to embed the actual image in Base64, but I'm not sure about that yet. Could work well for SVGs. Thoughts?