### PR TITLE
Add tax code validations for Italy's Partita IVA (P.IVA)

### DIFF
--- a/regimes/common/common.go
+++ b/regimes/common/common.go
@@ -53,3 +53,28 @@ func NormalizeTaxIdentity(tID *tax.Identity) error {
 	tID.Code = cbc.Code(code)
 	return nil
 }
+
+// ComputeLuhnCheckDigit expects as argument a number string excluding the check
+// digit. The returned integer should be checked against the check digit by the
+// caller.
+// Luhn Algorithm definition: https://en.wikipedia.org/wiki/Luhn_algorithm
+func ComputeLuhnCheckDigit(number string) int {
+	sum := 0
+	pos := 0
+
+	for i := len(number) - 1; i >= 0; i-- {
+		digit := int(number[i] - '0')
+
+		if pos%2 == 0 {
+			digit *= 2
+			if digit > 9 {
+				digit -= 9
+			}
+		}
+
+		sum += digit
+		pos++
+	}
+
+	return (10 - (sum % 10)) % 10
+}

--- a/regimes/it/it.go
+++ b/regimes/it/it.go
@@ -1,0 +1,24 @@
+package it
+
+import (
+	"github.com/invopop/gobl/tax"
+)
+
+// Validate checks the document type and determines if it can be validated.
+func Validate(doc interface{}) error {
+
+	switch obj := doc.(type) {
+	case *tax.Identity:
+		return validateTaxIdentity(obj)
+	}
+	return nil
+}
+
+// Calculate will perform any regime specific calculations.
+func Calculate(doc interface{}) error {
+	switch obj := doc.(type) {
+	case *tax.Identity:
+		return normalizeTaxIdentity(obj)
+	}
+	return nil
+}

--- a/regimes/it/tax_code.go
+++ b/regimes/it/tax_code.go
@@ -1,0 +1,78 @@
+package it
+
+// The tax code here refers to Partita IVA, which is a distinct construct from
+// Codice Fiscale. Italy operates with two types of tax identification codes.
+// Though not all Italian persons possess Partita IVA, all parties engaged in
+// economic activities within Italy are required to have one.
+
+import (
+	"errors"
+
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/regimes/common"
+	"github.com/invopop/gobl/tax"
+)
+
+// validateTaxIdentity looks at the provided identity's code and performs the
+// calculations required to determine if it is valid.
+// These methods assume the code has already been normalized
+// and thus only contains upper-case letters and numbers with
+// no white space.
+func validateTaxIdentity(tID *tax.Identity) error {
+	return validation.ValidateStruct(tID,
+		validation.Field(&tID.Code, validation.Required, validation.By(validateTaxCode)))
+}
+
+// normalizeTaxIdentity removes any whitespace or separation characters and ensures all letters are
+// uppercase.
+func normalizeTaxIdentity(tID *tax.Identity) error {
+	return common.NormalizeTaxIdentity(tID)
+}
+
+// source: https://it.wikipedia.org/wiki/Partita_IVA#Struttura_del_codice_identificativo_di_partita_IVA
+func validateTaxCode(value interface{}) error {
+	code, ok := value.(cbc.Code)
+	if !ok || code == "" {
+		return errors.New("code: cannot be blank")
+	}
+
+	for _, v := range code {
+		x := v - 48
+		if x < 0 || x > 9 {
+			return errors.New("contains invalid characters")
+		}
+	}
+
+	if len(code) != 11 {
+		return errors.New("invalid length")
+	}
+
+	if computeLuhnCheckDigit(string(code[:10])) != int(code[10]-'0') {
+		return errors.New("invalid check digit")
+	}
+
+	return nil
+}
+
+// Luhn Algorithm https://en.wikipedia.org/wiki/Luhn_algorithm
+func computeLuhnCheckDigit(number string) int {
+	sum := 0
+	pos := 0
+
+	for i := len(number) - 1; i >= 0; i-- {
+		digit := int(number[i] - '0')
+
+		if pos%2 == 0 {
+			digit *= 2
+			if digit > 9 {
+				digit -= 9
+			}
+		}
+
+		sum += digit
+		pos++
+	}
+
+	return (10 - (sum % 10)) % 10
+}

