### PR TITLE
Fixing cal date parsing and validation, simplify bill preceding

### DIFF
--- a/bill/preceding.go
+++ b/bill/preceding.go
@@ -18,7 +18,7 @@ type Preceding struct {
 	// Code of the previous document.
 	Code string `json:"code" jsonschema:"title=Code"`
 	// The issue date of the previous document.
-	IssueDate cal.Date `json:"issue_date" jsonschema:"title=Issue Date"`
+	IssueDate *cal.Date `json:"issue_date,omitempty" jsonschema:"title=Issue Date"`
 	// Human readable description on why the preceding invoice is being replaced.
 	Reason string `json:"reason,omitempty" jsonschema:"title=Reason"`
 	// Seals of approval from other organisations that may need to be listed.

--- a/bill/preceding_test.go
+++ b/bill/preceding_test.go
@@ -11,7 +11,7 @@ import (
 func TestPrecedingValidation(t *testing.T) {
 	p := new(bill.Preceding)
 	p.Code = "FOO"
-	p.IssueDate = cal.MakeDate(2022, 11, 6)
+	p.IssueDate = cal.NewDate(2022, 11, 6)
 
 	err := p.Validate()
 	assert.NoError(t, err)

--- a/build/schemas/bill/invoice.json
+++ b/build/schemas/bill/invoice.json
@@ -683,8 +683,7 @@
       },
       "type": "object",
       "required": [
-        "code",
-        "issue_date"
+        "code"
       ],
       "description": "Preceding allows for information to be provided about a previous invoice that this one will replace, subtract from, or add to."
     },

--- a/build/schemas/cbc/note.json
+++ b/build/schemas/cbc/note.json
@@ -4,111 +4,111 @@
   "$ref": "#/$defs/Note",
   "$defs": {
     "Note": {
-      "oneOf": [
-        {
-          "const": "goods",
-          "description": "Goods Description"
-        },
-        {
-          "const": "payment",
-          "description": "Terms of Payment"
-        },
-        {
-          "const": "legal",
-          "description": "Legal or regulatory information"
-        },
-        {
-          "const": "dangerous-goods",
-          "description": "Dangerous goods additional information"
-        },
-        {
-          "const": "ack",
-          "description": "Acknowledgement Description"
-        },
-        {
-          "const": "rate",
-          "description": "Rate additional information"
-        },
-        {
-          "const": "reason",
-          "description": "Reason"
-        },
-        {
-          "const": "dispute",
-          "description": "Dispute"
-        },
-        {
-          "const": "customer",
-          "description": "Customer remarks"
-        },
-        {
-          "const": "glossary",
-          "description": "Glossary"
-        },
-        {
-          "const": "customs",
-          "description": "Customs declaration information"
-        },
-        {
-          "const": "general",
-          "description": "General information"
-        },
-        {
-          "const": "handling",
-          "description": "Handling instructions"
-        },
-        {
-          "const": "packaging",
-          "description": "Packaging information"
-        },
-        {
-          "const": "loading",
-          "description": "Loading instructions"
-        },
-        {
-          "const": "price",
-          "description": "Price conditions"
-        },
-        {
-          "const": "priority",
-          "description": "Priority information"
-        },
-        {
-          "const": "regulatory",
-          "description": "Regulatory information"
-        },
-        {
-          "const": "safety",
-          "description": "Safety instructions"
-        },
-        {
-          "const": "ship-line",
-          "description": "Ship line"
-        },
-        {
-          "const": "supplier",
-          "description": "Supplier remarks"
-        },
-        {
-          "const": "transport",
-          "description": "Transportation information"
-        },
-        {
-          "const": "delivery",
-          "description": "Delivery information"
-        },
-        {
-          "const": "quarantine",
-          "description": "Quarantine information"
-        },
-        {
-          "const": "tax",
-          "description": "Tax declaration"
-        }
-      ],
       "properties": {
         "key": {
           "$ref": "https://gobl.org/draft-0/cbc/key",
+          "oneOf": [
+            {
+              "const": "goods",
+              "description": "Goods Description"
+            },
+            {
+              "const": "payment",
+              "description": "Terms of Payment"
+            },
+            {
+              "const": "legal",
+              "description": "Legal or regulatory information"
+            },
+            {
+              "const": "dangerous-goods",
+              "description": "Dangerous goods additional information"
+            },
+            {
+              "const": "ack",
+              "description": "Acknowledgement Description"
+            },
+            {
+              "const": "rate",
+              "description": "Rate additional information"
+            },
+            {
+              "const": "reason",
+              "description": "Reason"
+            },
+            {
+              "const": "dispute",
+              "description": "Dispute"
+            },
+            {
+              "const": "customer",
+              "description": "Customer remarks"
+            },
+            {
+              "const": "glossary",
+              "description": "Glossary"
+            },
+            {
+              "const": "customs",
+              "description": "Customs declaration information"
+            },
+            {
+              "const": "general",
+              "description": "General information"
+            },
+            {
+              "const": "handling",
+              "description": "Handling instructions"
+            },
+            {
+              "const": "packaging",
+              "description": "Packaging information"
+            },
+            {
+              "const": "loading",
+              "description": "Loading instructions"
+            },
+            {
+              "const": "price",
+              "description": "Price conditions"
+            },
+            {
+              "const": "priority",
+              "description": "Priority information"
+            },
+            {
+              "const": "regulatory",
+              "description": "Regulatory information"
+            },
+            {
+              "const": "safety",
+              "description": "Safety instructions"
+            },
+            {
+              "const": "ship-line",
+              "description": "Ship line"
+            },
+            {
+              "const": "supplier",
+              "description": "Supplier remarks"
+            },
+            {
+              "const": "transport",
+              "description": "Transportation information"
+            },
+            {
+              "const": "delivery",
+              "description": "Delivery information"
+            },
+            {
+              "const": "quarantine",
+              "description": "Quarantine information"
+            },
+            {
+              "const": "tax",
+              "description": "Tax declaration"
+            }
+          ],
           "title": "Key",
           "description": "Key specifying subject of the text"
         },

--- a/cal/date_test.go
+++ b/cal/date_test.go
@@ -1,0 +1,109 @@
+package cal_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/invopop/gobl/cal"
+	"github.com/invopop/validation"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDateJSONParsing(t *testing.T) {
+
+	// Handle a zero date
+	t.Run("zero date", func(t *testing.T) {
+		var d cal.Date
+		data, err := json.Marshal(d)
+		assert.NoError(t, err)
+		assert.EqualValues(t, string(data), `"0000-00-00"`)
+
+		err = json.Unmarshal([]byte(`"0000-00-00"`), &d)
+		assert.NoError(t, err)
+	})
+
+	t.Run("valid date", func(t *testing.T) {
+		d := cal.MakeDate(2021, time.May, 26)
+		data, err := json.Marshal(d)
+		assert.NoError(t, err)
+		assert.EqualValues(t, string(data), `"2021-05-26"`)
+
+		err = json.Unmarshal([]byte(`"2021-05-26"`), &d)
+		assert.NoError(t, err)
+		assert.Equal(t, d.Year, 2021)
+		assert.Equal(t, d.Month, time.May)
+		assert.Equal(t, d.Day, 26)
+	})
+}
+
+func TestDateValidation(t *testing.T) {
+	t.Run("basics", func(t *testing.T) {
+		d := cal.MakeDate(2021, time.May, 26)
+		err := validation.Validate(d)
+		assert.NoError(t, err)
+
+		d = cal.MakeDate(2021, 0, 1)
+		err = d.Validate()
+		assert.Error(t, err)
+		err = validation.Validate(d)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid date")
+
+		d = cal.MakeDate(2021, 1, 0)
+		err = validation.Validate(d)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid date")
+
+		// Pointer
+		dp := cal.NewDate(2021, 1, 0)
+		assert.Error(t, dp.Validate())
+		assert.Error(t, validation.Validate(dp))
+	})
+
+	t.Run("date not zero", func(t *testing.T) {
+		d := cal.MakeDate(2021, time.May, 26)
+		err := validation.Validate(d, cal.DateNotZero())
+		assert.NoError(t, err)
+
+		d = cal.Date{}
+		err = validation.Validate(d, cal.DateNotZero())
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "required")
+
+		dp := new(cal.Date)
+		err = validation.Validate(dp, cal.DateNotZero())
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "required")
+
+		dp = nil
+		err = validation.Validate(dp, cal.DateNotZero())
+		assert.NoError(t, err)
+	})
+
+	t.Run("date after", func(t *testing.T) {
+		d := cal.MakeDate(2023, time.March, 25)
+		err := validation.Validate(d, cal.DateAfter(cal.MakeDate(2023, time.March, 24)))
+		assert.NoError(t, err)
+
+		err = validation.Validate(d, cal.DateAfter(cal.MakeDate(2023, time.March, 25)))
+		assert.NoError(t, err)
+
+		err = validation.Validate(d, cal.DateAfter(cal.MakeDate(2023, time.March, 26)))
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "too early")
+	})
+
+	t.Run("date before", func(t *testing.T) {
+		d := cal.MakeDate(2023, time.March, 25)
+		err := validation.Validate(d, cal.DateBefore(cal.MakeDate(2023, time.March, 26)))
+		assert.NoError(t, err)
+
+		err = validation.Validate(d, cal.DateBefore(cal.MakeDate(2023, time.March, 25)))
+		assert.NoError(t, err)
+
+		err = validation.Validate(d, cal.DateBefore(cal.MakeDate(2023, time.March, 24)))
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "too late")
+	})
+}

