### PR TITLE
Fix Spanish spelling: Professional -> Profesional

### DIFF
--- a/build/regimes/es.json
+++ b/build/regimes/es.json
@@ -836,7 +836,7 @@
           "key": "pro",
           "name": {
             "en": "Professional Rate",
-            "es": "Professionales"
+            "es": "Profesionales"
           },
           "values": [
             {
@@ -861,7 +861,7 @@
           "key": "pro-start",
           "name": {
             "en": "Professional Starting Rate",
-            "es": "Professionales Inicio"
+            "es": "Profesionales Inicio"
           },
           "values": [
             {

--- a/regimes/es/es.go
+++ b/regimes/es/es.go
@@ -782,7 +782,7 @@ func New() *tax.Regime {
 						Key: TaxRatePro,
 						Name: i18n.String{
 							i18n.EN: "Professional Rate",
-							i18n.ES: "Professionales",
+							i18n.ES: "Profesionales",
 						},
 						Values: []*tax.RateValue{
 							{
@@ -807,7 +807,7 @@ func New() *tax.Regime {
 						Key: TaxRateProStart,
 						Name: i18n.String{
 							i18n.EN: "Professional Starting Rate",
-							i18n.ES: "Professionales Inicio",
+							i18n.ES: "Profesionales Inicio",
 						},
 						Values: []*tax.RateValue{
 							{


### PR DESCRIPTION
- Fix typo 
  - `Professionales` -> `Profesionales`
  - `Professionales Inicio` -> `Profesionales Inicio`