### PR TITLE
Add TaxCountryRegion & TaxCode codes to PT regime

### DIFF
--- a/build/regimes/pt.json
+++ b/build/regimes/pt.json
@@ -10,120 +10,180 @@
       "code": "01",
       "region": {
         "pt": "Aveiro"
+      },
+      "codes": {
+        "at-tax-country-region": "PT"
       }
     },
     {
       "code": "02",
       "region": {
         "pt": "Beja"
+      },
+      "codes": {
+        "at-tax-country-region": "PT"
       }
     },
     {
       "code": "03",
       "region": {
         "pt": "Braga"
+      },
+      "codes": {
+        "at-tax-country-region": "PT"
       }
     },
     {
       "code": "04",
       "region": {
         "pt": "Bragança"
+      },
+      "codes": {
+        "at-tax-country-region": "PT"
       }
     },
     {
       "code": "05",
       "region": {
         "pt": "Castelo Branco"
+      },
+      "codes": {
+        "at-tax-country-region": "PT"
       }
     },
     {
       "code": "06",
       "region": {
         "pt": "Coimbra"
+      },
+      "codes": {
+        "at-tax-country-region": "PT"
       }
     },
     {
       "code": "07",
       "region": {
         "pt": "Évora"
+      },
+      "codes": {
+        "at-tax-country-region": "PT"
       }
     },
     {
       "code": "08",
       "region": {
         "pt": "Faro"
+      },
+      "codes": {
+        "at-tax-country-region": "PT"
       }
     },
     {
       "code": "09",
       "region": {
         "pt": "Guarda"
+      },
+      "codes": {
+        "at-tax-country-region": "PT"
       }
     },
     {
       "code": "10",
       "region": {
         "pt": "Leiria"
+      },
+      "codes": {
+        "at-tax-country-region": "PT"
       }
     },
     {
       "code": "11",
       "region": {
         "pt": "Lisboa"
+      },
+      "codes": {
+        "at-tax-country-region": "PT"
       }
     },
     {
       "code": "12",
       "region": {
         "pt": "Portalegre"
+      },
+      "codes": {
+        "at-tax-country-region": "PT"
       }
     },
     {
       "code": "13",
       "region": {
         "pt": "Porto"
+      },
+      "codes": {
+        "at-tax-country-region": "PT"
       }
     },
     {
       "code": "14",
       "region": {
         "pt": "Santarém"
+      },
+      "codes": {
+        "at-tax-country-region": "PT"
       }
     },
     {
       "code": "15",
       "region": {
         "pt": "Setúbal"
+      },
+      "codes": {
+        "at-tax-country-region": "PT"
       }
     },
     {
       "code": "16",
       "region": {
         "pt": "Viana do Castelo"
+      },
+      "codes": {
+        "at-tax-country-region": "PT"
       }
     },
     {
       "code": "17",
       "region": {
         "pt": "Vila Real"
+      },
+      "codes": {
+        "at-tax-country-region": "PT"
       }
     },
     {
       "code": "18",
       "region": {
         "pt": "Viseu"
+      },
+      "codes": {
+        "at-tax-country-region": "PT"
       }
     },
     {
       "code": "20",
       "region": {
         "pt": "Região Autónoma dos Açores"
+      },
+      "codes": {
+        "at-tax-country-region": "PT-AC"
       }
     },
     {
       "code": "30",
       "region": {
         "pt": "Região Autónoma da Madeira"
+      },
+      "codes": {
+        "at-tax-country-region": "PT-MA"
       }
     }
   ],
@@ -239,7 +299,10 @@
               "since": "2011-01-01",
               "percent": "23.0%"
             }
-          ]
+          ],
+          "codes": {
+            "at-tax-code": "NOR"
+          }
         },
         {
           "key": "intermediate",
@@ -266,7 +329,10 @@
               "since": "2011-01-01",
               "percent": "13.0%"
             }
-          ]
+          ],
+          "codes": {
+            "at-tax-code": "INT"
+          }
         },
         {
           "key": "reduced",
@@ -293,7 +359,10 @@
               "since": "2011-01-01",
               "percent": "6.0%"
             }
-          ]
+          ],
+          "codes": {
+            "at-tax-code": "RED"
+          }
         },
         {
           "key": "exempt+outlay",
@@ -303,6 +372,7 @@
           },
           "exempt": true,
           "codes": {
+            "at-tax-code": "ISE",
             "at-tax-exemption-code": "M01"
           }
         },
@@ -314,6 +384,7 @@
           },
           "exempt": true,
           "codes": {
+            "at-tax-code": "ISE",
             "at-tax-exemption-code": "M02"
           }
         },
@@ -325,6 +396,7 @@
           },
           "exempt": true,
           "codes": {
+            "at-tax-code": "ISE",
             "at-tax-exemption-code": "M04"
           }
         },
@@ -336,6 +408,7 @@
           },
           "exempt": true,
           "codes": {
+            "at-tax-code": "ISE",
             "at-tax-exemption-code": "M05"
           }
         },
@@ -347,6 +420,7 @@
           },
           "exempt": true,
           "codes": {
+            "at-tax-code": "ISE",
             "at-tax-exemption-code": "M06"
           }
         },
@@ -358,6 +432,7 @@
           },
           "exempt": true,
           "codes": {
+            "at-tax-code": "ISE",
             "at-tax-exemption-code": "M07"
           }
         },
@@ -369,6 +444,7 @@
           },
           "exempt": true,
           "codes": {
+            "at-tax-code": "ISE",
             "at-tax-exemption-code": "M09"
           }
         },
@@ -380,6 +456,7 @@
           },
           "exempt": true,
           "codes": {
+            "at-tax-code": "ISE",
             "at-tax-exemption-code": "M10"
           }
         },
@@ -391,6 +468,7 @@
           },
           "exempt": true,
           "codes": {
+            "at-tax-code": "ISE",
             "at-tax-exemption-code": "M11"
           }
         },
@@ -402,6 +480,7 @@
           },
           "exempt": true,
           "codes": {
+            "at-tax-code": "ISE",
             "at-tax-exemption-code": "M12"
           }
         },
@@ -413,6 +492,7 @@
           },
           "exempt": true,
           "codes": {
+            "at-tax-code": "ISE",
             "at-tax-exemption-code": "M13"
           }
         },
@@ -424,6 +504,7 @@
           },
           "exempt": true,
           "codes": {
+            "at-tax-code": "ISE",
             "at-tax-exemption-code": "M14"
           }
         },
@@ -435,6 +516,7 @@
           },
           "exempt": true,
           "codes": {
+            "at-tax-code": "ISE",
             "at-tax-exemption-code": "M15"
           }
         },