--- a/cal/date_test.go
+++ b/cal/date_test.go
@@ -59,6 +59,9 @@ func TestDateValidation(t *testing.T) {
 		dp := cal.NewDate(2021, 1, 0)
 		assert.Error(t, dp.Validate())
 		assert.Error(t, validation.Validate(dp))
+
+		dp = nil
+		assert.NoError(t, validation.Validate(dp))
 	})
 
 	t.Run("date not zero", func(t *testing.T) {

--- a/cbc/notes.go
+++ b/cbc/notes.go
@@ -255,9 +255,11 @@ func (n *Note) WithSrc(src Key) *Note {
 
 // JSONSchemaExtend adds the list of definitions for the notes.
 func (Note) JSONSchemaExtend(schema *jsonschema.Schema) {
-	schema.OneOf = make([]*jsonschema.Schema, len(NoteKeyDefinitions))
+	ksv, _ := schema.Properties.Get("key")
+	ks := ksv.(*jsonschema.Schema)
+	ks.OneOf = make([]*jsonschema.Schema, len(NoteKeyDefinitions))
 	for i, v := range NoteKeyDefinitions {
-		schema.OneOf[i] = &jsonschema.Schema{
+		ks.OneOf[i] = &jsonschema.Schema{
 			Const:       v.Key.String(),
 			Description: v.Description,
 		}

--- a/regimes/co/invoices_test.go
+++ b/regimes/co/invoices_test.go
@@ -69,7 +69,7 @@ func creditNote() *bill.Invoice {
 		Preceding: []*bill.Preceding{
 			{
 				Code:             "TEST",
-				IssueDate:        cal.MakeDate(2022, 12, 27),
+				IssueDate:        cal.NewDate(2022, 12, 27),
 				CorrectionMethod: co.CorrectionMethodKeyRevoked,
 			},
 		},


### PR DESCRIPTION
* Added tests to confirm adequate `cal.Date` handling.
* Zero dates now properly handled as potentially "valid" data (fixes the JSON bidirectional parsing issue)
* Date now has its own validation method to ensure they contain reasonable data.
* `bill.Preceding`'s `issue_date` is now optional and uses a date pointer.
* Got in there a fix for the cbc note key issue in the JSON Schema