### PR TITLE
Italy fpa codes

### DIFF
--- a/regimes/it/README.md
+++ b/regimes/it/README.md
@@ -33,34 +33,50 @@ Italy uses the FatturaPA format for their e-invoicing system.
 
 #### Special Codes (WIP)
 
-FatturaPA demands very specific categorization for the type of economic activity,
-document type, fund type, etc. It will be a challenge to map these onto GOBL
-constructs.
+FatturaPA demands the classificationss of the invoice data using predefined
+alphanmueric code refered to as FPACodes in this package. These codes can be
+unbelieveably specific (e.g. TD28: "Purchase from San Marino with VAT (paper
+invoice)", RF06: "Match sales") and includes distinctions we normally would not
+(MP09, MP10, MP11, MP19, MP20, and MP21 all refer to different types of direct
+debit payments).
 
-##### RegimeFiscale (Tax System) - mandatory
+Additionally, there is no straightforward mapping between the FPACodes and
+fields supported in `bill.Invoice`. "Nature" codes, for example, include things
+like reverse charges (what we would find in a `inv.Tax.Schemes`) as well as
+classifications for "non-taxable" items (not really a scheme—more like a `Note`
+attached to a line item?).
 
-| Code | support | Description                                                            |
-|------|---------|------------------------------------------------------------------------|
-| RF01 | ✓       | Ordinary                                                               |
-| RF02 |         | Minimum taxpayers                                                      |
-| RF04 |         | Agriculture and connected activities and fishing                       |
-| RF05 |         | Sale of salts and tobaccos                                             |
-| RF06 |         | Match sales                                                            |
-| RF07 |         | Publishing                                                             |
-| RF08 |         | Management of public telephone services                                |
-| RF09 |         | Resale of public transport and parking documents                       |
-| RF10 |         | Entertainment, gaming, etc referred to by tariff in DPR 640/72         |
-| RF11 |         | Travel and tourism agencies                                            |
-| RF12 |         | Farmhouse accommodation/restaurants                                    |
-| RF13 |         | Door-to-door sales                                                     |
-| RF14 |         | Resale of used goods, artworks, antiques or collector's items          |
-| RF15 |         | Artwork, antiques or collector's items auction agencies                |
-| RF16 |         | VAT paid in cash by P.A.                                               |
-| RF17 |         | VAT paid in cash by subjects with business turnover below Euro 200,000 |
-| RF18 |         | Other                                                                  |
-| RF19 |         | Flat rate                                                              |
+##### Tax System (Regime Fiscale)
 
-##### TipoCassa (Fund Type)
+A "tax system" in Italy is a property of the seller and not the product or the
+service provided.
+
+<b>bill.Invoice Mapping:</b> none (or could we use `inv.Tax.Schemes`?)
+
+| Code | support | Description                                                    |
+|------|---------|----------------------------------------------------------------|
+| RF01 | ✓       | Ordinary                                                       |
+| RF02 |         | Minimum taxpayers                                              |
+| RF04 |         | Agriculture and connected activities and fishing               |
+| RF05 |         | Sale of salts and tobaccos                                     |
+| RF06 |         | Match sales                                                    |
+| RF07 |         | Publishing                                                     |
+| RF08 |         | Management of public telephone services                        |
+| RF09 |         | Resale of public transport and parking documents               |
+| RF10 |         | Entertainment, gaming, etc referred to by tariff in DPR 640/72 |
+| RF11 |         | Travel and tourism agencies                                    |
+| RF12 |         | Agrotourism (Farmhouse accomodations and restaurants)          |
+| RF13 |         | Door-to-door sales                                             |
+| RF14 |         | Resale of used goods, artworks, antiques or collector's items  |
+| RF15 |         | Artwork, antiques or collector's items auction agencies        |
+| RF16 |         | VAT paid in cash by P.A.                                       |
+| RF17 |         | VAT paid in cash by subjects with business turnover <€200,000  |
+| RF18 |         | Other                                                          |
+| RF19 |         | Flat rate                                                      |
+
+##### Fund Type (TipoCassa)
+
+<b>bill.Invoice Mapping:</b> none
 
 | Code | Supported | Description                                                                  |
 |------|-----------|------------------------------------------------------------------------------|
@@ -87,7 +103,9 @@ constructs.
 | TC21 |           | ENPAP (National pension and welfare board for psychologists)                 |
 | TC22 |           | INPS (National Social Security Institute)                                    |
 
-##### ModalitaPagamento (Payment Method)
+##### Payment Method (Modalita di Pagamento)
+
+<b>bill.Invoice Mapping:</b> inv.Payment.Instructions
 
 | Code | Support | Description                                       |
 |------|---------|---------------------------------------------------|
@@ -115,7 +133,9 @@ constructs.
 | MP22 |         | Deduction on sums already collected               |
 | MP23 |         | PagoPA                                            |
 
-##### TipoDocumento (Document Type)
+##### Document Type (Tipo Documento)
+
+<b>bill.Invoice Mapping:</b> inv.Type
 
 | Code | Support | Description                                                          |
 |------|---------|----------------------------------------------------------------------|
@@ -139,7 +159,9 @@ constructs.
 | TD27 |         | self invoicing for self consumption / free transfer without recourse |
 | TD28 |         | Purchases from San Marino with VAT (paper invoice)                   |
 
-##### Natura (Nature)
+##### Nature (Natura)
+
+<b>bill.Invoice Mapping:</b> inv.Tax.Schemes, (potentially) inv.Lines[].Notes
 
 | Code | Support | Description                                                             |
 |------|---------|-------------------------------------------------------------------------|
@@ -165,7 +187,9 @@ constructs.
 | N6.9 | ✓       | reverse charge - other cases                                            |
 | N7   |         | VAT paid in other EU countries (telecommunications)                     |
 
-##### TipoRitenuta (Withholding Type)
+##### Withholding Type (Tipo Ritenuta)
+
+<b>bill.Invoice Mapping:</b> inv.Totals.Taxes
 
 | Code | Support | Description                        |
 |------|---------|------------------------------------|

--- a/regimes/it/README.md
+++ b/regimes/it/README.md
@@ -29,9 +29,9 @@ Italy uses the FatturaPA format for their e-invoicing system.
 
 [Agenzia Entrate (Tax Office) IVA Doc](https://www.agenziaentrate.gov.it/portale/web/english/nse/business/vat-in-italy)
 
-### Challenges
+## Challenges
 
-#### Special Codes (WIP)
+### Special Codes (WIP)
 
 FatturaPA demands the classificationss of the invoice data using predefined
 alphanmueric code refered to as FPACodes in this package. These codes can be
@@ -46,12 +46,12 @@ like reverse charges (what we would find in a `inv.Tax.Schemes`) as well as
 classifications for "non-taxable" items (not really a scheme—more like a `Note`
 attached to a line item?).
 
-##### Tax System (Regime Fiscale)
+#### Tax System (Regime Fiscale)
 
 A "tax system" in Italy is a property of the seller and not the product or the
 service provided.
 
-<b>bill.Invoice Mapping:</b> none (or could we use `inv.Tax.Schemes`?)
+`bill.Invoice` Mapping: none (or could we use `inv.Tax.Schemes`?)
 
 | Code | support | Description                                                    |
 |------|---------|----------------------------------------------------------------|
@@ -74,9 +74,9 @@ service provided.
 | RF18 |         | Other                                                          |
 | RF19 |         | Flat rate                                                      |
 
-##### Fund Type (TipoCassa)
+#### Fund Type (TipoCassa)
 
-<b>bill.Invoice Mapping:</b> none
+`bill.Invoice` Mapping: none
 
 | Code | Supported | Description                                                                  |
 |------|-----------|------------------------------------------------------------------------------|
@@ -103,9 +103,9 @@ service provided.
 | TC21 |           | ENPAP (National pension and welfare board for psychologists)                 |
 | TC22 |           | INPS (National Social Security Institute)                                    |
 
-##### Payment Method (Modalita di Pagamento)
+#### Payment Method (Modalita di Pagamento)
 
-<b>bill.Invoice Mapping:</b> inv.Payment.Instructions
+`bill.Invoice` Mapping: `inv.Payment.Instructions`
 
 | Code | Support | Description                                       |
 |------|---------|---------------------------------------------------|
@@ -133,9 +133,9 @@ service provided.
 | MP22 |         | Deduction on sums already collected               |
 | MP23 |         | PagoPA                                            |
 
-##### Document Type (Tipo Documento)
+#### Document Type (Tipo Documento)
 
-<b>bill.Invoice Mapping:</b> inv.Type
+`bill.Invoice` Mapping: `inv.Type`
 
 | Code | Support | Description                                                          |
 |------|---------|----------------------------------------------------------------------|
@@ -159,9 +159,9 @@ service provided.
 | TD27 |         | self invoicing for self consumption / free transfer without recourse |
 | TD28 |         | Purchases from San Marino with VAT (paper invoice)                   |
 
-##### Nature (Natura)
+#### Nature (Natura)
 
-<b>bill.Invoice Mapping:</b> inv.Tax.Schemes, (potentially) inv.Lines[].Notes
+`bill.Invoice` Mapping: `inv.Tax.Schemes`, (potentially) `inv.Lines[].Notes`
 
 | Code | Support | Description                                                             |
 |------|---------|-------------------------------------------------------------------------|
@@ -187,9 +187,9 @@ service provided.
 | N6.9 | ✓       | reverse charge - other cases                                            |
 | N7   |         | VAT paid in other EU countries (telecommunications)                     |
 
-##### Withholding Type (Tipo Ritenuta)
+#### Withholding Type (Tipo Ritenuta)
 
-<b>bill.Invoice Mapping:</b> inv.Totals.Taxes
+`bill.Invoice` Mapping: `inv.Totals.Taxes`
 
 | Code | Support | Description                        |
 |------|---------|------------------------------------|

--- a/regimes/it/README.md
+++ b/regimes/it/README.md
@@ -39,139 +39,139 @@ constructs.
 
 ##### RegimeFiscale (Tax System) - mandatory
 
-|  |  |
-|---|---|
-| RF01 | Ordinary |
-| RF02 | "Minimum taxpayers (Art. 1, section 96-117, Italian Law 244/07)" |
-| RF04 | "Agriculture and connected activities and fishing (Arts. 34 and 34-bis, Italian Presidential Decree 633/72)" |
-| RF05 | "Sale of salts and tobaccos (Art. 74, section 1, Italian Presidential Decree 633/72)" |
-| RF06 | "Match sales (Art. 74, section 1, Italian Presidential Decree 633/72)" |
-| RF07 | "Publishing (Art. 74, section 1, Italian Presidential Decree 633/72)" |
-| RF08 | "Management of public telephone services (Art. 74, section 1, Italian Presidential Decree 633/72)" |
-| RF09 | "Resale of public transport and parking documents (Art. 74, section 1, Italian Presidential Decree 633/72)" |
-| RF10 | "Entertainment, gaming and other activities referred to by the tariff attached to Italian Presidential Decree 640/72 (Art. 74, section 6, Italian Presidential Decree 633/72)" |
-| RF11 | "Travel and tourism agencies (Art. 74-ter, Italian Presidential Decree 633/72)" |
-| RF12 | "Farmhouse accommodation/restaurants (Art. 5, section 2, Italian law 413/91)" |
-| RF13 | "Door-to-door sales (Art. 25-bis, section 6, Italian Presidential Decree 600/73)" |
-| RF14 | "Resale of used goods, artworks, antiques or collector's items (Art. 36, Italian Decree Law 41/95)" |
-| RF15 | "Artwork, antiques or collector's items auction agencies (Art. 40-bis, Italian Decree Law 41/95)" |
-| RF16 | "VAT paid in cash by P.A. (Art. 6, section 5, Italian Presidential Decree 633/72)" |
-| RF17 | "VAT paid in cash by subjects with business turnover below Euro 200,000 (Art. 7, Italian Decree Law 185/2008)" |
-| RF18 | Other |
-| RF19 | "Flat rate (Art. 1, section 54-89, Italian Law 190/2014)" |
+| Code | support | Description                                                            |
+|------|---------|------------------------------------------------------------------------|
+| RF01 | ✓       | Ordinary                                                               |
+| RF02 |         | Minimum taxpayers                                                      |
+| RF04 |         | Agriculture and connected activities and fishing                       |
+| RF05 |         | Sale of salts and tobaccos                                             |
+| RF06 |         | Match sales                                                            |
+| RF07 |         | Publishing                                                             |
+| RF08 |         | Management of public telephone services                                |
+| RF09 |         | Resale of public transport and parking documents                       |
+| RF10 |         | Entertainment, gaming, etc referred to by tariff in DPR 640/72         |
+| RF11 |         | Travel and tourism agencies                                            |
+| RF12 |         | Farmhouse accommodation/restaurants                                    |
+| RF13 |         | Door-to-door sales                                                     |
+| RF14 |         | Resale of used goods, artworks, antiques or collector's items          |
+| RF15 |         | Artwork, antiques or collector's items auction agencies                |
+| RF16 |         | VAT paid in cash by P.A.                                               |
+| RF17 |         | VAT paid in cash by subjects with business turnover below Euro 200,000 |
+| RF18 |         | Other                                                                  |
+| RF19 |         | Flat rate                                                              |
 
-##### TipoCassa (Fund Type) - optional
+##### TipoCassa (Fund Type)
 
-| | |
-|---|---|
-| TC01 | National Pension and Welfare Fund for Lawyers and Solicitors |
-| TC02 | Pension fund for accountants |
-| TC03 | Pension and welfare fund for surveyors |
-| TC04 | National pension and welfare fund for self-employed engineers and architects |
-| TC05 | National fund for solicitors |
-| TC06 | National pension and welfare fund for bookkeepers and commercial experts |
-| TC07 | National welfare board for sales agents and representatives (ENASARCO - Ente Nazionale Assistenza Agenti e Rappresentanti di Commercio) |
-| TC08 | National pension and welfare board for employment consultants (ENPACL - Ente Nazionale Previdenza e Assistenza Consulenti del Lavoro) |
-| TC09 | National pension and welfare board for doctors (ENPAM - Ente Nazionale Previdenza e Assistenza Medici) |
-| TC10 | National pension and welfare board for pharmacists (ENPAF - Ente Nazionale Previdenza e Assistenza Farmacisti ) |
-| TC11 | National pension and welfare board for veterinary physicians (ENPAV - Ente Nazionale Previdenza e Assistenza Veterinari) |
-| TC12 | National pension and welfare board for agricultural employees (ENPAIA - Ente Nazionale Previdenza e Assistenza Impiegati dell'Agricoltura) |
-| TC13 | Pension fund for employees of shipping companies and maritime agencies) |
-| TC14 | National pension institute for Italian journalists (INPGI - Istituto Nazionale Previdenza Giornalisti Italiani) |
-| TC15 | National welfare board for orphans of Italian doctors (ONAOSI - Opera Nazionale Assistenza Orfani Sanitari Italiani) |
-| TC16 | Autonomous supplementary welfare fund for Italian journalists (CASAGIT - Cassa Autonoma Assistenza Integrativa Giornalisti Italiani) |
-| TC17 | Pension board for industrial experts and graduate industrial experts (EPPI - Ente Previdenza Periti Industriali e Periti Industriali Laureati) |
-| TC18 | National multi-category pension and welfare board (EPAP - Ente Previdenza e Assistenza Pluricategoriale) |
-| TC19 | National pension and welfare board for biologists (ENPAB - Ente Nazionale Previdenza e Assistenza Biologi) |
-| TC20 | National pension and welfare board for the nursing profession (ENPAPI - Ente Nazionale Previdenza e Assistenza Professione Infermieristica) |
-| TC21 | National pension and welfare board for psychologists (ENPAP - Ente Nazionale Previdenza e Assistenza Psicologi) |
-| TC22 | National Social Security Institute (INPS - Istituto Nazionale della Previdenza Sociale) |
+| Code | Supported | Description                                                                  |
+|------|-----------|------------------------------------------------------------------------------|
+| TC01 |           | National Pension and Welfare Fund for Lawyers and Solicitors                 |
+| TC02 |           | Pension fund for accountants                                                 |
+| TC03 |           | Pension and welfare fund for surveyors                                       |
+| TC04 |           | National pension and welfare fund for self-employed engineers and architects |
+| TC05 |           | National fund for solicitors                                                 |
+| TC06 |           | National pension and welfare fund for bookkeepers and commercial experts     |
+| TC07 |           | ENASARCO (National welfare board for sales agents and representatives)       |
+| TC08 |           | ENPACL (National pension and welfare board for employment consultants)       |
+| TC09 |           | ENPAM (National pension and welfare board for doctors)                       |
+| TC10 |           | ENPAF (National pension and welfare board for pharmacists)                   |
+| TC11 |           | ENPAV (National pension and welfare board for veterinary physicians)         |
+| TC12 |           | ENPAIA (National pension and welfare board for agricultural employees)       |
+| TC13 |           | Pension fund for employees of shipping companies and maritime agencies)      |
+| TC14 |           | INPGI (National pension institute for Italian journalists)                   |
+| TC15 |           | ONAOSI (National welfare board for orphans of Italian doctors)               |
+| TC16 |           | CASAGIT (Autonomous supplementary welfare fund for Italian journalists)      |
+| TC17 |           | EPPI (Pension board for industrial experts and graduate industrial experts)  |
+| TC18 |           | EPAP (National multi-category pension and welfare board)                     |
+| TC19 |           | ENPAB (National pension and welfare board for biologists)                    |
+| TC20 |           | ENPAPI (National pension and welfare board for the nursing profession)       |
+| TC21 |           | ENPAP (National pension and welfare board for psychologists)                 |
+| TC22 |           | INPS (National Social Security Institute)                                    |
 