@@ -446,6 +528,7 @@
           },
           "exempt": true,
           "codes": {
+            "at-tax-code": "ISE",
             "at-tax-exemption-code": "M16"
           }
         },
@@ -457,6 +540,7 @@
           },
           "exempt": true,
           "codes": {
+            "at-tax-code": "ISE",
             "at-tax-exemption-code": "M19"
           }
         },
@@ -468,6 +552,7 @@
           },
           "exempt": true,
           "codes": {
+            "at-tax-code": "ISE",
             "at-tax-exemption-code": "M20"
           }
         },
@@ -479,6 +564,7 @@
           },
           "exempt": true,
           "codes": {
+            "at-tax-code": "ISE",
             "at-tax-exemption-code": "M21"
           }
         },
@@ -490,6 +576,7 @@
           },
           "exempt": true,
           "codes": {
+            "at-tax-code": "ISE",
             "at-tax-exemption-code": "M25"
           }
         },
@@ -501,6 +588,7 @@
           },
           "exempt": true,
           "codes": {
+            "at-tax-code": "ISE",
             "at-tax-exemption-code": "M30"
           }
         },
@@ -512,6 +600,7 @@
           },
           "exempt": true,
           "codes": {
+            "at-tax-code": "ISE",
             "at-tax-exemption-code": "M31"
           }
         },
@@ -523,6 +612,7 @@
           },
           "exempt": true,
           "codes": {
+            "at-tax-code": "ISE",
             "at-tax-exemption-code": "M32"
           }
         },
@@ -534,6 +624,7 @@
           },
           "exempt": true,
           "codes": {
+            "at-tax-code": "ISE",
             "at-tax-exemption-code": "M33"
           }
         },
@@ -545,6 +636,7 @@
           },
           "exempt": true,
           "codes": {
+            "at-tax-code": "ISE",
             "at-tax-exemption-code": "M40"
           }
         },
@@ -556,6 +648,7 @@
           },
           "exempt": true,
           "codes": {
+            "at-tax-code": "ISE",
             "at-tax-exemption-code": "M41"
           }
         },
@@ -567,6 +660,7 @@
           },
           "exempt": true,
           "codes": {
+            "at-tax-code": "ISE",
             "at-tax-exemption-code": "M42"
           }
         },
@@ -578,6 +672,7 @@
           },
           "exempt": true,
           "codes": {
+            "at-tax-code": "ISE",
             "at-tax-exemption-code": "M43"
           }
         },
@@ -589,6 +684,7 @@
           },
           "exempt": true,
           "codes": {
+            "at-tax-code": "ISE",
             "at-tax-exemption-code": "M99"
           }
         }

--- a/regimes/pt/README.md
+++ b/regimes/pt/README.md
@@ -21,9 +21,43 @@ Portugal doesn't have an e-invoicing format per se. Tax information is reported 
 | ND | Nota de débito | `credit-note` | |
 | NC | Nota de crédito | `debit-note` | |
 
+### `TaxCountryRegion` (País ou região do imposto)
+
+| Code | Name | GOBL Tax Identity Zone |
+| --- | --- | --- |
+| PT | Aveiro | `01` |
+| PT | Beja | `02` |
+| PT | Braga | `03` |
+| PT | Bragança | `04` |
+| PT | Castelo Branco | `05` |
+| PT | Coimbra | `06` |
+| PT | Évora | `07` |
+| PT | Faro | `08` |
+| PT | Guarda | `09` |
+| PT | Leiria | `10` |
+| PT | Lisboa | `11` |
+| PT | Portalegre | `12` |
+| PT | Porto | `13` |
+| PT | Santarém | `14` |
+| PT | Setúbal | `15` |
+| PT | Viana do Castelo | `16` |
+| PT | Vila Real | `17` |
+| PT | Viseu | `18` |
+| PT-AC | Região Autónoma dos Açores | `20` |
+| PT-MA | Região Autónoma da Madeira | `30` |
+
+### `TaxCode` (Código do imposto)
+
+| Code | Name | GOBL Tax Rate |
+| --- | --- | --- |
+| NOR | Tipo Geral | `standard` |
+| INT | Taxa Intermédia | `intermediate` |
+| RED | Taxa Reduzida | `reduced` |
+| ISE | Isenta | `exempt+*` (see `TaxExemptionCode` below) |
+
 ### `TaxExemptionCode` (Código do motivo de isenção de imposto)
 
-| Code | Description | GOBL Line Tax (VAT) Tag |
+| Code | Description | GOBL Tax Rate |
 | --- | --- | --- |
 | M01 | Artigo 16.°, n.° 6 do CIVA | `exempt+outlay` |
 | M02 | Artigo 6.° do Decreto-Lei n.° 198/90, de 19 de junho | `exempt+intrastate-export` |

--- a/regimes/pt/README.md
+++ b/regimes/pt/README.md
@@ -13,6 +13,8 @@ Portugal doesn't have an e-invoicing format per se. Tax information is reported 
 
 ### `InvoiceType` (Tipo de documento)
 
+AT's `InvoiceType` (Tipo de document) specifies the type of a Portuguese tax document. The following table lists all the supported invoice types and how GOBL will map them with a combination of invoice type and tax tags:
+
 | Code | Name | GOBL Type | GOBL Tax Tag |
 | --- | --- | --- | --- |
 | FT | Fatura, emitida nos termos do artigo 36.o do Código do IVA | `standard` | |
@@ -22,6 +24,8 @@ Portugal doesn't have an e-invoicing format per se. Tax information is reported 
 | NC | Nota de crédito | `debit-note` | |
 
 ### `TaxCountryRegion` (País ou região do imposto)
+
+AT's `TaxCountryRegion` (País ou região do imposto) specifies the region of taxation (Portugal mainland, Açores or Madeira) in a Portuguese invoice. GOBL will map them using the supplier's tax identity zone (ISO 3166-2:PT codes) as per the following table:
 
 | Code | Name | GOBL Tax Identity Zone |
 | --- | --- | --- |
@@ -48,14 +52,18 @@ Portugal doesn't have an e-invoicing format per se. Tax information is reported 
 
 ### `TaxCode` (Código do imposto)
 
+AT's `TaxCode` (Código do imposto) specifies the rate type of the VAT tax in a Portugese invoice. The following table lists the supported tax codes and how GOBL will map them from tax rate codes. (Please, note that there are multiple exempt tax rates mapping to the `ISE` code; see the `TaxExemptionCode` section below for the full list):
+
 | Code | Name | GOBL Tax Rate |
 | --- | --- | --- |
 | NOR | Tipo Geral | `standard` |
 | INT | Taxa Intermédia | `intermediate` |
 | RED | Taxa Reduzida | `reduced` |
