### PR TITLE
Using cal.Period for delivery instead of custom range

### DIFF
--- a/bill/delivery.go
+++ b/bill/delivery.go
@@ -2,6 +2,7 @@ package bill
 
 import (
 	"github.com/invopop/gobl/cal"
+	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/org"
 	"github.com/invopop/validation"
 )
@@ -11,10 +12,12 @@ import (
 type Delivery struct {
 	// The party who will receive delivery of the goods defined in the invoice and is not responsible for taxes.
 	Receiver *org.Party `json:"receiver,omitempty" jsonschema:"title=Receiver"`
-	// When the goods should be expected
+	// When the goods should be expected.
 	Date *cal.Date `json:"date,omitempty" jsonschema:"title=Date"`
-	// Period of time in which to expect delivery if a specific date is not available
+	// Period of time in which to expect delivery if a specific date is not available.
 	Period *cal.Period `json:"period,omitempty" jsonschema:"title=Period"`
+	// Additional custom data.
+	Meta *cbc.Meta `json:"meta,omitempty" jsonschema:"title=Meta"`
 }
 
 // Validate the delivery details
@@ -23,5 +26,6 @@ func (d *Delivery) Validate() error {
 		validation.Field(&d.Receiver),
 		validation.Field(&d.Date),
 		validation.Field(&d.Period),
+		validation.Field(&d.Meta),
 	)
 }

--- a/bill/delivery.go
+++ b/bill/delivery.go
@@ -13,10 +13,8 @@ type Delivery struct {
 	Receiver *org.Party `json:"receiver,omitempty" jsonschema:"title=Receiver"`
 	// When the goods should be expected
 	Date *cal.Date `json:"date,omitempty" jsonschema:"title=Date"`
-	// Start of an invoicing or delivery period
-	StartDate *cal.Date `json:"start_date,omitempty" jsonschema:"title=Start Date"`
-	// End of an invoicing or delivery period
-	EndDate *cal.Date `json:"end_date,omitempty" jsonschema:"title=End Date"`
+	// Period of time in which to expect delivery if a specific date is not available
+	Period *cal.Period `json:"period,omitempty" jsonschema:"title=Period"`
 }
 
 // Validate the delivery details
@@ -24,7 +22,6 @@ func (d *Delivery) Validate() error {
 	return validation.ValidateStruct(d,
 		validation.Field(&d.Receiver),
 		validation.Field(&d.Date),
-		validation.Field(&d.StartDate),
-		validation.Field(&d.EndDate),
+		validation.Field(&d.Period),
 	)
 }

--- a/bill/ordering.go
+++ b/bill/ordering.go
@@ -1,6 +1,7 @@
 package bill
 
 import (
+	"github.com/invopop/gobl/cal"
 	"github.com/invopop/gobl/org"
 	"github.com/invopop/gobl/uuid"
 	"github.com/invopop/validation"
@@ -12,6 +13,8 @@ import (
 type Ordering struct {
 	// Identifier assigned by the customer or buyer for internal routing purposes.
 	Code string `json:"code,omitempty" jsonschema:"title=Code"`
+	// Period of time that the invoice document refers to.
+	Period *cal.Period `json:"period,omitempty" jsonschema:"title=Period"`
 	// Project this invoice refers to.
 	Project *DocumentReference `json:"project,omitempty" jsonschema:"title=Project"`
 	// The identification of a contract.

--- a/bill/ordering.go
+++ b/bill/ordering.go
@@ -13,7 +13,8 @@ import (
 type Ordering struct {
 	// Identifier assigned by the customer or buyer for internal routing purposes.
 	Code string `json:"code,omitempty" jsonschema:"title=Code"`
-	// Period of time that the invoice document refers to.
+	// Period of time that the invoice document refers to often used in addition to the details
+	// provided in the individual line items.
 	Period *cal.Period `json:"period,omitempty" jsonschema:"title=Period"`
 	// Project this invoice refers to.
 	Project *DocumentReference `json:"project,omitempty" jsonschema:"title=Project"`

--- a/build/schemas/bill/invoice.json
+++ b/build/schemas/bill/invoice.json
@@ -498,7 +498,7 @@
         "period": {
           "$ref": "https://gobl.org/draft-0/cal/period",
           "title": "Period",
-          "description": "Period of time that the invoice document refers to."
+          "description": "Period of time that the invoice document refers to often used in addition to the details\nprovided in the individual line items."
         },
         "project": {
           "$ref": "#/$defs/DocumentReference",

--- a/build/schemas/bill/invoice.json
+++ b/build/schemas/bill/invoice.json
@@ -75,17 +75,17 @@
         "date": {
           "$ref": "https://gobl.org/draft-0/cal/date",
           "title": "Date",
-          "description": "When the goods should be expected"
+          "description": "When the goods should be expected."
         },
-        "start_date": {
-          "$ref": "https://gobl.org/draft-0/cal/date",
-          "title": "Start Date",
-          "description": "Start of an invoicing or delivery period"
+        "period": {
+          "$ref": "https://gobl.org/draft-0/cal/period",
+          "title": "Period",
+          "description": "Period of time in which to expect delivery if a specific date is not available."
         },
-        "end_date": {
-          "$ref": "https://gobl.org/draft-0/cal/date",
-          "title": "End Date",
-          "description": "End of an invoicing or delivery period"
+        "meta": {
+          "$ref": "https://gobl.org/draft-0/cbc/meta",
+          "title": "Meta",
+          "description": "Additional custom data."
         }
       },
       "type": "object",
@@ -494,6 +494,11 @@
           "type": "string",
           "title": "Code",
           "description": "Identifier assigned by the customer or buyer for internal routing purposes."
+        },
+        "period": {
+          "$ref": "https://gobl.org/draft-0/cal/period",
+          "title": "Period",
+          "description": "Period of time that the invoice document refers to."
         },
         "project": {
           "$ref": "#/$defs/DocumentReference",

--- a/build/schemas/cal/period.json
+++ b/build/schemas/cal/period.json
@@ -5,11 +5,18 @@
   "$defs": {
     "Period": {
       "properties": {
+        "label": {
+          "type": "string",
+          "title": "Label",
+          "description": "Label is a short description of the period."
+        },
         "start": {
-          "$ref": "https://gobl.org/draft-0/cal/date"
+          "$ref": "https://gobl.org/draft-0/cal/date",
+          "description": "Start indicates when this period starts."
         },
         "end": {
-          "$ref": "https://gobl.org/draft-0/cal/date"
+          "$ref": "https://gobl.org/draft-0/cal/date",
+          "description": "End indicates when the period ends, and must be after the start date."
         }
       },
       "type": "object",

--- a/cal/period.go
+++ b/cal/period.go
@@ -4,8 +4,12 @@ import "github.com/invopop/validation"
 
 // Period represents two dates with a start and finish.
 type Period struct {
+	// Label is a short description of the period.
+	Label string `json:"label,omitempty" jsonschema:"title=Label"`
+	// Start indicates when this period starts.
 	Start Date `json:"start"`
-	End   Date `json:"end"`
+	// End indicates when the period ends, and must be after the start date.
+	End Date `json:"end"`
 }
 
 // Validate checks to ensure the period looks correct.


### PR DESCRIPTION
* Refactor bill delivery details to use the Period object instead of a custom range.
* Adding Period to ordering.
* cal.Period now includes a label field.