### PR TITLE
Header efficient add stamp support

### DIFF
--- a/header.go
+++ b/header.go
@@ -48,3 +48,18 @@ func (h *Header) Validate() error {
 		validation.Field(&h.Stamps),
 	)
 }
+
+// AddStamp adds a new stamp to the header. If the stamp already exists,
+// it will be overwritten.
+func (h *Header) AddStamp(s *cbc.Stamp) {
+	if h.Stamps == nil {
+		h.Stamps = make([]*cbc.Stamp, 0)
+	}
+	for _, v := range h.Stamps {
+		if v.Provider == s.Provider {
+			v.Value = s.Value
+			return
+		}
+	}
+	h.Stamps = append(h.Stamps, s)
+}

--- a/header_test.go
+++ b/header_test.go
@@ -18,3 +18,15 @@ func TestNewHeader(t *testing.T) {
 		h.Stamps = append(h.Stamps, &cbc.Stamp{})
 	}, "header and meta hash should have been initialized")
 }
+
+func TestHeaderAddStamp(t *testing.T) {
+	h := gobl.NewHeader()
+	h.AddStamp(&cbc.Stamp{Provider: "foo", Value: "bar"})
+	assert.Len(t, h.Stamps, 1)
+	h.AddStamp(&cbc.Stamp{Provider: "foo", Value: "baz"})
+	assert.Len(t, h.Stamps, 1)
+	assert.Equal(t, "baz", h.Stamps[0].Value)
+	h.AddStamp(&cbc.Stamp{Provider: "bar", Value: "bax"})
+	assert.Len(t, h.Stamps, 2)
+	assert.Equal(t, "bax", h.Stamps[1].Value)
+}


### PR DESCRIPTION
* Quick hack to be able to add a stamp to the envelope header and avoid duplicates.