-| ISE | Isenta | `exempt+*` (see `TaxExemptionCode` below) |
+| ISE | Isenta | `exempt+*` _(see `TaxExemptionCode` below)_ |
 
 ### `TaxExemptionCode` (Código do motivo de isenção de imposto)
+
+AT's `TaxExemptionCode` (Código do motivo de isenção de imposto) is a code that specifies the reason the VAT tax is exempt in a Portuguese invoice. GOBL will map them from tax rate codes as per the following table (Please, note that GOBL's tax rates are also used to map to `TaxCode`; see the `TaxCode` section above for details):
 
 | Code | Description | GOBL Tax Rate |
 | --- | --- | --- |

--- a/regimes/pt/pt.go
+++ b/regimes/pt/pt.go
@@ -16,6 +16,8 @@ func init() {
 
 // Custom keys used typically in meta information
 const (
+	KeyATTaxCountryRegion cbc.Key = "at-tax-country-region"
+	KeyATTaxCode          cbc.Key = "at-tax-code"
 	KeyATTaxExemptionCode cbc.Key = "at-tax-exemption-code"
 	KeyATInvoiceType      cbc.Key = "at-invoice-type"
 )

--- a/regimes/pt/tax_categories.go
+++ b/regimes/pt/tax_categories.go
@@ -80,6 +80,9 @@ var taxCategories = []*tax.Category{
 						Percent: num.MakePercentage(230, 3),
 					},
 				},
+				Codes: cbc.CodeSet{
+					KeyATTaxCode: "NOR",
+				},
 			},
 			{
 				Key: common.TaxRateIntermediate,
@@ -102,6 +105,9 @@ var taxCategories = []*tax.Category{
 						Since:   cal.NewDate(2011, 1, 1),
 						Percent: num.MakePercentage(130, 3),
 					},
+				},
+				Codes: cbc.CodeSet{
+					KeyATTaxCode: "INT",
 				},
 			},
 			{
@@ -126,6 +132,9 @@ var taxCategories = []*tax.Category{
 						Percent: num.MakePercentage(60, 3),
 					},
 				},
+				Codes: cbc.CodeSet{
+					KeyATTaxCode: "RED",
+				},
 			},
 			{
 				Key:    TaxRateExempt.With(TaxRateOutlay),
@@ -135,6 +144,7 @@ var taxCategories = []*tax.Category{
 					i18n.PT: "Artigo 16.°, n.° 6 do CIVA",
 				},
 				Codes: cbc.CodeSet{
+					KeyATTaxCode:          "ISE",
 					KeyATTaxExemptionCode: "M01",
 				},
 			},
@@ -146,6 +156,7 @@ var taxCategories = []*tax.Category{
 					i18n.PT: "Artigo 6.° do Decreto-Lei n.° 198/90, de 19 de junho",
 				},
 				Codes: cbc.CodeSet{
+					KeyATTaxCode:          "ISE",
 					KeyATTaxExemptionCode: "M02",
 				},
 			},
@@ -157,6 +168,7 @@ var taxCategories = []*tax.Category{
 					i18n.PT: "Isento artigo 13.° do CIVA",
 				},
 				Codes: cbc.CodeSet{
+					KeyATTaxCode:          "ISE",
 					KeyATTaxExemptionCode: "M04",
 				},
 			},
@@ -168,6 +180,7 @@ var taxCategories = []*tax.Category{
 					i18n.PT: "Isento artigo 14.° do CIVA",
 				},
 				Codes: cbc.CodeSet{
+					KeyATTaxCode:          "ISE",
 					KeyATTaxExemptionCode: "M05",
 				},
 			},
@@ -179,6 +192,7 @@ var taxCategories = []*tax.Category{
 					i18n.PT: "Isento artigo 15.° do CIVA",
 				},
 				Codes: cbc.CodeSet{
+					KeyATTaxCode:          "ISE",
 					KeyATTaxExemptionCode: "M06",
 				},
 			},
@@ -190,6 +204,7 @@ var taxCategories = []*tax.Category{
 					i18n.PT: "Isento artigo 9.° do CIVA",
 				},
 				Codes: cbc.CodeSet{
+					KeyATTaxCode:          "ISE",
 					KeyATTaxExemptionCode: "M07",
 				},
 			},
@@ -201,6 +216,7 @@ var taxCategories = []*tax.Category{
 					i18n.PT: "IVA - não confere direito a dedução / Artigo 62.° alínea b) do CIVA",
 				},
 				Codes: cbc.CodeSet{
+					KeyATTaxCode:          "ISE",
 					KeyATTaxExemptionCode: "M09",
 				},
 			},
@@ -212,6 +228,7 @@ var taxCategories = []*tax.Category{
 					i18n.PT: "IVA - regime de isenção / Artigo 57.° do CIVA",
 				},
 				Codes: cbc.CodeSet{
+					KeyATTaxCode:          "ISE",
 					KeyATTaxExemptionCode: "M10",
 				},
 			},
@@ -223,6 +240,7 @@ var taxCategories = []*tax.Category{
 					i18n.PT: "Regime particular do tabaco / Decreto-Lei n.° 346/85, de 23 de agosto",
 				},
 				Codes: cbc.CodeSet{
+					KeyATTaxCode:          "ISE",
 					KeyATTaxExemptionCode: "M11",
 				},
 			},
@@ -234,6 +252,7 @@ var taxCategories = []*tax.Category{
 					i18n.PT: "Regime da margem de lucro - Agências de viagens / Decreto-Lei n.° 221/85, de 3 de julho",
 				},
 				Codes: cbc.CodeSet{
+					KeyATTaxCode:          "ISE",
 					KeyATTaxExemptionCode: "M12",
 				},
 			},
@@ -245,6 +264,7 @@ var taxCategories = []*tax.Category{
 					i18n.PT: "Regime da margem de lucro - Bens em segunda mão / Decreto-Lei n.° 199/96, de 18 de outubro",
 				},
 				Codes: cbc.CodeSet{
+					KeyATTaxCode:          "ISE",
 					KeyATTaxExemptionCode: "M13",
 				},
 			},
@@ -256,6 +276,7 @@ var taxCategories = []*tax.Category{
 					i18n.PT: "Regime da margem de lucro - Objetos de arte / Decreto-Lei n.° 199/96, de 18 de outubro",
 				},
 				Codes: cbc.CodeSet{
+					KeyATTaxCode:          "ISE",
 					KeyATTaxExemptionCode: "M14",
 				},
 			},
