### PR TITLE
Rename "cufe" to the more generic "cude" in stamps

### DIFF
--- a/regimes/co/co.go
+++ b/regimes/co/co.go
@@ -28,8 +28,8 @@ const (
 
 // DIAN official codes to include in stamps.
 const (
-	StampProviderDIANCUDE org.Key = "dian-cude"
-	StampProviderDIANQR   org.Key = "dian-qr"
+	StampProviderDIANCUDE cbc.Key = "dian-cude"
+	StampProviderDIANQR   cbc.Key = "dian-qr"
 )
 
 // New provides the tax region definition

--- a/regimes/co/co.go
+++ b/regimes/co/co.go
@@ -28,8 +28,8 @@ const (
 
 // DIAN official codes to include in stamps.
 const (
-	StampProviderDIANCUFE cbc.Key = "dian-cufe"
-	StampProviderDIANQR   cbc.Key = "dian-qr"
+	StampProviderDIANCUDE org.Key = "dian-cude"
+	StampProviderDIANQR   org.Key = "dian-qr"
 )
 
 // New provides the tax region definition


### PR DESCRIPTION
* Rename CUFE (Código Único de Factura Electrónica) to the more generic term CUDE (Código Único de Documento Electrónico) that can be used with invoices and credit notes
* Related: 
  * invopop/plemsi#22
  * invopop/pdf#48