-##### ModalitaPagamento (Payment Method) - mandatory
+##### ModalitaPagamento (Payment Method)
 
-| | |
-|---|---|
-| MP01 | cash |
-| MP02 | cheque |
-| MP03 | banker's draft |
-| MP04 | cash at Treasury |
-| MP05 | bank transfer |
-| MP06 | money order |
-| MP07 | pre-compiled bank payment slip |
-| MP08 | payment card |
-| MP09 | direct debit |
-| MP10 | utilities direct debit |
-| MP11 | fast direct debit |
-| MP12 | collection order |
-| MP13 | payment by notice |
-| MP14 | tax office quittance |
-| MP15 | transfer on special accounting accounts |
-| MP16 | order for direct payment from bank account |
-| MP17 | order for direct payment from post office account |
-| MP18 | bulletin postal account |
-| MP19 | SEPA Direct Debit |
-| MP20 | SEPA Direct Debit CORE |
-| MP21 | SEPA Direct Debit B2B |
-| MP22 | Deduction on sums already collected |
-| MP23 | PagoPA |
+| Code | Support | Description                                       |
+|------|---------|---------------------------------------------------|
+| MP01 | ✓       | cash                                              |
+| MP02 |         | cheque                                            |
+| MP03 |         | banker's draft                                    |
+| MP04 |         | cash at Treasury                                  |
+| MP05 | ✓       | bank transfer                                     |
+| MP06 |         | money order                                       |
+| MP07 |         | pre-compiled bank payment slip                    |
+| MP08 | ✓       | payment card                                      |
+| MP09 | ✓       | direct debit                                      |
+| MP10 | ✓       | utilities direct debit                            |
+| MP11 | ✓       | fast direct debit                                 |
+| MP12 |         | collection order                                  |
+| MP13 |         | payment by notice                                 |
+| MP14 |         | tax office quittance                              |
+| MP15 |         | transfer on special accounting accounts           |
+| MP16 |         | order for direct payment from bank account        |
+| MP17 |         | order for direct payment from post office account |
+| MP18 |         | bulletin postal account                           |
+| MP19 | ✓       | SEPA Direct Debit                                 |
+| MP20 | ✓       | SEPA Direct Debit CORE                            |
+| MP21 | ✓       | SEPA Direct Debit B2B                             |
+| MP22 |         | Deduction on sums already collected               |
+| MP23 |         | PagoPA                                            |
 
-##### TipoDocumento (Document Type) - mandatory
-| | |
-|---|---|
-| TD01 | invoice |
-| TD02 | advance/down payment on invoice |
-| TD03 | advance/down payment on fee |
-| TD04 | credit note |
-| TD05 | debit note |
-| TD06 | fee |
-| TD16 | reverse charge internal invoice integration |
-| TD17 | integration/self invoicing for purchase services from abroad |
-| TD18 | integration for purchase of intra UE goods |
-| TD19 | integration/self invoicing for purchase of goods ex art.17 c.2 DPR 633/72 |
-| TD20 | self invoicing for regularisation and integration of invoices (ex art.6 c.8 and 9-bis d.lgs 471/97 or art.46 c.5 D.L. 331/93) |
-| TD21 | self invoicing for splaphoning |
-| TD22 | extractions of goods from VAT Warehouse |
-| TD23 | extractions of goods from VAT Warehouse with payment of VAT |
-| TD24 | "deferred invoice ex art.21, c.4, lett. a) DPR 633/72" |
-| TD25 | "deferred invoice ex art.21, c.4, third period lett. b) DPR 633/72" |
-| TD26 | sale of depreciable assets and for internal transfers (ex art.36 DPR 633/72) |
-| TD27 | self invoicing for self consumption or for free transfer without recourse |
-| TD28 | Purchases from San Marino with VAT (paper invoice) |
+##### TipoDocumento (Document Type)
 
-##### Natura (Nature) - optional
-| | |
-|---|---|
-| N1 | excluded pursuant to Art. 15, DPR 633/72 |
-| N2 | not subject  (this code is no longer permitted to use on invoices emitted from 1 January 2021 ) |
-| N2.1 | not subject to VAT under the articles from 7 to 7-septies of DPR 633/72 |
-| N2.2 | not subject – other cases |
-| N3 | not taxable  (this code is no longer permitted to use on invoices emitted from 1 January 2021 ) |
-| N3.1 | not taxable - exportations |
-| N3.2 | not taxable - intra Community transfers |
-| N3.3 | not taxable - transfers to San Marino |
-| N3.4 | not taxable - transactions treated as export supplies |
-| N3.5 | not taxable - for declaration of intent |
-| N3.6 | not taxable – other transactions that don’t contribute to the determination of ceiling |
-| N4 | exempt |
-| N5 | margin regime / VAT not exposed on invoice |
-| N6 | "reverse charge (for transactions in reverse charge or for self invoicing for purchase of extra UE services or for import of goods only in the cases provided for) — (this code is no longer permitted to use on invoices emitted from 1 January 2021 )" |  |
-| N6.1 | reverse charge - transfer of scrap and of other recyclable materials |
-| N6.2 | reverse charge - trasnfer of gold and pure silver pursuant to law 7/2000 as well as used jewelery to OPO |
-| N6.3 | reverse charge - subcontracting in the construction sector |
-| N6.4 | reverse charge - transfer of buildings |
-| N6.5 | reverse charge - transfer of mobile phones |
-| N6.6 | reverse charge - transfer of electronic products |
-| N6.7 | reverse charge - provisions in the construction and related sectors |
-| N6.8 | reverse charge - transactions in the energy sector |
-| N6.9 | reverse charge - other cases |
-| N7 | "VAT paid in other EU countries (telecommunications, tele-broadcasting and electronic services provision pursuant to Art. 7 -octies letter a, b, art. 74-sexies Italian Presidential Decree 633/72)" |
+| Code | Support | Description                                                          |
+|------|---------|----------------------------------------------------------------------|
+| TD01 | ✓       | invoice                                                              |
+| TD02 |         | advance/down payment on invoice                                      |
+| TD03 |         | advance/down payment on fee                                          |
+| TD04 | ✓       | credit note                                                          |
+| TD05 |         | debit note                                                           |
+| TD06 |         | fee                                                                  |
+| TD16 |         | reverse charge internal invoice integration                          |
+| TD17 |         | integration/self invoicing for purchase services from abroad         |
+| TD18 |         | integration for purchase of intra UE goods                           |
+| TD19 |         | integration/self invoicing for purchase of goods                     |
+| TD20 |         | self invoicing for regularisation and integration of invoices        |
+| TD21 |         | self invoicing for splaphoning                                       |
+| TD22 |         | extractions of goods from VAT Warehouse                              |
+| TD23 |         | extractions of goods from VAT Warehouse with payment of VAT          |
+| TD24 |         | "deferred invoice ex art.21, c.4, lett. a) DPR 633/72"               |
+| TD25 |         | "deferred invoice ex art.21, c.4, third period lett. b) DPR 633/72"  |
+| TD26 |         | sale of depreciable assets and for internal transfers                |
+| TD27 |         | self invoicing for self consumption / free transfer without recourse |
+| TD28 |         | Purchases from San Marino with VAT (paper invoice)                   |
 