@@ -267,6 +288,7 @@ var taxCategories = []*tax.Category{
 					i18n.PT: "Regime da margem de lucro - Objetos de coleção e antiguidades / Decreto-Lei n.° 199/96, de 18 de outubro",
 				},
 				Codes: cbc.CodeSet{
+					KeyATTaxCode:          "ISE",
 					KeyATTaxExemptionCode: "M15",
 				},
 			},
@@ -278,6 +300,7 @@ var taxCategories = []*tax.Category{
 					i18n.PT: "Isento artigo 14.° do RITI",
 				},
 				Codes: cbc.CodeSet{
+					KeyATTaxCode:          "ISE",
 					KeyATTaxExemptionCode: "M16",
 				},
 			},
@@ -289,6 +312,7 @@ var taxCategories = []*tax.Category{
 					i18n.PT: "Outras isenções - Isenções temporárias determinadas em diploma próprio",
 				},
 				Codes: cbc.CodeSet{
+					KeyATTaxCode:          "ISE",
 					KeyATTaxExemptionCode: "M19",
 				},
 			},
@@ -300,6 +324,7 @@ var taxCategories = []*tax.Category{
 					i18n.PT: "IVA - regime forfetário / Artigo 59.°-D n.°2 do CIVA",
 				},
 				Codes: cbc.CodeSet{
+					KeyATTaxCode:          "ISE",
 					KeyATTaxExemptionCode: "M20",
 				},
 			},
@@ -311,6 +336,7 @@ var taxCategories = []*tax.Category{
 					i18n.PT: "IVA - não confere direito à dedução (ou expressão similar) - Artigo 72.° n.° 4 do CIVA",
 				},
 				Codes: cbc.CodeSet{
+					KeyATTaxCode:          "ISE",
 					KeyATTaxExemptionCode: "M21",
 				},
 			},
@@ -322,6 +348,7 @@ var taxCategories = []*tax.Category{
 					i18n.PT: "Mercadorias à consignação - Artigo 38.° n.° 1 alínea a) do CIVA",
 				},
 				Codes: cbc.CodeSet{
+					KeyATTaxCode:          "ISE",
 					KeyATTaxExemptionCode: "M25",
 				},
 			},
@@ -333,6 +360,7 @@ var taxCategories = []*tax.Category{
 					i18n.PT: "IVA - autoliquidação / Artigo 2.° n.° 1 alínea i) do CIVA",
 				},
 				Codes: cbc.CodeSet{
+					KeyATTaxCode:          "ISE",
 					KeyATTaxExemptionCode: "M30",
 				},
 			},
@@ -344,6 +372,7 @@ var taxCategories = []*tax.Category{
 					i18n.PT: "IVA - autoliquidação / Artigo 2.° n.° 1 alínea j) do CIVA",
 				},
 				Codes: cbc.CodeSet{
+					KeyATTaxCode:          "ISE",
 					KeyATTaxExemptionCode: "M31",
 				},
 			},
@@ -355,6 +384,7 @@ var taxCategories = []*tax.Category{
 					i18n.PT: "IVA - autoliquidação / Artigo 2.° n.° 1 alínea I) do CIVA",
 				},
 				Codes: cbc.CodeSet{
+					KeyATTaxCode:          "ISE",
 					KeyATTaxExemptionCode: "M32",
 				},
 			},
@@ -366,6 +396,7 @@ var taxCategories = []*tax.Category{
 					i18n.PT: "IVA - autoliquidação / Artigo 2.° n.° 1 alínea m) do CIVA",
 				},
 				Codes: cbc.CodeSet{
+					KeyATTaxCode:          "ISE",
 					KeyATTaxExemptionCode: "M33",
 				},
 			},
@@ -377,6 +408,7 @@ var taxCategories = []*tax.Category{
 					i18n.PT: "IVA - autoliquidação / Artigo 6.° n.° 6 alínea a) do CIVA, a contrário",
 				},
 				Codes: cbc.CodeSet{
+					KeyATTaxCode:          "ISE",
 					KeyATTaxExemptionCode: "M40",
 				},
 			},
@@ -388,6 +420,7 @@ var taxCategories = []*tax.Category{
 					i18n.PT: "IVA - autoliquidação / Artigo 8.° n.° 3 do RITI",
 				},
 				Codes: cbc.CodeSet{
+					KeyATTaxCode:          "ISE",
 					KeyATTaxExemptionCode: "M41",
 				},
 			},
@@ -399,6 +432,7 @@ var taxCategories = []*tax.Category{
 					i18n.PT: "IVA - autoliquidação / Decreto-Lei n.° 21/2007, de 29 de janeiro",
 				},
 				Codes: cbc.CodeSet{
+					KeyATTaxCode:          "ISE",
 					KeyATTaxExemptionCode: "M42",
 				},
 			},
@@ -410,6 +444,7 @@ var taxCategories = []*tax.Category{
 					i18n.PT: "IVA - autoliquidação / Decreto-Lei n.° 362/99, de 16 de setembro",
 				},
 				Codes: cbc.CodeSet{
+					KeyATTaxCode:          "ISE",
 					KeyATTaxExemptionCode: "M43",
 				},
 			},
@@ -421,6 +456,7 @@ var taxCategories = []*tax.Category{
 					i18n.PT: "Não sujeito ou não tributado",
 				},
 				Codes: cbc.CodeSet{
+					KeyATTaxCode:          "ISE",
 					KeyATTaxExemptionCode: "M99",
 				},
 			},

--- a/regimes/pt/tax_categories.go
+++ b/regimes/pt/tax_categories.go
@@ -44,6 +44,15 @@ const (
 	TaxRateNonTaxable    cbc.Key = "non-taxable"
 )
 
+// AT Tax Codes
+const (
+	TaxCodeStandard     cbc.Code = "NOR"
+	TaxCodeIntermediate cbc.Code = "INT"
+	TaxCodeReduced      cbc.Code = "RED"
+	TaxCodeExempt       cbc.Code = "ISE"
+	TaxCodeOther        cbc.Code = "OUT"
+)
+
 var taxCategories = []*tax.Category{
 	// VAT
 	{
@@ -81,7 +90,7 @@ var taxCategories = []*tax.Category{
 					},
 				},
 				Codes: cbc.CodeSet{
-					KeyATTaxCode: "NOR",
+					KeyATTaxCode: TaxCodeStandard,
 				},
 			},
 			{
@@ -107,7 +116,7 @@ var taxCategories = []*tax.Category{
 					},
 				},
 				Codes: cbc.CodeSet{
-					KeyATTaxCode: "INT",
+					KeyATTaxCode: TaxCodeIntermediate,
 				},
 			},
 			{
@@ -133,7 +142,7 @@ var taxCategories = []*tax.Category{
 					},
 				},
 				Codes: cbc.CodeSet{
-					KeyATTaxCode: "RED",
+					KeyATTaxCode: TaxCodeReduced,
 				},
 			},
 			{
@@ -144,7 +153,7 @@ var taxCategories = []*tax.Category{
 					i18n.PT: "Artigo 16.°, n.° 6 do CIVA",
 				},
 				Codes: cbc.CodeSet{
-					KeyATTaxCode:          "ISE",
+					KeyATTaxCode:          TaxCodeExempt,
 					KeyATTaxExemptionCode: "M01",
 				},
 			},
