### PR TITLE
Validations for bare minimum MX invoice

### DIFF
--- a/bill/line.go
+++ b/bill/line.go
@@ -65,6 +65,10 @@ func (l *Line) ValidateWithContext(ctx context.Context) error {
 
 // calculate figures out the totals according to quantity and discounts.
 func (l *Line) calculate() {
+	if l.Item == nil {
+		return
+	}
+
 	// First we figure out how much the item costs, and get the total
 	l.Sum = l.Item.Price.Multiply(l.Quantity)
 	l.Total = l.Sum

--- a/regimes/mx/invoice_validator.go
+++ b/regimes/mx/invoice_validator.go
@@ -1,0 +1,72 @@
+package mx
+
+import (
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/num"
+	"github.com/invopop/gobl/org"
+	"github.com/invopop/validation"
+)
+
+type invoiceValidator struct {
+	inv *bill.Invoice
+}
+
+func validateInvoice(inv *bill.Invoice) error {
+	v := &invoiceValidator{inv: inv}
+	return v.validate()
+}
+
+func (v *invoiceValidator) validate() error {
+	inv := v.inv
+	return validation.ValidateStruct(inv,
+		validation.Field(&inv.Customer,
+			validation.Required,
+			validation.By(v.validCustomer),
+		),
+		validation.Field(&inv.Lines,
+			validation.Each(
+				validation.By(v.validLine),
+				validation.Skip, // Prevents each line's `ValidateWithContext` function from being called again.
+			),
+			validation.Skip, // Prevents each line's `ValidateWithContext` function from being called again.
+		),
+	)
+}
+
+func (v *invoiceValidator) validCustomer(value interface{}) error {
+	obj, _ := value.(*org.Party)
+	if obj == nil {
+		return nil
+	}
+	return validation.ValidateStruct(obj,
+		validation.Field(&obj.TaxID, validation.Required),
+	)
+}
+
+func (v *invoiceValidator) validLine(value interface{}) error {
+	line, _ := value.(*bill.Line)
+	if line == nil {
+		return nil
+	}
+
+	return validation.ValidateStruct(line,
+		validation.Field(&line.Quantity, validation.By(v.validatePositiveAmount)),
+		validation.Field(&line.Total, validation.By(v.validatePositiveAmount)),
+		validation.Field(&line.Taxes,
+			validation.Required,
+			validation.Skip, // Prevents each tax's `ValidateWithContext` function from being called again.
+		),
+	)
+}
+
+func (v *invoiceValidator) validatePositiveAmount(value interface{}) error {
+	amount, ok := value.(num.Amount)
+	if !ok {
+		return nil
+	}
+
+	if amount.Compare(num.MakeAmount(0, 0)) != 1 {
+		return validation.NewError("validation_positive_amount", "must be positive")
+	}
+	return nil
+}

--- a/regimes/mx/invoice_validator_test.go
+++ b/regimes/mx/invoice_validator_test.go
@@ -1,0 +1,99 @@
+package mx_test
+
+import (
+	"testing"
+
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/cal"
+	"github.com/invopop/gobl/l10n"
+	"github.com/invopop/gobl/num"
+	"github.com/invopop/gobl/org"
+	"github.com/invopop/gobl/tax"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func validInvoice() *bill.Invoice {
+	return &bill.Invoice{
+		Code:      "123",
+		Currency:  "MXN",
+		IssueDate: cal.MakeDate(2023, 1, 1),
+		Supplier: &org.Party{
+			Name: "Test Supplier",
+			TaxID: &tax.Identity{
+				Country: l10n.MX,
+				Code:    "AAA010101AAA",
+				Zone:    "21000",
+			},
+		},
+		Customer: &org.Party{
+			Name: "Test Customer",
+			TaxID: &tax.Identity{
+				Country: l10n.MX,
+				Code:    "ZZZ010101ZZZ",
+				Zone:    "65000",
+			},
+		},
+		Lines: []*bill.Line{
+			{
+				Quantity: num.MakeAmount(1, 0),
+				Item: &org.Item{
+					Name:  "bogus",
+					Price: num.MakeAmount(10000, 2),
+				},
+				Taxes: tax.Set{
+					{
+						Category: "VAT",
+						Rate:     "standard",
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestValidInvoice(t *testing.T) {
+	inv := validInvoice()
+	require.NoError(t, inv.Calculate())
+	require.NoError(t, inv.Validate())
+}
+
+func TestCustomerValidation(t *testing.T) {
+	inv := validInvoice()
+
+	inv.Customer.TaxID = nil
+	assertValidationError(t, inv, "customer: (tax_id: cannot be blank.)")
+
+	inv.Customer = nil
+	assertValidationError(t, inv, "customer: cannot be blank")
+}
+
+func TestLineValidation(t *testing.T) {
+	inv := validInvoice()
+
+	inv.Lines[0].Quantity = num.MakeAmount(0, 0)
+	assertValidationError(t, inv, "lines: (0: (quantity: must be positive; total: must be positive.).)")
+
+	inv.Lines[0].Quantity = num.MakeAmount(-1, 0)
+	assertValidationError(t, inv, "lines: (0: (quantity: must be positive; total: must be positive.).)")
+
+	inv = validInvoice()
+
+	inv.Lines[0].Item.Price = num.MakeAmount(0, 0)
+	assertValidationError(t, inv, "lines: (0: (total: must be positive.).)")
+
+	inv.Lines[0].Item.Price = num.MakeAmount(-1, 0)
+	assertValidationError(t, inv, "lines: (0: (total: must be positive.).)")
+
+	inv = validInvoice()
+
+	inv.Lines[0].Taxes = nil
+	assertValidationError(t, inv, "lines: (0: (taxes: cannot be blank.).)")
+}
+
+func assertValidationError(t *testing.T, inv *bill.Invoice, expected string) {
+	require.NoError(t, inv.Calculate())
+	err := inv.Validate()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), expected)
+}

--- a/regimes/mx/mx.go
+++ b/regimes/mx/mx.go
@@ -2,6 +2,7 @@
 package mx
 
 import (
+	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/currency"
 	"github.com/invopop/gobl/i18n"
 	"github.com/invopop/gobl/l10n"
@@ -31,6 +32,8 @@ func New() *tax.Regime {
 // Validate validates a document against the tax regime.
 func Validate(doc interface{}) error {
 	switch obj := doc.(type) {
+	case *bill.Invoice:
+		return validateInvoice(obj)
 	case *tax.Identity:
 		return validateTaxIdentity(obj)
 	}

--- a/regimes/mx/tax_identity.go
+++ b/regimes/mx/tax_identity.go
@@ -42,8 +42,10 @@ var (
 func validateTaxIdentity(tID *tax.Identity) error {
 	return validation.ValidateStruct(tID,
 		validation.Field(&tID.Code,
+			validation.Required,
 			validation.By(validateTaxCode),
 		),
+		validation.Field(&tID.Zone, validation.Required),
 	)
 }
 


### PR DESCRIPTION
* Adds validations necessary to generate an invoice with the bare minimum amount of attributes in Mexico
* Fixes a crash when a line without an item was being calculated