### PR TITLE
Stamp checks

### DIFF
--- a/cbc/stamps.go
+++ b/cbc/stamps.go
@@ -1,6 +1,9 @@
 package cbc
 
 import (
+	"errors"
+	"fmt"
+
 	"github.com/invopop/validation"
 )
 
@@ -19,4 +22,34 @@ func (s *Stamp) Validate() error {
 		validation.Field(&s.Provider, validation.Required),
 		validation.Field(&s.Value, validation.Required),
 	)
+}
+
+// In checks if the stamp is in the list of stamps.
+func (s *Stamp) In(ss []*Stamp) bool {
+	for _, r := range ss {
+		if s.Provider == r.Provider {
+			return true
+		}
+	}
+	return false
+}
+
+// DetectDuplicateStamps checks if the list of stamps contains duplicate
+// provider keys.
+var DetectDuplicateStamps = validation.By(duplicateDuplicateStamps)
+
+func duplicateDuplicateStamps(list interface{}) error {
+	values, ok := list.([]*Stamp)
+	if !ok {
+		return errors.New("must be a stamp array")
+	}
+	set := []*Stamp{}
+	// loop through and check order of Since value
+	for _, v := range values {
+		if v.In(set) {
+			return fmt.Errorf("duplicate stamp '%v'", v.Provider)
+		}
+		set = append(set, v)
+	}
+	return nil
 }

--- a/cbc/stamps_test.go
+++ b/cbc/stamps_test.go
@@ -1,0 +1,41 @@
+package cbc_test
+
+import (
+	"testing"
+
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/validation"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDuplicateStamps(t *testing.T) {
+	st := struct {
+		Stamps []*cbc.Stamp
+	}{
+		Stamps: []*cbc.Stamp{
+			{
+				Provider: cbc.Key("provider"),
+				Value:    "value",
+			},
+			{
+				Provider: cbc.Key("provider2"),
+				Value:    "value2",
+			},
+		},
+	}
+
+	err := validation.ValidateStruct(&st,
+		validation.Field(&st.Stamps, cbc.DetectDuplicateStamps),
+	)
+	assert.NoError(t, err)
+
+	st.Stamps = append(st.Stamps, &cbc.Stamp{
+		Provider: cbc.Key("provider"),
+		Value:    "value3",
+	})
+	err = validation.ValidateStruct(&st,
+		validation.Field(&st.Stamps, cbc.DetectDuplicateStamps),
+	)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate stamp 'provider'")
+}

--- a/envelope.go
+++ b/envelope.go
@@ -167,11 +167,6 @@ func (e *Envelope) calculate() error {
 	if err != nil {
 		return err
 	}
-	if e.Head.Draft {
-		// Draft envelopes should not contain any stamps. This helps prevent
-		// mistakes with data that could be "stamped" and then change later.
-		e.Head.Stamps = nil
-	}
 
 	return nil
 }

--- a/envelope.go
+++ b/envelope.go
@@ -167,6 +167,11 @@ func (e *Envelope) calculate() error {
 	if err != nil {
 		return err
 	}
+	if e.Head.Draft {
+		// Draft envelopes should not contain any stamps. This helps prevent
+		// mistakes with data that could be "stamped" and then change later.
+		e.Head.Stamps = nil
+	}
 
 	return nil
 }