@@ -156,7 +165,7 @@ var taxCategories = []*tax.Category{
 					i18n.PT: "Artigo 6.° do Decreto-Lei n.° 198/90, de 19 de junho",
 				},
 				Codes: cbc.CodeSet{
-					KeyATTaxCode:          "ISE",
+					KeyATTaxCode:          TaxCodeExempt,
 					KeyATTaxExemptionCode: "M02",
 				},
 			},
@@ -168,7 +177,7 @@ var taxCategories = []*tax.Category{
 					i18n.PT: "Isento artigo 13.° do CIVA",
 				},
 				Codes: cbc.CodeSet{
-					KeyATTaxCode:          "ISE",
+					KeyATTaxCode:          TaxCodeExempt,
 					KeyATTaxExemptionCode: "M04",
 				},
 			},
@@ -180,7 +189,7 @@ var taxCategories = []*tax.Category{
 					i18n.PT: "Isento artigo 14.° do CIVA",
 				},
 				Codes: cbc.CodeSet{
-					KeyATTaxCode:          "ISE",
+					KeyATTaxCode:          TaxCodeExempt,
 					KeyATTaxExemptionCode: "M05",
 				},
 			},
@@ -192,7 +201,7 @@ var taxCategories = []*tax.Category{
 					i18n.PT: "Isento artigo 15.° do CIVA",
 				},
 				Codes: cbc.CodeSet{
-					KeyATTaxCode:          "ISE",
+					KeyATTaxCode:          TaxCodeExempt,
 					KeyATTaxExemptionCode: "M06",
 				},
 			},
@@ -204,7 +213,7 @@ var taxCategories = []*tax.Category{
 					i18n.PT: "Isento artigo 9.° do CIVA",
 				},
 				Codes: cbc.CodeSet{
-					KeyATTaxCode:          "ISE",
+					KeyATTaxCode:          TaxCodeExempt,
 					KeyATTaxExemptionCode: "M07",
 				},
 			},
@@ -216,7 +225,7 @@ var taxCategories = []*tax.Category{
 					i18n.PT: "IVA - não confere direito a dedução / Artigo 62.° alínea b) do CIVA",
 				},
 				Codes: cbc.CodeSet{
-					KeyATTaxCode:          "ISE",
+					KeyATTaxCode:          TaxCodeExempt,
 					KeyATTaxExemptionCode: "M09",
 				},
 			},
@@ -228,7 +237,7 @@ var taxCategories = []*tax.Category{
 					i18n.PT: "IVA - regime de isenção / Artigo 57.° do CIVA",
 				},
 				Codes: cbc.CodeSet{
-					KeyATTaxCode:          "ISE",
+					KeyATTaxCode:          TaxCodeExempt,
 					KeyATTaxExemptionCode: "M10",
 				},
 			},
@@ -240,7 +249,7 @@ var taxCategories = []*tax.Category{
 					i18n.PT: "Regime particular do tabaco / Decreto-Lei n.° 346/85, de 23 de agosto",
 				},
 				Codes: cbc.CodeSet{
-					KeyATTaxCode:          "ISE",
+					KeyATTaxCode:          TaxCodeExempt,
 					KeyATTaxExemptionCode: "M11",
 				},
 			},
@@ -252,7 +261,7 @@ var taxCategories = []*tax.Category{
 					i18n.PT: "Regime da margem de lucro - Agências de viagens / Decreto-Lei n.° 221/85, de 3 de julho",
 				},
 				Codes: cbc.CodeSet{
-					KeyATTaxCode:          "ISE",
+					KeyATTaxCode:          TaxCodeExempt,
 					KeyATTaxExemptionCode: "M12",
 				},
 			},
@@ -264,7 +273,7 @@ var taxCategories = []*tax.Category{
 					i18n.PT: "Regime da margem de lucro - Bens em segunda mão / Decreto-Lei n.° 199/96, de 18 de outubro",
 				},
 				Codes: cbc.CodeSet{
-					KeyATTaxCode:          "ISE",
+					KeyATTaxCode:          TaxCodeExempt,
 					KeyATTaxExemptionCode: "M13",
 				},
 			},
@@ -276,7 +285,7 @@ var taxCategories = []*tax.Category{
 					i18n.PT: "Regime da margem de lucro - Objetos de arte / Decreto-Lei n.° 199/96, de 18 de outubro",
 				},
 				Codes: cbc.CodeSet{
-					KeyATTaxCode:          "ISE",
+					KeyATTaxCode:          TaxCodeExempt,
 					KeyATTaxExemptionCode: "M14",
 				},
 			},
@@ -288,7 +297,7 @@ var taxCategories = []*tax.Category{
 					i18n.PT: "Regime da margem de lucro - Objetos de coleção e antiguidades / Decreto-Lei n.° 199/96, de 18 de outubro",
 				},
 				Codes: cbc.CodeSet{
-					KeyATTaxCode:          "ISE",
+					KeyATTaxCode:          TaxCodeExempt,
 					KeyATTaxExemptionCode: "M15",
 				},
 			},
@@ -300,7 +309,7 @@ var taxCategories = []*tax.Category{
 					i18n.PT: "Isento artigo 14.° do RITI",
 				},
 				Codes: cbc.CodeSet{
-					KeyATTaxCode:          "ISE",
+					KeyATTaxCode:          TaxCodeExempt,
 					KeyATTaxExemptionCode: "M16",
 				},
 			},
@@ -312,7 +321,7 @@ var taxCategories = []*tax.Category{
 					i18n.PT: "Outras isenções - Isenções temporárias determinadas em diploma próprio",
 				},
 				Codes: cbc.CodeSet{
-					KeyATTaxCode:          "ISE",
+					KeyATTaxCode:          TaxCodeExempt,
 					KeyATTaxExemptionCode: "M19",
 				},
 			},