-##### TipoRitenuta (Withholding Type) - optional
-| | |
-|---|---|
-| RT01 | witholding tax natural persons |
-| RT02 | witholding corporate entities |
-| RT03 | INPS contribution |
-| RT04 | ENASARCO contribution |
-| RT05 | ENPAM contribution |
-| RT06 | Other social security contribution |
+##### Natura (Nature)
+
+| Code | Support | Description                                                             |
+|------|---------|-------------------------------------------------------------------------|
+| N1   |         | excluded pursuant to Art. 15, DPR 633/72                                |
+| N2.1 |         | not subject to VAT under the articles from 7 to 7-septies of DPR 633/72 |
+| N2.2 |         | not subject – other cases                                               |
+| N3.1 |         | not taxable - exportations                                              |
+| N3.2 |         | not taxable - intra Community transfers                                 |
+| N3.3 |         | not taxable - transfers to San Marino                                   |
+| N3.4 |         | not taxable - transactions treated as export supplies                   |
+| N3.5 |         | not taxable - for declaration of intent                                 |
+| N3.6 |         | not taxable – other transactions that do not count towards the plafond. |
+| N4   |         | exempt                                                                  |
+| N5   |         | margin regime / VAT not exposed on invoice                              |
+| N6.1 | ✓       | reverse charge - transfer of scrap and of other recyclable materials    |
+| N6.2 | ✓       | reverse charge - transfer of gold, silver, and jewelry                  |
+| N6.3 | ✓       | reverse charge - subcontracting in the construction sector              |
+| N6.4 | ✓       | reverse charge - transfer of buildings                                  |
+| N6.5 | ✓       | reverse charge - transfer of mobile phones                              |
+| N6.6 | ✓       | reverse charge - transfer of electronic products                        |
+| N6.7 | ✓       | reverse charge - provisions in the construction and related sectors     |
+| N6.8 | ✓       | reverse charge - transactions in the energy sector                      |
+| N6.9 | ✓       | reverse charge - other cases                                            |
+| N7   |         | VAT paid in other EU countries (telecommunications)                     |
+
+##### TipoRitenuta (Withholding Type)
+
+| Code | Support | Description                        |
+|------|---------|------------------------------------|
+| RT01 | ✓       | witholding tax natural persons     |
+| RT02 | ✓       | witholding corporate entities      |
+| RT03 | ✓       | INPS contribution                  |
+| RT04 | ✓       | ENASARCO contribution              |
+| RT05 | ✓       | ENPAM contribution                 |
+| RT06 | ✓       | Other social security contribution |

--- a/regimes/it/README.md
+++ b/regimes/it/README.md
@@ -37,7 +37,7 @@ FatturaPA demands very specific categorization for the type of economic activity
 document type, fund type, etc. It will be a challenge to map these onto GOBL
 constructs.
 
-##### RegimeFiscale (Tax System)
+##### RegimeFiscale (Tax System) - mandatory
 
 |  |  |
 |---|---|
@@ -60,7 +60,7 @@ constructs.
 | RF18 | Other |
 | RF19 | "Flat rate (Art. 1, section 54-89, Italian Law 190/2014)" |
 
-##### TipoCassa (Fund Type)
+##### TipoCassa (Fund Type) - optional
 
 | | |
 |---|---|
@@ -87,7 +87,7 @@ constructs.
 | TC21 | National pension and welfare board for psychologists (ENPAP - Ente Nazionale Previdenza e Assistenza Psicologi) |
 | TC22 | National Social Security Institute (INPS - Istituto Nazionale della Previdenza Sociale) |
 
-##### ModalitaPagamento (Payment Method)
+##### ModalitaPagamento (Payment Method) - mandatory
 
 | | |
 |---|---|
@@ -115,7 +115,7 @@ constructs.
 | MP22 | Deduction on sums already collected |
 | MP23 | PagoPA |
 
-##### TipoDocumento (Document Type)
+##### TipoDocumento (Document Type) - mandatory
 | | |
 |---|---|
 | TD01 | invoice |
@@ -138,7 +138,7 @@ constructs.
 | TD27 | self invoicing for self consumption or for free transfer without recourse |
 | TD28 | Purchases from San Marino with VAT (paper invoice) |
 
-##### Natura (Nature)
+##### Natura (Nature) - optional
 | | |
 |---|---|
 | N1 | excluded pursuant to Art. 15, DPR 633/72 |
@@ -166,7 +166,7 @@ constructs.
 | N6.9 | reverse charge - other cases |
 | N7 | "VAT paid in other EU countries (telecommunications, tele-broadcasting and electronic services provision pursuant to Art. 7 -octies letter a, b, art. 74-sexies Italian Presidential Decree 633/72)" |
 
-##### TipoRitenuta (Withholding Type)
+##### TipoRitenuta (Withholding Type) - optional
 | | |
 |---|---|
 | RT01 | witholding tax natural persons |

--- a/regimes/it/code_maps.go
+++ b/regimes/it/code_maps.go
@@ -1,0 +1,63 @@
+package it
+
+import (
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/i18n"
+	"github.com/invopop/gobl/pay"
+	"github.com/invopop/gobl/regimes/common"
+)
+
+const (
+	FPACodeTypeTaxSystem       cbc.Key = "fpa-tax-system"
+	FPACodeTypeFundType        cbc.Key = "fpa-fund-type"
+	FPACodeTypePaymentMethod   cbc.Key = "fpa-payment-method"
+	FPACodeTypeDocumentType    cbc.Key = "fpa-document-type"
+	FPACodeTypeNature          cbc.Key = "fpa-nature"
+	FPACodeTypeWithholdingType cbc.Key = "fpa-withholding-type"
+)
+
+type FPACodeOptions struct {
+	FPACodeType cbc.Key
+	FPACodes    []string
+}
+
+var InvoiceTypeMap = map[bill.InvoiceType]*FPACodeOptions{
+	bill.InvoiceTypeNone: {
+		FPACodeType: FPACodeTypeDocumentType,
+		FPACodes:    {"TD01"},
+	},
+	bill.InvoiceTypeCreditNote: {
+		FPACodeType: FPACodeTypeDocumentType,
+		FPACodes:    {"TD04"},
+	},
+}
+
+var PaymentMethodMap = map[pay.MethodKey]*FPACodeOptions{
+	pay.MethodKeyCash: {
+		FPACodeType: FPACodeTypePaymentMethod,
+		FPACodes:    {"MP01"},
+	},
+	pay.MethodKeyCard: {
+		FPACodeType: FPACodeTypePaymentMethod,
+		FPACodes:    {"MP08"},
+	},
+	pay.MethodKeyDirectDebit: {
+		FPACodeType: FPACodeTypePaymentMethod,
+		FPACodes:    {"MP10"},
+	},
+}
+
+var SchemeMap = map[cbc.Key]*FPACodeOptions{
+	common.SchemeReverseCharge: {
+		FPACodeType: FPACodeTypeNature,
+		FPACodes:    {"N6.1", "N6.2", "N6.3", "N6.4", "N6.5", "N6.6", "N6.7", "N6.8", "N6.9"},
+	},
+}
+
+var TaxCategoryMap = map[cbc.Code]*FPACodeOptions{
+	TaxCategoryRA: {
+		FPACodeType: FPACodeTypeWithholdingType,
+		FPACodes:    {"RT01", "RT02", "RT03", "RT04", "RT05", "RT06"},
+	},
+}

--- a/regimes/it/fpa_code_maps.go
+++ b/regimes/it/fpa_code_maps.go
@@ -71,13 +71,13 @@ var PaymentMethodMap = map[pay.MethodKey]*FPACodeGroup{
 	pay.MethodKeyCreditTransfer: {
 		Type: FPACodeTypePaymentMethod,
 		Codes: []FPACode{
-			FPACodePaymentBankTransfer
+			FPACodePaymentBankTransfer,
 		},
 	},
 	pay.MethodKeyDebitTransfer: {
 		Type: FPACodeTypePaymentMethod,
 		Codes: []FPACode{
-			FPACodePaymentBankTransfer
+			FPACodePaymentBankTransfer,
 		},
 	},
 }

--- a/regimes/it/fpa_code_maps.go
+++ b/regimes/it/fpa_code_maps.go
@@ -7,56 +7,96 @@ import (
 	"github.com/invopop/gobl/regimes/common"
 )
 
+// Fattura PA codes are used by the Italian tax system to classify various
+// aspects of the invoice, namely the type of document, the payment method,
+// the nature of the transaction, the type of fund (if applicable), and the
+// type of withholding taxes (if applicable).
 const (
-	FPACodeTypeTaxSystem       cbc.Key = "fpa-tax-system"
-	FPACodeTypeFundType        cbc.Key = "fpa-fund-type"
-	FPACodeTypePaymentMethod   cbc.Key = "fpa-payment-method"
-	FPACodeTypeDocumentType    cbc.Key = "fpa-document-type"
-	FPACodeTypeNature          cbc.Key = "fpa-nature"
-	FPACodeTypeWithholdingType cbc.Key = "fpa-withholding-type"
+	FPACodeTypeTaxSystem         cbc.Key = "fpa-tax-system"         // RegimeFiscale
+	FPACodeTypeFundType          cbc.Key = "fpa-fund-type"          // TipoCassa
+	FPACodeTypePaymentMethod     cbc.Key = "fpa-payment-method"     // ModalitaPagamento
+	FPACodeTypeDocumentType      cbc.Key = "fpa-document-type"      // TipoDocumento
+	FPACodeTypeTransactionNature cbc.Key = "fpa-transaction-nature" // Natura
+	FPACodeTypeWithholdingType   cbc.Key = "fpa-withholding-type"   // TipoRitenuta
 )
 
