### PR TITLE
Correct invoices in place

### DIFF
--- a/bill/invoice.go
+++ b/bill/invoice.go
@@ -2,7 +2,6 @@ package bill
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -140,20 +139,6 @@ func (inv *Invoice) ValidateWithContext(ctx context.Context) error {
 	return err
 }
 
-// Clone makes a copy of the invoice by serializing and deserializing it.
-// the contents.
-func (inv *Invoice) Clone() (*Invoice, error) {
-	i2 := new(Invoice)
-	data, err := json.Marshal(inv)
-	if err != nil {
-		return nil, err
-	}
-	if err = json.Unmarshal(data, i2); err != nil {
-		return nil, err
-	}
-	return i2, nil
-}
-
 // Invert effectively reverses the invoice by inverting the sign of all quantity
 // or amount values.
 func (inv *Invoice) Invert() {
@@ -169,6 +154,7 @@ func (inv *Invoice) Invert() {
 	for _, row := range inv.Outlays {
 		row.Amount = row.Amount.Invert()
 	}
+	inv.Totals = nil
 }
 
 // Empty is a convenience method that will empty all the lines and
@@ -178,6 +164,8 @@ func (inv *Invoice) Empty() {
 	inv.Charges = make([]*Charge, 0)
 	inv.Discounts = make([]*Discount, 0)
 	inv.Outlays = make([]*Outlay, 0)
+	inv.Totals = nil
+	inv.Payment.ResetAdvances()
 }
 
 // Calculate performs all the calculations required for the invoice totals and taxes. If the original

--- a/bill/invoice_correct.go
+++ b/bill/invoice_correct.go
@@ -155,5 +155,8 @@ func (inv *Invoice) Correct(opts ...cbc.Option) error {
 	// Replace all previous preceding data
 	inv.Preceding = []*Preceding{pre}
 
+	// Running a Calculate feels a bit out of place, but not performing
+	// this operation on the corrected invoice results in potentially
+	// conflicting or incomplete data.
 	return inv.Calculate()
 }

--- a/bill/payment.go
+++ b/bill/payment.go
@@ -29,6 +29,14 @@ func (p *Payment) Validate() error {
 	)
 }
 
+// ResetAdvances clears the advances list.
+func (p *Payment) ResetAdvances() {
+	if p == nil {
+		return
+	}
+	p.Advances = make([]*pay.Advance, 0)
+}
+
 func (p *Payment) calculateAdvances(totalWithTax num.Amount) {
 	for _, a := range p.Advances {
 		a.CalculateFrom(totalWithTax)

--- a/envelope_test.go
+++ b/envelope_test.go
@@ -248,3 +248,25 @@ func TestEnvelopeSign(t *testing.T) {
 		assert.Len(t, env.Signatures, 1)
 	})
 }
+func TestEnvelopeCorrect(t *testing.T) {
+	t.Run("correct invoice", func(t *testing.T) {
+		env := gobl.NewEnvelope()
+
+		data, err := ioutil.ReadFile("./regimes/es/examples/invoice-es-es.env.yaml")
+		require.NoError(t, err)
+		err = yaml.Unmarshal(data, env)
+		require.NoError(t, err)
+		require.NoError(t, env.Calculate())
+
+		_, err = env.Correct()
+		require.NoError(t, err)
+
+		doc := env.Extract().(*bill.Invoice)
+		assert.Equal(t, doc.Type, bill.InvoiceTypeStandard, "no change")
+
+		e2, err := env.Correct()
+		require.NoError(t, err)
+		doc = e2.Extract().(*bill.Invoice)
+		assert.Equal(t, doc.Type, bill.InvoiceTypeCorrective, "corrected")
+	})
+}


### PR DESCRIPTION
* Refactoring the correction handling to make the interfaces a bit more generic
* Correction of document is now performed in-place.
* Document `Clone()` method added to be able to duplicate a document before corrections or calculations.
* Double check that the source document for a correction has a Code.