@@ -324,7 +333,7 @@ var taxCategories = []*tax.Category{
 					i18n.PT: "IVA - regime forfetário / Artigo 59.°-D n.°2 do CIVA",
 				},
 				Codes: cbc.CodeSet{
-					KeyATTaxCode:          "ISE",
+					KeyATTaxCode:          TaxCodeExempt,
 					KeyATTaxExemptionCode: "M20",
 				},
 			},
@@ -336,7 +345,7 @@ var taxCategories = []*tax.Category{
 					i18n.PT: "IVA - não confere direito à dedução (ou expressão similar) - Artigo 72.° n.° 4 do CIVA",
 				},
 				Codes: cbc.CodeSet{
-					KeyATTaxCode:          "ISE",
+					KeyATTaxCode:          TaxCodeExempt,
 					KeyATTaxExemptionCode: "M21",
 				},
 			},
@@ -348,7 +357,7 @@ var taxCategories = []*tax.Category{
 					i18n.PT: "Mercadorias à consignação - Artigo 38.° n.° 1 alínea a) do CIVA",
 				},
 				Codes: cbc.CodeSet{
-					KeyATTaxCode:          "ISE",
+					KeyATTaxCode:          TaxCodeExempt,
 					KeyATTaxExemptionCode: "M25",
 				},
 			},
@@ -360,7 +369,7 @@ var taxCategories = []*tax.Category{
 					i18n.PT: "IVA - autoliquidação / Artigo 2.° n.° 1 alínea i) do CIVA",
 				},
 				Codes: cbc.CodeSet{
-					KeyATTaxCode:          "ISE",
+					KeyATTaxCode:          TaxCodeExempt,
 					KeyATTaxExemptionCode: "M30",
 				},
 			},
@@ -372,7 +381,7 @@ var taxCategories = []*tax.Category{
 					i18n.PT: "IVA - autoliquidação / Artigo 2.° n.° 1 alínea j) do CIVA",
 				},
 				Codes: cbc.CodeSet{
-					KeyATTaxCode:          "ISE",
+					KeyATTaxCode:          TaxCodeExempt,
 					KeyATTaxExemptionCode: "M31",
 				},
 			},
@@ -384,7 +393,7 @@ var taxCategories = []*tax.Category{
 					i18n.PT: "IVA - autoliquidação / Artigo 2.° n.° 1 alínea I) do CIVA",
 				},
 				Codes: cbc.CodeSet{
-					KeyATTaxCode:          "ISE",
+					KeyATTaxCode:          TaxCodeExempt,
 					KeyATTaxExemptionCode: "M32",
 				},
 			},
@@ -396,7 +405,7 @@ var taxCategories = []*tax.Category{
 					i18n.PT: "IVA - autoliquidação / Artigo 2.° n.° 1 alínea m) do CIVA",
 				},
 				Codes: cbc.CodeSet{
-					KeyATTaxCode:          "ISE",
+					KeyATTaxCode:          TaxCodeExempt,
 					KeyATTaxExemptionCode: "M33",
 				},
 			},
@@ -408,7 +417,7 @@ var taxCategories = []*tax.Category{
 					i18n.PT: "IVA - autoliquidação / Artigo 6.° n.° 6 alínea a) do CIVA, a contrário",
 				},
 				Codes: cbc.CodeSet{
-					KeyATTaxCode:          "ISE",
+					KeyATTaxCode:          TaxCodeExempt,
 					KeyATTaxExemptionCode: "M40",
 				},
 			},
@@ -420,7 +429,7 @@ var taxCategories = []*tax.Category{
 					i18n.PT: "IVA - autoliquidação / Artigo 8.° n.° 3 do RITI",
 				},
 				Codes: cbc.CodeSet{
-					KeyATTaxCode:          "ISE",
+					KeyATTaxCode:          TaxCodeExempt,
 					KeyATTaxExemptionCode: "M41",
 				},
 			},
@@ -432,7 +441,7 @@ var taxCategories = []*tax.Category{
 					i18n.PT: "IVA - autoliquidação / Decreto-Lei n.° 21/2007, de 29 de janeiro",
 				},
 				Codes: cbc.CodeSet{
-					KeyATTaxCode:          "ISE",
+					KeyATTaxCode:          TaxCodeExempt,
 					KeyATTaxExemptionCode: "M42",
 				},
 			},
@@ -444,7 +453,7 @@ var taxCategories = []*tax.Category{
 					i18n.PT: "IVA - autoliquidação / Decreto-Lei n.° 362/99, de 16 de setembro",
 				},
 				Codes: cbc.CodeSet{
-					KeyATTaxCode:          "ISE",
+					KeyATTaxCode:          TaxCodeExempt,
 					KeyATTaxExemptionCode: "M43",
 				},
 			},
@@ -456,7 +465,7 @@ var taxCategories = []*tax.Category{
 					i18n.PT: "Não sujeito ou não tributado",
 				},
 				Codes: cbc.CodeSet{
-					KeyATTaxCode:          "ISE",
+					KeyATTaxCode:          TaxCodeExempt,
 					KeyATTaxExemptionCode: "M99",
 				},
 			},

