### PR TITLE
Fix tax included bug when using percentage instead of rate

### DIFF
--- a/tax/totals.go
+++ b/tax/totals.go
@@ -128,8 +128,7 @@ func (tc *TotalCalculator) Calculate(t *Total) error {
 	// we'll add an extra couple of 0s.
 	if !tc.Includes.IsEmpty() {
 		for _, tl := range taxLines {
-			if rate := tl.rateForCategory(tc.Includes); rate != "" {
-				c := tl.taxes.Get(tc.Includes)
+			if c := tl.taxes.Get(tc.Includes); c != nil {
 				if c.category.Retained {
 					return ErrInvalidPricesInclude.WithMessage("cannot include retained category '%s'", tc.Includes.String())
 				}
@@ -240,10 +239,6 @@ func (t *Total) rateTotalFor(c *Combo, zero num.Amount) *RateTotal {
 type taxLine struct {
 	price num.Amount
 	taxes Set
-}
-
-func (tl *taxLine) rateForCategory(code cbc.Code) cbc.Key {
-	return tl.taxes.Rate(code)
 }
 
 func mapTaxLines(lines []TaxableLine) []*taxLine {

--- a/tax/totals_test.go
+++ b/tax/totals_test.go
@@ -491,6 +491,53 @@ func TestTotalCalculate(t *testing.T) {
 			},
 		},
 		{
+			desc: "with multirate VAT as percentages, and included in price",
+			lines: []tax.TaxableLine{
+				&taxableLine{
+					taxes: tax.Set{
+						{
+							Category: common.TaxCategoryVAT,
+							Percent:  num.MakePercentage(210, 3),
+						},
+					},
+					amount: num.MakeAmount(10000, 2),
+				},
+				&taxableLine{
+					taxes: tax.Set{
+						{
+							Category: common.TaxCategoryVAT,
+							Percent:  num.MakePercentage(100, 3),
+						},
+					},
+					amount: num.MakeAmount(15000, 2),
+				},
+			},
+			taxIncluded: common.TaxCategoryVAT,
+			want: &tax.Total{
+				Categories: []*tax.CategoryTotal{
+					{
+						Code:     common.TaxCategoryVAT,
+						Retained: false,
+						Rates: []*tax.RateTotal{
+							{
+								Base:    num.MakeAmount(8264, 2),
+								Percent: num.MakePercentage(210, 3),
+								Amount:  num.MakeAmount(1736, 2),
+							},
+							{
+								Base:    num.MakeAmount(13636, 2),
+								Percent: num.MakePercentage(100, 3),
+								Amount:  num.MakeAmount(1364, 2),
+							},
+						},
+						Base:   num.MakeAmount(21900, 2),
+						Amount: num.MakeAmount(3100, 2),
+					},
+				},
+				Sum: num.MakeAmount(3100, 2),
+			},
+		},
+		{
 			desc: "with multirate VAT and retained tax",
 			lines: []tax.TaxableLine{
 				&taxableLine{


### PR DESCRIPTION
* Fixes an issue for prices that include a tax that was defined using a `percent` value instead of `rate`.