### PR TITLE
Refining payment means keys with codes, and adding to advances

### DIFF
--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"time"
+
+	"github.com/invopop/gobl"
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/cal"
+	"github.com/invopop/gobl/l10n"
+	"github.com/invopop/gobl/num"
+	"github.com/invopop/gobl/org"
+	"github.com/invopop/gobl/regimes/common"
+	"github.com/invopop/gobl/tax"
+)
+
+func main() {
+	// Build up a basic invoice document
+	inv := &bill.Invoice{
+		Series:    "F23",
+		Code:      "00010",
+		IssueDate: cal.MakeDate(2023, time.May, 11),
+		Supplier: &org.Party{
+			TaxID: &tax.Identity{
+				Country: l10n.US,
+			},
+			Name:  "Provider One Inc.",
+			Alias: "Provider One",
+			Emails: []*org.Email{
+				{
+					Address: "billing@provideone.com",
+				},
+			},
+			Addresses: []*org.Address{
+				{
+					Number:   "16",
+					Street:   "Jessie Street",
+					Locality: "San Francisco",
+					Region:   "CA",
+					Code:     "94105",
+					Country:  l10n.US,
+				},
+			},
+		},
+		Customer: &org.Party{
+			Name: "Sample Customer",
+			Emails: []*org.Email{
+				{
+					Address: "email@sample.com",
+				},
+			},
+		},
+		Lines: []*bill.Line{
+			{
+				Quantity: num.MakeAmount(20, 0),
+				Item: &org.Item{
+					Name:  "A stylish mug",
+					Price: num.MakeAmount(2000, 2),
+					Unit:  org.UnitHour,
+				},
+				Taxes: []*tax.Combo{
+					{
+						Category: common.TaxCategoryST,
+						Percent:  num.NewPercentage(85, 3),
+					},
+				},
+			},
+		},
+	}
+
+	// Prepare an "Envelope"
+	env := gobl.NewEnvelope()
+	if err := env.Insert(inv); err != nil {
+		panic(err)
+	}
+
+}

--- a/pay/instructions.go
+++ b/pay/instructions.go
@@ -8,60 +8,18 @@ import (
 	"github.com/invopop/validation/is"
 )
 
