### PR TITLE
Initial support for a party and item 'Identity'

### DIFF
--- a/bill/invoice.go
+++ b/bill/invoice.go
@@ -125,7 +125,7 @@ func (inv *Invoice) Validate() error {
 			return errors.New("supplier: missing tax identity")
 		}
 		r := tax.Regimes().For(tID.Country, tID.Zone)
-		err = r.ValidateDocument(inv)
+		err = r.ValidateObject(inv)
 	}
 	return err
 }

--- a/cbc/code.go
+++ b/cbc/code.go
@@ -11,12 +11,16 @@ import (
 // at. We use "code" instead of "id", to reenforce the fact that codes should
 // be more easily set and used by humans within definitions than IDs or UUIDs.
 // Codes are standardised so that when validated they must contain between
-// 2 and 6 inclusive upper-case letters or numbers.
+// 1 and 24 inclusive upper-case letters or numbers.
 type Code string
 
 var (
-	codePattern          = `^[A-Z0-9]{1,6}$`
+	codePattern          = `^[A-Z0-9]+$`
 	codeValidationRegexp = regexp.MustCompile(codePattern)
+)
+
+const (
+	codeMaxLength = 24
 )
 
 // CodeEmpty is used when no code is defined.
@@ -25,7 +29,7 @@ const CodeEmpty Code = ""
 // Validate ensures that the code complies with the expected rules.
 func (c Code) Validate() error {
 	return validation.Validate(string(c),
-		validation.Length(1, 6),
+		validation.Length(1, codeMaxLength),
 		validation.Match(codeValidationRegexp),
 	)
 }
@@ -58,7 +62,7 @@ func (Code) JSONSchema() *jsonschema.Schema {
 		Pattern:     codePattern,
 		Title:       "Code",
 		MinLength:   1,
-		MaxLength:   6,
-		Description: "Short upper-case identifier.",
+		MaxLength:   codeMaxLength,
+		Description: "Alphanumerical text identifier with upper-case letters, no whitespace, nor symbols.",
 	}
 }

--- a/cbc/code_test.go
+++ b/cbc/code_test.go
@@ -15,16 +15,30 @@ func TestCodeIn(t *testing.T) {
 }
 
 func TestCodeValidation(t *testing.T) {
-	c := cbc.Code("ABC")
-	if err := c.Validate(); err != nil {
-		t.Errorf("did not expect error: %v", err)
-	}
-	c = cbc.Code("abc")
-	if err := c.Validate(); err == nil {
-		t.Errorf("expected a validation error")
-	}
+	c := cbc.Code("ABC123")
+	err := c.Validate()
+	assert.NoError(t, err)
+
+	c = cbc.Code("12345678901234567890ABCD")
+	err = c.Validate()
+	assert.NoError(t, err)
+
+	c = cbc.Code("")
+	err = c.Validate()
+	assert.NoError(t, err)
+
+	c = cbc.Code("B-1234567")
+	err = c.Validate()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "valid format")
+
+	c = cbc.Code("12345678901234567890ABCDE")
+	err = c.Validate()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "length must be between")
+
 	c = cbc.Code("ab")
-	if err := c.Validate(); err == nil {
-		t.Errorf("expected a validation error")
-	}
+	err = c.Validate()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "valid format")
 }

--- a/org/identity.go
+++ b/org/identity.go
@@ -1,0 +1,29 @@
+package org
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/uuid"
+)
+
+// Identity is used to define a code for a specific context.
+type Identity struct {
+	// Unique identity for this identity object.
+	UUID *uuid.UUID `json:"uuid,omitempty" jsonschema:"title=UUID"`
+	// Optional label useful for non-standard identities to give a bit more context.
+	Label string `json:"label,omitempty" jsonschema:"title=Label"`
+	// The type of Code being represented and usually specific for
+	// a particular context, country, or tax regime.
+	Type cbc.Code `json:"type,omitempty" jsonschema:"title=Type"`
+	// The actual value of the identity code.
+	Code cbc.Code `json:"code" jsonschema:"title=Code"`
+}
+
+// Validate ensures the identity looks valid.
+func (i *Identity) Validate() error {
+	return validation.ValidateStruct(i,
+		validation.Field(&i.Label),
+		validation.Field(&i.Type),
+		validation.Field(&i.Code, validation.Required),
+	)
+}

