### PR TITLE
Clarify usage of French tax codes

### DIFF
--- a/regimes/fr/README.md
+++ b/regimes/fr/README.md
@@ -1,0 +1,47 @@
+# GOBL France
+
+## Tax IDs
+
+France has three main company IDs which are all very closely related and may be included on Invoice documents:
+
+- VAT code, an 11 digit number that starts with a two digit checksum followed by 9 numbers that form the SIREN. In standardised form, this is always presented with the country code (`FR`), e.g. `44732829320` or `FR44732829320`.
+- SIREN is the national company ID register and consists of 9 digits with a final digit representing a checksum, e.g. `732829320`.
+- SIRET is the SIREN with an additional 5 digits representing a department inside the company or tax agency, e.g. `73282932000015`
+
+During the normalization process of Tax Identities, GOBL will automatically convert a SIREN into a VAT code by adding the checksum to beginning.
+
+The SIREN and SIRET numbers may also be defined inside the `org.Party`'s `identities` property, for example a supplier inside an invoice might look like:
+
+```json
+{
+  "tax_id": {
+    "country": "FR",
+    "code": "44732829320"
+  },
+  "name": "Dummy FR Inc.",
+  "addresses": [
+    {
+      "num": "1",
+      "street": "Rue Sundacsakn",
+      "locality": "Saint-Germain-En-Laye",
+      "code": "75050",
+      "country": "FR"
+    }
+  ],
+  "emails": [
+    {
+      "addr": "email@dummycom.fr"
+    }
+  ],
+  "identities": [
+    {
+      "type": "SIREN",
+      "code": "73282932"
+    },
+    {
+      "type": "SIRET",
+      "code": "73282932000015"
+    }
+  ]
+}
+```