--- a/envelope_test.go
+++ b/envelope_test.go
@@ -20,6 +20,8 @@ import (
 
 var testKey = dsig.NewES256Key()
 
+const testMessageContent = "This is test content."
+
 func ExampleNewEnvelope_complete() {
 	// Prepare a new Envelope with a region
 	env := gobl.NewEnvelope()
@@ -59,7 +61,7 @@ func ExampleNewEnvelope_complete() {
 }
 
 func TestEnvelop(t *testing.T) {
-	msg := &note.Message{Content: "This is test content."}
+	msg := &note.Message{Content: testMessageContent}
 	e, err := gobl.Envelop(msg)
 	require.NoError(t, err)
 	if assert.NotNil(t, e) {
@@ -69,7 +71,7 @@ func TestEnvelop(t *testing.T) {
 
 func TestEnvelopeDocument(t *testing.T) {
 	m := new(note.Message)
-	m.Content = "This is test content."
+	m.Content = testMessageContent
 
 	e := gobl.NewEnvelope()
 	if assert.NotNil(t, e.Head) {
@@ -106,7 +108,7 @@ func TestEnvelopeExtract(t *testing.T) {
 
 func TestEnvelopeInsert(t *testing.T) {
 	m := new(note.Message)
-	m.Content = "This is test content."
+	m.Content = testMessageContent
 
 	t.Run("missing head", func(t *testing.T) {
 		e := new(gobl.Envelope)
@@ -125,7 +127,7 @@ func TestEnvelopeInsert(t *testing.T) {
 
 func TestEnvelopeCalculate(t *testing.T) {
 	m := new(note.Message)
-	m.Content = "This is test content."
+	m.Content = testMessageContent
 
 	t.Run("basics", func(t *testing.T) {
 		e := gobl.NewEnvelope()

--- a/envelope_test.go
+++ b/envelope_test.go
@@ -136,7 +136,7 @@ func TestEnvelopeCalculate(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("remove stamps", func(t *testing.T) {
+	t.Run("handle stamps", func(t *testing.T) {
 		e := gobl.NewEnvelope()
 		require.NoError(t, e.Insert(m))
 		e.Head.AddStamp(&cbc.Stamp{Provider: cbc.Key("test"), Value: "test"})
@@ -149,9 +149,13 @@ func TestEnvelopeCalculate(t *testing.T) {
 		assert.Contains(t, err.Error(), "stamps: must be blank.")
 		err = e.Calculate()
 		assert.NoError(t, err)
-		assert.Empty(t, e.Head.Stamps)
-		err = e.Validate()
-		assert.NoError(t, err)
+		assert.Len(t, e.Head.Stamps, 1)
+		/*
+			// Removed for now as we prefer to just validate.
+			assert.Empty(t, e.Head.Stamps)
+			err = e.Validate()
+			assert.NoError(t, err)
+		*/
 	})
 }
 

--- a/envelope_test.go
+++ b/envelope_test.go
@@ -142,9 +142,14 @@ func TestEnvelopeCalculate(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotEmpty(t, e.Head.Stamps)
 		e.Head.Draft = true
+		err = e.Validate()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "stamps: must be blank.")
 		err = e.Calculate()
 		assert.NoError(t, err)
 		assert.Empty(t, e.Head.Stamps)
+		err = e.Validate()
+		assert.NoError(t, err)
 	})
 }
 

--- a/header.go
+++ b/header.go
@@ -18,7 +18,8 @@ type Header struct {
 	// Digest of the canonical JSON body.
 	Digest *dsig.Digest `json:"dig" jsonschema:"title=Digest"`
 
-	// Seals of approval from other organisations.
+	// Seals of approval from other organisations that can only be added to
+	// non-draft envelopes.
 	Stamps []*cbc.Stamp `json:"stamps,omitempty" jsonschema:"title=Stamps"`
 
 	// Set of labels that describe but have no influence on the data.
@@ -52,7 +53,10 @@ func (h *Header) ValidateWithContext(ctx context.Context) error {
 	return validation.ValidateStructWithContext(ctx, h,
 		validation.Field(&h.UUID, validation.Required, uuid.IsV1),
 		validation.Field(&h.Digest, validation.Required),
-		validation.Field(&h.Stamps),
+		validation.Field(&h.Stamps,
+			validation.When(h.Draft, validation.Empty),
+			cbc.DetectDuplicateStamps,
+		),
 	)
 }
 


### PR DESCRIPTION
* Validate that stamps are not duplicated.
* Only allow stamps on non-draft envelopes.