### PR TITLE
Add validations for customer and supplier tax IDs

### DIFF
--- a/org/party.go
+++ b/org/party.go
@@ -37,6 +37,8 @@ type Party struct {
 	Registration *Registration `json:"registration,omitempty" jsonschema:"title=Registration"`
 	// Images that can be used to identify the party visually.
 	Logos []*Image `json:"logos,omitempty" jsonschema:"title=Logos"`
+	// Type of party
+	Type cbc.Key `json:"type,omitempty" jsonschema:"title=Type Key"`
 	// Any additional semi-structured information that does not fit into the rest of the party.
 	Meta cbc.Meta `json:"meta,omitempty" jsonschema:"title=Meta"`
 }

--- a/regimes/it/invoices.go
+++ b/regimes/it/invoices.go
@@ -1,0 +1,93 @@
+package it
+
+import (
+	"errors"
+
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/org"
+	"github.com/invopop/gobl/tax"
+	"github.com/invopop/validation"
+)
+
+// invoiceValidator adds validation checks to invoices which are relevant
+// for the region.
+type invoiceValidator struct {
+	inv *bill.Invoice
+}
+
+func validateInvoice(inv *bill.Invoice) error {
+	v := &invoiceValidator{inv: inv}
+	return v.validate()
+}
+
+func (v *invoiceValidator) validate() error {
+	inv := v.inv
+	return validation.ValidateStruct(inv,
+		validation.Field(&inv.Customer, validation.By(v.customer)),
+		validation.Field(&inv.Supplier, validation.By(v.supplier)),
+	)
+}
+
+func (v *invoiceValidator) supplier(value interface{}) error {
+	obj, _ := value.(*org.Party)
+
+	if obj == nil {
+		return nil
+	}
+
+	return validation.ValidateStruct(obj,
+		validation.Field(&obj.TaxID,
+			validation.Required,
+			tax.RequireIdentityCode,
+		),
+	)
+}
+
+func (v *invoiceValidator) customer(value interface{}) error {
+	p, _ := value.(*org.Party)
+
+	if p == nil {
+		return nil
+	}
+
+	// Customers must have a tax ID (PartitaIVA) if they are legal entities like
+	// government offices and companies.
+	return validation.ValidateStruct(p,
+		validation.Field(&p.Type, validation.Required),
+		validation.Field(&p.TaxID,
+			validation.Required,
+			validation.When(
+				p.Type == PartyTypePublicAdministration || p.Type == PartyTypeLegalPerson,
+				tax.RequireIdentityCode,
+			),
+		),
+		validation.Field(&p.Identities,
+			validation.Required,
+			validation.When(
+				p.Type == PartyTypeNaturalPerson,
+				validation.By(v.customerNaturalPerson),
+			),
+		),
+	)
+}
+
+func (v *invoiceValidator) customerNaturalPerson(value interface{}) error {
+	p, _ := value.(*org.Party)
+	if p == nil {
+		return nil
+	}
+
+	var cf *org.Identity
+
+	for _, id := range p.Identities {
+		if id.Type == IdentityTypeCodiceFiscale {
+			cf = id
+		}
+	}
+
+	if cf == nil {
+		return errors.New("natural persons must have a codice fiscale")
+	}
+
+	return nil
+}

--- a/regimes/it/it.go
+++ b/regimes/it/it.go
@@ -2,6 +2,7 @@
 package it
 
 import (
+	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/currency"
 	"github.com/invopop/gobl/i18n"
@@ -13,6 +14,11 @@ func init() {
 	tax.RegisterRegime(New())
 }
 
+// IdentityTypeCodiceFiscale is different from the VAT number (Partita IVA), and
+// it is used as the tax identification number when the subject does not have a
+// VAT number, such as individuals.
+const IdentityTypeCodiceFiscale = "CF"
+
 // Keys used for meta data from external sources.
 const (
 	KeyFatturaPATipoDocumento    cbc.Key = "fatturapa-tipo-documento"
@@ -20,6 +26,13 @@ const (
 	KeyFatturaPANatura           cbc.Key = "fatturapa-natura"
 	KeyFatturaPATipoRitenuta     cbc.Key = "fatturapa-tipo-ritenuta"
 	KeyFatturaPACausalePagamento cbc.Key = "fatturapa-causale-pagamento"
+)
+
+// Valid types for Italian tax identities
+const (
+	PartyTypePublicAdministration cbc.Key = "government"
+	PartyTypeNaturalPerson        cbc.Key = "individual"
+	PartyTypeLegalPerson          cbc.Key = "entity"
 )
 
 // New instantiates a new Italian regime.
@@ -45,6 +58,8 @@ func Validate(doc interface{}) error {
 	switch obj := doc.(type) {
 	case *tax.Identity:
 		return validateTaxIdentity(obj)
+	case *bill.Invoice:
+		return validateInvoice(obj)
 	}
 	return nil
 }

--- a/regimes/it/tax_code.go
+++ b/regimes/it/tax_code.go
@@ -16,9 +16,8 @@ import (
 
 // validateTaxIdentity looks at the provided identity's code and performs the
 // calculations required to determine if it is valid.
-// These methods assume the code has already been normalized
-// and thus only contains upper-case letters and numbers with
-// no white space.
+// These methods assume the code has already been normalized and thus only
+// contains upper-case letters and numbers with no white space.
 func validateTaxIdentity(tID *tax.Identity) error {
 	return validation.ValidateStruct(tID,
 		validation.Field(&tID.Code, validation.Required, validation.By(validateTaxCode)))


### PR DESCRIPTION
Identifying the type of the party (gov, individual, or person) is not trivial and I'm waiting on answers form Italian tax specialists. (It seems that it is not possible to definitively determine this based solely on PartitaIVA + CodiceFiscale)

If this turns out to be possible, then we will be able to add a mechanism to calculate `Party.Type`