-// Standard payment method codes. This is a heavily reduced list of practical
-// codes which can be linked to UNTDID 4461 counterparts.
-// If you require more payment method options, please send your pull requests.
-const (
-	MethodKeyAny            cbc.Key = "any" // Use any method available.
-	MethodKeyCard           cbc.Key = "card"
-	MethodKeyCreditTransfer cbc.Key = "credit-transfer"
-	MethodKeyDebitTransfer  cbc.Key = "debit-transfer"
-	MethodKeyCash           cbc.Key = "cash"
-	MethodKeyCheque         cbc.Key = "cheque"
-	MethodKeyCredit         cbc.Key = "credit"
-	MethodKeyBankDraft      cbc.Key = "bank-draft"
-	MethodKeyDirectDebit    cbc.Key = "direct-debit" // aka. Mandate
-	MethodKeyOnline         cbc.Key = "online"       // Website from which payment can be made
-)
-
-// MethodKeyDef is used to define each of the Method Keys
-// that can be accepted by GOBL.
-type MethodKeyDef struct {
-	// Key being described
-	Key cbc.Key `json:"key" jsonschema:"title=Key"`
-	// Human value of the key
-	Title string `json:"title" jsonschema:"title=Title"`
-	// Details about the meaning of the key
-	Description string `json:"description" jsonschema:"title=Description"`
-	// UNTDID 4461 Equivalent Code
-	UNTDID4461 cbc.Code `json:"untdid4461" jsonschema:"title=UNTDID 4461 Code"`
-}
-
-// MethodKeyDefinitions includes all the payment method keys that
-// are accepted by GOBL.
-var MethodKeyDefinitions = []MethodKeyDef{
-	{MethodKeyAny, "Any", "Any method available, no preference.", "1"},                            // Instrument not defined
-	{MethodKeyCard, "Card", "Credit or debit card.", "48"},                                        // Bank card
-	{MethodKeyCreditTransfer, "Credit Transfer", "Sender initiated bank or wire transfer.", "30"}, // credit transfer
-	{MethodKeyDebitTransfer, "Debit Transfer", "Receiver initiated bank or wire transfer.", "31"}, // debit transfer
-	{MethodKeyCash, "Cash", "Cash in hand.", "10"},                                                // in cash
-	{MethodKeyCheque, "Cheque", "Cheque from bank.", ""},                                          // cheque
-	{MethodKeyCredit, "Credit", "Using credit from previous transactions with the supplier.", ""}, // credit
-	{MethodKeyBankDraft, "Draft", "Bankers Draft or Bank Cheque.", ""},                            // Banker's draft,
-	{MethodKeyDirectDebit, "Direct Debit", "Direct debit from the customers bank account.", "49"}, // direct debit
-	{MethodKeyOnline, "Online", "Online or web payment.", "68"},                                   // online payment service
-}
-
 // Instructions determine how the payment has or should be made. A
 // single "key" exists in which the preferred payment method
 // should be provided, all other details serve as a reference.
 type Instructions struct {
-	// How payment is expected or has been arranged to be collected
+	// The payment means expected or that have been arranged to be used to make the payment.
 	Key cbc.Key `json:"key" jsonschema:"title=Key"`
+	// Additional code for the payment means if not defined in the standard list of keys.
+	Code cbc.Code `json:"code,omitempty" jsonschema:"title=Code"`
 	// Optional text description of the payment method
 	Detail string `json:"detail,omitempty" jsonschema:"title=Detail"`
-	// Remittance information, a text value used to link the payment with the invoice.
-	Ref string `json:"ref,omitempty" jsonschema:"title=Ref"`
+	// Remittance information or concept, a text value used to link the payment with the invoice.
+	Ref string `json:"ref,omitempty" jsonschema:"title=Reference"`
 	// Instructions for sending payment via a bank transfer.
 	CreditTransfer []*CreditTransfer `json:"credit_transfer,omitempty" jsonschema:"title=Credit Transfer"`
 	// Details of the payment that will be made via a credit or debit card.
@@ -119,7 +77,7 @@ type Online struct {
 
 // UNTDID4461 provides the standard UNTDID 4461 code for the instruction's key.
 func (i *Instructions) UNTDID4461() cbc.Code {
-	for _, v := range MethodKeyDefinitions {
+	for _, v := range MeansKeyDefinitions {
 		if v.Key == i.Key {
 			return v.UNTDID4461
 		}
@@ -137,21 +95,11 @@ func (u *Online) Validate() error {
 // Validate ensures the fields provided in the instructions are valid.
 func (i *Instructions) Validate() error {
 	return validation.ValidateStruct(i,
-		validation.Field(&i.Key, validation.Required, isValidMethodKey),
+		validation.Field(&i.Key, validation.Required, isValidMeansKey),
 		validation.Field(&i.CreditTransfer),
 		validation.Field(&i.DirectDebit),
 		validation.Field(&i.Online),
 	)
-}
-
-var isValidMethodKey = validation.In(validMethodKeys()...)
-
-func validMethodKeys() []interface{} {
-	list := make([]interface{}, len(MethodKeyDefinitions))
-	for i, v := range MethodKeyDefinitions {
-		list[i] = v.Key
-	}
-	return list
 }
 
 // JSONSchemaExtend adds the method key definitions to the schema.
@@ -159,8 +107,8 @@ func (Instructions) JSONSchemaExtend(schema *jsonschema.Schema) {
 	val, _ := schema.Properties.Get("key")
 	prop, ok := val.(*jsonschema.Schema)
 	if ok {
-		prop.OneOf = make([]*jsonschema.Schema, len(MethodKeyDefinitions))
-		for i, v := range MethodKeyDefinitions {
+		prop.OneOf = make([]*jsonschema.Schema, len(MeansKeyDefinitions))
+		for i, v := range MeansKeyDefinitions {
 			prop.OneOf[i] = &jsonschema.Schema{
 				Const:       v.Key,
 				Title:       v.Title,

--- a/pay/instructions_test.go
+++ b/pay/instructions_test.go
@@ -15,7 +15,7 @@ func TestInstructionsKey(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "key: must be a valid value")
 
-	i.Key = pay.MethodKeyCard
+	i.Key = pay.MeansKeyCard
 	err = i.Validate()
 	assert.NoError(t, err)
 }

--- a/pay/means_keys.go
+++ b/pay/means_keys.go
@@ -1,0 +1,64 @@
+package pay
+
+import (
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/validation"
+)
+
+// Standard payment means codes for instructions. This is a heavily reduced list
+// practical codes which can be linked to UNTDID 4461 counterparts.
+// If you require more payment means options, please send your pull requests.
+const (
+	MeansKeyAny            cbc.Key = "any" // Use any method available.
+	MeansKeyCard           cbc.Key = "card"
+	MeansKeyCreditTransfer cbc.Key = "credit-transfer"
+	MeansKeyDebitTransfer  cbc.Key = "debit-transfer"
+	MeansKeyCash           cbc.Key = "cash"
+	MeansKeyPromissoryNote cbc.Key = "promissory-note"
+	MeansKeyNetting        cbc.Key = "netting"
+	MeansKeyCheque         cbc.Key = "cheque"
+	MeansKeyBankDraft      cbc.Key = "bank-draft"
+	MeansKeyDirectDebit    cbc.Key = "direct-debit" // aka. Mandate
+	MeansKeyOnline         cbc.Key = "online"       // Website from which payment can be made
+	MeansKeyOther          cbc.Key = "other"        // See the means_code value, if available.
+)
+
+// MeansKeyDef is used to define each of the payment means keys
+// that can be accepted by GOBL.
+type MeansKeyDef struct {
+	// Key being described
+	Key cbc.Key `json:"key" jsonschema:"title=Key"`
+	// Human value of the key
+	Title string `json:"title" jsonschema:"title=Title"`
+	// Details about the meaning of the key
+	Description string `json:"description" jsonschema:"title=Description"`
+	// UNTDID 4461 Equivalent Code
+	UNTDID4461 cbc.Code `json:"untdid4461" jsonschema:"title=UNTDID 4461 Code"`
+}
+
+// MeansKeyDefinitions includes all the payment means keys that
+// are accepted by GOBL.
+var MeansKeyDefinitions = []MeansKeyDef{
+	{MeansKeyAny, "Any", "Any method available, no preference.", "1"},                            // Instrument not defined
+	{MeansKeyCard, "Card", "Payment card.", "48"},                                                // Bank card
+	{MeansKeyCreditTransfer, "Credit Transfer", "Sender initiated bank or wire transfer.", "30"}, // credit transfer
+	{MeansKeyDebitTransfer, "Debit Transfer", "Receiver initiated bank or wire transfer.", "31"}, // debit transfer
+	{MeansKeyCash, "Cash", "Cash in hand.", "10"},                                                // in cash
+	{MeansKeyCheque, "Cheque", "Cheque from bank.", "20"},                                        // cheque
+	{MeansKeyBankDraft, "Draft", "Bankers Draft or Bank Cheque.", "21"},                          // Banker's draft,
+	{MeansKeyDirectDebit, "Direct Debit", "Direct debit from the customers bank account.", "49"}, // direct debit
+	{MeansKeyOnline, "Online", "Online or web payment.", "68"},                                   // online payment service
+	{MeansKeyPromissoryNote, "Promissory Note", "Promissory note contract.", "60"},               // Promissory note
+	{MeansKeyNetting, "Netting", "Intercompany clearing or clearing between partners.", "97"},    // Netting
+	{MeansKeyOther, "Other", "Other or mutually defined means of payment.", "ZZZ"},               // Other
+}
+
+var isValidMeansKey = validation.In(validMeansKeys()...)
+
+func validMeansKeys() []interface{} {
+	list := make([]interface{}, len(MeansKeyDefinitions))
+	for i, v := range MeansKeyDefinitions {
+		list[i] = v.Key
+	}
+	return list
+}

--- a/regimes/it/README.md
+++ b/regimes/it/README.md
@@ -35,9 +35,11 @@ Italy uses the FatturaPA format for their e-invoicing system.
 ### Italy-specific Details
 
 #### Stamp Duty
+
 Add an invoice-level `bill.Charge` and use `it.ChargeKeyStampDuty` as the `bill.Charge.Key`.
 
 #### Numero REA
+
 `Party.Registration` is used to store the Numero REA (Registro delle Imprese) of the company.
 The `Office` field is used to store the Provincia (Province) of the company, the `Entry` field is used to store the Numero REA. Additionally, the share capital is stored in the `Capital` field used in conjunction with `Currency`.
 
@@ -96,33 +98,37 @@ document type, fund type, etc.
 | TC21 | National pension and welfare board for psychologists (ENPAP - Ente Nazionale Previdenza e Assistenza Psicologi)                                |
 | TC22 | National Social Security Institute (INPS - Istituto Nazionale della Previdenza Sociale)                                                        |
 
-##### ModalitaPagamento (Payment Method)
+##### ModalitaPagamento (Payment Means)
 
-| Code | Key               | SubKey      | Description                                       |
-| ---- | ----------------- | ----------- | ------------------------------------------------- |
-| MP01 | `cash`            |             | Cash                                              |
-| MP02 | `cheque`          |             | cheque                                            |
-| MP03 | `bank-draft`      |             | Banker's draft                                    |
-| MP04 | `cash`            | `treasury`  | Cash at Treasury                                  |
-| MP05 | `credit-transfer` |             | bank transfer                                     |
-| MP06 | NA                |             | money order                                       |
-| MP07 | NA                |             | pre-compiled bank payment slip                    |
-| MP08 | `card`            |             | payment card                                      |
-| MP09 | `direct-debit`    |             | direct debit                                      |
-| MP10 | `direct-debit`    | `utilities` | Utilities direct debit (must be rare!)            |
-| MP11 | `direct-debit`    | `fast`      | fast direct debit                                 |
-| MP12 | NA                |             | collection order                                  |
-| MP13 | NA                |             | payment by notice                                 |
-| MP14 | NA                |             | tax office quittance                              |
-| MP15 | NA                |             | transfer on special accounting accounts           |
-| MP16 | NA                |             | order for direct payment from bank account        |
-| MP17 | NA                |             | order for direct payment from post office account |
-| MP18 | NA                |             | bulletin postal account                           |
-| MP19 | `direct-debit`    | `sepa`      | SEPA Direct Debit                                 |
-| MP20 | `direct-debit`    | `sepa-core` | SEPA Direct Debit CORE                            |
-| MP21 | `direct-debit`    | `sepa-b2b`  | SEPA Direct Debit B2B                             |
-| MP22 | `credit`          |             | Deduction on sums already collected               |
-| MP23 | `online`          | `pagopa`    | PagoPA                                            |
+The following table describes how to map the Italian payment means codes to those of GOBL. The list is based on the official mapping of the FatturaPA codes to EU Semantic invoice definition, more details available [here](https://www.agenziaentrate.gov.it/portale/documents/20143/288396/Technical+Rules+for+European+Invoicing+v2.1.pdf).
+
+If more precision is required for the type of payment means, the `code` property when available can be use to override the main value.
+
+| Code | Key               | Code   | Description                                                     |
+| ---- | ----------------- | ------ | --------------------------------------------------------------- |
+| MP01 | `cash`            |        | Cash                                                            |
+| MP02 | `cheque`          |        | Cheque                                                          |
+| MP03 | `bank-draft`      |        | Banker's draft                                                  |
+| MP04 | `cash`            | `MP04` | Cash at Treasury                                                |
+| MP05 | `credit-transfer` |        | bank transfer                                                   |
+| MP06 | `promissory-note` |        | Promissory Note                                                 |
+| MP07 | `other`           | `MP07` | Pre-compiled bank payment slip                                  |
+| MP08 | `card`            |        | Any type of payment card                                        |
+| MP09 | `direct-debit`    | `MP09` | Direct debit (RID)                                              |
+| MP10 | `direct-debit`    | `MP10` | Utilities direct debit (RID utenze)                             |
+| MP11 | `direct-debit`    | `MP11` | Fast direct debit (RID veloce)                                  |
+| MP12 | `other`           | `MP12` | Collection order (RIBA)                                         |
+| MP13 | `debit-transfer`  |        | Payment by notice (MAV)                                         |
+| MP14 | `other`           | `MP14` | Tax office quittance                                            |
+| MP15 | `other`           | `MP15` | Transfer on special accounting accounts                         |
+| MP16 | `other`           | `MP16` | Order for direct payment from bank account                      |
+| MP17 | `other`           | `MP17` | Order for direct payment from post office account               |
+| MP18 | `other`           | `MP18` | Bulletin postal account                                         |
+| MP19 | `direct-debit`    |        | SEPA Direct Debit (default type of direct debit)                |
+| MP20 | `direct-debit`    | `MP20` | SEPA Direct Debit CORE                                          |
+| MP21 | `direct-debit`    | `MP21` | SEPA Direct Debit B2B                                           |
+| MP22 | `netting`         |        | Deduction on sums already collected from previous transactions. |
+| MP23 | `online`          | `MP23` | PagoPA                                                          |
 
 ##### TipoDocumento (Document Type)
 
@@ -155,8 +161,8 @@ Note: fields marked with (\*) are for simplified invoice documents.
 
 ##### Natura (Nature)
 
-|      |                                                                                                                                                                                                                                                          |
-| ---- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --- |
+| Code | Description                                                                                                                                                                                                                                              |
+| ---- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | N1   | excluded pursuant to Art. 15, DPR 633/72                                                                                                                                                                                                                 |
 | N2   | not subject (this code is no longer permitted to use on invoices emitted from 1 January 2021 )                                                                                                                                                           |
 | N2.1 | not subject to VAT under the articles from 7 to 7-septies of DPR 633/72                                                                                                                                                                                  |
@@ -170,7 +176,7 @@ Note: fields marked with (\*) are for simplified invoice documents.
 | N3.6 | not taxable – other transactions that don’t contribute to the determination of ceiling                                                                                                                                                                   |
 | N4   | exempt                                                                                                                                                                                                                                                   |
 | N5   | margin regime / VAT not exposed on invoice                                                                                                                                                                                                               |
-| N6   | "reverse charge (for transactions in reverse charge or for self invoicing for purchase of extra UE services or for import of goods only in the cases provided for) — (this code is no longer permitted to use on invoices emitted from 1 January 2021 )" |     |
+| N6   | "reverse charge (for transactions in reverse charge or for self invoicing for purchase of extra UE services or for import of goods only in the cases provided for) — (this code is no longer permitted to use on invoices emitted from 1 January 2021 )" |
 | N6.1 | reverse charge - transfer of scrap and of other recyclable materials                                                                                                                                                                                     |
 | N6.2 | reverse charge - trasnfer of gold and pure silver pursuant to law 7/2000 as well as used jewelery to OPO                                                                                                                                                 |
 | N6.3 | reverse charge - subcontracting in the construction sector                                                                                                                                                                                               |
@@ -194,5 +200,6 @@ Note: fields marked with (\*) are for simplified invoice documents.
 | RT06 | Other social security contribution |
 
 ## TODO
+
 - Document Codice Destinatario (uses inbox codes)
 - Document how local codes are mapped


### PR DESCRIPTION
* `pay.MethodKeys` are now `pay.MeansKeys`, which is a more accurate name.
* Adding `code` property to `pay.Instructions` so that custom local codes can be used when necessary.
* Updated Italian readme docs to help better under stand the payment means.
* `pay.Advances` now also uses the list of `pay.MeansKeys`