### PR TITLE
Adding validation rules for min or max amounts

### DIFF
--- a/num/validation.go
+++ b/num/validation.go
@@ -26,9 +26,9 @@ const (
 
 var (
 	// Positive validates the that value is greater than or equal to zero.
-	Positive = Min(MakeAmount(0, 0))
+	Positive = Min(MakeAmount(0, 0)).Exclusive()
 	// Negative validates the value is less than or equal to zero.
-	Negative = Max(MakeAmount(0, 0))
+	Negative = Max(MakeAmount(0, 0)).Exclusive()
 	// NotZero validates that the value is not zero.
 	NotZero = ThresholdRule{
 		threshold: Amount{0, 0},

--- a/num/validation.go
+++ b/num/validation.go
@@ -63,6 +63,8 @@ func (r ThresholdRule) Exclusive() ThresholdRule {
 	return r
 }
 
+// Validate checks if the provided value confirms with the threshold
+// rule.
 func (r ThresholdRule) Validate(value interface{}) error {
 	value, isNil := validation.Indirect(value)
 	if isNil || validation.IsEmpty(value) {

--- a/num/validation.go
+++ b/num/validation.go
@@ -1,0 +1,92 @@
+package num
+
+import (
+	"github.com/invopop/validation"
+)
+
+// ThresholdRule is a validator for Amounts and Percentages
+type ThresholdRule struct {
+	threshold Amount
+	operator  int
+	err       validation.Error
+}
+
+const (
+	greaterThan = iota
+	greaterEqualThan
+	lessThan
+	lessEqualThan
+)
+
+// Min checks if the value is greater than or equal to the provided amount or percentage
+func Min(min interface{}) ThresholdRule {
+	return ThresholdRule{
+		threshold: interfaceToAmount(min),
+		operator:  greaterEqualThan,
+		err:       validation.ErrMinGreaterEqualThanRequired,
+	}
+}
+
+// Max checks if the value is less than or equal to the provided amount or percentage
+func Max(max interface{}) ThresholdRule {
+	return ThresholdRule{
+		threshold: interfaceToAmount(max),
+		operator:  lessEqualThan,
+		err:       validation.ErrMaxLessEqualThanRequired,
+	}
+}
+
+func interfaceToAmount(val interface{}) Amount {
+	val, isNil := validation.Indirect(val)
+	if isNil {
+		return Amount{}
+	}
+	switch a := val.(type) {
+	case Amount:
+		return a
+	case Percentage:
+		return a.Amount
+	default:
+		return Amount{}
+	}
+}
+
+// Exclusive sets the comparison to exclude the boundary value.
+func (r ThresholdRule) Exclusive() ThresholdRule {
+	if r.operator == greaterEqualThan {
+		r.operator = greaterThan
+		r.err = validation.ErrMinGreaterThanRequired
+	} else if r.operator == lessEqualThan {
+		r.operator = lessThan
+		r.err = validation.ErrMaxLessThanRequired
+	}
+	return r
+}
+
+func (r ThresholdRule) Validate(value interface{}) error {
+	value, isNil := validation.Indirect(value)
+	if isNil || validation.IsEmpty(value) {
+		return nil
+	}
+
+	a := interfaceToAmount(value)
+	if !r.compare(a) {
+		return r.err.SetParams(map[string]interface{}{"threshold": r.threshold.String()})
+	}
+
+	return nil
+}
+
+func (r ThresholdRule) compare(value Amount) bool {
+	cmp := value.Compare(r.threshold)
+	switch r.operator {
+	case greaterThan:
+		return cmp == 1
+	case greaterEqualThan:
+		return cmp == 1 || cmp == 0
+	case lessThan:
+		return cmp == -1
+	default:
+		return cmp == -1 || cmp == 0
+	}
+}

--- a/num/validation.go
+++ b/num/validation.go
@@ -11,11 +11,30 @@ type ThresholdRule struct {
 	err       validation.Error
 }
 
+var (
+	// ErrIsZero indicates that the value is zero when it should not be.
+	ErrIsZero = validation.NewError("validation_is_zero", "must not be zero")
+)
+
 const (
 	greaterThan = iota
 	greaterEqualThan
 	lessThan
 	lessEqualThan
+	notZero
+)
+
+var (
+	// Positive validates the that value is greater than or equal to zero.
+	Positive = Min(MakeAmount(0, 0))
+	// Negative validates the value is less than or equal to zero.
+	Negative = Max(MakeAmount(0, 0))
+	// NotZero validates that the value is not zero.
+	NotZero = ThresholdRule{
+		threshold: Amount{0, 0},
+		operator:  notZero,
+		err:       ErrIsZero,
+	}
 )
 
 // Min checks if the value is greater than or equal to the provided amount or percentage
@@ -88,7 +107,9 @@ func (r ThresholdRule) compare(value Amount) bool {
 		return cmp == 1 || cmp == 0
 	case lessThan:
 		return cmp == -1
-	default:
+	case lessEqualThan:
 		return cmp == -1 || cmp == 0
+	default:
+		return cmp == -1 || cmp == 1
 	}
 }

--- a/num/validation_test.go
+++ b/num/validation_test.go
@@ -95,3 +95,36 @@ func TestValidationMax(t *testing.T) {
 		})
 	}
 }
+
+func TestValidationFixedRules(t *testing.T) {
+	tests := []struct {
+		tag   string
+		rule  ThresholdRule
+		value interface{}
+		err   string
+	}{
+		{"t1.1", Positive, MakeAmount(10, 0), ""},
+		{"t1.2", Positive, MakeAmount(0, 0), ""},
+		{"t1.3", Positive, MakeAmount(-10, 0), "must be no less than 0"},
+		{"t2.1", Negative, MakeAmount(-10, 0), ""},
+		{"t2.2", Negative, MakeAmount(0, 0), ""},
+		{"t2.3", Negative, MakeAmount(10, 0), "must be no greater than 0"},
+		{"t3.1", NotZero, MakeAmount(10, 0), ""},
+		{"t3.2", NotZero, MakeAmount(-10, 0), ""},
+		{"t3.3", NotZero, MakeAmount(0, 0), "must not be zero"},
+		{"t3.4", NotZero, nil, ""}, // out of scope!
+	}
+
+	for _, test := range tests {
+		t.Run(test.tag, func(t *testing.T) {
+			err := test.rule.Validate(test.value)
+			if test.err == "" {
+				assert.NoError(t, err)
+			} else {
+				if assert.Error(t, err) {
+					assert.Contains(t, err.Error(), test.err)
+				}
+			}
+		})
+	}
+}

--- a/num/validation_test.go
+++ b/num/validation_test.go
@@ -104,11 +104,13 @@ func TestValidationFixedRules(t *testing.T) {
 		err   string
 	}{
 		{"t1.1", Positive, MakeAmount(10, 0), ""},
-		{"t1.2", Positive, MakeAmount(0, 0), ""},
-		{"t1.3", Positive, MakeAmount(-10, 0), "must be no less than 0"},
+		{"t1.2", Positive, MakeAmount(0, 0), "must be greater than 0"},
+		{"t1.3", Positive, MakeAmount(-10, 0), "must be greater than 0"},
+		{"t1.4", Positive, nil, ""}, // ignore empty
 		{"t2.1", Negative, MakeAmount(-10, 0), ""},
-		{"t2.2", Negative, MakeAmount(0, 0), ""},
-		{"t2.3", Negative, MakeAmount(10, 0), "must be no greater than 0"},
+		{"t2.2", Negative, MakeAmount(0, 0), "must be less than 0"},
+		{"t2.3", Negative, MakeAmount(10, 0), "must be less than 0"},
+		{"t2.4", Negative, nil, ""}, // ignore empty
 		{"t3.1", NotZero, MakeAmount(10, 0), ""},
 		{"t3.2", NotZero, MakeAmount(-10, 0), ""},
 		{"t3.3", NotZero, MakeAmount(0, 0), "must not be zero"},

--- a/num/validation_test.go
+++ b/num/validation_test.go
@@ -1,0 +1,97 @@
+package num
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidationMin(t *testing.T) {
+	tests := []struct {
+		tag       string
+		threshold interface{}
+		exclusive bool
+		value     interface{}
+		err       string
+	}{
+		{"t1.1", MakeAmount(0, 0), false, MakeAmount(10, 0), ""},
+		{"t1.2", MakeAmount(2, 0), false, MakeAmount(10, 0), ""},
+		{"t1.3", MakeAmount(-2, 0), false, MakeAmount(10, 0), ""},
+		{"t1.4", MakeAmount(10, 0), false, MakeAmount(10, 0), ""},
+		{"t1.5", MakeAmount(9, 0), true, MakeAmount(10, 0), ""},
+		{"t1.6", NewAmount(0, 0), true, MakeAmount(10, 0), ""},
+		{"t1.7", NewAmount(0, 0), true, NewAmount(10, 0), ""},
+		{"t1.8", MakeAmount(0, 0), true, NewAmount(10, 0), ""},
+		{"t1.9", MakeAmount(10, 0), true, MakeAmount(10, 0), "must be greater than 10"},
+		{"t1.10", MakeAmount(11, 0), false, MakeAmount(10, 0), "must be no less than 11"},
+		{"t1.11", MakeAmount(-1, 0), false, MakeAmount(-2, 0), "must be no less than -1"},
+		{"t2.1", MakePercentage(0, 0), false, MakePercentage(10, 0), ""},
+		{"t2.2", MakePercentage(2, 0), false, MakePercentage(10, 0), ""},
+		{"t2.3", MakePercentage(2, 0), false, MakePercentage(1, 0), "must be no less than 2"},
+		{"t3.1", MakeAmount(0, 0), false, "", ""},   // ignore empty
+		{"t3.2", nil, false, MakeAmount(10, 0), ""}, // same as zero
+		{"t3.3", "", false, MakeAmount(10, 0), ""},  // same as zero
+		{"t3.4", "", false, MakeAmount(-1, 0), "must be no less than 0"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.tag, func(t *testing.T) {
+			r := Min(test.threshold)
+			if test.exclusive {
+				r = r.Exclusive()
+			}
+			err := r.Validate(test.value)
+			if test.err == "" {
+				assert.NoError(t, err)
+			} else {
+				if assert.Error(t, err) {
+					assert.Contains(t, err.Error(), test.err)
+				}
+			}
+		})
+	}
+}
+
+func TestValidationMax(t *testing.T) {
+	tests := []struct {
+		tag       string
+		threshold interface{}
+		exclusive bool
+		value     interface{}
+		err       string
+	}{
+		{"t1.1", MakeAmount(10, 0), false, MakeAmount(5, 0), ""},
+		{"t1.2", MakeAmount(0, 0), false, MakeAmount(-2, 0), ""},
+		{"t1.3", MakeAmount(-2, 0), false, MakeAmount(-5, 0), ""},
+		{"t1.4", MakeAmount(10, 0), false, MakeAmount(10, 0), ""},
+		{"t1.5", MakeAmount(11, 0), true, MakeAmount(10, 0), ""},
+		{"t1.6", NewAmount(10, 0), true, MakeAmount(0, 0), ""},
+		{"t1.9", MakeAmount(10, 0), true, MakeAmount(10, 0), "must be less than 10"},
+		{"t1.10", MakeAmount(9, 0), false, MakeAmount(10, 0), "must be no greater than 9"},
+		{"t1.10", MakeAmount(-5, 0), false, MakeAmount(-1, 0), "must be no greater than -5"},
+		{"t2.1", MakePercentage(10, 0), false, MakePercentage(1, 0), ""},
+		{"t2.2", MakePercentage(2, 0), false, MakePercentage(-1, 0), ""},
+		{"t2.3", MakePercentage(1, 0), false, MakePercentage(2, 0), "must be no greater than 1"},
+		{"t3.1", MakeAmount(0, 0), false, "", ""},   // ignore empty
+		{"t3.2", nil, false, MakeAmount(-1, 0), ""}, // same as zero
+		{"t3.3", "", false, MakeAmount(-1, 0), ""},  // same as zero
+		{"t3.4", "", false, MakeAmount(10, 0), "must be no greater than 0"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.tag, func(t *testing.T) {
+			r := Max(test.threshold)
+			if test.exclusive {
+				r = r.Exclusive()
+			}
+			err := r.Validate(test.value)
+			if test.err == "" {
+				assert.NoError(t, err)
+			} else {
+				if assert.Error(t, err) {
+					assert.Contains(t, err.Error(), test.err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
* Amounts and percentages can now be validated using `num.Min()` and `num.Max()` rules. 