### PR TITLE
Making the Tax Combo Percent property optional

### DIFF
--- a/bill/charges.go
+++ b/bill/charges.go
@@ -81,10 +81,10 @@ func (m *Charge) GetTotal() num.Amount {
 
 func (m *Charge) removeIncludedTaxes(cat cbc.Code, accuracy uint32) *Charge {
 	rate := m.Taxes.Get(cat)
-	if rate == nil {
+	if rate == nil || rate.Percent == nil {
 		return m
 	}
 	m2 := *m
-	m2.Amount = m2.Amount.Upscale(accuracy).Remove(rate.Percent)
+	m2.Amount = m2.Amount.Upscale(accuracy).Remove(*rate.Percent)
 	return &m2
 }

--- a/bill/discounts.go
+++ b/bill/discounts.go
@@ -83,10 +83,10 @@ func (m *Discount) GetTotal() num.Amount {
 
 func (m *Discount) removeIncludedTaxes(cat cbc.Code, accuracy uint32) *Discount {
 	rate := m.Taxes.Get(cat)
-	if rate == nil {
+	if rate == nil || rate.Percent == nil {
 		return m
 	}
 	m2 := *m
-	m2.Amount = m2.Amount.Upscale(accuracy).Remove(rate.Percent)
+	m2.Amount = m2.Amount.Upscale(accuracy).Remove(*rate.Percent)
 	return &m2
 }

--- a/bill/line.go
+++ b/bill/line.go
@@ -86,22 +86,22 @@ func (l *Line) calculate() {
 
 func (l *Line) removeIncludedTaxes(cat cbc.Code, accuracy uint32) *Line {
 	rate := l.Taxes.Get(cat)
-	if rate == nil {
+	if rate == nil || rate.Percent == nil {
 		return l
 	}
 
 	l2 := *l
 	l2i := *l.Item
 
-	l2i.Price = l2i.Price.Upscale(accuracy).Remove(rate.Percent)
-	l2.Sum = l2.Sum.Upscale(accuracy).Remove(rate.Percent)
-	l2.Total = l2.Total.Upscale(accuracy).Remove(rate.Percent)
+	l2i.Price = l2i.Price.Upscale(accuracy).Remove(*rate.Percent)
+	l2.Sum = l2.Sum.Upscale(accuracy).Remove(*rate.Percent)
+	l2.Total = l2.Total.Upscale(accuracy).Remove(*rate.Percent)
 
 	if len(l2.Discounts) > 0 {
 		rows := make([]*LineDiscount, len(l2.Discounts))
 		for i, v := range l.Discounts {
 			d := *v
-			d.Amount = d.Amount.Upscale(accuracy).Remove(rate.Percent)
+			d.Amount = d.Amount.Upscale(accuracy).Remove(*rate.Percent)
 			rows[i] = &d
 		}
 		l2.Discounts = rows
@@ -111,7 +111,7 @@ func (l *Line) removeIncludedTaxes(cat cbc.Code, accuracy uint32) *Line {
 		rows := make([]*LineCharge, len(l2.Charges))
 		for i, v := range l.Charges {
 			d := *v
-			d.Amount = d.Amount.Upscale(accuracy).Remove(rate.Percent)
+			d.Amount = d.Amount.Upscale(accuracy).Remove(*rate.Percent)
 			rows[i] = &d
 		}
 		l2.Charges = rows

--- a/tax/set_test.go
+++ b/tax/set_test.go
@@ -23,6 +23,7 @@ func TestSetValidation(t *testing.T) {
 				{
 					Category: "VAT",
 					Rate:     "standard",
+					Percent:  num.NewPercentage(20, 3),
 				},
 			},
 			err: nil,
@@ -38,10 +39,12 @@ func TestSetValidation(t *testing.T) {
 				{
 					Category: "VAT",
 					Rate:     "standard",
+					Percent:  num.NewPercentage(20, 3),
 				},
 				{
 					Category: "IRPF",
 					Rate:     "pro",
+					Percent:  num.NewPercentage(15, 3),
 				},
 			},
 		},
@@ -51,11 +54,13 @@ func TestSetValidation(t *testing.T) {
 				{
 					Category: "VAT",
 					Rate:     "standard",
+					Percent:  num.NewPercentage(20, 3),
 					Tags:     []cbc.Key{es.TagServices},
 				},
 				{
 					Category: "IRPF",
 					Rate:     "pro",
+					Percent:  num.NewPercentage(15, 3),
 				},
 			},
 		},
@@ -65,20 +70,40 @@ func TestSetValidation(t *testing.T) {
 				{
 					Category: "VAT",
 					Rate:     "standard",
+					Percent:  num.NewPercentage(20, 3),
 				},
 				{
 					Category: "VAT",
 					Rate:     "reduced",
+					Percent:  num.NewPercentage(20, 3),
 				},
 			},
 			err: "duplicated",
+		},
+		{
+			desc: "missing percentage",
+			set: tax.Set{
+				{
+					Category: "VAT",
+				},
+			},
+			err: "percent: cannot be blank",
+		},
+		{
+			desc: "missing percentage with tag",
+			set: tax.Set{
+				{
+					Category: "VAT",
+					Tags:     []cbc.Key{es.TagServices},
+				},
+			},
 		},
 		{
 			desc: "undefined category code",
 			set: tax.Set{
 				{
 					Category: "VAT2",
-					Percent:  num.MakePercentage(20, 2),
+					Percent:  num.NewPercentage(20, 3),
 				},
 			},
 			err: "cat: must be a valid value",
@@ -88,7 +113,7 @@ func TestSetValidation(t *testing.T) {
 			set: tax.Set{
 				{
 					Category: "VAT",
-					Percent:  num.MakePercentage(20, 2),
+					Percent:  num.NewPercentage(20, 3),
 					Tags:     []cbc.Key{es.TagServices, "invalid-tag"},
 				},
 			},
@@ -100,6 +125,7 @@ func TestSetValidation(t *testing.T) {
 				{
 					Category: "VAT",
 					Rate:     "STD",
+					Percent:  num.NewPercentage(20, 3),
 				},
 			},
 			err: "rate: must be in a valid format",

--- a/tax/totals_test.go
+++ b/tax/totals_test.go
@@ -91,6 +91,25 @@ func TestTotalCalculate(t *testing.T) {
 			},
 		},
 		{
+			desc: "with exemption",
+			lines: []tax.TaxableLine{
+				&taxableLine{
+					taxes: tax.Set{
+						{
+							Category: common.TaxCategoryVAT,
+							Tags:     []cbc.Key{es.TagExempt},
+						},
+					},
+					amount: num.MakeAmount(10000, 2),
+				},
+			},
+			taxIncluded: "",
+			want: &tax.Total{
+				Categories: []*tax.CategoryTotal{},
+				Sum:        num.MakeAmount(0, 2),
+			},
+		},
+		{
 			desc:   "with VAT in Azores",
 			regime: portugal,
 			zone:   pt.ZoneAzores,
@@ -133,7 +152,7 @@ func TestTotalCalculate(t *testing.T) {
 					taxes: tax.Set{
 						{
 							Category: common.TaxCategoryVAT,
-							Percent:  num.MakePercentage(210, 3),
+							Percent:  num.NewPercentage(210, 3),
 						},
 					},
 					amount: num.MakeAmount(10000, 2),
@@ -168,7 +187,7 @@ func TestTotalCalculate(t *testing.T) {
 						{
 							Category: common.TaxCategoryVAT,
 							Rate:     common.TaxRateStandard,
-							Percent:  num.MakePercentage(200, 3),
+							Percent:  num.NewPercentage(200, 3),
 						},
 					},
 					amount: num.MakeAmount(10000, 2),
@@ -308,7 +327,7 @@ func TestTotalCalculate(t *testing.T) {
 					taxes: tax.Set{
 						{
 							Category: common.TaxCategoryVAT,
-							Percent:  num.MakePercentage(210, 3),
+							Percent:  num.NewPercentage(210, 3),
 						},
 					},
 					amount: num.MakeAmount(10000, 2),
@@ -317,7 +336,7 @@ func TestTotalCalculate(t *testing.T) {
 					taxes: tax.Set{
 						{
 							Category: common.TaxCategoryVAT,
-							Percent:  num.MakePercentage(2100, 4), // different exp.
+							Percent:  num.NewPercentage(2100, 4), // different exp.
 						},
 					},
 					amount: num.MakeAmount(15000, 2),
@@ -399,7 +418,7 @@ func TestTotalCalculate(t *testing.T) {
 					taxes: tax.Set{
 						{
 							Category: common.TaxCategoryVAT,
-							Percent:  num.MakePercentage(210, 3),
+							Percent:  num.NewPercentage(210, 3),
 						},
 					},
 					amount: num.MakeAmount(10000, 2),
@@ -408,7 +427,7 @@ func TestTotalCalculate(t *testing.T) {
 					taxes: tax.Set{
 						{
 							Category: common.TaxCategoryVAT,
-							Percent:  num.MakePercentage(100, 3),
+							Percent:  num.NewPercentage(100, 3),
 						},
 					},
 					amount: num.MakeAmount(15000, 2),
@@ -497,7 +516,7 @@ func TestTotalCalculate(t *testing.T) {
 					taxes: tax.Set{
 						{
 							Category: common.TaxCategoryVAT,
-							Percent:  num.MakePercentage(210, 3),
+							Percent:  num.NewPercentage(210, 3),
 						},
 					},
 					amount: num.MakeAmount(10000, 2),
@@ -506,7 +525,7 @@ func TestTotalCalculate(t *testing.T) {
 					taxes: tax.Set{
 						{
 							Category: common.TaxCategoryVAT,
-							Percent:  num.MakePercentage(100, 3),
+							Percent:  num.NewPercentage(100, 3),
 						},
 					},
 					amount: num.MakeAmount(15000, 2),


### PR DESCRIPTION
* The Tax Combo Percent is now optional, as long as a tag is provided with an explanation as to why effectively the row is "exempt" of tax.
* Related to #114 