### PR TITLE
Passing the draft status of an envelope to validation

### DIFF
--- a/bill/invoice.go
+++ b/bill/invoice.go
@@ -8,6 +8,7 @@ import (
 	"github.com/invopop/gobl/cal"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/currency"
+	"github.com/invopop/gobl/internal"
 	"github.com/invopop/gobl/org"
 	"github.com/invopop/gobl/regimes/common"
 	"github.com/invopop/gobl/tax"
@@ -104,7 +105,9 @@ func (inv *Invoice) ValidateWithContext(ctx context.Context) error {
 	ctx = r.WithContext(ctx)
 	err := validation.ValidateStructWithContext(ctx, inv,
 		validation.Field(&inv.UUID),
-		validation.Field(&inv.Code, validation.Required),
+		validation.Field(&inv.Code,
+			validation.When(!internal.IsDraft(ctx), validation.Required),
+		),
 		validation.Field(&inv.Type, validation.Required, isValidInvoiceType),
 		validation.Field(&inv.Currency, validation.Required),
 		validation.Field(&inv.ExchangeRates),

--- a/cbc/key.go
+++ b/cbc/key.go
@@ -20,6 +20,12 @@ var (
 	KeyPattern = `^(?:[a-z]|[a-z0-9][a-z0-9-+]*[a-z0-9])$`
 	// KeyValidationRegexp is used for key validation
 	KeyValidationRegexp = regexp.MustCompile(KeyPattern)
+	// KeySeparator is used to separate keys join using the "With"
+	// method.
+	KeySeparator = "+"
+)
+
+const (
 	// KeyMinLength defines the minimum key length
 	KeyMinLength = 1
 	// KeyMaxLength defines the maximum key length
@@ -28,10 +34,6 @@ var (
 
 // KeyEmpty is used when no key is available.
 const KeyEmpty Key = ""
-
-// KeySeparator is used to separate keys join using the "With"
-// method.
-const KeySeparator = "+"
 
 // Validate ensures the key complies with the basic syntax
 // requirements.

--- a/envelope.go
+++ b/envelope.go
@@ -9,6 +9,7 @@ import (
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/dsig"
+	"github.com/invopop/gobl/internal"
 	"github.com/invopop/gobl/schema"
 	"github.com/invopop/gobl/uuid"
 )
@@ -62,6 +63,7 @@ func (e *Envelope) Validate() error {
 
 // ValidateWithContext ensures that the envelope contains everything it should to be considered valid GoBL.
 func (e *Envelope) ValidateWithContext(ctx context.Context) error {
+	ctx = context.WithValue(ctx, internal.KeyDraft, e.Head != nil && e.Head.Draft)
 	err := validation.ValidateStructWithContext(ctx, e,
 		validation.Field(&e.Schema, validation.Required),
 		validation.Field(&e.Head, validation.Required),

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -1,0 +1,23 @@
+// Package internal contains internal objects that may be used for reference
+// inside GOBL but are not intended for use outside of the library.
+package internal
+
+import (
+	"context"
+
+	"github.com/invopop/gobl/cbc"
+)
+
+const (
+	// KeyDraft is used for extract the draft status from the context.
+	KeyDraft cbc.Key = "draft"
+)
+
+// IsDraft returns true if the context indicates we're working with an
+// envelope with the header draft status marked as true.
+func IsDraft(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	return ctx.Value(KeyDraft) == true
+}

--- a/signatures.go
+++ b/signatures.go
@@ -1,7 +1,0 @@
-package gobl
-
-import "github.com/invopop/gobl/dsig"
-
-// Signatures keeps together a list of signatures that we're used to sign the document
-// head contents.
-type Signatures []*dsig.Signature


### PR DESCRIPTION
* Documents can now check if the envelope is in draft mode by looking at the context.
* Useful for allowing the Invoice Code field to be blank while in draft, but not allowed when transitioning to a closed invoice, which is the default if no envelope is present.