--- a/org/item.go
+++ b/org/item.go
@@ -13,22 +13,20 @@ import (
 // implies just adding a name and price, more complete usage consists
 // of adding descriptions, supplier IDs, SKUs, dimensions, etc.
 //
-// A set of additional code, ID, or SKU can be included in the `codes` property.
-// Each `ItemCode` can be defined with an optional type agreed upon between the
+// A set of additional code, ID, or SKU can be included in the `identities` property.
+// Each `Identity` can be defined with an optional type agreed upon between the
 // supplier and customer.
-// For general purpose use, the Item's `Ref` property is much
-// easier to use.
-//
-// We recommend setting prices with the item's "net" value, without tax,
-// unless the document you're building supports the `price_includes_tax`
-// option included in the `bill.Invoice` definition for example.
+// For general purpose use, the Item's `Ref` property is easier to use.
 type Item struct {
-	// Unique identify of this item independent of the Supplier IDs
+	// Unique identity of this item
 	UUID *uuid.UUID `json:"uuid,omitempty" jsonschema:"title=UUID"`
-	// Primary reference code that identifies this item. Additional codes can be provided in the 'codes' field.
+	// Primary reference code that identifies this item.
+	// Additional codes can be provided in the 'identities' property.
 	Ref string `json:"ref,omitempty" jsonschema:"title=Ref"`
 	// Brief name of the item
 	Name string `json:"name"`
+	// List of additional codes, IDs, or SKUs which can be used to identify the item. They should be agreed upon between supplier and customer.
+	Identities []*Identity `json:"identities,omitempty" jsonschema:"title=Identities"`
 	// Detailed description
 	Description string `json:"desc,omitempty"`
 	// Currency used for the item's price.
@@ -37,22 +35,10 @@ type Item struct {
 	Price num.Amount `json:"price" jsonschema:"title=Price"`
 	// Unit of measure.
 	Unit Unit `json:"unit,omitempty" jsonschema:"title=Unit"`
-	//	List of additional codes, IDs, or SKUs which can be used to identify the item. The should be agreed upon between supplier and customer.
-	Codes []*ItemCode `json:"codes,omitempty" jsonschema:"title=Codes"`
 	// Country code of where this item was from originally.
 	Origin l10n.CountryCode `json:"origin,omitempty" jsonschema:"title=Country of Origin"`
 	// Additional meta information that may be useful
 	Meta cbc.Meta `json:"meta,omitempty" jsonschema:"title=Meta"`
-}
-
-// ItemCode contains a value and optional label property that means additional
-// codes can be added to an item.
-type ItemCode struct {
-	// Local or human reference for the type of code the value
-	// represents.
-	Label string `json:"label,omitempty" jsonschema:"title=Label"`
-	// The item code's value.
-	Value string `json:"value" jsonschema:"title=Value"`
 }
 
 // Validate checks that an address looks okay.
@@ -60,9 +46,9 @@ func (i *Item) Validate() error {
 	return validation.ValidateStruct(i,
 		validation.Field(&i.UUID),
 		validation.Field(&i.Name, validation.Required),
+		validation.Field(&i.Identities),
 		validation.Field(&i.Price, validation.Required),
 		validation.Field(&i.Unit),
-		validation.Field(&i.Codes),
 		validation.Field(&i.Origin),
 		validation.Field(&i.Meta),
 	)

--- a/org/org.go
+++ b/org/org.go
@@ -4,17 +4,18 @@ import "github.com/invopop/gobl/schema"
 
 func init() {
 	schema.Register(schema.GOBL.Add("org"),
-		Unit(""),
 		Address{},
 		Coordinates{},
+		Email{},
+		Identity{},
+		Image{},
+		Inbox{},
 		Item{},
+		Name{},
 		Party{},
 		Person{},
-		Name{},
-		Email{},
-		Telephone{},
 		Registration{},
-		Inbox{},
-		Image{},
+		Telephone{},
+		Unit(""),
 	)
 }

--- a/org/party.go
+++ b/org/party.go
@@ -141,7 +141,7 @@ func (p *Party) Calculate() error {
 			return err
 		}
 		r = p.TaxID.Regime()
-		return r.Calculate(p)
+		return r.CalculateObject(p)
 	}
 	return nil
 }

--- a/regimes/co/tax_code.go
+++ b/regimes/co/tax_code.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/i18n"
 	"github.com/invopop/gobl/org"
 	"github.com/invopop/gobl/regimes/common"
@@ -61,7 +62,7 @@ func validZoneCodes() []interface{} {
 }
 
 func validateTaxCode(value interface{}) error {
-	code, ok := value.(string)
+	code, ok := value.(cbc.Code)
 	if !ok {
 		return nil
 	}
@@ -85,8 +86,8 @@ func validateTaxCode(value interface{}) error {
 	return validateDigits(code[0:l-1], code[l-1:l])
 }
 
-func validateDigits(code, check string) error {
-	ck, err := strconv.Atoi(check)
+func validateDigits(code, check cbc.Code) error {
+	ck, err := strconv.Atoi(string(check))
 	if err != nil {
 		return fmt.Errorf("invalid check: %w", err)
 	}

--- a/regimes/co/tax_code_test.go
+++ b/regimes/co/tax_code_test.go
@@ -3,6 +3,7 @@ package co_test
 import (
 	"testing"
 
+	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/l10n"
 	"github.com/invopop/gobl/org"
 	"github.com/invopop/gobl/regimes/co"
@@ -12,8 +13,8 @@ import (
 
 func TestNormalizeTaxIdentity(t *testing.T) {
 	tests := []struct {
-		Code     string
-		Expected string
+		Code     cbc.Code
+		Expected cbc.Code
 	}{
 		{
 			Code:     "901.458.652-7",
@@ -59,7 +60,7 @@ func TestNormalizeParty(t *testing.T) {
 func TestValidateTaxIdentity(t *testing.T) {
 	tests := []struct {
 		name string
-		code string
+		code cbc.Code
 		zone l10n.Code
 		err  string
 	}{

--- a/regimes/common/common.go
+++ b/regimes/common/common.go
@@ -10,7 +10,9 @@ import (
 
 // Standard tax categories that may be shared between countries.
 const (
-	TaxCategoryVAT cbc.Code = "VAT"
+	TaxCategoryST  cbc.Code = "ST"  // Sales Tax
+	TaxCategoryVAT cbc.Code = "VAT" // Value Added Tax
+	TaxCategoryGST cbc.Code = "GST" // Goods and Services Tax
 )
 
 // Most commonly used codes. Local regions may add their own rate codes.
@@ -33,6 +35,11 @@ const (
 	InboxKeyPEPPOL cbc.Key = "peppol-id"
 )
 
+// Common Identity Type Codes that are not country specific.
+const (
+	IdentityTypeDUNS cbc.Code = "DUNS" // Dun & Bradstreet - Data Universal Numbering System
+)
+
 var (
 	taxCodeBadCharsRegexp = regexp.MustCompile(`[^A-Z0-9]+`)
 )
@@ -40,9 +47,9 @@ var (
 // NormalizeTaxIdentity removes any whitespace or separation characters and ensures all letters are
 // uppercase.
 func NormalizeTaxIdentity(tID *tax.Identity) error {
-	code := strings.ToUpper(tID.Code)
+	code := strings.ToUpper(tID.Code.String())
 	code = taxCodeBadCharsRegexp.ReplaceAllString(code, "")
 	code = strings.TrimPrefix(code, string(tID.Country))
-	tID.Code = code
+	tID.Code = cbc.Code(code)
 	return nil
 }

--- a/regimes/es/tax_code_test.go
+++ b/regimes/es/tax_code_test.go
@@ -3,6 +3,7 @@ package es_test
 import (
 	"testing"
 
+	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/l10n"
 	"github.com/invopop/gobl/regimes/es"
 	"github.com/invopop/gobl/tax"
@@ -12,8 +13,8 @@ import (
 func TestNormalizeTaxIdentity(t *testing.T) {
 	r := es.New()
 	tests := []struct {
-		Code     string
-		Expected string
+		Code     cbc.Code
+		Expected cbc.Code
 	}{
 		{
 			Code:     "93471790-C",
@@ -38,7 +39,7 @@ func TestNormalizeTaxIdentity(t *testing.T) {
 	}
 	for _, ts := range tests {
 		tID := &tax.Identity{Country: l10n.ES, Code: ts.Code}
-		err := r.CalculateDocument(tID)
+		err := r.Calculate(tID)
 		assert.NoError(t, err)
 		assert.Equal(t, ts.Expected, tID.Code)
 	}
@@ -46,7 +47,7 @@ func TestNormalizeTaxIdentity(t *testing.T) {
 
 func TestValidateTaxIdentity(t *testing.T) {
 	tests := []struct {
-		Code     string
+		Code     cbc.Code
 		Expected error
 	}{
 		// *** EMPTY ***
@@ -181,7 +182,7 @@ func TestValidateTaxIdentity(t *testing.T) {
 	}
 	r := es.New()
 	for _, ts := range tests {
-		t.Run(ts.Code, func(t *testing.T) {
+		t.Run(string(ts.Code), func(t *testing.T) {
 			tID := &tax.Identity{Country: l10n.ES, Code: ts.Code}
 			err := r.ValidateDocument(tID)
 			if ts.Expected == nil {

--- a/regimes/es/tax_code_test.go
+++ b/regimes/es/tax_code_test.go
@@ -39,7 +39,7 @@ func TestNormalizeTaxIdentity(t *testing.T) {
 	}
 	for _, ts := range tests {
 		tID := &tax.Identity{Country: l10n.ES, Code: ts.Code}
-		err := r.Calculate(tID)
+		err := r.CalculateObject(tID)
 		assert.NoError(t, err)
 		assert.Equal(t, ts.Expected, tID.Code)
 	}
@@ -184,7 +184,7 @@ func TestValidateTaxIdentity(t *testing.T) {
 	for _, ts := range tests {
 		t.Run(string(ts.Code), func(t *testing.T) {
 			tID := &tax.Identity{Country: l10n.ES, Code: ts.Code}
-			err := r.ValidateDocument(tID)
+			err := r.ValidateObject(tID)
 			if ts.Expected == nil {
 				assert.NoError(t, err)
 			} else {

--- a/regimes/fr/fr.go
+++ b/regimes/fr/fr.go
@@ -2,11 +2,21 @@ package fr
 
 import (
 	"github.com/invopop/gobl/cal"
+	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/i18n"
 	"github.com/invopop/gobl/l10n"
 	"github.com/invopop/gobl/num"
 	"github.com/invopop/gobl/regimes/common"
 	"github.com/invopop/gobl/tax"
+)
+
+// Identification keys used for additional codes not
+// covered by the standard fields.
+const (
+	IdentityTypeSIRET cbc.Code = "SIRET" // SIRET number is used to identify each establishment that makes up a company.
+	IdentityTypeRCS   cbc.Code = "RCS"   // Trade and Companies Register.
+	IdentityTypeRM    cbc.Code = "RM"    // Directory of Traders.
+	IdentityTypeNAF   cbc.Code = "NAF"   // Identifies the main branch of activity of the company or self-employed person.
 )
 
 func init() {

--- a/regimes/gb/gb.go
+++ b/regimes/gb/gb.go
@@ -3,6 +3,7 @@ package gb
 import (
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cal"
+	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/i18n"
 	"github.com/invopop/gobl/l10n"
 	"github.com/invopop/gobl/num"
@@ -13,6 +14,11 @@ import (
 func init() {
 	tax.RegisterRegime(New())
 }
+
+// Identification code types unique to the United Kingdom.
+const (
+	IdentityTypeCRN cbc.Code = "CRN" // Company Registration Number
+)
 
 // New provides the tax region definition
 func New() *tax.Regime {

--- a/regimes/nl/tax_code.go
+++ b/regimes/nl/tax_code.go
@@ -2,10 +2,12 @@ package nl
 
 import (
 	"errors"
+	"fmt"
 	"strconv"
 
 	validation "github.com/go-ozzo/ozzo-validation/v4"
 
+	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/regimes/common"
 	"github.com/invopop/gobl/tax"
 )
@@ -27,7 +29,7 @@ func ValidateTaxIdentity(tID *tax.Identity) error {
 }
 
 func validateTaxCode(value interface{}) error {
-	code, ok := value.(string)
+	code, ok := value.(cbc.Code)
 	if !ok {
 		return nil
 	}
@@ -50,12 +52,12 @@ func NormalizeTaxIdentity(tID *tax.Identity) error {
 	return common.NormalizeTaxIdentity(tID)
 }
 
-func validateDigits(code, check string) error {
-	num, err := strconv.ParseInt(code, 10, 64)
+func validateDigits(code, check cbc.Code) error {
+	num, err := strconv.ParseInt(string(code), 10, 64)
 	if err != nil {
 		return errInvalidVAT
 	}
-	_, err = strconv.Atoi(check)
+	_, err = strconv.Atoi(string(check))
 	if err != nil {
 		return errInvalidVAT
 	}
@@ -65,7 +67,7 @@ func validateDigits(code, check string) error {
 
 	// changes in 2020 mean that NL VAT numbers have a different check
 	// digit and should be checked with Mod 97 (like an IBAN).
-	if sum != ck && !checkMod97("NL"+code+"B"+check) {
+	if sum != ck && !checkMod97(fmt.Sprintf("NL%sB%s", code, check)) {
 		return errors.New("checksum mismatch")
 	}
 

--- a/regimes/nl/tax_code_test.go
+++ b/regimes/nl/tax_code_test.go
@@ -3,6 +3,7 @@ package nl_test
 import (
 	"testing"
 
+	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/l10n"
 	"github.com/invopop/gobl/regimes/nl"
 	"github.com/invopop/gobl/tax"
@@ -11,8 +12,8 @@ import (
 
 func TestNormalizeTaxIdentity(t *testing.T) {
 	tests := []struct {
-		Code     string
-		Expected string
+		Code     cbc.Code
+		Expected cbc.Code
 	}{
 		{
 			Code:     "000099995b57",
@@ -38,7 +39,7 @@ func TestNormalizeTaxIdentity(t *testing.T) {
 func TestValidateTaxIdentity(t *testing.T) {
 	tests := []struct {
 		name string
-		code string
+		code cbc.Code
 		err  string
 	}{
 		{

--- a/regimes/pt/tax_code.go
+++ b/regimes/pt/tax_code.go
@@ -6,12 +6,13 @@ import (
 	"strconv"
 
 	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/regimes/common"
 	"github.com/invopop/gobl/tax"
 )
 
 var (
-	validPrefixes = map[string]bool{
+	validPrefixes = map[cbc.Code]bool{
 		"1": true, "2": true, "3": true, "5": true, "6": true, "8": true,
 		"45": true, "70": true, "71": true, "72": true, "74": true, "75": true,
 		"77": true, "78": true, "79": true, "90": true, "91": true, "98": true, "99": true}
@@ -43,7 +44,7 @@ func validZoneCodes() []interface{} {
 
 // based on example provided by https://pt.wikipedia.org/wiki/N%C3%BAmero_de_identifica%C3%A7%C3%A3o_fiscal
 func validateTaxCode(value interface{}) error {
-	code, ok := value.(string)
+	code, ok := value.(cbc.Code)
 	if !ok {
 		return nil
 	}

--- a/regimes/pt/tax_code_test.go
+++ b/regimes/pt/tax_code_test.go
@@ -3,6 +3,7 @@ package pt_test
 import (
 	"testing"
 
+	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/l10n"
 	"github.com/invopop/gobl/regimes/pt"
 	"github.com/invopop/gobl/tax"
@@ -11,8 +12,8 @@ import (
 
 func TestNormalizeTaxIdentity(t *testing.T) {
 	tests := []struct {
-		Code     string
-		Expected string
+		Code     cbc.Code
+		Expected cbc.Code
 	}{
 		{
 			Code:     "901.458.652",
@@ -42,7 +43,7 @@ func TestNormalizeTaxIdentity(t *testing.T) {
 func TestValidateTaxIdentity(t *testing.T) {
 	tests := []struct {
 		name string
-		code string
+		code cbc.Code
 		zone l10n.Code
 		err  string
 	}{

--- a/regimes/us/invoice_validator.go
+++ b/regimes/us/invoice_validator.go
@@ -1,0 +1,28 @@
+package us
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"github.com/invopop/gobl/bill"
+)
+
+// invoiceValidator adds validation checks to invoices which are relevant
+// for the region.
+type invoiceValidator struct {
+	inv *bill.Invoice
+}
+
+func validateInvoice(inv *bill.Invoice) error {
+	v := &invoiceValidator{inv: inv}
+	return v.validate()
+}
+
+func (v *invoiceValidator) validate() error {
+	inv := v.inv
+	return validation.ValidateStruct(inv,
+		validation.Field(&inv.Supplier, validation.Required),
+		validation.Field(&inv.Customer, validation.When(
+			inv.Type != bill.InvoiceTypeSimplified,
+			validation.Required,
+		)),
+	)
+}

--- a/regimes/us/us.go
+++ b/regimes/us/us.go
@@ -1,0 +1,57 @@
+package us
+
+import (
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/currency"
+	"github.com/invopop/gobl/i18n"
+	"github.com/invopop/gobl/l10n"
+	"github.com/invopop/gobl/regimes/common"
+	"github.com/invopop/gobl/tax"
+)
+
+func init() {
+	tax.RegisterRegime(New())
+}
+
+// Identification codes unique to the United States.
+const (
+	IdentityTypeEIN cbc.Code = "EIN" // Employer Identification Number
+)
+
+// New provides the tax region definition
+func New() *tax.Regime {
+	return &tax.Regime{
+		Country:  l10n.US,
+		Currency: currency.USD,
+		Name: i18n.String{
+			i18n.EN: "United States of America",
+		},
+		Validator: Validate,
+		Categories: []*tax.Category{
+			//
+			// Sales Tax
+			//
+			{
+				Code: common.TaxCategoryST,
+				Name: i18n.String{
+					i18n.EN: "Sales Tax",
+				},
+				Desc: i18n.String{
+					i18n.EN: "Sales Tax",
+				},
+				Retained: false,
+				Rates:    []*tax.Rate{},
+			},
+		},
+	}
+}
+
+// Validate checks the document type and determines if it can be validated.
+func Validate(doc interface{}) error {
+	switch obj := doc.(type) {
+	case *bill.Invoice:
+		return validateInvoice(obj)
+	}
+	return nil
+}

--- a/tax/identity.go
+++ b/tax/identity.go
@@ -112,7 +112,7 @@ func (id *Identity) Regime() *Regime {
 func (id *Identity) Calculate() error {
 	r := id.Regime()
 	if r != nil {
-		return r.Calculate(id)
+		return r.CalculateObject(id)
 	}
 	return nil
 }
@@ -126,6 +126,7 @@ func (id *Identity) Validate() error {
 		validation.Field(&id.Country, validation.Required),
 		validation.Field(&id.Zone),
 		validation.Field(&id.Source, validation.In(validSourceKeys...)),
+		validation.Field(&id.Code),
 		validation.Field(&id.Meta),
 	)
 	if err != nil {
@@ -133,7 +134,7 @@ func (id *Identity) Validate() error {
 	}
 	r := regimes.For(id.Country, id.Zone)
 	if r != nil {
-		return r.ValidateDocument(id)
+		return r.ValidateObject(id)
 	}
 	return nil
 }

--- a/tax/identity.go
+++ b/tax/identity.go
@@ -33,7 +33,7 @@ type Identity struct {
 	Source SourceKey `json:"source,omitempty" jsonschema:"title=Source Key"`
 
 	// Normalized code shown on the original identity document.
-	Code string `json:"code,omitempty" jsonschema:"title=Code"`
+	Code cbc.Code `json:"code,omitempty" jsonschema:"title=Code"`
 
 	// Additional details that may be required.
 	Meta cbc.Meta `json:"meta,omitempty" jsonschema:"title=Meta"`
@@ -112,7 +112,7 @@ func (id *Identity) Regime() *Regime {
 func (id *Identity) Calculate() error {
 	r := id.Regime()
 	if r != nil {
-		return r.CalculateDocument(id)
+		return r.Calculate(id)
 	}
 	return nil
 }

--- a/tax/identity_test.go
+++ b/tax/identity_test.go
@@ -25,8 +25,9 @@ func TestTaxIdentity(t *testing.T) {
 		Code:    "X3157928MMM",
 	}
 	err = tID.Validate()
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "code: unknown type")
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "code: unknown type")
+	}
 
 	tID = &tax.Identity{
 		Country: l10n.ES,
@@ -34,5 +35,5 @@ func TestTaxIdentity(t *testing.T) {
 	}
 	err = tID.Calculate()
 	assert.NoError(t, err)
-	assert.Equal(t, tID.Code, "X3157928M")
+	assert.Equal(t, tID.Code.String(), "X3157928M")
 }

--- a/tax/regime.go
+++ b/tax/regime.go
@@ -111,17 +111,18 @@ type RateValue struct {
 	Disabled bool `json:"disabled,omitempty" jsonschema:"title=Disabled"`
 }
 
-// ValidateDocument performs validation on the provided document.
-func (r *Regime) ValidateDocument(obj interface{}) error {
+// ValidateObject performs validation on the provided object in the context
+// of the regime.
+func (r *Regime) ValidateObject(obj interface{}) error {
 	if r.Validator != nil {
 		return r.Validator(obj)
 	}
 	return nil
 }
 
-// Calculate performs any region specific calculations on the provided
+// CalculateObject performs any regime specific calculations on the provided
 // object.
-func (r *Regime) Calculate(obj interface{}) error {
+func (r *Regime) CalculateObject(obj interface{}) error {
 	if r.Calculator != nil {
 		return r.Calculator(obj)
 	}

--- a/tax/regime.go
+++ b/tax/regime.go
@@ -119,9 +119,9 @@ func (r *Regime) ValidateDocument(obj interface{}) error {
 	return nil
 }
 
-// CalculateDocument performs any region specific calculations on the provided
+// Calculate performs any region specific calculations on the provided
 // object.
-func (r *Regime) CalculateDocument(obj interface{}) error {
+func (r *Regime) Calculate(obj interface{}) error {
 	if r.Calculator != nil {
 		return r.Calculator(obj)
 	}

--- a/tax/set_test.go
+++ b/tax/set_test.go
@@ -64,7 +64,7 @@ func TestSetValidation(t *testing.T) {
 					Rate:     "standard",
 				},
 			},
-			err: "cat: the length must be between",
+			err: "cat: must be in a valid format",
 		},
 		{
 			desc: "invalid rate",


### PR DESCRIPTION
* Added a new `Identity` model to the `org` package to be used to define additional IDs that are not associated with tax.
* Defined some common, French, and US, identity type examples.
* Refined the meaning of the `cbc.Code` so that it can be re-used for more identifies and include restrictions to help with normalization.