### PR TITLE
Aligning ordering details with EN16931

### DIFF
--- a/bill/delivery.go
+++ b/bill/delivery.go
@@ -13,9 +13,9 @@ type Delivery struct {
 	Receiver *org.Party `json:"receiver,omitempty" jsonschema:"title=Receiver"`
 	// When the goods should be expected
 	Date *cal.Date `json:"date,omitempty" jsonschema:"title=Date"`
-	// Start of a n invoicing or delivery period
+	// Start of an invoicing or delivery period
 	StartDate *cal.Date `json:"start_date,omitempty" jsonschema:"title=Start Date"`
-	// End of a n invoicing or delivery period
+	// End of an invoicing or delivery period
 	EndDate *cal.Date `json:"end_date,omitempty" jsonschema:"title=End Date"`
 }
 

--- a/bill/invoice.go
+++ b/bill/invoice.go
@@ -24,10 +24,10 @@ type Invoice struct {
 	// Unique document ID. Not required, but always recommended in addition to the Code.
 	UUID *uuid.UUID `json:"uuid,omitempty" jsonschema:"title=UUID"`
 
+	// Used as a prefix to group codes.
+	Series string `json:"series,omitempty" jsonschema:"title=Series"`
 	// Sequential code used to identify this invoice in tax declarations.
 	Code string `json:"code" jsonschema:"title=Code"`
-	// Used in addition to the Code in some regions.
-	Series string `json:"series,omitempty" jsonschema:"title=Series"`
 	// Optional invoice type, leave empty unless needed for a specific situation.
 	Type InvoiceType `json:"type,omitempty" jsonschema:"title=Type"`
 	// Currency for all invoice totals.
@@ -62,8 +62,11 @@ type Invoice struct {
 	// Expenses paid for by the supplier but invoiced directly to the customer.
 	Outlays []*Outlay `json:"outlays,omitempty" jsonschema:"title=Outlays"`
 
+	// Ordering details including document references and buyer or seller parties.
 	Ordering *Ordering `json:"ordering,omitempty" jsonschema:"title=Ordering Details"`
-	Payment  *Payment  `json:"payment,omitempty" jsonschema:"title=Payment Details"`
+	// Information on when, how, and to whom the invoice should be paid.
+	Payment *Payment `json:"payment,omitempty" jsonschema:"title=Payment Details"`
+	// Specific details on delivery of the goods referenced in the invoice.
 	Delivery *Delivery `json:"delivery,omitempty" jsonschema:"title=Delivery Details"`
 
 	// Summary of all the invoice totals, including taxes (calculated).

--- a/bill/ordering.go
+++ b/bill/ordering.go
@@ -41,8 +41,8 @@ type DocumentReference struct {
 	UUID *uuid.UUID `json:"uuid,omitempty" jsonschema:"title=UUID"`
 	// Series the reference document belongs to.
 	Series string `json:"series,omitempty" jsonschema:"title=Series"`
-	// Source document's code.
-	Code string `json:"code" jsonschema:"title=Code"`
+	// Source document's code or other identifier.
+	Code string `json:"code,omitempty" jsonschema:"title=Code"`
 	// Link to the source document.
 	URL string `json:"url,omitempty" jsonschema:"title=URL,format=uri"`
 }
@@ -66,7 +66,7 @@ func (o *Ordering) Validate() error {
 func (dr *DocumentReference) Validate() error {
 	return validation.ValidateStruct(dr,
 		validation.Field(&dr.UUID),
-		validation.Field(&dr.Code, validation.Required),
+		validation.Field(&dr.Code),
 		validation.Field(&dr.URL, is.URL),
 	)
 }

--- a/bill/ordering.go
+++ b/bill/ordering.go
@@ -2,18 +2,71 @@ package bill
 
 import (
 	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"github.com/go-ozzo/ozzo-validation/v4/is"
 	"github.com/invopop/gobl/org"
+	"github.com/invopop/gobl/uuid"
 )
 
-// Ordering allows additional order details to be appended
+// Ordering provides additional information about the ordering process including references
+// to other documents and alternative parties involved in the order-to-delivery process.
 type Ordering struct {
-	// Party who is selling the goods and is not responsible for taxes
+	// Identifier assigned by the customer or buyer for internal routing purposes.
+	Code string `json:"code,omitempty" jsonschema:"title=Code"`
+	// Project this invoice refers to.
+	Project *DocumentReference `json:"project,omitempty" jsonschema:"title=Project"`
+	// The identification of a contract.
+	Contract *DocumentReference `json:"contract,omitempty" jsonschema:"title=Contract"`
+	// Purchase order issued by the customer or buyer.
+	Purchase *DocumentReference `json:"purchase,omitempty" jsonschema:"title=Purchase Order"`
+	// Sales order issued by the supplier or seller.
+	Sale *DocumentReference `json:"sale,omitempty" jsonschena:"title=Sales Order"`
+	// Receiving Advice.
+	Receiving *DocumentReference `json:"receiving,omitempty" jsonschame:"title=Receiving Advice"`
+	// Despatch advice.
+	Despatch *DocumentReference `json:"despatch,omitempty" jsonschema:"title=Despatch Advice"`
+	// Tender advice, the identification of the call for tender or lot the invoice relates to.
+	Tender *DocumentReference `json:"tender,omitempty" jsonscheme:"title=Tender Advice"`
+
+	// Party who is responsible for making the purchase, but is not responsible
+	// for handling taxes.
+	Buyer *org.Party `json:"buyer,omitempty" jsonschema:"title=Buyer"`
+	// Party who is selling the goods but is not responsible for taxes like the
+	// supplier.
 	Seller *org.Party `json:"seller,omitempty" jsonschema:"title=Seller"`
+}
+
+// DocumentReference provides a link to a existing document.
+type DocumentReference struct {
+	// Unique ID copied from the source document.
+	UUID *uuid.UUID `json:"uuid,omitempty" jsonschema:"title=UUID"`
+	// Series the reference document belongs to.
+	Series string `json:"series,omitempty" jsonschema:"title=Series"`
+	// Source document's code.
+	Code string `json:"code" jsonschema:"title=Code"`
+	// Link to the source document.
+	URL string `json:"url,omitempty" jsonschema:"title=URL,format=uri"`
 }
 
 // Validate the ordering details.
 func (o *Ordering) Validate() error {
 	return validation.ValidateStruct(o,
+		validation.Field(&o.Project),
+		validation.Field(&o.Contract),
+		validation.Field(&o.Purchase),
+		validation.Field(&o.Sale),
+		validation.Field(&o.Receiving),
+		validation.Field(&o.Despatch),
+		validation.Field(&o.Tender),
+		validation.Field(&o.Buyer),
 		validation.Field(&o.Seller),
+	)
+}
+
+// Validate ensures the Document Reference looks correct.
+func (dr *DocumentReference) Validate() error {
+	return validation.ValidateStruct(dr,
+		validation.Field(&dr.UUID),
+		validation.Field(&dr.Code, validation.Required),
+		validation.Field(&dr.URL, is.URL),
 	)
 }

--- a/bill/payment.go
+++ b/bill/payment.go
@@ -9,8 +9,8 @@ import (
 
 // Payment contains details as to how the invoice should be paid.
 type Payment struct {
-	// The party responsible for paying for the invoice, if not the customer.
-	Payer *org.Party `json:"payer,omitempty" jsonschema:"title=Payer"`
+	// The party responsible for receiving payment of the invoice, if not the supplier.
+	Payee *org.Party `json:"payee,omitempty" jsonschema:"title=Payer"`
 	// Payment terms or conditions.
 	Terms *pay.Terms `json:"terms,omitempty" jsonschema:"title=Terms"`
 	// Any amounts that have been paid in advance and should be deducted from the amount due.
@@ -22,7 +22,7 @@ type Payment struct {
 // Validate checks to make sure the payment data looks good
 func (p *Payment) Validate() error {
 	return validation.ValidateStruct(p,
-		validation.Field(&p.Payer),
+		validation.Field(&p.Payee),
 		validation.Field(&p.Terms),
 		validation.Field(&p.Advances),
 		validation.Field(&p.Instructions),

--- a/build/schemas/bill/invoice.json
+++ b/build/schemas/bill/invoice.json
@@ -175,7 +175,7 @@
         "code": {
           "type": "string",
           "title": "Code",
-          "description": "Source document's code."
+          "description": "Source document's code or other identifier."
         },
         "url": {
           "type": "string",
@@ -185,9 +185,6 @@
         }
       },
       "type": "object",
-      "required": [
-        "code"
-      ],
       "description": "DocumentReference provides a link to a existing document."
     },
     "ExchangeRates": {

--- a/build/schemas/bill/invoice.json
+++ b/build/schemas/bill/invoice.json
@@ -87,12 +87,12 @@
         "start_date": {
           "$ref": "https://gobl.org/draft-0/cal/date",
           "title": "Start Date",
-          "description": "Start of a n invoicing or delivery period"
+          "description": "Start of an invoicing or delivery period"
         },
         "end_date": {
           "$ref": "https://gobl.org/draft-0/cal/date",
           "title": "End Date",
-          "description": "End of a n invoicing or delivery period"
+          "description": "End of an invoicing or delivery period"
         }
       },
       "type": "object",
@@ -160,6 +160,36 @@
       ],
       "description": "Discount represents an allowance applied to the complete document independent from the individual lines."
     },
+    "DocumentReference": {
+      "properties": {
+        "uuid": {
+          "$ref": "https://gobl.org/draft-0/uuid/uuid",
+          "title": "UUID",
+          "description": "Unique ID copied from the source document."
+        },
+        "series": {
+          "type": "string",
+          "title": "Series",
+          "description": "Series the reference document belongs to."
+        },
+        "code": {
+          "type": "string",
+          "title": "Code",
+          "description": "Source document's code."
+        },
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "title": "URL",
+          "description": "Link to the source document."
+        }
+      },
+      "type": "object",
+      "required": [
+        "code"
+      ],
+      "description": "DocumentReference provides a link to a existing document."
+    },
     "ExchangeRates": {
       "items": {
         "$ref": "https://gobl.org/draft-0/currency/exchange-rate"
@@ -174,15 +204,15 @@
           "title": "UUID",
           "description": "Unique document ID. Not required, but always recommended in addition to the Code."
         },
+        "series": {
+          "type": "string",
+          "title": "Series",
+          "description": "Used as a prefix to group codes."
+        },
         "code": {
           "type": "string",
           "title": "Code",
           "description": "Sequential code used to identify this invoice in tax declarations."
-        },
-        "series": {
-          "type": "string",
-          "title": "Series",
-          "description": "Used in addition to the Code in some regions."
         },
         "type": {
           "$ref": "#/$defs/InvoiceType",
@@ -271,15 +301,18 @@
         },
         "ordering": {
           "$ref": "#/$defs/Ordering",
-          "title": "Ordering Details"
+          "title": "Ordering Details",
+          "description": "Ordering details including document references and buyer or seller parties."
         },
         "payment": {
           "$ref": "#/$defs/Payment",
-          "title": "Payment Details"
+          "title": "Payment Details",
+          "description": "Information on when, how, and to whom the invoice should be paid."
         },
         "delivery": {
           "$ref": "#/$defs/Delivery",
-          "title": "Delivery Details"
+          "title": "Delivery Details",
+          "description": "Specific details on delivery of the goods referenced in the invoice."
         },
         "totals": {
           "$ref": "#/$defs/Totals",
@@ -483,14 +516,56 @@
     },
     "Ordering": {
       "properties": {
+        "code": {
+          "type": "string",
+          "title": "Code",
+          "description": "Identifier assigned by the customer or buyer for internal routing purposes."
+        },
+        "project": {
+          "$ref": "#/$defs/DocumentReference",
+          "title": "Project",
+          "description": "Project this invoice refers to."
+        },
+        "contract": {
+          "$ref": "#/$defs/DocumentReference",
+          "title": "Contract",
+          "description": "The identification of a contract."
+        },
+        "purchase": {
+          "$ref": "#/$defs/DocumentReference",
+          "title": "Purchase Order",
+          "description": "Purchase order issued by the customer or buyer."
+        },
+        "sale": {
+          "$ref": "#/$defs/DocumentReference",
+          "description": "Sales order issued by the supplier or seller."
+        },
+        "receiving": {
+          "$ref": "#/$defs/DocumentReference",
+          "description": "Receiving Advice."
+        },
+        "despatch": {
+          "$ref": "#/$defs/DocumentReference",
+          "title": "Despatch Advice",
+          "description": "Despatch advice."
+        },
+        "tender": {
+          "$ref": "#/$defs/DocumentReference",
+          "description": "Tender advice, the identification of the call for tender or lot the invoice relates to."
+        },
+        "buyer": {
+          "$ref": "https://gobl.org/draft-0/org/party",
+          "title": "Buyer",
+          "description": "Party who is responsible for making the purchase, but is not responsible\nfor handling taxes."
+        },
         "seller": {
           "$ref": "https://gobl.org/draft-0/org/party",
           "title": "Seller",
-          "description": "Party who is selling the goods and is not responsible for taxes"
+          "description": "Party who is selling the goods but is not responsible for taxes like the\nsupplier."
         }
       },
       "type": "object",
-      "description": "Ordering allows additional order details to be appended"
+      "description": "Ordering provides additional information about the ordering process including references to other documents and alternative parties involved in the order-to-delivery process."
     },
     "Outlay": {
       "properties": {
@@ -546,10 +621,10 @@
     },
     "Payment": {
       "properties": {
-        "payer": {
+        "payee": {
           "$ref": "https://gobl.org/draft-0/org/party",
           "title": "Payer",
-          "description": "The party responsible for paying for the invoice, if not the customer."
+          "description": "The party responsible for receiving payment of the invoice, if not the supplier."
         },
         "terms": {
           "$ref": "https://gobl.org/draft-0/pay/terms",

--- a/build/schemas/org/party.json
+++ b/build/schemas/org/party.json
@@ -62,6 +62,13 @@
           "title": "Email Addresses",
           "description": "Electronic mail addresses"
         },
+        "websites": {
+          "items": {
+            "$ref": "#/$defs/Website"
+          },
+          "type": "array",
+          "title": "Websites"
+        },
         "telephones": {
           "items": {
             "$ref": "https://gobl.org/draft-0/org/telephone"
@@ -86,6 +93,36 @@
         "name"
       ],
       "description": "Party represents a person or business entity."
+    },
+    "Website": {
+      "properties": {
+        "uuid": {
+          "$ref": "https://gobl.org/draft-0/uuid/uuid",
+          "title": "UUID",
+          "description": "Unique identity code"
+        },
+        "label": {
+          "type": "string",
+          "title": "Label",
+          "description": "Identifier for this number."
+        },
+        "title": {
+          "type": "string",
+          "title": "Title",
+          "description": "Title of the website to help distinguish between this and other links."
+        },
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "title": "URL",
+          "description": "URL for the website."
+        }
+      },
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "description": "Website describes what is expected for a web address."
     }
   },
   "$comment": "Generated with GOBL v0.34.1"

--- a/build/schemas/org/party.json
+++ b/build/schemas/org/party.json
@@ -67,7 +67,8 @@
             "$ref": "#/$defs/Website"
           },
           "type": "array",
-          "title": "Websites"
+          "title": "Websites",
+          "description": "Public websites that provide further information about the party."
         },
         "telephones": {
           "items": {

--- a/org/party.go
+++ b/org/party.go
@@ -29,6 +29,8 @@ type Party struct {
 	Addresses []*Address `json:"addresses,omitempty" jsonschema:"title=Postal Addresses"`
 	// Electronic mail addresses
 	Emails []*Email `json:"emails,omitempty" jsonschema:"title=Email Addresses"`
+	//
+	Websites []*Website `json:"websites,omitempty" jsonschema:"title=Websites"`
 	// Regular telephone numbers
 	Telephones []*Telephone `json:"telephones,omitempty" jsonschema:"title=Telephone Numbers"`
 	// Additional registration details about the company that may need to be included in a document.
@@ -101,6 +103,18 @@ type Telephone struct {
 	Number string `json:"num" jsonschema:"title=Number"`
 }
 
+// Website describes what is expected for a web address.
+type Website struct {
+	// Unique identity code
+	UUID *uuid.UUID `json:"uuid,omitempty" jsonschema:"title=UUID"`
+	// Identifier for this number.
+	Label string `json:"label,omitempty" jsonschema:"title=Label"`
+	// Title of the website to help distinguish between this and other links.
+	Title string `json:"title,omitempty" jsonschema:"title=Title"`
+	// URL for the website.
+	URL string `json:"url" jsonschema:"title=URL,format=uri"`
+}
+
 // Registration is used in countries that require additional information to be associated
 // with a company usually related to a specific registration office.
 // The definition found here is based on the details required for spain.
@@ -137,6 +151,7 @@ func (p *Party) Validate() error {
 		validation.Field(&p.People),
 		validation.Field(&p.Emails),
 		validation.Field(&p.Telephones),
+		validation.Field(&p.Websites),
 	)
 }
 
@@ -151,5 +166,12 @@ func (e *Email) Validate() error {
 func (t *Telephone) Validate() error {
 	return validation.ValidateStruct(t,
 		validation.Field(&t.Number, validation.Required, is.E164),
+	)
+}
+
+// Validate checks the telephone objects number to ensure it looks correct.
+func (w *Website) Validate() error {
+	return validation.ValidateStruct(w,
+		validation.Field(&w.URL, validation.Required, is.URL),
 	)
 }

--- a/org/party.go
+++ b/org/party.go
@@ -29,7 +29,7 @@ type Party struct {
 	Addresses []*Address `json:"addresses,omitempty" jsonschema:"title=Postal Addresses"`
 	// Electronic mail addresses
 	Emails []*Email `json:"emails,omitempty" jsonschema:"title=Email Addresses"`
-	//
+	// Public websites that provide further information about the party.
 	Websites []*Website `json:"websites,omitempty" jsonschema:"title=Websites"`
 	// Regular telephone numbers
 	Telephones []*Telephone `json:"telephones,omitempty" jsonschema:"title=Telephone Numbers"`


### PR DESCRIPTION
* After comments about being able to include purchase order details from clients, we realised that GOBL was not completely in sync with the EN16931-1:2017 standard.
* Added `websites` property to `org.Party` which for some reason had been forgotten about!