### PR TITLE
Add Percentage.Rescale function

### DIFF
--- a/num/percentage.go
+++ b/num/percentage.go
@@ -80,6 +80,7 @@ func (p Percentage) StringWithoutSymbol() string {
 	return v.String()
 }
 
+// Rescale will rescale the percentage value to the provided exponent.
 func (p Percentage) Rescale(exp uint32) Percentage {
 	return Percentage{Amount: p.Amount.Rescale(exp)}
 }

--- a/num/percentage.go
+++ b/num/percentage.go
@@ -80,6 +80,10 @@ func (p Percentage) StringWithoutSymbol() string {
 	return v.String()
 }
 
+func (p Percentage) Rescale(exp uint32) Percentage {
+	return Percentage{Amount: p.Amount.Rescale(exp)}
+}
+
 // Of calculates the "percent of" the provided amount. The exponent of the
 // provided amount is used.
 func (p Percentage) Of(a Amount) Amount {

--- a/num/percentage_test.go
+++ b/num/percentage_test.go
@@ -77,3 +77,17 @@ func TestPercentageFrom(t *testing.T) {
 		t.Errorf("unexpected percentage from result: %v", x.String())
 	}
 }
+
+func TestPercentageRescale(t *testing.T) {
+	p := num.MakePercentage(160, 3)
+	x := p.Rescale(4)
+	if x.String() != "16.00%" {
+		t.Errorf("unexpected percentage from result: %v", x.String())
+	}
+
+	p = num.MakePercentage(20, 3)
+	x = p.Rescale(2)
+	if x.String() != "2%" {
+		t.Errorf("unexpected percentage from result: %v", x.String())
+	}
+}


### PR DESCRIPTION
- Enable rescaling of percentages 
- Previously, calling `Rescale` on a `num.Percentage` was returning a `num.Amount`