--- a/regimes/pt/zones.go
+++ b/regimes/pt/zones.go
@@ -1,29 +1,30 @@
 package pt
 
 import (
+	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/i18n"
 	"github.com/invopop/gobl/tax"
 )
 
 var zones = []tax.Zone{
-	{Code: ZoneAveiro, Region: i18n.String{i18n.PT: "Aveiro"}},
-	{Code: ZoneBeja, Region: i18n.String{i18n.PT: "Beja"}},
-	{Code: ZoneBraga, Region: i18n.String{i18n.PT: "Braga"}},
-	{Code: ZoneBraganca, Region: i18n.String{i18n.PT: "Bragança"}},
-	{Code: ZoneCasteloBranco, Region: i18n.String{i18n.PT: "Castelo Branco"}},
-	{Code: ZoneCoimbra, Region: i18n.String{i18n.PT: "Coimbra"}},
-	{Code: ZoneEvora, Region: i18n.String{i18n.PT: "Évora"}},
-	{Code: ZoneFaro, Region: i18n.String{i18n.PT: "Faro"}},
-	{Code: ZoneGuarda, Region: i18n.String{i18n.PT: "Guarda"}},
-	{Code: ZoneLeiria, Region: i18n.String{i18n.PT: "Leiria"}},
-	{Code: ZoneLisboa, Region: i18n.String{i18n.PT: "Lisboa"}},
-	{Code: ZonePortalegre, Region: i18n.String{i18n.PT: "Portalegre"}},
-	{Code: ZonePorto, Region: i18n.String{i18n.PT: "Porto"}},
-	{Code: ZoneSantarem, Region: i18n.String{i18n.PT: "Santarém"}},
-	{Code: ZoneSetubal, Region: i18n.String{i18n.PT: "Setúbal"}},
-	{Code: ZoneVianaDoCastelo, Region: i18n.String{i18n.PT: "Viana do Castelo"}},
-	{Code: ZoneVilaReal, Region: i18n.String{i18n.PT: "Vila Real"}},
-	{Code: ZoneViseu, Region: i18n.String{i18n.PT: "Viseu"}},
-	{Code: ZoneAzores, Region: i18n.String{i18n.PT: "Região Autónoma dos Açores"}},
-	{Code: ZoneMadeira, Region: i18n.String{i18n.PT: "Região Autónoma da Madeira"}},
+	{Code: ZoneAveiro, Region: i18n.String{i18n.PT: "Aveiro"}, Codes: cbc.CodeSet{KeyATTaxCountryRegion: "PT"}},
+	{Code: ZoneBeja, Region: i18n.String{i18n.PT: "Beja"}, Codes: cbc.CodeSet{KeyATTaxCountryRegion: "PT"}},
+	{Code: ZoneBraga, Region: i18n.String{i18n.PT: "Braga"}, Codes: cbc.CodeSet{KeyATTaxCountryRegion: "PT"}},
+	{Code: ZoneBraganca, Region: i18n.String{i18n.PT: "Bragança"}, Codes: cbc.CodeSet{KeyATTaxCountryRegion: "PT"}},
+	{Code: ZoneCasteloBranco, Region: i18n.String{i18n.PT: "Castelo Branco"}, Codes: cbc.CodeSet{KeyATTaxCountryRegion: "PT"}},
+	{Code: ZoneCoimbra, Region: i18n.String{i18n.PT: "Coimbra"}, Codes: cbc.CodeSet{KeyATTaxCountryRegion: "PT"}},
+	{Code: ZoneEvora, Region: i18n.String{i18n.PT: "Évora"}, Codes: cbc.CodeSet{KeyATTaxCountryRegion: "PT"}},
+	{Code: ZoneFaro, Region: i18n.String{i18n.PT: "Faro"}, Codes: cbc.CodeSet{KeyATTaxCountryRegion: "PT"}},
+	{Code: ZoneGuarda, Region: i18n.String{i18n.PT: "Guarda"}, Codes: cbc.CodeSet{KeyATTaxCountryRegion: "PT"}},
+	{Code: ZoneLeiria, Region: i18n.String{i18n.PT: "Leiria"}, Codes: cbc.CodeSet{KeyATTaxCountryRegion: "PT"}},
+	{Code: ZoneLisboa, Region: i18n.String{i18n.PT: "Lisboa"}, Codes: cbc.CodeSet{KeyATTaxCountryRegion: "PT"}},
+	{Code: ZonePortalegre, Region: i18n.String{i18n.PT: "Portalegre"}, Codes: cbc.CodeSet{KeyATTaxCountryRegion: "PT"}},
+	{Code: ZonePorto, Region: i18n.String{i18n.PT: "Porto"}, Codes: cbc.CodeSet{KeyATTaxCountryRegion: "PT"}},
+	{Code: ZoneSantarem, Region: i18n.String{i18n.PT: "Santarém"}, Codes: cbc.CodeSet{KeyATTaxCountryRegion: "PT"}},
+	{Code: ZoneSetubal, Region: i18n.String{i18n.PT: "Setúbal"}, Codes: cbc.CodeSet{KeyATTaxCountryRegion: "PT"}},
+	{Code: ZoneVianaDoCastelo, Region: i18n.String{i18n.PT: "Viana do Castelo"}, Codes: cbc.CodeSet{KeyATTaxCountryRegion: "PT"}},
+	{Code: ZoneVilaReal, Region: i18n.String{i18n.PT: "Vila Real"}, Codes: cbc.CodeSet{KeyATTaxCountryRegion: "PT"}},
+	{Code: ZoneViseu, Region: i18n.String{i18n.PT: "Viseu"}, Codes: cbc.CodeSet{KeyATTaxCountryRegion: "PT"}},
+	{Code: ZoneAzores, Region: i18n.String{i18n.PT: "Região Autónoma dos Açores"}, Codes: cbc.CodeSet{KeyATTaxCountryRegion: "PT-AC"}},
+	{Code: ZoneMadeira, Region: i18n.String{i18n.PT: "Região Autónoma da Madeira"}, Codes: cbc.CodeSet{KeyATTaxCountryRegion: "PT-MA"}},
 }

--- a/regimes/pt/zones.go
+++ b/regimes/pt/zones.go
@@ -6,25 +6,32 @@ import (
 	"github.com/invopop/gobl/tax"
 )
 