-type FPACodeOptions struct {
-	FPACodeType cbc.Key
-	FPACodes    []string
+// FPACodeGroup is a group of FPA codes under the same type that are variations
+// of a related concept.
+type FPACodeGroup struct {
+	Type  cbc.Key
+	Codes []FPACode
 }
 
-var InvoiceTypeMap = map[bill.InvoiceType]*FPACodeOptions{
+// InvoiceTypeMap maps invoice types to FPA codes.
+var InvoiceTypeMap = map[bill.InvoiceType]*FPACodeGroup{
 	bill.InvoiceTypeNone: {
-		FPACodeType: FPACodeTypeDocumentType,
-		FPACodes:    []string{"TD01"},
+		Type: FPACodeTypeDocumentType,
+		Codes: []FPACode{
+			FPACodeDocumentTypeInvoice,
+		},
 	},
 	bill.InvoiceTypeCreditNote: {
-		FPACodeType: FPACodeTypeDocumentType,
-		FPACodes:    []string{"TD04"},
+		Type: FPACodeTypeDocumentType,
+		Codes: []FPACode{
+			FPACodeDocumentTypeCreditNote,
+		},
 	},
 }
 
-var PaymentMethodMap = map[pay.MethodKey]*FPACodeOptions{
+// PaymentMethodMap maps the invoice's payment instruction keys to FPA codes.
+var PaymentMethodMap = map[pay.MethodKey]*FPACodeGroup{
 	pay.MethodKeyCash: {
-		FPACodeType: FPACodeTypePaymentMethod,
-		FPACodes:    []string{"MP01"},
+		Type: FPACodeTypePaymentMethod,
+		Codes: []FPACode{
+			FPACodePaymentMethodCash,
+		},
 	},
 	pay.MethodKeyCard: {
-		FPACodeType: FPACodeTypePaymentMethod,
-		FPACodes:    []string{"MP08"},
+		Type: FPACodeTypePaymentMethod,
+		Codes: []FPACode{
+			FPACodePaymentMethodCard,
+		},
 	},
 	pay.MethodKeyDirectDebit: {
-		FPACodeType: FPACodeTypePaymentMethod,
-		FPACodes:    []string{"MP10"},
+		Type: FPACodeTypePaymentMethod,
+		Codes: []FPACode{
+			FPACodePaymentDirectDebit,
+		},
 	},
 }
 
-var SchemeMap = map[cbc.Key]*FPACodeOptions{
+// SchemeMap maps the invoice's scheme keys to FPA codes. There is a limitation
+// here, in that the FPA codes of "Nature" do not necessarily map onto the
+// general concept of "Scheme" and vice versa.
+var SchemeMap = map[cbc.Key]*FPACodeGroup{
 	common.SchemeReverseCharge: {
-		FPACodeType: FPACodeTypeNature,
-		FPACodes:    []string{"N6.1", "N6.2", "N6.3", "N6.4", "N6.5", "N6.6", "N6.7", "N6.8", "N6.9"},
+		Type: FPACodeTypeTransactionNature,
+		Codes: []FPACode{
+			FPACodeNatureRCScrapMaterials,
+			FPACodeNatureRCGoldSilver,
+			FPACodeNatureRCConstructionSubcontracting,
+			FPACodeNatureRCBuildings,
+			FPACodeNatureRCMobile,
+			FPACodeNatureRCElectronics,
+			FPACodeNatureRCConstructionProvisions,
+			FPACodeNatureRCEnergy,
+			FPACodeNatureRCOther,
+		},
 	},
 }
 
-var TaxCategoryMap = map[cbc.Code]*FPACodeOptions{
+// TaxCategoryMap maps the invoice's tax category keys to FPA codes related to
+// withholding taxes.
+var TaxCategoryMap = map[cbc.Code]*FPACodeGroup{
 	TaxCategoryRA: {
-		FPACodeType: FPACodeTypeWithholdingType,
-		FPACodes:    []string{"RT01", "RT02", "RT03", "RT04", "RT05", "RT06"},
+		Type: FPACodeTypeWithholdingType,
+		Codes: []FPACode{
+			FPACodeWithholdingNaturalPersons,
+			FPACodeWithholdingLegalPersons,
+			FPACodeWithholdingINPSContribution,
+			FPACodeWithholdingENASARCOContribution,
+			FPACodeWithholdingENPAMContribution,
+			FPACodeWithholdingOtherSocialSecurity,
+		},
 	},
 }

--- a/regimes/it/fpa_code_maps.go
+++ b/regimes/it/fpa_code_maps.go
@@ -3,7 +3,6 @@ package it
 import (
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cbc"
-	"github.com/invopop/gobl/i18n"
 	"github.com/invopop/gobl/pay"
 	"github.com/invopop/gobl/regimes/common"
 )
@@ -25,39 +24,39 @@ type FPACodeOptions struct {
 var InvoiceTypeMap = map[bill.InvoiceType]*FPACodeOptions{
 	bill.InvoiceTypeNone: {
 		FPACodeType: FPACodeTypeDocumentType,
-		FPACodes:    {"TD01"},
+		FPACodes:    []string{"TD01"},
 	},
 	bill.InvoiceTypeCreditNote: {
 		FPACodeType: FPACodeTypeDocumentType,
-		FPACodes:    {"TD04"},
+		FPACodes:    []string{"TD04"},
 	},
 }
 
 var PaymentMethodMap = map[pay.MethodKey]*FPACodeOptions{
 	pay.MethodKeyCash: {
 		FPACodeType: FPACodeTypePaymentMethod,
-		FPACodes:    {"MP01"},
+		FPACodes:    []string{"MP01"},
 	},
 	pay.MethodKeyCard: {
 		FPACodeType: FPACodeTypePaymentMethod,
-		FPACodes:    {"MP08"},
+		FPACodes:    []string{"MP08"},
 	},
 	pay.MethodKeyDirectDebit: {
 		FPACodeType: FPACodeTypePaymentMethod,
-		FPACodes:    {"MP10"},
+		FPACodes:    []string{"MP10"},
 	},
 }
 
 var SchemeMap = map[cbc.Key]*FPACodeOptions{
 	common.SchemeReverseCharge: {
 		FPACodeType: FPACodeTypeNature,
-		FPACodes:    {"N6.1", "N6.2", "N6.3", "N6.4", "N6.5", "N6.6", "N6.7", "N6.8", "N6.9"},
+		FPACodes:    []string{"N6.1", "N6.2", "N6.3", "N6.4", "N6.5", "N6.6", "N6.7", "N6.8", "N6.9"},
 	},
 }
 
 var TaxCategoryMap = map[cbc.Code]*FPACodeOptions{
 	TaxCategoryRA: {
 		FPACodeType: FPACodeTypeWithholdingType,
-		FPACodes:    {"RT01", "RT02", "RT03", "RT04", "RT05", "RT06"},
+		FPACodes:    []string{"RT01", "RT02", "RT03", "RT04", "RT05", "RT06"},
 	},
 }

--- a/regimes/it/fpa_code_maps.go
+++ b/regimes/it/fpa_code_maps.go
@@ -48,31 +48,36 @@ var PaymentMethodMap = map[pay.MethodKey]*FPACodeGroup{
 	pay.MethodKeyCash: {
 		Type: FPACodeTypePaymentMethod,
 		Codes: []FPACode{
-			FPACodePaymentMethodCash,
+			FPACodePaymentCash,
 		},
 	},
 	pay.MethodKeyCard: {
 		Type: FPACodeTypePaymentMethod,
 		Codes: []FPACode{
-			FPACodePaymentMethodCard,
+			FPACodePaymentCard,
 		},
 	},
 	pay.MethodKeyDirectDebit: {
 		Type: FPACodeTypePaymentMethod,
 		Codes: []FPACode{
-			FPACodePaymentMethodDirectDebit,
+			FPACodePaymentDirectDebit,
+			FPACodePaymentDirectDebitUtilities,
+			FPACodePaymentDirectDebitFast,
+			FPACodePaymentDirectDebitSepa,
+			FPACodePaymentDirectDebitSepaCore,
+			FPACodePaymentDirectDebitSepaB2B,
 		},
 	},
 	pay.MethodKeyCreditTransfer: {
 		Type: FPACodeTypePaymentMethod,
 		Codes: []FPACode{
-			FPACodePaymentMethodBankTransfer
+			FPACodePaymentBankTransfer
 		},
 	},
 	pay.MethodKeyDebitTransfer: {
 		Type: FPACodeTypePaymentMethod,
 		Codes: []FPACode{
-			FPACodePaymentMethodBankTransfer
+			FPACodePaymentBankTransfer
 		},
 	},
 }

--- a/regimes/it/fpa_code_maps.go
+++ b/regimes/it/fpa_code_maps.go
@@ -60,7 +60,19 @@ var PaymentMethodMap = map[pay.MethodKey]*FPACodeGroup{
 	pay.MethodKeyDirectDebit: {
 		Type: FPACodeTypePaymentMethod,
 		Codes: []FPACode{
-			FPACodePaymentDirectDebit,
+			FPACodePaymentMethodDirectDebit,
+		},
+	},
+	pay.MethodKeyCreditTransfer: {
+		Type: FPACodeTypePaymentMethod,
+		Codes: []FPACode{
+			FPACodePaymentMethodBankTransfer
+		},
+	},
+	pay.MethodKeyDebitTransfer: {
+		Type: FPACodeTypePaymentMethod,
+		Codes: []FPACode{
+			FPACodePaymentMethodBankTransfer
 		},
 	},
 }

--- a/regimes/it/fpa_codes.go
+++ b/regimes/it/fpa_codes.go
@@ -1,0 +1,157 @@
+package it
+
+import (
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/i18n"
+)
+
+// KeyDefinition defines properties of a key that is specific for a regime.
+type KeyDefinition struct {
+	// Actual key value.
+	Key cbc.Key `json:"key" jsonschema:"title=Key"`
+	// There is usually a mapping between a key and some local code.
+	Code string `json:"code,omitempty" jsonschema:"title=Code"`
+	// Short name for the key, if relevant.
+	Name i18n.String `json:"name,omitempty" jsonschema:"title=Name"`
+	// Description offering more details about when the key should be used.
+	Desc i18n.String `json:"desc,omitempty" jsonschema:"title=Description"`
+	// Any additional data that might be relevant in some regimes?
+	Meta cbc.Meta `json:"meta,omitempty" jsonschema:"title=Meta"`
+}
+
+const (
+	// Tax System (RegimeFiscale) Codes
+	FPACodeTaxSystemOrdinary cbc.Key = "tax-system-ordinary" // RF01
+
+	// Payment Method (ModalitaPagamento) Codes
+	FPACodePaymentMethodCash         cbc.Key = "tax-system-cash"          // MP01
+	FPACodePaymentMethodBankTransfer cbc.Key = "tax-system-bank-transfer" // MP05
+	FPACodePaymentMethodCard         cbc.Key = "tax-system-card"          // MP08
+	FPACodePaymentDirectDebit        cbc.Key = "tax-system-direct-debit"  // MP10
+
+	// Document Type (TipoDocumento) Codes
+	FPACodeDocumentTypeInvoice    cbc.Key = "document-type-invoice"     // TD01
+	FPACodeDocumentTypeCreditNote cbc.Key = "document-type-credit-note" // TD04
+
+	// Withholding Tax (TipoRitenuta) Codes
+	FPAWithholdingTaxNaturalPersons    cbc.Key = "withholding-tax-natural-persons"       // TR01
+	FPAWithholdingTaxLegalPersons      cbc.Key = "withholding-tax-legal-persons"         // TR02
+	FPAWithholdingINPSContribution     cbc.Key = "withholding-tax-inps-contribution"     // TR03
+	FPAWithholdingENASARCOContribution cbc.Key = "withholding-tax-enasarco-contribution" // TR04
+	FPAWithholdingENPAMContribution    cbc.Key = "withholding-tax-enpam-contribution"    // TR05
+	FPAWithholdingOtherSocialSecurity  cbc.Key = "withholding-tax-other-social-security" // TR06
+)
+
+// FPACode defines alphanumeric codes used by FatturaPA, Italy's e-invoicing
+// system
+var FPACodes = []*KeyDefinition{
+	// Tax System Codes
+	{
+		Key:  FPACodeTaxSystemOrdinary,
+		Code: "RF01",
+		Desc: i18n.String{
+			i18n.EN: "Ordinary tax system",
+			i18n.IT: "Regime ordinario",
+		},
+	},
+	// Payment Method Codes
+	{
+		Key:  FPACodePaymentMethodCash,
+		Code: "MP01",
+		Desc: i18n.String{
+			i18n.EN: "Cash",
+			i18n.IT: "Contanti",
+		},
+	},
+	{
+		Key:  FPACodePaymentMethodBankTransfer,
+		Code: "MP05",
+		Desc: i18n.String{
+			i18n.EN: "Bank transfer",
+			i18n.IT: "Bonifico bancario",
+		},
+	},
+	{
+		Key:  FPACodePaymentMethodCard,
+		Code: "MP08",
+		Desc: i18n.String{
+			i18n.EN: "Card",
+			i18n.IT: "Carta di credito",
+		},
+	},
+	{
+		Key:  FPACodePaymentDirectDebit,
+		Code: "MP10",
+		Desc: i18n.String{
+			i18n.EN: "Direct debit",
+			i18n.IT: "Rid",
+		},
+	},
+	// Document Type Codes
+	{
+		Key:  FPACodeDocumentTypeInvoice,
+		Code: "TD01",
+		Desc: i18n.String{
+			i18n.EN: "Invoice",
+			i18n.IT: "Fattura",
+		},
+	},
+	{
+		Key:  FPACodeDocumentTypeCreditNote,
+		Code: "TD04",
+		Desc: i18n.String{
+			i18n.EN: "Credit cote",
+			i18n.IT: "Nota di credito",
+		},
+	},
+	// Withholding Tax Codes
+	{
+		Key:  FPAWithholdingTaxNaturalPersons,
+		Code: "TR01",
+		Desc: i18n.String{
+			i18n.EN: "Withholding tax natural persons",
+			i18n.IT: "Ritenuta persone fisiche",
+		},
+	},
+	{
+		Key:  FPAWithholdingTaxLegalPersons,
+		Code: "TR02",
+		Desc: i18n.String{
+			i18n.EN: "Withholding tax legal persons",
+			i18n.IT: "Ritenuta persone giuridiche",
+		},
+	},
+	{
+		Key:  FPAWithholdingINPSContribution,
+		Code: "TR03",
+		Desc: i18n.String{
+			i18n.EN: "INPS contribution",
+			i18n.IT: "Contributo INPS",
+		},
+	},
+	{
+		Key:  FPAWithholdingENASARCOContribution,
+		Code: "TR04",
+		Desc: i18n.String{
+			i18n.EN: "ENASARCO contribution",
+			i18n.IT: "Contributo ENASARCO",
+		},
+	},
+	{
+		Key:  FPAWithholdingENPAMContribution,
+		Code: "TR05",
+		Desc: i18n.String{
+			i18n.EN: "ENPAM contribution",
+			i18n.IT: "Contributo ENPAM",
+		},
+	},
+	{
+		Key:  FPAWithholdingOtherSocialSecurity,
+		Code: "TR06",
+		Desc: i18n.String{
+			i18n.EN: "Other social security contribution",
+			i18n.IT: "Altro contributo previdenziale",
+		},
+	},
+}

--- a/regimes/it/fpa_codes.go
+++ b/regimes/it/fpa_codes.go
@@ -34,7 +34,7 @@ const (
 	FPACodePaymentMethodCash         FPACode = "MP01"
 	FPACodePaymentMethodBankTransfer FPACode = "MP05"
 	FPACodePaymentMethodCard         FPACode = "MP08"
-	FPACodePaymentDirectDebit        FPACode = "MP10"
+	FPACodePaymentMethodDirectDebit  FPACode = "MP10"
 
 	// Document Type (TipoDocumento) Codes
 	FPACodeDocumentTypeInvoice    FPACode = "TD01"

--- a/regimes/it/fpa_codes.go
+++ b/regimes/it/fpa_codes.go
@@ -7,13 +7,14 @@ import (
 	"github.com/invopop/gobl/i18n"
 )
 
-// FPACodeDefinition defines properties of an alphanumeric codes used by
-// FatturaPA, Italy's e-invoicing system. The codes are used to classify
-// various aspects of an invoice, namely the tax system, fund type, payment
-// method, document type, nature, and withholding type. An FPACode can include
-// uppercase letters, numbers, and a "." separator for the numeric portion.
+// FPACode is an alphanumeric code used by FatturaPA, Italy's e-invoicing
+// system. The codes are used to classify various aspects of an invoice, namely
+// the tax system, fund type, payment method, document type, transaction nature,
+// and withholding tax type. An FPACode can include uppercase letters, numbers,
+// and a "." separator for the numeric portion.
 type FPACode string
 
+// FPACodeDefinition defines properties of a FPACode
 type FPACodeDefinition struct {
 	// Alphanumeric code as required by FatturaPA.
 	Code FPACode
@@ -26,11 +27,13 @@ var (
 	codeValidationRegexp = regexp.MustCompile(codePattern)
 )
 
+// Tax System (RegimeFiscale) Codes
 const (
-	// Tax System (RegimeFiscale) Codes
 	FPACodeTaxSystemOrdinary FPACode = "RF01"
+)
 
-	// Payment Method (ModalitaPagamento) Codes
+// Payment Method (ModalitaPagamento) Codes
+const (
 	FPACodePaymentCash                 FPACode = "MP01"
 	FPACodePaymentBankTransfer         FPACode = "MP05"
 	FPACodePaymentCard                 FPACode = "MP08"
@@ -40,14 +43,18 @@ const (
 	FPACodePaymentDirectDebitSepa      FPACode = "MP19"
 	FPACodePaymentDirectDebitSepaCore  FPACode = "MP20"
 	FPACodePaymentDirectDebitSepaB2B   FPACode = "MP21"
+)
 
-	// Document Type (TipoDocumento) Codes
+// Document Type (TipoDocumento) Codes
+const (
 	FPACodeDocumentTypeInvoice    FPACode = "TD01"
 	FPACodeDocumentTypeCreditNote FPACode = "TD04"
+)
 
-	// Nature (Natura) Codes
+// Nature (Natura) Codes
+const (
 	// Reverse Charges
-	FPACodeNatureRCScrapMaterials             FPACode = "N6.1"
+	FPACodeNatureRCScrapMaterials             FPACode = "N6.1" // nolint:revive
 	FPACodeNatureRCGoldSilver                 FPACode = "N6.2"
 	FPACodeNatureRCConstructionSubcontracting FPACode = "N6.3"
 	FPACodeNatureRCBuildings                  FPACode = "N6.4"
@@ -56,8 +63,10 @@ const (
 	FPACodeNatureRCConstructionProvisions     FPACode = "N6.7"
 	FPACodeNatureRCEnergy                     FPACode = "N6.8"
 	FPACodeNatureRCOther                      FPACode = "N6.9"
+)
 
-	// Withholding Tax (TipoRitenuta) Codes
+// Withholding Tax (TipoRitenuta) Codes
+const (
 	FPACodeWithholdingNaturalPersons       FPACode = "TR01"
 	FPACodeWithholdingLegalPersons         FPACode = "TR02"
 	FPACodeWithholdingINPSContribution     FPACode = "TR03"
@@ -81,7 +90,7 @@ var FPACodeDefs = []*FPACodeDefinition{
 		Code: FPACodePaymentCash,
 		Desc: i18n.String{
 			i18n.EN: "Cash",
-			i18n.IT: "Contanti",
+			i18n.IT: "Contanti", // nolint:misspell
 		},
 	},
 	{
@@ -174,28 +183,28 @@ var FPACodeDefs = []*FPACodeDefinition{
 		Code: FPACodeWithholdingINPSContribution,
 		Desc: i18n.String{
 			i18n.EN: "INPS contribution",
-			i18n.IT: "Contributo INPS",
+			i18n.IT: "Contributo INPS", // nolint:misspell
 		},
 	},
 	{
 		Code: FPACodeWithholdingENASARCOContribution,
 		Desc: i18n.String{
 			i18n.EN: "ENASARCO contribution",
-			i18n.IT: "Contributo ENASARCO",
+			i18n.IT: "Contributo ENASARCO", // nolint:misspell
 		},
 	},
 	{
 		Code: FPACodeWithholdingENPAMContribution,
 		Desc: i18n.String{
 			i18n.EN: "ENPAM contribution",
-			i18n.IT: "Contributo ENPAM",
+			i18n.IT: "Contributo ENPAM", // nolint:misspell
 		},
 	},
 	{
 		Code: FPACodeWithholdingOtherSocialSecurity,
 		Desc: i18n.String{
 			i18n.EN: "Other social security contribution",
-			i18n.IT: "Altro contributo previdenziale",
+			i18n.IT: "Altro contributo previdenziale", // nolint:misspell
 		},
 	},
 	// Nature Codes
@@ -209,7 +218,7 @@ var FPACodeDefs = []*FPACodeDefinition{
 	{
 		Code: FPACodeNatureRCGoldSilver,
 		Desc: i18n.String{
-			i18n.EN: "Reverse charge - trasnfer of gold, pure silver, and jewelery",
+			i18n.EN: "Reverse charge - transfer of gold, pure silver, and jewelery",
 			i18n.IT: "Inversione contabile - cessione di oro e argento puro",
 		},
 	},

--- a/regimes/it/fpa_codes.go
+++ b/regimes/it/fpa_codes.go
@@ -1,23 +1,21 @@
 package it
 
 import (
-	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/i18n"
 )
 
-// KeyDefinition defines properties of a key that is specific for a regime.
-type KeyDefinition struct {
+// FPACodeDefinition defines properties of an alphanumeric codes used by
+// FatturaPA, Italy's e-invoicing system. The codes are used to classify
+// various aspects of an invoice, namely the tax system, fund type, payment
+// method, document type, nature, and withholding type.
+type FPACodeDefinition struct {
 	// Actual key value.
 	Key cbc.Key `json:"key" jsonschema:"title=Key"`
-	// There is usually a mapping between a key and some local code.
+	//
 	Code string `json:"code,omitempty" jsonschema:"title=Code"`
-	// Short name for the key, if relevant.
-	Name i18n.String `json:"name,omitempty" jsonschema:"title=Name"`
 	// Description offering more details about when the key should be used.
 	Desc i18n.String `json:"desc,omitempty" jsonschema:"title=Description"`
-	// Any additional data that might be relevant in some regimes?
-	Meta cbc.Meta `json:"meta,omitempty" jsonschema:"title=Meta"`
 }
 
 const (
@@ -34,18 +32,29 @@ const (
 	FPACodeDocumentTypeInvoice    cbc.Key = "document-type-invoice"     // TD01
 	FPACodeDocumentTypeCreditNote cbc.Key = "document-type-credit-note" // TD04
 
+	// Nature (Natura) Codes
+	// Reverse Charges
+	FPACodeNatureRCScrapMaterials             cbc.Key = "nature-rc-scrap-materials"             // N6.1
+	FPACodeNatureRCGoldSilver                 cbc.Key = "nature-rc-gold-silver"                 // N6.2
+	FPACodeNatureRCConstructionSubcontracting cbc.Key = "nature-rc-construction-subcontracting" // N6.3
+	FPACodeNatureRCBuildings                  cbc.Key = "nature-rc-buildings"                   // N6.4
+	FPACodeNatureRCMobile                     cbc.Key = "nature-rc-mobile"                      // N6.5
+	FPACodeNatureRCElectronics                cbc.Key = "nature-rc-electronics"                 // N6.6
+	FPACodeNatureRCConstructionProvisions     cbc.Key = "nature-rc-construction-provisions"     // N6.7
+	FPACodeNatureRCEnergy                     cbc.Key = "nature-rc-energy"                      // N6.8
+	FPACodeNatureRCOther                      cbc.Key = "nature-rc-other"                       // N6.9
+
 	// Withholding Tax (TipoRitenuta) Codes
-	FPAWithholdingTaxNaturalPersons    cbc.Key = "withholding-tax-natural-persons"       // TR01
-	FPAWithholdingTaxLegalPersons      cbc.Key = "withholding-tax-legal-persons"         // TR02
-	FPAWithholdingINPSContribution     cbc.Key = "withholding-tax-inps-contribution"     // TR03
-	FPAWithholdingENASARCOContribution cbc.Key = "withholding-tax-enasarco-contribution" // TR04
-	FPAWithholdingENPAMContribution    cbc.Key = "withholding-tax-enpam-contribution"    // TR05
-	FPAWithholdingOtherSocialSecurity  cbc.Key = "withholding-tax-other-social-security" // TR06
+	FPACodeWithholdingNaturalPersons       cbc.Key = "withholding-tax-natural-persons"       // TR01
+	FPACodeWithholdingLegalPersons         cbc.Key = "withholding-tax-legal-persons"         // TR02
+	FPACodeWithholdingINPSContribution     cbc.Key = "withholding-tax-inps-contribution"     // TR03
+	FPACodeWithholdingENASARCOContribution cbc.Key = "withholding-tax-enasarco-contribution" // TR04
+	FPACodeWithholdingENPAMContribution    cbc.Key = "withholding-tax-enpam-contribution"    // TR05
+	FPACodeWithholdingOtherSocialSecurity  cbc.Key = "withholding-tax-other-social-security" // TR06
 )
 
-// FPACode defines alphanumeric codes used by FatturaPA, Italy's e-invoicing
-// system
-var FPACodes = []*KeyDefinition{
+// FPACodeDefs includes all FatturaPA codes currently supported in GOBL
+var FPACodeDefs = []*FPACodeDefinition{
 	// Tax System Codes
 	{
 		Key:  FPACodeTaxSystemOrdinary,
@@ -107,7 +116,7 @@ var FPACodes = []*KeyDefinition{
 	},
 	// Withholding Tax Codes
 	{
-		Key:  FPAWithholdingTaxNaturalPersons,
+		Key:  FPACodeWithholdingNaturalPersons,
 		Code: "TR01",
 		Desc: i18n.String{
 			i18n.EN: "Withholding tax natural persons",
@@ -115,7 +124,7 @@ var FPACodes = []*KeyDefinition{
 		},
 	},
 	{
-		Key:  FPAWithholdingTaxLegalPersons,
+		Key:  FPACodeWithholdingLegalPersons,
 		Code: "TR02",
 		Desc: i18n.String{
 			i18n.EN: "Withholding tax legal persons",
@@ -123,7 +132,7 @@ var FPACodes = []*KeyDefinition{
 		},
 	},
 	{
-		Key:  FPAWithholdingINPSContribution,
+		Key:  FPACodeWithholdingINPSContribution,
 		Code: "TR03",
 		Desc: i18n.String{
 			i18n.EN: "INPS contribution",
@@ -131,7 +140,7 @@ var FPACodes = []*KeyDefinition{
 		},
 	},
 	{
-		Key:  FPAWithholdingENASARCOContribution,
+		Key:  FPACodeWithholdingENASARCOContribution,
 		Code: "TR04",
 		Desc: i18n.String{
 			i18n.EN: "ENASARCO contribution",
@@ -139,7 +148,7 @@ var FPACodes = []*KeyDefinition{
 		},
 	},
 	{
-		Key:  FPAWithholdingENPAMContribution,
+		Key:  FPACodeWithholdingENPAMContribution,
 		Code: "TR05",
 		Desc: i18n.String{
 			i18n.EN: "ENPAM contribution",
@@ -147,11 +156,84 @@ var FPACodes = []*KeyDefinition{
 		},
 	},
 	{
-		Key:  FPAWithholdingOtherSocialSecurity,
+		Key:  FPACodeWithholdingOtherSocialSecurity,
 		Code: "TR06",
 		Desc: i18n.String{
 			i18n.EN: "Other social security contribution",
 			i18n.IT: "Altro contributo previdenziale",
+		},
+	},
+	// Nature Codes
+	{
+		Key:  FPACodeNatureRCScrapMaterials,
+		Code: "N6.1",
+		Desc: i18n.String{
+			i18n.EN: "Reverse charge - transfer of scrap and other recyclable materials",
+			i18n.IT: "Inversione contabile - cessione di rottami e altri materiali di recupero",
+		},
+	},
+	{
+		Key:  FPACodeNatureRCGoldSilver,
+		Code: "N6.2",
+		Desc: i18n.String{
+			i18n.EN: "Reverse charge - trasnfer of gold, pure silver, and jewelery",
+			i18n.IT: "Inversione contabile - cessione di oro e argento puro",
+		},
+	},
+	{
+		Key:  FPACodeNatureRCConstructionSubcontracting,
+		Code: "N6.3",
+		Desc: i18n.String{
+			i18n.EN: "Reverse charge - subcontracting in the construction sector",
+			i18n.IT: "Inversione contabile - subappalto nel settore edile",
+		},
+	},
+	{
+		Key:  FPACodeNatureRCBuildings,
+		Code: "N6.4",
+		Desc: i18n.String{
+			i18n.EN: "Reverse charge - transfer of buildings",
+			i18n.IT: "Inversione contabile - cessione di fabbricati",
+		},
+	},
+	{
+		Key:  FPACodeNatureRCMobile,
+		Code: "N6.5",
+		Desc: i18n.String{
+			i18n.EN: "Reverse charge - transfer of mobile phones",
+			i18n.IT: "Inversione contabile - cessione di telefoni cellulari",
+		},
+	},
+	{
+		Key:  FPACodeNatureRCElectronics,
+		Code: "N6.6",
+		Desc: i18n.String{
+			i18n.EN: "Reverse charge - transfer of electronic products",
+			i18n.IT: "Inversione contabile - cessione di prodotti elettronici",
+		},
+	},
+	{
+		Key:  FPACodeNatureRCConstructionProvisions,
+		Code: "N6.7",
+		Desc: i18n.String{
+			i18n.EN: "Reverse charge - provisions in the construction and related sectors",
+			i18n.IT: "Inversione contabile - prestazioni comparto edile e settori connessi",
+		},
+	},
+	{
+		Key:  FPACodeNatureRCEnergy,
+		Code: "N6.8",
+		Desc: i18n.String{
+			i18n.EN: "Reverse charge - transactions in the energy sector",
+			i18n.IT: "Inversione contabile - operazioni settore energetico",
+		},
+	},
+	{
+		Key:  FPACodeNatureRCOther,
+		Code: "N6.9",
+		Desc: i18n.String{
+			i18n.EN: "Reverse charge - other cases",
+			i18n.IT: "Inversione contabile - altri casi",
 		},
 	},
 }

--- a/regimes/it/fpa_codes.go
+++ b/regimes/it/fpa_codes.go
@@ -31,10 +31,15 @@ const (
 	FPACodeTaxSystemOrdinary FPACode = "RF01"
 
 	// Payment Method (ModalitaPagamento) Codes
-	FPACodePaymentMethodCash         FPACode = "MP01"
-	FPACodePaymentMethodBankTransfer FPACode = "MP05"
-	FPACodePaymentMethodCard         FPACode = "MP08"
-	FPACodePaymentMethodDirectDebit  FPACode = "MP10"
+	FPACodePaymentCash                 FPACode = "MP01"
+	FPACodePaymentBankTransfer         FPACode = "MP05"
+	FPACodePaymentCard                 FPACode = "MP08"
+	FPACodePaymentDirectDebit          FPACode = "MP10"
+	FPACodePaymentDirectDebitUtilities FPACode = "MP10"
+	FPACodePaymentDirectDebitFast      FPACode = "MP11"
+	FPACodePaymentDirectDebitSepa      FPACode = "MP19"
+	FPACodePaymentDirectDebitSepaCore  FPACode = "MP20"
+	FPACodePaymentDirectDebitSepaB2B   FPACode = "MP21"
 
 	// Document Type (TipoDocumento) Codes
 	FPACodeDocumentTypeInvoice    FPACode = "TD01"
@@ -73,21 +78,21 @@ var FPACodeDefs = []*FPACodeDefinition{
 	},
 	// Payment Method Codes
 	{
-		Code: FPACodePaymentMethodCash,
+		Code: FPACodePaymentCash,
 		Desc: i18n.String{
 			i18n.EN: "Cash",
 			i18n.IT: "Contanti",
 		},
 	},
 	{
-		Code: FPACodePaymentMethodBankTransfer,
+		Code: FPACodePaymentBankTransfer,
 		Desc: i18n.String{
 			i18n.EN: "Bank transfer",
 			i18n.IT: "Bonifico bancario",
 		},
 	},
 	{
-		Code: FPACodePaymentMethodCard,
+		Code: FPACodePaymentCard,
 		Desc: i18n.String{
 			i18n.EN: "Card",
 			i18n.IT: "Carta di credito",
@@ -97,7 +102,42 @@ var FPACodeDefs = []*FPACodeDefinition{
 		Code: FPACodePaymentDirectDebit,
 		Desc: i18n.String{
 			i18n.EN: "Direct debit",
-			i18n.IT: "Rid",
+			i18n.IT: "RID",
+		},
+	},
+	{
+		Code: FPACodePaymentDirectDebitUtilities,
+		Desc: i18n.String{
+			i18n.EN: "Direct debit utilities",
+			i18n.IT: "RID utenze",
+		},
+	},
+	{
+		Code: FPACodePaymentDirectDebitFast,
+		Desc: i18n.String{
+			i18n.EN: "Direct debit fast",
+			i18n.IT: "RID veloce",
+		},
+	},
+	{
+		Code: FPACodePaymentDirectDebitSepa,
+		Desc: i18n.String{
+			i18n.EN: "SEPA Direct Debit",
+			i18n.IT: "SEPA Direct Debit",
+		},
+	},
+	{
+		Code: FPACodePaymentDirectDebitSepaCore,
+		Desc: i18n.String{
+			i18n.EN: "SEPA Direct Debit CORE",
+			i18n.IT: "SEPA Direct Debit CORE",
+		},
+	},
+	{
+		Code: FPACodePaymentDirectDebitSepaB2B,
+		Desc: i18n.String{
+			i18n.EN: "SEPA Direct Debit B2B",
+			i18n.IT: "SEPA Direct Debit B2B",
 		},
 	},
 	// Document Type Codes

--- a/regimes/it/fpa_codes.go
+++ b/regimes/it/fpa_codes.go
@@ -1,64 +1,71 @@
 package it
 
 import (
-	"github.com/invopop/gobl/cbc"
+	"regexp"
+
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/invopop/gobl/i18n"
 )
 
 // FPACodeDefinition defines properties of an alphanumeric codes used by
 // FatturaPA, Italy's e-invoicing system. The codes are used to classify
 // various aspects of an invoice, namely the tax system, fund type, payment
-// method, document type, nature, and withholding type.
+// method, document type, nature, and withholding type. An FPACode can include
+// uppercase letters, numbers, and a "." separator for the numeric portion.
+type FPACode string
+
 type FPACodeDefinition struct {
-	// Actual key value.
-	Key cbc.Key `json:"key" jsonschema:"title=Key"`
-	//
-	Code string `json:"code,omitempty" jsonschema:"title=Code"`
+	// Alphanumeric code as required by FatturaPA.
+	Code FPACode
 	// Description offering more details about when the key should be used.
 	Desc i18n.String `json:"desc,omitempty" jsonschema:"title=Description"`
 }
 
+var (
+	codePattern          = `^[A-Z]+[0-9]+(\.[0-9]+)?$`
+	codeValidationRegexp = regexp.MustCompile(codePattern)
+)
+
 const (
 	// Tax System (RegimeFiscale) Codes
-	FPACodeTaxSystemOrdinary cbc.Key = "tax-system-ordinary" // RF01
+	FPACodeTaxSystemOrdinary FPACode = "RF01"
 
 	// Payment Method (ModalitaPagamento) Codes
-	FPACodePaymentMethodCash         cbc.Key = "tax-system-cash"          // MP01
-	FPACodePaymentMethodBankTransfer cbc.Key = "tax-system-bank-transfer" // MP05
-	FPACodePaymentMethodCard         cbc.Key = "tax-system-card"          // MP08
-	FPACodePaymentDirectDebit        cbc.Key = "tax-system-direct-debit"  // MP10
+	FPACodePaymentMethodCash         FPACode = "MP01"
+	FPACodePaymentMethodBankTransfer FPACode = "MP05"
+	FPACodePaymentMethodCard         FPACode = "MP08"
+	FPACodePaymentDirectDebit        FPACode = "MP10"
 
 	// Document Type (TipoDocumento) Codes
-	FPACodeDocumentTypeInvoice    cbc.Key = "document-type-invoice"     // TD01
-	FPACodeDocumentTypeCreditNote cbc.Key = "document-type-credit-note" // TD04
+	FPACodeDocumentTypeInvoice    FPACode = "TD01"
+	FPACodeDocumentTypeCreditNote FPACode = "TD04"
 
 	// Nature (Natura) Codes
 	// Reverse Charges
-	FPACodeNatureRCScrapMaterials             cbc.Key = "nature-rc-scrap-materials"             // N6.1
-	FPACodeNatureRCGoldSilver                 cbc.Key = "nature-rc-gold-silver"                 // N6.2
-	FPACodeNatureRCConstructionSubcontracting cbc.Key = "nature-rc-construction-subcontracting" // N6.3
-	FPACodeNatureRCBuildings                  cbc.Key = "nature-rc-buildings"                   // N6.4
-	FPACodeNatureRCMobile                     cbc.Key = "nature-rc-mobile"                      // N6.5
-	FPACodeNatureRCElectronics                cbc.Key = "nature-rc-electronics"                 // N6.6
-	FPACodeNatureRCConstructionProvisions     cbc.Key = "nature-rc-construction-provisions"     // N6.7
-	FPACodeNatureRCEnergy                     cbc.Key = "nature-rc-energy"                      // N6.8
-	FPACodeNatureRCOther                      cbc.Key = "nature-rc-other"                       // N6.9
+	FPACodeNatureRCScrapMaterials             FPACode = "N6.1"
+	FPACodeNatureRCGoldSilver                 FPACode = "N6.2"
+	FPACodeNatureRCConstructionSubcontracting FPACode = "N6.3"
+	FPACodeNatureRCBuildings                  FPACode = "N6.4"
+	FPACodeNatureRCMobile                     FPACode = "N6.5"
+	FPACodeNatureRCElectronics                FPACode = "N6.6"
+	FPACodeNatureRCConstructionProvisions     FPACode = "N6.7"
+	FPACodeNatureRCEnergy                     FPACode = "N6.8"
+	FPACodeNatureRCOther                      FPACode = "N6.9"
 
 	// Withholding Tax (TipoRitenuta) Codes
-	FPACodeWithholdingNaturalPersons       cbc.Key = "withholding-tax-natural-persons"       // TR01
-	FPACodeWithholdingLegalPersons         cbc.Key = "withholding-tax-legal-persons"         // TR02
-	FPACodeWithholdingINPSContribution     cbc.Key = "withholding-tax-inps-contribution"     // TR03
-	FPACodeWithholdingENASARCOContribution cbc.Key = "withholding-tax-enasarco-contribution" // TR04
-	FPACodeWithholdingENPAMContribution    cbc.Key = "withholding-tax-enpam-contribution"    // TR05
-	FPACodeWithholdingOtherSocialSecurity  cbc.Key = "withholding-tax-other-social-security" // TR06
+	FPACodeWithholdingNaturalPersons       FPACode = "TR01"
+	FPACodeWithholdingLegalPersons         FPACode = "TR02"
+	FPACodeWithholdingINPSContribution     FPACode = "TR03"
+	FPACodeWithholdingENASARCOContribution FPACode = "TR04"
+	FPACodeWithholdingENPAMContribution    FPACode = "TR05"
+	FPACodeWithholdingOtherSocialSecurity  FPACode = "TR06"
 )
 
 // FPACodeDefs includes all FatturaPA codes currently supported in GOBL
 var FPACodeDefs = []*FPACodeDefinition{
 	// Tax System Codes
 	{
-		Key:  FPACodeTaxSystemOrdinary,
-		Code: "RF01",
+		Code: FPACodeTaxSystemOrdinary,
 		Desc: i18n.String{
 			i18n.EN: "Ordinary tax system",
 			i18n.IT: "Regime ordinario",
@@ -66,32 +73,28 @@ var FPACodeDefs = []*FPACodeDefinition{
 	},
 	// Payment Method Codes
 	{
-		Key:  FPACodePaymentMethodCash,
-		Code: "MP01",
+		Code: FPACodePaymentMethodCash,
 		Desc: i18n.String{
 			i18n.EN: "Cash",
 			i18n.IT: "Contanti",
 		},
 	},
 	{
-		Key:  FPACodePaymentMethodBankTransfer,
-		Code: "MP05",
+		Code: FPACodePaymentMethodBankTransfer,
 		Desc: i18n.String{
 			i18n.EN: "Bank transfer",
 			i18n.IT: "Bonifico bancario",
 		},
 	},
 	{
-		Key:  FPACodePaymentMethodCard,
-		Code: "MP08",
+		Code: FPACodePaymentMethodCard,
 		Desc: i18n.String{
 			i18n.EN: "Card",
 			i18n.IT: "Carta di credito",
 		},
 	},
 	{
-		Key:  FPACodePaymentDirectDebit,
-		Code: "MP10",
+		Code: FPACodePaymentDirectDebit,
 		Desc: i18n.String{
 			i18n.EN: "Direct debit",
 			i18n.IT: "Rid",
@@ -99,16 +102,14 @@ var FPACodeDefs = []*FPACodeDefinition{
 	},
 	// Document Type Codes
 	{
-		Key:  FPACodeDocumentTypeInvoice,
-		Code: "TD01",
+		Code: FPACodeDocumentTypeInvoice,
 		Desc: i18n.String{
 			i18n.EN: "Invoice",
 			i18n.IT: "Fattura",
 		},
 	},
 	{
-		Key:  FPACodeDocumentTypeCreditNote,
-		Code: "TD04",
+		Code: FPACodeDocumentTypeCreditNote,
 		Desc: i18n.String{
 			i18n.EN: "Credit cote",
 			i18n.IT: "Nota di credito",
@@ -116,48 +117,42 @@ var FPACodeDefs = []*FPACodeDefinition{
 	},
 	// Withholding Tax Codes
 	{
-		Key:  FPACodeWithholdingNaturalPersons,
-		Code: "TR01",
+		Code: FPACodeWithholdingNaturalPersons,
 		Desc: i18n.String{
 			i18n.EN: "Withholding tax natural persons",
 			i18n.IT: "Ritenuta persone fisiche",
 		},
 	},
 	{
-		Key:  FPACodeWithholdingLegalPersons,
-		Code: "TR02",
+		Code: FPACodeWithholdingLegalPersons,
 		Desc: i18n.String{
 			i18n.EN: "Withholding tax legal persons",
 			i18n.IT: "Ritenuta persone giuridiche",
 		},
 	},
 	{
-		Key:  FPACodeWithholdingINPSContribution,
-		Code: "TR03",
+		Code: FPACodeWithholdingINPSContribution,
 		Desc: i18n.String{
 			i18n.EN: "INPS contribution",
 			i18n.IT: "Contributo INPS",
 		},
 	},
 	{
-		Key:  FPACodeWithholdingENASARCOContribution,
-		Code: "TR04",
+		Code: FPACodeWithholdingENASARCOContribution,
 		Desc: i18n.String{
 			i18n.EN: "ENASARCO contribution",
 			i18n.IT: "Contributo ENASARCO",
 		},
 	},
 	{
-		Key:  FPACodeWithholdingENPAMContribution,
-		Code: "TR05",
+		Code: FPACodeWithholdingENPAMContribution,
 		Desc: i18n.String{
 			i18n.EN: "ENPAM contribution",
 			i18n.IT: "Contributo ENPAM",
 		},
 	},
 	{
-		Key:  FPACodeWithholdingOtherSocialSecurity,
-		Code: "TR06",
+		Code: FPACodeWithholdingOtherSocialSecurity,
 		Desc: i18n.String{
 			i18n.EN: "Other social security contribution",
 			i18n.IT: "Altro contributo previdenziale",
@@ -165,75 +160,73 @@ var FPACodeDefs = []*FPACodeDefinition{
 	},
 	// Nature Codes
 	{
-		Key:  FPACodeNatureRCScrapMaterials,
-		Code: "N6.1",
+		Code: FPACodeNatureRCScrapMaterials,
 		Desc: i18n.String{
 			i18n.EN: "Reverse charge - transfer of scrap and other recyclable materials",
 			i18n.IT: "Inversione contabile - cessione di rottami e altri materiali di recupero",
 		},
 	},
 	{
-		Key:  FPACodeNatureRCGoldSilver,
-		Code: "N6.2",
+		Code: FPACodeNatureRCGoldSilver,
 		Desc: i18n.String{
 			i18n.EN: "Reverse charge - trasnfer of gold, pure silver, and jewelery",
 			i18n.IT: "Inversione contabile - cessione di oro e argento puro",
 		},
 	},
 	{
-		Key:  FPACodeNatureRCConstructionSubcontracting,
-		Code: "N6.3",
+		Code: FPACodeNatureRCConstructionSubcontracting,
 		Desc: i18n.String{
 			i18n.EN: "Reverse charge - subcontracting in the construction sector",
 			i18n.IT: "Inversione contabile - subappalto nel settore edile",
 		},
 	},
 	{
-		Key:  FPACodeNatureRCBuildings,
-		Code: "N6.4",
+		Code: FPACodeNatureRCBuildings,
 		Desc: i18n.String{
 			i18n.EN: "Reverse charge - transfer of buildings",
 			i18n.IT: "Inversione contabile - cessione di fabbricati",
 		},
 	},
 	{
-		Key:  FPACodeNatureRCMobile,
-		Code: "N6.5",
+		Code: FPACodeNatureRCMobile,
 		Desc: i18n.String{
 			i18n.EN: "Reverse charge - transfer of mobile phones",
 			i18n.IT: "Inversione contabile - cessione di telefoni cellulari",
 		},
 	},
 	{
-		Key:  FPACodeNatureRCElectronics,
-		Code: "N6.6",
+		Code: FPACodeNatureRCElectronics,
 		Desc: i18n.String{
 			i18n.EN: "Reverse charge - transfer of electronic products",
 			i18n.IT: "Inversione contabile - cessione di prodotti elettronici",
 		},
 	},
 	{
-		Key:  FPACodeNatureRCConstructionProvisions,
-		Code: "N6.7",
+		Code: FPACodeNatureRCConstructionProvisions,
 		Desc: i18n.String{
 			i18n.EN: "Reverse charge - provisions in the construction and related sectors",
 			i18n.IT: "Inversione contabile - prestazioni comparto edile e settori connessi",
 		},
 	},
 	{
-		Key:  FPACodeNatureRCEnergy,
-		Code: "N6.8",
+		Code: FPACodeNatureRCEnergy,
 		Desc: i18n.String{
 			i18n.EN: "Reverse charge - transactions in the energy sector",
 			i18n.IT: "Inversione contabile - operazioni settore energetico",
 		},
 	},
 	{
-		Key:  FPACodeNatureRCOther,
-		Code: "N6.9",
+		Code: FPACodeNatureRCOther,
 		Desc: i18n.String{
 			i18n.EN: "Reverse charge - other cases",
 			i18n.IT: "Inversione contabile - altri casi",
 		},
 	},
+}
+
+// Validate ensures that the code complies with the expected rules.
+func (c FPACode) Validate() error {
+	return validation.Validate(string(c),
+		validation.Match(codeValidationRegexp),
+	)
 }

--- a/regimes/it/invoice_validator.go
+++ b/regimes/it/invoice_validator.go
@@ -1,0 +1,77 @@
+package it
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/org"
+	"github.com/invopop/gobl/tax"
+)
+
+// invoiceValidator adds validation checks to invoices which are relevant
+// for the region.
+type invoiceValidator struct {
+	inv *bill.Invoice
+}
+
+func validateInvoice(inv *bill.Invoice) error {
+	v := &invoiceValidator{inv: inv}
+	return v.validate()
+}
+
+func (v *invoiceValidator) validate() error {
+	inv := v.inv
+	return validation.ValidateStruct(inv,
+		// Currently only supporting invoices and credit notes for Italy
+		validation.Field(&inv.Type, validation.In(
+			bill.InvoiceTypeNone,
+			bill.InvoiceTypeCreditNote,
+		)),
+		validation.Field(&inv.Supplier, validation.Required, validation.By(v.supplier)),
+		validation.Field(&inv.Customer, validation.Required, validation.By(v.customer)),
+	)
+}
+
+func (v *invoiceValidator) supplier(value interface{}) error {
+	sup, _ := value.(*org.Party)
+	if sup == nil {
+		return nil
+	}
+	// Suppliers must have a VAT ID (Partita IVA)
+	return validation.ValidateStruct(sup,
+		validation.Field(&sup.TaxID,
+			validation.Required,
+			tax.RequireIdentityCode,
+		),
+	)
+}
+
+func (v *invoiceValidator) customer(value interface{}) error {
+	cus, _ := value.(*org.Party)
+	if cus == nil {
+		return nil
+	}
+	if cus.TaxID == nil {
+		return nil // validation already handled, this prevents panics
+	}
+	// Customers must have a VAT ID (Partita IVA) OR a fiscal code (Codice Fiscale)
+	return validation.ValidateStruct(cus,
+		validation.Field(&cus.TaxID, validation.When(
+			fiscalCode(cus) != nil,
+			validation.Required,
+			tax.RequireIdentityCode,
+		)),
+		validation.Field(fiscalCode(cus), validation.When(
+			cus.TaxID == nil,
+			validation.Required,
+		)),
+	)
+}
+
+func fiscalCode(party *org.Party) *org.Identity {
+	for _, identity := range party.Identities {
+		if identity.Type == IdentityTypeFiscalCode {
+			return identity
+		}
+	}
+	return nil
+}

--- a/regimes/it/invoice_validator.go
+++ b/regimes/it/invoice_validator.go
@@ -3,6 +3,7 @@ package it
 import (
 	validation "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/org"
 	"github.com/invopop/gobl/tax"
 )
@@ -21,13 +22,14 @@ func validateInvoice(inv *bill.Invoice) error {
 func (v *invoiceValidator) validate() error {
 	inv := v.inv
 	return validation.ValidateStruct(inv,
-		// Currently only supporting invoices and credit notes for Italy
+		// Currently only supporting invoices and credit notes
 		validation.Field(&inv.Type, validation.In(
 			bill.InvoiceTypeNone,
 			bill.InvoiceTypeCreditNote,
 		)),
 		validation.Field(&inv.Supplier, validation.Required, validation.By(v.supplier)),
 		validation.Field(&inv.Customer, validation.Required, validation.By(v.customer)),
+		validation.Field(&inv.Meta, validation.Required, validation.By(v.meta)),
 	)
 }
 
@@ -53,25 +55,103 @@ func (v *invoiceValidator) customer(value interface{}) error {
 	if cus.TaxID == nil {
 		return nil // validation already handled, this prevents panics
 	}
-	// Customers must have a VAT ID (Partita IVA) OR a fiscal code (Codice Fiscale)
+
+	var fiscalCode *org.Identity
+	for _, identity := range cus.Identities {
+		if identity.Type == IdentityTypeFiscalCode {
+			fiscalCode = identity
+			break
+		}
+	}
+
+	// Customers must have either a VAT ID (Partita IVA) or a fiscal code (Codice
+	// Fiscale)
 	return validation.ValidateStruct(cus,
-		validation.Field(&cus.TaxID, validation.When(
-			fiscalCode(cus) != nil,
-			validation.Required,
-			tax.RequireIdentityCode,
-		)),
-		validation.Field(fiscalCode(cus), validation.When(
+		validation.Field(fiscalCode, validation.When(
 			cus.TaxID == nil,
 			validation.Required,
+		)),
+		validation.Field(&cus.TaxID, validation.When(
+			fiscalCode == nil,
+			validation.Required,
+			tax.RequireIdentityCode,
 		)),
 	)
 }
 
-func fiscalCode(party *org.Party) *org.Identity {
-	for _, identity := range party.Identities {
-		if identity.Type == IdentityTypeFiscalCode {
-			return identity
+// Meta data of the invoice must contain valid FatturaPA codes
+func (v *invoiceValidator) meta(value interface{}) error {
+	meta, _ := value.(cbc.Meta)
+	if meta == nil {
+		return nil
+	}
+
+	// Validate Tax System FPA code. Currently only supporting
+	// RF01 "Ordinary" tax system
+	err := validation.Validate(meta[FPACodeTypeTaxSystem],
+		validation.Required,
+		validation.In(FPACodeTaxSystemOrdinary),
+	)
+	if err != nil {
+		return err
+	}
+
+	// Validate Document Type FPA code
+	invoiceType := v.inv.Type
+	codeGroup := InvoiceTypeMap[invoiceType]
+	err = validateMetaFPACode(meta, codeGroup)
+	if err != nil {
+		return err
+	}
+
+	// Validate Payment Method FPA code
+	payMethod := v.inv.Payment.Instructions.Key
+	codeGroup = PaymentMethodMap[payMethod]
+	err = validateMetaFPACode(meta, codeGroup)
+	if err != nil {
+		return err
+	}
+
+	// Validate Tax Scheme FPA code
+	// Currently only reverse charge schemes are supported.
+	for _, scheme := range v.inv.Tax.Schemes {
+		codeGroup = SchemeMap[scheme]
+		err = validateMetaFPACode(meta, codeGroup)
+		if err != nil {
+			return err
 		}
 	}
+
+	// Validate Withholding Tax FPA code
+	// Only retained taxes are considered.
+	for _, cat := range v.inv.Totals.Taxes.Categories {
+		if !taxCategoryFromCode(cat.Code).Retained {
+			break
+		}
+		codeGroup = TaxCategoryMap[cat.Code]
+		err = validateMetaFPACode(meta, codeGroup)
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
+}
+
+func validateMetaFPACode(meta cbc.Meta, codeGroup *FPACodeGroup) error {
+	if codeGroup == nil {
+		return nil
+	}
+
+	key := codeGroup.Type
+	fpaCodes := codeGroup.Codes
+	codes := make([]interface{}, len(fpaCodes))
+	for i, code := range fpaCodes {
+		codes[i] = code
+	}
+
+	return validation.Validate(meta[key],
+		validation.Required,
+		validation.In(codes...),
+	)
 }

--- a/regimes/it/invoice_validator.go
+++ b/regimes/it/invoice_validator.go
@@ -124,11 +124,11 @@ func (v *invoiceValidator) meta(value interface{}) error {
 
 	// Validate Withholding Tax FPA code
 	// Only retained taxes are considered.
-	for _, cat := range v.inv.Totals.Taxes.Categories {
-		if !taxCategoryFromCode(cat.Code).Retained {
+	for _, catTotal := range v.inv.Totals.Taxes.Categories {
+		if !catTotal.Retained {
 			break
 		}
-		codeGroup = TaxCategoryMap[cat.Code]
+		codeGroup = TaxCategoryMap[catTotal.Code]
 		err = validateMetaFPACode(meta, codeGroup)
 		if err != nil {
 			return err

--- a/regimes/it/it.go
+++ b/regimes/it/it.go
@@ -1,10 +1,11 @@
 package it
 
 import (
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/i18n"
 	"github.com/invopop/gobl/l10n"
 	"github.com/invopop/gobl/tax"
-	"github.com/invopop/gobl/cbc"
 )
 
 var IdentityTypeFiscalCode cbc.Code = "CF" // Codice Fiscale
@@ -20,9 +21,9 @@ func New() *tax.Regime {
 		},
 		Validator:  Validate,
 		Calculator: Calculate,
-		Zones:      zones,      // zones.go
-		Categories: categories, // categories.go
-		Schemes:    schemes,    // schemes.go
+		Zones:      zones,         // zones.go
+		Categories: taxCategories, // tax_categories.go
+		Schemes:    schemes,       // schemes.go
 	}
 }
 
@@ -30,6 +31,8 @@ func New() *tax.Regime {
 func Validate(doc interface{}) error {
 
 	switch obj := doc.(type) {
+	case *bill.Invoice:
+		return validateInvoice(obj)
 	case *tax.Identity:
 		return validateTaxIdentity(obj)
 	}

--- a/regimes/it/it.go
+++ b/regimes/it/it.go
@@ -19,6 +19,7 @@ func New() *tax.Regime {
 		Calculator: Calculate,
 		Zones:      zones,      // zones.go
 		Categories: categories, // categories.go
+		Schemes:    schemes,    // schemes.go
 	}
 }
 

--- a/regimes/it/it.go
+++ b/regimes/it/it.go
@@ -8,6 +8,10 @@ import (
 	"github.com/invopop/gobl/tax"
 )
 
+// IdentityTypeFiscalCode represents the Italian Fiscal Code (Codice Fiscale).
+// See https://en.wikipedia.org/wiki/Italian_fiscal_code. Every natural person
+// has a fiscal code, and it is used to identify them for tax purposes. Not to
+// be confused with the Italian VAT number (Partita IVA).
 var IdentityTypeFiscalCode cbc.Code = "CF" // Codice Fiscale
 
 // New instantiates a new Italian regime.

--- a/regimes/it/it.go
+++ b/regimes/it/it.go
@@ -4,7 +4,10 @@ import (
 	"github.com/invopop/gobl/i18n"
 	"github.com/invopop/gobl/l10n"
 	"github.com/invopop/gobl/tax"
+	"github.com/invopop/gobl/cbc"
 )
+
+var IdentityTypeFiscalCode cbc.Code = "CF" // Codice Fiscale
 
 // New instantiates a new Italian regime.
 func New() *tax.Regime {

--- a/regimes/it/schemes.go
+++ b/regimes/it/schemes.go
@@ -1,0 +1,22 @@
+package it
+
+import (
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/i18n"
+	"github.com/invopop/gobl/regimes/common"
+	"github.com/invopop/gobl/tax"
+)
+
+var schemes = []*tax.Scheme{
+	// Reverse Charge Scheme
+	{
+		Key: common.SchemeReverseCharge,
+		Name: i18n.String{
+			i18n.EN: "Reverse Charge",
+			i18n.IT: "Inversione Contabile",
+		},
+		Categories: []cbc.Code{
+			common.TaxCategoryVAT,
+		},
+	},
+}

--- a/regimes/it/tax_categories.go
+++ b/regimes/it/tax_categories.go
@@ -10,11 +10,10 @@ import (
 
 // Local tax category definitions which are not considered standard.
 const (
-	TaxCategoryRA   cbc.Code = "RA" // https://www.agenziaentrate.gov.it/portale/imposta-sul-reddito-delle-persone-fisiche-irpef-/aliquote-e-calcolo-dell-irpef
-	TaxCategoryINPS cbc.Code = "INPS"
+	TaxCategoryRA cbc.Code = "RA" // https://www.agenziaentrate.gov.it/portale/imposta-sul-reddito-delle-persone-fisiche-irpef-/aliquote-e-calcolo-dell-irpef
 )
 
-var categories = []*tax.Category{
+var taxCategories = []*tax.Category{
 	{
 		Code:     common.TaxCategoryVAT,
 		Retained: false,
@@ -115,4 +114,13 @@ var categories = []*tax.Category{
 			},
 		},
 	},
+}
+
+func taxCategoryFromCode(code cbc.Code) *tax.Category {
+	for _, c := range taxCategories {
+		if c.Code == code {
+			return c
+		}
+	}
+	return nil
 }

--- a/regimes/it/tax_categories.go
+++ b/regimes/it/tax_categories.go
@@ -115,12 +115,3 @@ var taxCategories = []*tax.Category{
 		},
 	},
 }
-
-func taxCategoryFromCode(code cbc.Code) *tax.Category {
-	for _, c := range taxCategories {
-		if c.Code == code {
-			return c
-		}
-	}
-	return nil
-}


### PR DESCRIPTION
- Include list of Fattura PA Codes (`FPACodes`)  that we currently support
- Create mapping between invoice constructs to FPA Codes
- Update it/README
- Add invoice validations to italy regime
    - Validate supplier's VAT ID presence
    - Validate customer has either VAT ID or fiscal cod
    - Validate invoice meta data includes correct FPA Codes based on invoice data

### Limitations

Currently not all FPA Codes are supported. The goal is to be able to represent a typical Italian freelancer invoice using GOBL. In the beginning we will not be supporting super-specific invoice types and tax schemes. 

Using invoice meta data will enable us to move forward for now, but I don't think it's terribly scalable. Some codes, like Nature, can take on different values in multiple different parts of the final FatturaPA document. Some of these FPACodes can appear inside a list of items as well, making matters even more complicated. Currently the meta field looks like 
```
Meta["fpa-transaction-nature"] = "N5",
Meta["fpa-document-type"] = "TD15",
// etc
```
Luckily, `TipoDocumento` codes are only expected in one mandatory field at the invoice header. However, the above doesn't include information for which of the 3+ `Natura` slots `N5` should be used. Currently we'd have to do something like
```
Meta["fpa-transaction-nature-1"] = "N5",
Meta["fpa-transaction-nature-2"] = "N1.3",
// or 
Meta["fpa-some-section-transaction-nature"] = "N5",
Meta["fpa-another-section-transaction-nature"] = "N1.3",
```
We do not need to support multiple `Naturas` to generate a basic invoice. But this something to keep in mind if we want to eventually expand support for Italy. 