### PR TITLE
Add other retained tax types besides IRPEF

### DIFF
--- a/regimes/it/categories.go
+++ b/regimes/it/categories.go
@@ -9,6 +9,8 @@ import (
 )
 
 // Local tax category definitions which are not considered standard.
+// There is a 6th retained tax type, RT06 "Other contributions", which is
+// currently not supported.
 const (
 	// https://www.agenziaentrate.gov.it/portale/imposta-sul-reddito-delle-persone-fisiche-irpef-/aliquote-e-calcolo-dell-irpef
 	TaxCategoryIRPEF    cbc.Code = "IRPEF"
@@ -16,7 +18,6 @@ const (
 	TaxCategoryINPS     cbc.Code = "INPS"
 	TaxCategoryENASARCO cbc.Code = "ENASARCO"
 	TaxCategoryENPAM    cbc.Code = "ENPAM"
-	TaxCategoryOther    cbc.Code = "OTHER"
 )
 
 var categories = []*tax.Category{
@@ -203,22 +204,6 @@ var categories = []*tax.Category{
 		Tags: retainedTaxTags,
 		Meta: cbc.Meta{
 			KeyFatturaPATipoRitenuta: "RT05",
-		},
-	},
-	{
-		Code:     TaxCategoryOther,
-		Retained: true,
-		Name: i18n.String{
-			i18n.EN: "Other",
-			i18n.IT: "Altra",
-		},
-		Desc: i18n.String{
-			i18n.EN: "Other social security contribution",
-			i18n.IT: "Altro contributo previdenziale", // nolint:misspell
-		},
-		Tags: retainedTaxTags,
-		Meta: cbc.Meta{
-			KeyFatturaPATipoRitenuta: "RT06",
 		},
 	},
 }

--- a/regimes/it/categories.go
+++ b/regimes/it/categories.go
@@ -11,8 +11,12 @@ import (
 // Local tax category definitions which are not considered standard.
 const (
 	// https://www.agenziaentrate.gov.it/portale/imposta-sul-reddito-delle-persone-fisiche-irpef-/aliquote-e-calcolo-dell-irpef
-	TaxCategoryIRPEF cbc.Code = "IRPEF"
-	TaxCategoryINPS  cbc.Code = "INPS"
+	TaxCategoryIRPEF    cbc.Code = "IRPEF"
+	TaxCategoryIRES     cbc.Code = "IRES"
+	TaxCategoryINPS     cbc.Code = "INPS"
+	TaxCategoryENASARCO cbc.Code = "ENASARCO"
+	TaxCategoryENPAM    cbc.Code = "ENPAM"
+	TaxCategoryOther    cbc.Code = "OTHER"
 )
 
 var categories = []*tax.Category{
@@ -121,6 +125,100 @@ var categories = []*tax.Category{
 					},
 				},
 			},
+		},
+	},
+	{
+		Code:     TaxCategoryIRES,
+		Retained: true,
+		Name: i18n.String{
+			i18n.EN: "IRES",
+			i18n.IT: "IRES",
+		},
+		Desc: i18n.String{
+			i18n.EN: "Corporate Income Tax",
+			i18n.IT: "Imposta sul Reddito delle Società",
+		},
+		Tags: retainedTaxTags,
+		Meta: cbc.Meta{
+			KeyFatturaPATipoRitenuta: "RT02",
+		},
+		Rates: []*tax.Rate{
+			{
+				Key: common.TaxRateStandard,
+				Name: i18n.String{
+					i18n.EN: "Ordinary Rate",
+					i18n.IT: "Aliquota Ordinaria",
+				},
+				Values: []*tax.RateValue{
+					{
+						Percent: num.MakePercentage(240, 3),
+					},
+				},
+			},
+		},
+	},
+	{
+		Code:     TaxCategoryINPS,
+		Retained: true,
+		Name: i18n.String{
+			i18n.EN: "INPS Contribution",
+			i18n.IT: "Contributo INPS", // nolint:misspell
+		},
+		Desc: i18n.String{
+			i18n.EN: "Contribution to the National Social Security Institute",
+			i18n.IT: "Contributo Istituto Nazionale della Previdenza Sociale", // nolint:misspell
+		},
+		Tags: retainedTaxTags,
+		Meta: cbc.Meta{
+			KeyFatturaPATipoRitenuta: "RT03",
+		},
+	},
+	{
+		Code:     TaxCategoryENASARCO,
+		Retained: true,
+		Name: i18n.String{
+			i18n.EN: "ENASARCO Contribution",
+			i18n.IT: "Contributo ENASARCO", // nolint:misspell
+		},
+		Desc: i18n.String{
+			i18n.EN: "Contribution to the National Welfare Board for Sales Agents and Representatives",
+			i18n.IT: "Contributo Ente Nazionale Assistenza Agenti e Rappresentanti di Commercio", // nolint:misspell
+		},
+		Tags: retainedTaxTags,
+		Meta: cbc.Meta{
+			KeyFatturaPATipoRitenuta: "RT04",
+		},
+	},
+	{
+		Code:     TaxCategoryENPAM,
+		Retained: true,
+		Name: i18n.String{
+			i18n.EN: "ENPAM Contribution",
+			i18n.IT: "Contributo ENPAM", // nolint:misspell
+		},
+		Desc: i18n.String{
+			i18n.EN: "Contribution to the National Pension and Welfare Board for Doctors",
+			i18n.IT: "Contributo - Ente Nazionale Previdenza e Assistenza Medici", // nolint:misspell
+		},
+		Tags: retainedTaxTags,
+		Meta: cbc.Meta{
+			KeyFatturaPATipoRitenuta: "RT05",
+		},
+	},
+	{
+		Code:     TaxCategoryOther,
+		Retained: true,
+		Name: i18n.String{
+			i18n.EN: "Other",
+			i18n.IT: "Altra",
+		},
+		Desc: i18n.String{
+			i18n.EN: "Other social security contribution",
+			i18n.IT: "Altro contributo previdenziale", // nolint:misspell
+		},
+		Tags: retainedTaxTags,
+		Meta: cbc.Meta{
+			KeyFatturaPATipoRitenuta: "RT06",
 		},
 	},
 }


### PR DESCRIPTION
Two concerns:
- IRPEF and IRES are definitely taxes, but the rest are contributions to welfare and pension funds. They're not _quite_ taxes, but maybe I'm being too picky. 
- The "other" category doesn't quite have a code. Maybe we define `OTHER` code in `cbc` so that we can use it any time an "other" code is required? 