--- a/regimes/it/tax_code.go
+++ b/regimes/it/tax_code.go
@@ -48,31 +48,9 @@ func validateTaxCode(value interface{}) error {
 		return errors.New("invalid length")
 	}
 
-	if computeLuhnCheckDigit(string(code[:10])) != int(code[10]-'0') {
+	if common.ComputeLuhnCheckDigit(string(code[:10])) != int(code[10]-'0') {
 		return errors.New("invalid check digit")
 	}
 
 	return nil
-}
-
-// Luhn Algorithm https://en.wikipedia.org/wiki/Luhn_algorithm
-func computeLuhnCheckDigit(number string) int {
-	sum := 0
-	pos := 0
-
-	for i := len(number) - 1; i >= 0; i-- {
-		digit := int(number[i] - '0')
-
-		if pos%2 == 0 {
-			digit *= 2
-			if digit > 9 {
-				digit -= 9
-			}
-		}
-
-		sum += digit
-		pos++
-	}
-
-	return (10 - (sum % 10)) % 10
 }

--- a/regimes/it/tax_code_test.go
+++ b/regimes/it/tax_code_test.go
@@ -1,0 +1,103 @@
+package it_test
+
+import (
+	"testing"
+
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/l10n"
+	"github.com/invopop/gobl/regimes/it"
+	"github.com/invopop/gobl/tax"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizeTaxIdentity(t *testing.T) {
+	tests := []struct {
+		code     cbc.Code
+		expected cbc.Code
+	}{
+		{
+			code:     "12345678901",
+			expected: "12345678901",
+		},
+		{
+			code:     "123-456-789-01",
+			expected: "12345678901",
+		},
+		{
+			code:     "123456 789 01",
+			expected: "12345678901",
+		},
+		{
+			code:     "IT 12345678901",
+			expected: "12345678901",
+		},
+	}
+	for _, ts := range tests {
+		tID := &tax.Identity{Country: l10n.IT, Code: ts.code}
+		err := it.Calculate(tID)
+		assert.NoError(t, err)
+		assert.Equal(t, ts.expected, tID.Code)
+	}
+}
+
+func TestValidateTaxIdentity(t *testing.T) {
+	tests := []struct {
+		name string
+		code cbc.Code
+		zone l10n.Code
+		err  string
+	}{
+		{name: "good 1", code: "12345678903"},
+		{name: "good 2", code: "13029381004"},
+		{name: "good 3", code: "10182640150"},
+		{
+			name: "empty",
+			code: "",
+			err:  "code: cannot be blank",
+		},
+		{
+			name: "too long",
+			code: "123456789001",
+			err:  "invalid length",
+		},
+		{
+			name: "too short",
+			code: "1234567890",
+			err:  "invalid length",
+		},
+		{
+			name: "not normalized",
+			code: "12.449.965-439",
+			err:  "contains invalid characters",
+		},
+		{
+			name: "includes non-numeric characters",
+			code: "A764352056Z",
+			err:  "contains invalid characters",
+		},
+		{
+			name: "invalid check digit",
+			code: "12345678901",
+			err:  "invalid check digit",
+		},
+		{
+			name: "invalid check digit",
+			code: "13029381009",
+			err:  "invalid check digit",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tID := &tax.Identity{Country: l10n.IT, Code: tt.code}
+			err := it.Validate(tID)
+			if tt.err == "" {
+				assert.NoError(t, err)
+			} else {
+				if assert.Error(t, err) {
+					assert.Contains(t, err.Error(), tt.err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Add validations for [P.IVA ](https://it.wikipedia.org/wiki/Partita_IVA)

- The validation assumes that the Tax code is already that of an Italian entity. However, PatturaPA allows the entry of foreign VAT numbers in the same field where P.IVA is expected—when the validation of the invoice happens, how should we support these cases of foreign IDs? For the time being, should we at least check if the ID is Italian and skip the validation if not? 

- The Luhn Algorithm is pretty commonly used by tax authorities globally. Would it make sense to move it into `common`? 