### PR TITLE
Add Type to bill.Charge

### DIFF
--- a/bill/charges.go
+++ b/bill/charges.go
@@ -35,7 +35,7 @@ func (lc *LineCharge) Validate() error {
 type Charge struct {
 	// Unique identifying for the discount entry
 	UUID *uuid.UUID `json:"uuid,omitempty" jsonschema:"title=UUID"`
-	// Type of the charge, useful when regimes require special types of charges.
+	// Key for grouping or identifying charges for tax purposes.
 	Key cbc.Key `json:"key,omitempty" jsonschema:"title=Key"`
 	// Line number inside the list of discounts (calculated).
 	Index int `json:"i" jsonschema:"title=Index" jsonschema_extras:"calculated=true"`

--- a/bill/charges.go
+++ b/bill/charges.go
@@ -35,6 +35,8 @@ func (lc *LineCharge) Validate() error {
 type Charge struct {
 	// Unique identifying for the discount entry
 	UUID *uuid.UUID `json:"uuid,omitempty" jsonschema:"title=UUID"`
+	// Type of the charge, useful when regimes require special types of charges.
+	Type cbc.Key `json:"key,omitempty" jsonschema:"title=Key"`
 	// Line number inside the list of discounts (calculated).
 	Index int `json:"i" jsonschema:"title=Index" jsonschema_extras:"calculated=true"`
 	// Code to used to refer to the this charge

--- a/bill/charges.go
+++ b/bill/charges.go
@@ -36,7 +36,7 @@ type Charge struct {
 	// Unique identifying for the discount entry
 	UUID *uuid.UUID `json:"uuid,omitempty" jsonschema:"title=UUID"`
 	// Type of the charge, useful when regimes require special types of charges.
-	Type cbc.Key `json:"key,omitempty" jsonschema:"title=Key"`
+	Key cbc.Key `json:"key,omitempty" jsonschema:"title=Key"`
 	// Line number inside the list of discounts (calculated).
 	Index int `json:"i" jsonschema:"title=Index" jsonschema_extras:"calculated=true"`
 	// Code to used to refer to the this charge

--- a/regimes/it/README.md
+++ b/regimes/it/README.md
@@ -32,7 +32,10 @@ Italy uses the FatturaPA format for their e-invoicing system.
 
 [Agenzia Entrate (Tax Office) IVA Doc](https://www.agenziaentrate.gov.it/portale/web/english/nse/business/vat-in-italy)
 
-### Challenges
+### Italy-specific Details
+
+#### Stamp Duty
+Add an invoice-level `bill.Charge` and use `it.ChargeKeyStampDuty` as the `bill.Charge.Key`.
 
 #### Special Codes (WIP)
 

--- a/regimes/it/charges.go
+++ b/regimes/it/charges.go
@@ -1,0 +1,25 @@
+package it
+
+import (
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/i18n"
+	"github.com/invopop/gobl/tax"
+)
+
+const (
+	ChargeTypeBollo cbc.Key = "bollo"
+)
+
+var chargeTypes = []*tax.KeyDefinition{
+	{
+		Key: ChargeTypeBollo,
+		Name: i18n.String{
+			i18n.EN: "Duty Stamp",
+			i18n.IT: "Bollo",
+		},
+		Desc: i18n.String{
+			i18n.EN: "A fixed-price tax applied to the production, request or presentation of certain documents: civil, commercial, judicial and extrajudicial documents, on notices, on posters.",
+			i18n.IT: "Un'imposta applicata alla produzione, richiesta o presentazione di determinati documenti: atti civili, commerciali, giudiziali ed extragiudiziali, sugli avvisi, sui manifesti.",
+		},
+	},
+}

--- a/regimes/it/charges.go
+++ b/regimes/it/charges.go
@@ -15,8 +15,8 @@ var chargeKeys = []*tax.KeyDefinition{
 	{
 		Key: ChargeKeyStampDuty,
 		Name: i18n.String{
-			i18n.EN: "Stamp Stamp",
-			i18n.IT: "Bollo",
+			i18n.EN: "Stamp Duty",
+			i18n.IT: "Imposta di bollo",
 		},
 		Desc: i18n.String{
 			i18n.EN: "A fixed-price tax applied to the production, request or presentation of certain documents: civil, commercial, judicial and extrajudicial documents, on notices, on posters.",

--- a/regimes/it/charges.go
+++ b/regimes/it/charges.go
@@ -6,15 +6,16 @@ import (
 	"github.com/invopop/gobl/tax"
 )
 
+// List of charge types specific to the italian regime.
 const (
-	ChargeTypeBollo cbc.Key = "bollo"
+	ChargeKeyStampDuty cbc.Key = "stamp-duty"
 )
 
-var chargeTypes = []*tax.KeyDefinition{
+var chargeKeys = []*tax.KeyDefinition{
 	{
-		Key: ChargeTypeBollo,
+		Key: ChargeKeyStampDuty,
 		Name: i18n.String{
-			i18n.EN: "Duty Stamp",
+			i18n.EN: "Stamp Stamp",
 			i18n.IT: "Bollo",
 		},
 		Desc: i18n.String{

--- a/regimes/it/it.go
+++ b/regimes/it/it.go
@@ -32,6 +32,7 @@ func New() *tax.Regime {
 			i18n.EN: "Italy",
 			i18n.IT: "Italia",
 		},
+		ChargeTypes:   chargeTypes, // charges.go
 		IdentityTypes: taxIdentityTypes,
 		Tags:          invoiceTags,
 		Scenarios:     scenarios, // scenarios.go

--- a/regimes/it/it.go
+++ b/regimes/it/it.go
@@ -32,7 +32,7 @@ func New() *tax.Regime {
 			i18n.EN: "Italy",
 			i18n.IT: "Italia",
 		},
-		ChargeTypes:   chargeTypes, // charges.go
+		ChargeKeys:    chargeKeys, // charges.go
 		IdentityTypes: taxIdentityTypes,
 		Tags:          invoiceTags,
 		Scenarios:     scenarios, // scenarios.go

--- a/tax/regime.go
+++ b/tax/regime.go
@@ -42,6 +42,9 @@ type Regime struct {
 	// against.
 	IdentityTypes []*IdentityType `json:"identity_types,omitempty" jsonschema:"title=Identity Types"`
 
+	// Charge types specific for the regime and may be validated or used in the UI as suggestions
+	ChargeTypes []*KeyDefinition `json:"charge_types,omitempty" jsonschema:"title=Charge Types"`
+
 	// Tags that can be applied at the document level to identify additional
 	// considerations.
 	Tags []*Tag `json:"tags,omitempty" jsonschema:"title=Tags"`

--- a/tax/regime.go
+++ b/tax/regime.go
@@ -43,7 +43,7 @@ type Regime struct {
 	IdentityTypes []*IdentityType `json:"identity_types,omitempty" jsonschema:"title=Identity Types"`
 
 	// Charge types specific for the regime and may be validated or used in the UI as suggestions
-	ChargeTypes []*KeyDefinition `json:"charge_types,omitempty" jsonschema:"title=Charge Types"`
+	ChargeKeys []*KeyDefinition `json:"charge_types,omitempty" jsonschema:"title=Charge Types"`
 
 	// Tags that can be applied at the document level to identify additional
 	// considerations.


### PR DESCRIPTION
- Add a new field `Type` to Charges
- For certain types of Charges that are distinguished from others at the regime-level. In the case of Italy, there is `Bollo`, or duty stamps, which is to be included in a special field. 

--
**Notes**
- I was going to create a `ChargeTypeDef` in the `bill` package, but it since the `bill` package depends on `tax` I was not able to utilise ChargeTypeDef in `tax.Regime`. Went with reutilising `tax.KeyDefinition` instead. 