--- a/regimes/fr/README.md
+++ b/regimes/fr/README.md
@@ -36,7 +36,7 @@ The SIREN and SIRET numbers may also be defined inside the `org.Party`'s `identi
   "identities": [
     {
       "type": "SIREN",
-      "code": "73282932"
+      "code": "732829320"
     },
     {
       "type": "SIRET",

--- a/regimes/fr/examples/invoice-fr-fr.yaml
+++ b/regimes/fr/examples/invoice-fr-fr.yaml
@@ -1,0 +1,47 @@
+$schema: "https://gobl.org/draft-0/bill/invoice"
+currency: "EUR"
+issue_date: "2022-02-01"
+series: "SAMPLE"
+code: "001"
+
+supplier:
+  tax_id:
+    country: "FR"
+    code: "44732829320" # random
+  name: "Provide One Inc."
+  emails:
+    - addr: "billing@example.com"
+  addresses:
+    - num: "42"
+      street: "Calle Pradillo"
+      locality: "Madrid"
+      region: "Madrid"
+      code: "28002"
+      country: "ES"
+
+customer:
+  tax_id:
+    country: "FR"
+    code: "356000000"
+  name: "Sample Consumer"
+  emails:
+    - addr: "email@sample.com"
+  addresses:
+    - num: "1"
+      street: "Rue Sundacsakn"
+      locality: "Saint-Germain-En-Laye"
+      code: "75050"
+      country": "FR"
+
+lines:
+  - quantity: 20
+    item:
+      name: "Development services"
+      price: "90.00"
+      unit: "h"
+    discounts:
+      - percent: "10%"
+        reason: "Special discount"
+    taxes:
+      - cat: VAT
+        rate: standard

--- a/regimes/fr/fr.go
+++ b/regimes/fr/fr.go
@@ -6,14 +6,14 @@ import (
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/i18n"
 	"github.com/invopop/gobl/l10n"
-	"github.com/invopop/gobl/regimes/common"
 	"github.com/invopop/gobl/tax"
 )
 
 // Identification keys used for additional codes not
 // covered by the standard fields.
 const (
-	IdentityTypeSIRET cbc.Code = "SIRET" // SIRET number is used to identify each establishment that makes up a company.
+	IdentityTypeSIREN cbc.Code = "SIREN" // SIREN is the main local tax code used in france, we use the normalized VAT version for the tax ID.
+	IdentityTypeSIRET cbc.Code = "SIRET" // SIRET number combines the SIREN with a branch number.
 	IdentityTypeRCS   cbc.Code = "RCS"   // Trade and Companies Register.
 	IdentityTypeRM    cbc.Code = "RM"    // Directory of Traders.
 	IdentityTypeNAF   cbc.Code = "NAF"   // Identifies the main branch of activity of the company or self-employed person.
@@ -58,7 +58,7 @@ func Validate(doc interface{}) error {
 func Calculate(doc interface{}) error {
 	switch obj := doc.(type) {
 	case *tax.Identity:
-		return common.NormalizeTaxIdentity(obj)
+		return normalizeTaxIdentity(obj)
 	}
 	return nil
 }

--- a/regimes/fr/tax_identity.go
+++ b/regimes/fr/tax_identity.go
@@ -2,7 +2,9 @@ package fr
 
 import (
 	"errors"
+	"fmt"
 	"regexp"
+	"strconv"
 
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/regimes/common"
@@ -11,22 +13,70 @@ import (
 )
 
 var (
+	taxCodeVATRegexp   = regexp.MustCompile(`^\d{11}$`)
 	taxCodeSIRENRegexp = regexp.MustCompile(`^\d{9}$`)
 )
+
+// normalizeTaxIdentity normalizes the SIREN code and ensures it includes the VAT check digits.
+func normalizeTaxIdentity(tID *tax.Identity) error {
+	if tID.Code == "" {
+		return nil
+	}
+	if err := common.NormalizeTaxIdentity(tID); err != nil {
+		return err
+	}
+	str := tID.Code.String()
+	if len(str) == 9 {
+		// Check is we have a SIREN
+		if err := validateSIRENTaxCode(tID.Code); err != nil {
+			return err
+		}
+		chk := calculateVATCheckDigit(str)
+		tID.Code = cbc.Code(fmt.Sprintf("%s%s", chk, str))
+	}
+	return nil
+}
 
 // validateTaxIdentity checks to ensure the SIRET code looks okay.
 func validateTaxIdentity(tID *tax.Identity) error {
 	return validation.ValidateStruct(tID,
-		validation.Field(&tID.Code, validation.Required, validation.By(validateSIRENTaxCode)),
+		validation.Field(&tID.Code, validation.Required, validation.By(validateVATTaxCode)),
 	)
+}
+
+func validateVATTaxCode(value interface{}) error {
+	code, ok := value.(cbc.Code)
+	if !ok || code == "" {
+		return nil
+	}
+	str := code.String()
+
+	if !taxCodeVATRegexp.MatchString(str) {
+		return errors.New("invalid format")
+	}
+
+	// Extract the last nine digits as an integer.
+	siren := str[2:] // extract last nine digits
+	chk := calculateVATCheckDigit(siren)
+	expectStr := str[:2] // compare with first two digits
+	if chk != expectStr {
+		return errors.New("checksum mismatch")
+	}
+
+	return nil
+}
+
+func calculateVATCheckDigit(str string) string {
+	// Assume we have a SIREN
+	total, _ := strconv.Atoi(str)
+	total = (total*100 + 12) % 97
+
+	return fmt.Sprintf("%02d", total)
 }
 
 func validateSIRENTaxCode(value interface{}) error {
 	code, ok := value.(cbc.Code)
-	if !ok {
-		return nil
-	}
-	if code == "" {
+	if !ok || code == "" {
 		return nil
 	}
 	str := code.String()

--- a/regimes/fr/tax_identity_test.go
+++ b/regimes/fr/tax_identity_test.go
@@ -10,15 +10,50 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestNormalizeTaxIdentity(t *testing.T) {
+	r := fr.New()
+	tests := []struct {
+		Code     cbc.Code
+		Expected cbc.Code
+	}{
+		{
+			Code:     "356000000", // SIREN to VAT
+			Expected: "39356000000",
+		},
+		{
+			Code:     "44 73282 9320 ",
+			Expected: "44732829320",
+		},
+		{
+			Code:     "391-838-042",
+			Expected: "44391838042",
+		},
+		{
+			Code:     "FR391838042",
+			Expected: "44391838042",
+		},
+		{
+			Code:     "FR44391838042",
+			Expected: "44391838042",
+		},
+	}
+	for _, ts := range tests {
+		tID := &tax.Identity{Country: l10n.FR, Code: ts.Code}
+		err := r.CalculateObject(tID)
+		assert.NoError(t, err)
+		assert.Equal(t, ts.Expected, tID.Code)
+	}
+}
+
 func TestValidateTaxIdentity(t *testing.T) {
 	tests := []struct {
 		name string
 		code cbc.Code
 		err  string
 	}{
-		{name: "good 1", code: "356000000"},
-		{name: "good 2", code: "732829320"},
-		{name: "good 3", code: "391838042"},
+		{name: "good 1", code: "39356000000"},
+		{name: "good 2", code: "44732829320"},
+		{name: "good 3", code: "44391838042"},
 		{
 			name: "empty",
 			code: "",
@@ -26,7 +61,7 @@ func TestValidateTaxIdentity(t *testing.T) {
 		},
 		{
 			name: "too long",
-			code: "123456789100",
+			code: "44123456789100",
 			err:  "invalid format",
 		},
 		{
@@ -41,7 +76,7 @@ func TestValidateTaxIdentity(t *testing.T) {
 		},
 		{
 			name: "bad checksum",
-			code: "999999991",
+			code: "44999999991",
 			err:  "checksum mismatch",
 		},
 	}


### PR DESCRIPTION
* Using the official VAT Code, which is a regular SIREN with a two digit prefix checksum.
* Normalize the tax ids.