+// AT Tax Country Regions
+const (
+	TaxCountryRegionPT = "PT"
+	TaxCountryRegionAC = "PT-AC"
+	TaxCountryRegionMA = "PT-MA"
+)
+
 var zones = []tax.Zone{
-	{Code: ZoneAveiro, Region: i18n.String{i18n.PT: "Aveiro"}, Codes: cbc.CodeSet{KeyATTaxCountryRegion: "PT"}},
-	{Code: ZoneBeja, Region: i18n.String{i18n.PT: "Beja"}, Codes: cbc.CodeSet{KeyATTaxCountryRegion: "PT"}},
-	{Code: ZoneBraga, Region: i18n.String{i18n.PT: "Braga"}, Codes: cbc.CodeSet{KeyATTaxCountryRegion: "PT"}},
-	{Code: ZoneBraganca, Region: i18n.String{i18n.PT: "Bragança"}, Codes: cbc.CodeSet{KeyATTaxCountryRegion: "PT"}},
-	{Code: ZoneCasteloBranco, Region: i18n.String{i18n.PT: "Castelo Branco"}, Codes: cbc.CodeSet{KeyATTaxCountryRegion: "PT"}},
-	{Code: ZoneCoimbra, Region: i18n.String{i18n.PT: "Coimbra"}, Codes: cbc.CodeSet{KeyATTaxCountryRegion: "PT"}},
-	{Code: ZoneEvora, Region: i18n.String{i18n.PT: "Évora"}, Codes: cbc.CodeSet{KeyATTaxCountryRegion: "PT"}},
-	{Code: ZoneFaro, Region: i18n.String{i18n.PT: "Faro"}, Codes: cbc.CodeSet{KeyATTaxCountryRegion: "PT"}},
-	{Code: ZoneGuarda, Region: i18n.String{i18n.PT: "Guarda"}, Codes: cbc.CodeSet{KeyATTaxCountryRegion: "PT"}},
-	{Code: ZoneLeiria, Region: i18n.String{i18n.PT: "Leiria"}, Codes: cbc.CodeSet{KeyATTaxCountryRegion: "PT"}},
-	{Code: ZoneLisboa, Region: i18n.String{i18n.PT: "Lisboa"}, Codes: cbc.CodeSet{KeyATTaxCountryRegion: "PT"}},
-	{Code: ZonePortalegre, Region: i18n.String{i18n.PT: "Portalegre"}, Codes: cbc.CodeSet{KeyATTaxCountryRegion: "PT"}},
-	{Code: ZonePorto, Region: i18n.String{i18n.PT: "Porto"}, Codes: cbc.CodeSet{KeyATTaxCountryRegion: "PT"}},
-	{Code: ZoneSantarem, Region: i18n.String{i18n.PT: "Santarém"}, Codes: cbc.CodeSet{KeyATTaxCountryRegion: "PT"}},
-	{Code: ZoneSetubal, Region: i18n.String{i18n.PT: "Setúbal"}, Codes: cbc.CodeSet{KeyATTaxCountryRegion: "PT"}},
-	{Code: ZoneVianaDoCastelo, Region: i18n.String{i18n.PT: "Viana do Castelo"}, Codes: cbc.CodeSet{KeyATTaxCountryRegion: "PT"}},
-	{Code: ZoneVilaReal, Region: i18n.String{i18n.PT: "Vila Real"}, Codes: cbc.CodeSet{KeyATTaxCountryRegion: "PT"}},
-	{Code: ZoneViseu, Region: i18n.String{i18n.PT: "Viseu"}, Codes: cbc.CodeSet{KeyATTaxCountryRegion: "PT"}},
-	{Code: ZoneAzores, Region: i18n.String{i18n.PT: "Região Autónoma dos Açores"}, Codes: cbc.CodeSet{KeyATTaxCountryRegion: "PT-AC"}},
-	{Code: ZoneMadeira, Region: i18n.String{i18n.PT: "Região Autónoma da Madeira"}, Codes: cbc.CodeSet{KeyATTaxCountryRegion: "PT-MA"}},
+	{Code: ZoneAveiro, Region: i18n.String{i18n.PT: "Aveiro"}, Codes: cbc.CodeSet{KeyATTaxCountryRegion: TaxCountryRegionPT}},
+	{Code: ZoneBeja, Region: i18n.String{i18n.PT: "Beja"}, Codes: cbc.CodeSet{KeyATTaxCountryRegion: TaxCountryRegionPT}},
+	{Code: ZoneBraga, Region: i18n.String{i18n.PT: "Braga"}, Codes: cbc.CodeSet{KeyATTaxCountryRegion: TaxCountryRegionPT}},
+	{Code: ZoneBraganca, Region: i18n.String{i18n.PT: "Bragança"}, Codes: cbc.CodeSet{KeyATTaxCountryRegion: TaxCountryRegionPT}},
+	{Code: ZoneCasteloBranco, Region: i18n.String{i18n.PT: "Castelo Branco"}, Codes: cbc.CodeSet{KeyATTaxCountryRegion: TaxCountryRegionPT}},
+	{Code: ZoneCoimbra, Region: i18n.String{i18n.PT: "Coimbra"}, Codes: cbc.CodeSet{KeyATTaxCountryRegion: TaxCountryRegionPT}},
+	{Code: ZoneEvora, Region: i18n.String{i18n.PT: "Évora"}, Codes: cbc.CodeSet{KeyATTaxCountryRegion: TaxCountryRegionPT}},
+	{Code: ZoneFaro, Region: i18n.String{i18n.PT: "Faro"}, Codes: cbc.CodeSet{KeyATTaxCountryRegion: TaxCountryRegionPT}},
+	{Code: ZoneGuarda, Region: i18n.String{i18n.PT: "Guarda"}, Codes: cbc.CodeSet{KeyATTaxCountryRegion: TaxCountryRegionPT}},
+	{Code: ZoneLeiria, Region: i18n.String{i18n.PT: "Leiria"}, Codes: cbc.CodeSet{KeyATTaxCountryRegion: TaxCountryRegionPT}},
+	{Code: ZoneLisboa, Region: i18n.String{i18n.PT: "Lisboa"}, Codes: cbc.CodeSet{KeyATTaxCountryRegion: TaxCountryRegionPT}},
+	{Code: ZonePortalegre, Region: i18n.String{i18n.PT: "Portalegre"}, Codes: cbc.CodeSet{KeyATTaxCountryRegion: TaxCountryRegionPT}},
+	{Code: ZonePorto, Region: i18n.String{i18n.PT: "Porto"}, Codes: cbc.CodeSet{KeyATTaxCountryRegion: TaxCountryRegionPT}},
+	{Code: ZoneSantarem, Region: i18n.String{i18n.PT: "Santarém"}, Codes: cbc.CodeSet{KeyATTaxCountryRegion: TaxCountryRegionPT}},
+	{Code: ZoneSetubal, Region: i18n.String{i18n.PT: "Setúbal"}, Codes: cbc.CodeSet{KeyATTaxCountryRegion: TaxCountryRegionPT}},
+	{Code: ZoneVianaDoCastelo, Region: i18n.String{i18n.PT: "Viana do Castelo"}, Codes: cbc.CodeSet{KeyATTaxCountryRegion: TaxCountryRegionPT}},
+	{Code: ZoneVilaReal, Region: i18n.String{i18n.PT: "Vila Real"}, Codes: cbc.CodeSet{KeyATTaxCountryRegion: TaxCountryRegionPT}},
+	{Code: ZoneViseu, Region: i18n.String{i18n.PT: "Viseu"}, Codes: cbc.CodeSet{KeyATTaxCountryRegion: TaxCountryRegionPT}},
+	{Code: ZoneAzores, Region: i18n.String{i18n.PT: "Região Autónoma dos Açores"}, Codes: cbc.CodeSet{KeyATTaxCountryRegion: TaxCountryRegionAC}},
+	{Code: ZoneMadeira, Region: i18n.String{i18n.PT: "Região Autónoma da Madeira"}, Codes: cbc.CodeSet{KeyATTaxCountryRegion: TaxCountryRegionMA}},
 }


### PR DESCRIPTION
* Adds `TaxCountryRegion` and `TaxCode` codes to the PT regime
* Adds table documentation on how to map GOBL fields to those codes
* Enables replacing hard-coded mapping logic in IX provider (see https://github.com/invopop/invoicexpress/pull/35)