### PR TITLE
Add label, code, and meta to Registration

### DIFF
--- a/org/party.go
+++ b/org/party.go
@@ -2,6 +2,8 @@ package org
 
 import (
 	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/currency"
+	"github.com/invopop/gobl/num"
 	"github.com/invopop/gobl/tax"
 	"github.com/invopop/gobl/uuid"
 
@@ -122,14 +124,16 @@ type Website struct {
 // The definition found here is based on the details required for spain.
 // If your country requires additional fields, please let us know.
 type Registration struct {
-	UUID    *uuid.UUID `json:"uuid,omitempty" jsonschema:"title=UUID"`
-	Office  string     `json:"office,omitempty" jsonschema:"title=Office"`
-	Book    string     `json:"book,omitempty" jsonschema:"title=Book"`
-	Volume  string     `json:"volume,omitempty" jsonschema:"title=Volume"`
-	Sheet   string     `json:"sheet,omitempty" jsonschema:"title=Sheet"`
-	Section string     `json:"section,omitempty" jsonschema:"title=Section"`
-	Page    string     `json:"page,omitempty" jsonschema:"title=Page"`
-	Entry   string     `json:"entry,omitempty" jsonschema:"title=Entry"`
+	UUID     *uuid.UUID    `json:"uuid,omitempty" jsonschema:"title=UUID"`
+	Capital  *num.Amount   `json:"social_capital,omitempty" jsonschema:"title=Capital"`
+	Currency currency.Code `json:"currency,omitempty" jsonschema:"title=Currency"`
+	Office   string        `json:"office,omitempty" jsonschema:"title=Office"`
+	Book     string        `json:"book,omitempty" jsonschema:"title=Book"`
+	Volume   string        `json:"volume,omitempty" jsonschema:"title=Volume"`
+	Sheet    string        `json:"sheet,omitempty" jsonschema:"title=Sheet"`
+	Section  string        `json:"section,omitempty" jsonschema:"title=Section"`
+	Page     string        `json:"page,omitempty" jsonschema:"title=Page"`
+	Entry    string        `json:"entry,omitempty" jsonschema:"title=Entry"`
 }
 
 // Calculate performs any calculations required on the Party or

--- a/regimes/it/README.md
+++ b/regimes/it/README.md
@@ -32,13 +32,16 @@ Italy uses the FatturaPA format for their e-invoicing system.
 
 [Agenzia Entrate (Tax Office) IVA Doc](https://www.agenziaentrate.gov.it/portale/web/english/nse/business/vat-in-italy)
 
-### Challenges
+### Italy-specific Details
 
-#### Special Codes (WIP)
+#### Numero REA
+`Party.Registration` is used to store the Numero REA (Registro delle Imprese) of the company.
+The `Office` field is used to store the Provincia (Province) of the company, the `Entry` field is used to store the Numero REA. Additionally, the share capital is stored in the `Capital` field used in conjunction with `Currency`.
+
+#### Local Codes
 
 FatturaPA demands very specific categorization for the type of economic activity,
-document type, fund type, etc. It will be a challenge to map these onto GOBL
-constructs.
+document type, fund type, etc.
 
 ##### RegimeFiscale (Tax System)
 

--- a/regimes/it/README.md
+++ b/regimes/it/README.md
@@ -178,7 +178,7 @@ Note: fields marked with (\*) are for simplified invoice documents.
 
 ##### TipoRitenuta (Withholding Type)
 
-|      |                                    |
+| Code | Description                        |
 | ---- | ---------------------------------- |
 | RT01 | witholding tax natural persons     |
 | RT02 | witholding corporate entities      |
@@ -186,3 +186,7 @@ Note: fields marked with (\*) are for simplified invoice documents.
 | RT04 | ENASARCO contribution              |
 | RT05 | ENPAM contribution                 |
 | RT06 | Other social security contribution |
+
+## TODO
+- Document Codice Destinatario (uses inbox codes)
+- Document how local codes are mapped

--- a/regimes/it/examples/freelance.json
+++ b/regimes/it/examples/freelance.json
@@ -22,6 +22,12 @@
         }
       }
     ],
+    "registration": {
+      "capital": "50000.00",
+      "currency": "EUR",
+      "entry": "123456",
+      "office": "RM"
+    },
     "addresses": [
       {
         "num": "9",


### PR DESCRIPTION
Italy requires companies registered with the local Chamber of Commerce (CCIAA) to include the Numero REA (Repertorio Economico Amministrativo) and related information. 

The `NumeroREA` block in FatturaPA requires the provincial code of the CCIAA, the registration number, and a code indicating whether the company is in liquidation or not. It also requires the equity capital to be listed for certain types of companies (SpA, SApA, SRL). 

<img width="909" alt="Screenshot 2023-04-05 at 17 11 55" src="https://user-images.githubusercontent.com/26794720/230124755-ef1ad207-9f03-475b-b19c-16bbcfac9cf0.png">

Proposed additional fields to `org.Registration`:
- `Label`: to be used to describe the type of registration (in this case `CCIAA` or `REA`)
- `Code`: to include the registration number
- `Meta`: to include highly specific things like equity capital and liquidation status 