### PR TITLE
`FormaPago` and `UsoCFDI` mapping codes for MX

### DIFF
--- a/bill/invoice.go
+++ b/bill/invoice.go
@@ -98,7 +98,7 @@ func (inv *Invoice) Validate() error {
 // ValidateWithContext checks to ensure the invoice is valid and contains all the
 // information we need.
 func (inv *Invoice) ValidateWithContext(ctx context.Context) error {
-	r := taxRegimeFor(inv.Supplier)
+	r := inv.TaxRegime()
 	if r == nil {
 		return errors.New("supplier: invalid or unknown tax regime")
 	}
@@ -243,10 +243,16 @@ func (inv *Invoice) RemoveIncludedTaxes(accuracy uint32) *Invoice {
 	return &i2
 }
 
+// TaxRegime determines the tax regime for the invoice based on the supplier tax
+// identity.
+func (inv *Invoice) TaxRegime() *tax.Regime {
+	return taxRegimeFor(inv.Supplier)
+}
+
 // ScenarioSummary determines a summary of the tax scenario for the invoice based on
 // the document type and tax tags.
 func (inv *Invoice) ScenarioSummary() *tax.ScenarioSummary {
-	r := taxRegimeFor(inv.Supplier)
+	r := inv.TaxRegime()
 	if r == nil {
 		return nil
 	}
@@ -266,7 +272,7 @@ func (inv *Invoice) scenarioSummary(r *tax.Regime) *tax.ScenarioSummary {
 }
 
 func (inv *Invoice) prepareTagsAndScenarios() error {
-	r := taxRegimeFor(inv.Supplier)
+	r := inv.TaxRegime()
 	if r == nil {
 		return nil
 	}

--- a/build/regimes/mx.json
+++ b/build/regimes/mx.json
@@ -6,6 +6,597 @@
   },
   "country": "MX",
   "currency": "MXN",
+  "tags": [
+    {
+      "key": "use+goods-acquisition",
+      "name": {
+        "en": "Acquisition of goods",
+        "es": "Adquisición de mercancías"
+      }
+    },
+    {
+      "key": "use+returns",
+      "name": {
+        "en": "Returns, discounts or rebates",
+        "es": "Devoluciones, descuentos o bonificaciones"
+      }
+    },
+    {
+      "key": "use+general-expenses",
+      "name": {
+        "en": "General expenses",
+        "es": "Gastos en general"
+      }
+    },
+    {
+      "key": "use+construction",
+      "name": {
+        "en": "Construction",
+        "es": "Construcciones"
+      }
+    },
+    {
+      "key": "use+office-equipment",
+      "name": {
+        "en": "Office furniture and equipment as investmen",
+        "es": "Mobiliario y equipo de oficina por inversiones"
+      }
+    },
+    {
+      "key": "use+transport-equipment",
+      "name": {
+        "en": "Transport equipment",
+        "es": "Equipo de transporte"
+      }
+    },
+    {
+      "key": "use+computer-equipment",
+      "name": {
+        "en": "Computer equipment and accessories",
+        "es": "Equipo de computo y accesorios"
+      }
+    },
+    {
+      "key": "use+manufacturing-tooling",
+      "name": {
+        "en": "Dies, punches, molds, matrices and other toolin",
+        "es": "Dados, troqueles, moldes, matrices y herramental"
+      }
+    },
+    {
+      "key": "use+telephone-comms",
+      "name": {
+        "en": "Telephone communications",
+        "es": "Comunicaciones telefónicas"
+      }
+    },
+    {
+      "key": "use+satellite-comms",
+      "name": {
+        "en": "Satellite communications",
+        "es": "Comunicaciones satelitales"
+      }
+    },
+    {
+      "key": "use+other-machinery",
+      "name": {
+        "en": "Other machinery and equipment",
+        "es": "Otra maquinaria y equipo"
+      }
+    },
+    {
+      "key": "use+medical-expenses",
+      "name": {
+        "en": "Medical and dental fees and hospital expenses",
+        "es": "Honorarios médicos, dentales y gastos hospitalarios"
+      }
+    },
+    {
+      "key": "use+medical-expenses+disability",
+      "name": {
+        "en": "Medical expenses for disability or incapacity",
+        "es": "Gastos médicos por incapacidad o discapacidad"
+      }
+    },
+    {
+      "key": "use+funeral-expenses",
+      "name": {
+        "en": "Funeral expenses",
+        "es": "Gastos funerales"
+      }
+    },
+    {
+      "key": "use+donation",
+      "name": {
+        "en": "Donations",
+        "es": "Donativos"
+      }
+    },
+    {
+      "key": "use+mortgage-interest",
+      "name": {
+        "en": "Interest actually paid on mortgage loans (housing)",
+        "es": "Intereses reales efectivamente pagados por créditos hipotecarios (casa habitación)"
+      }
+    },
+    {
+      "key": "use+sar-contribution",
+      "name": {
+        "en": "Voluntary contributions to the SAR",
+        "es": "Aportaciones voluntarias al SAR"
+      }
+    },
+    {
+      "key": "use+medical-insurance",
+      "name": {
+        "en": "Medical insurance premiums",
+        "es": "Primas por seguros de gastos médicos"
+      }
+    },
+    {
+      "key": "use+school-transportation",
+      "name": {
+        "en": "Mandatory school transportation expenses",
+        "es": "Gastos de transportación escolar obligatoria"
+      }
+    },
+    {
+      "key": "use+savings-deposit",
+      "name": {
+        "en": "Deposits in savings accounts, pension plans premiums",
+        "es": "Depósitos en cuentas para el ahorro, primas que tengan como base planes de pensiones"
+      }
+    },
+    {
+      "key": "use+school-fees",
+      "name": {
+        "en": "Payments for educational services (school fees)",
+        "es": "Pagos por servicios educativos (colegiaturas)"
+      }
+    },
+    {
+      "key": "use+no-tax-effects",
+      "name": {
+        "en": "Without tax effects",
+        "es": "Sin efectos fiscales"
+      }
+    },
+    {
+      "key": "use+suplementary-payment",
+      "name": {
+        "en": "Payments",
+        "es": "Pagos"
+      }
+    },
+    {
+      "key": "use+payroll",
+      "name": {
+        "en": "Payroll",
+        "es": "Nómina"
+      }
+    }
+  ],
+  "payment_means": [
+    {
+      "key": "cash",
+      "name": {
+        "en": "Cash",
+        "es": "Efectivo"
+      },
+      "codes": {
+        "sat-forma-pago": "01"
+      }
+    },
+    {
+      "key": "cheque",
+      "name": {
+        "en": "Nominative cheque",
+        "es": "Cheque nominativo"
+      },
+      "codes": {
+        "sat-forma-pago": "02"
+      }
+    },
+    {
+      "key": "credit-transfer",
+      "name": {
+        "en": "Electronic funds transfer",
+        "es": "Transferencia electrónica de fondos"
+      },
+      "codes": {
+        "sat-forma-pago": "03"
+      }
+    },
+    {
+      "key": "card",
+      "name": {
+        "en": "Credit card",
+        "es": "Tarjeta de crédito"
+      },
+      "codes": {
+        "sat-forma-pago": "04"
+      }
+    },
+    {
+      "key": "online+wallet",
+      "name": {
+        "en": "Electronic wallet",
+        "es": "Monedero electrónico"
+      },
+      "codes": {
+        "sat-forma-pago": "05"
+      }
+    },
+    {
+      "key": "online",
+      "name": {
+        "en": "Online or electronic payment",
+        "es": "Dinero electrónico"
+      },
+      "codes": {
+        "sat-forma-pago": "06"
+      }
+    },
+    {
+      "key": "other+food-vouchers",
+      "name": {
+        "en": "Food vouchers",
+        "es": "Vales de despensa"
+      },
+      "codes": {
+        "sat-forma-pago": "08"
+      }
+    },
+    {
+      "key": "other+in-kind",
+      "name": {
+        "en": "Payment in kind",
+        "es": "Dación en pago"
+      },
+      "codes": {
+        "sat-forma-pago": "12"
+      }
+    },
+    {
+      "key": "other+subrogation",
+      "name": {
+        "en": "Payment by subrogation",
+        "es": "Pago por subrogación"
+      },
+      "codes": {
+        "sat-forma-pago": "13"
+      }
+    },
+    {
+      "key": "other+consignation",
+      "name": {
+        "en": "Payment by consignation",
+        "es": "Pago por consignación"
+      },
+      "codes": {
+        "sat-forma-pago": "14"
+      }
+    },
+    {
+      "key": "other+condonation",
+      "name": {
+        "en": "Debt condonation",
+        "es": "Condonación"
+      },
+      "codes": {
+        "sat-forma-pago": "15"
+      }
+    },
+    {
+      "key": "netting",
+      "name": {
+        "en": "Netting",
+        "es": "Compensación"
+      },
+      "codes": {
+        "sat-forma-pago": "17"
+      }
+    },
+    {
+      "key": "other+novation",
+      "name": {
+        "en": "Novation",
+        "es": "Novación"
+      },
+      "codes": {
+        "sat-forma-pago": "23"
+      }
+    },
+    {
+      "key": "other+conflicting",
+      "name": {
+        "en": "Conflicting",
+        "es": "Confusión"
+      },
+      "codes": {
+        "sat-forma-pago": "24"
+      }
+    },
+    {
+      "key": "other+remission",
+      "name": {
+        "en": "Debt remission",
+        "es": "Remisión de deuda"
+      },
+      "codes": {
+        "sat-forma-pago": "25"
+      }
+    },
+    {
+      "key": "other+expiration",
+      "name": {
+        "en": "Expiration of payment obligation",
+        "es": "Prescripción o caducidad"
+      },
+      "codes": {
+        "sat-forma-pago": "26"
+      }
+    },
+    {
+      "key": "other+extinguishment",
+      "name": {
+        "en": "Extinguishment of payment obligation",
+        "es": "A satisfacción del acreedor"
+      },
+      "codes": {
+        "sat-forma-pago": "27"
+      }
+    },
+    {
+      "key": "card+debit",
+      "name": {
+        "en": "Debit card",
+        "es": "Tarjeta de débito"
+      },
+      "codes": {
+        "sat-forma-pago": "28"
+      }
+    },
+    {
+      "key": "card+services",
+      "name": {
+        "en": "Services card",
+        "es": "Tarjeta de servicios"
+      },
+      "codes": {
+        "sat-forma-pago": "29"
+      }
+    },
+    {
+      "key": "other+advance",
+      "name": {
+        "en": "Advance payment",
+        "es": "Aplicación de anticipos"
+      },
+      "codes": {
+        "sat-forma-pago": "30"
+      }
+    },
+    {
+      "key": "other+intermediary",
+      "name": {
+        "en": "Payment via intermediary",
+        "es": "Intermediario pagos"
+      },
+      "codes": {
+        "sat-forma-pago": "31"
+      }
+    },
+    {
+      "key": "other+tbd",
+      "name": {
+        "en": "To be defined",
+        "es": "Por definir"
+      },
+      "codes": {
+        "sat-forma-pago": "99"
+      }
+    }
+  ],
+  "scenarios": [
+    {
+      "schema": "bill/invoice",
+      "list": [
+        {
+          "tags": [
+            "use+goods-acquisition"
+          ],
+          "codes": {
+            "sat-uso-cfdi": "G01"
+          }
+        },
+        {
+          "tags": [
+            "use+returns"
+          ],
+          "codes": {
+            "sat-uso-cfdi": "G02"
+          }
+        },
+        {
+          "tags": [
+            "use+general-expenses"
+          ],
+          "codes": {
+            "sat-uso-cfdi": "G03"
+          }
+        },
+        {
+          "tags": [
+            "use+construction"
+          ],
+          "codes": {
+            "sat-uso-cfdi": "I01"
+          }
+        },
+        {
+          "tags": [
+            "use+office-equipment"
+          ],
+          "codes": {
+            "sat-uso-cfdi": "I02"
+          }
+        },
+        {
+          "tags": [
+            "use+transport-equipment"
+          ],
+          "codes": {
+            "sat-uso-cfdi": "I03"
+          }
+        },
+        {
+          "tags": [
+            "use+computer-equipment"
+          ],
+          "codes": {
+            "sat-uso-cfdi": "I04"
+          }
+        },
+        {
+          "tags": [
+            "use+manufacturing-tooling"
+          ],
+          "codes": {
+            "sat-uso-cfdi": "I05"
+          }
+        },
+        {
+          "tags": [
+            "use+telephone-comms"
+          ],
+          "codes": {
+            "sat-uso-cfdi": "I06"
+          }
+        },
+        {
+          "tags": [
+            "use+satellite-comms"
+          ],
+          "codes": {
+            "sat-uso-cfdi": "I07"
+          }
+        },
+        {
+          "tags": [
+            "use+other-machinery"
+          ],
+          "codes": {
+            "sat-uso-cfdi": "I08"
+          }
+        },
+        {
+          "tags": [
+            "use+medical-expenses"
+          ],
+          "codes": {
+            "sat-uso-cfdi": "D01"
+          }
+        },
+        {
+          "tags": [
+            "use+medical-expenses+disability"
+          ],
+          "codes": {
+            "sat-uso-cfdi": "D02"
+          }
+        },
+        {
+          "tags": [
+            "use+funeral-expenses"
+          ],
+          "codes": {
+            "sat-uso-cfdi": "D03"
+          }
+        },
+        {
+          "tags": [
+            "use+donation"
+          ],
+          "codes": {
+            "sat-uso-cfdi": "D04"
+          }
+        },
+        {
+          "tags": [
+            "use+mortgage-interest"
+          ],
+          "codes": {
+            "sat-uso-cfdi": "D05"
+          }
+        },
+        {
+          "tags": [
+            "use+sar-contribution"
+          ],
+          "codes": {
+            "sat-uso-cfdi": "D06"
+          }
+        },
+        {
+          "tags": [
+            "use+medical-insurance"
+          ],
+          "codes": {
+            "sat-uso-cfdi": "D07"
+          }
+        },
+        {
+          "tags": [
+            "use+school-transportation"
+          ],
+          "codes": {
+            "sat-uso-cfdi": "D08"
+          }
+        },
+        {
+          "tags": [
+            "use+savings-deposit"
+          ],
+          "codes": {
+            "sat-uso-cfdi": "D09"
+          }
+        },
+        {
+          "tags": [
+            "use+school-fees"
+          ],
+          "codes": {
+            "sat-uso-cfdi": "D10"
+          }
+        },
+        {
+          "tags": [
+            "use+no-tax-effects"
+          ],
+          "codes": {
+            "sat-uso-cfdi": "S01"
+          }
+        },
+        {
+          "tags": [
+            "use+suplementary-payment"
+          ],
+          "codes": {
+            "sat-uso-cfdi": "CP01"
+          }
+        },
+        {
+          "tags": [
+            "use+payroll"
+          ],
+          "codes": {
+            "sat-uso-cfdi": "CN01"
+          }
+        }
+      ]
+    }
+  ],
   "categories": [
     {
       "code": "VAT",

--- a/build/regimes/mx.json
+++ b/build/regimes/mx.json
@@ -238,9 +238,9 @@
       }
     },
     {
-      "key": "other+food-vouchers",
+      "key": "other+grocery-vouchers",
       "name": {
-        "en": "Food vouchers",
+        "en": "Grocery vouchers",
         "es": "Vales de despensa"
       },
       "codes": {
@@ -268,9 +268,9 @@
       }
     },
     {
-      "key": "other+consignation",
+      "key": "other+consignment",
       "name": {
-        "en": "Payment by consignation",
+        "en": "Payment by consignment",
         "es": "Pago por consignación"
       },
       "codes": {
@@ -278,9 +278,9 @@
       }
     },
     {
-      "key": "other+condonation",
+      "key": "other+debt-relief",
       "name": {
-        "en": "Debt condonation",
+        "en": "Debt relief",
         "es": "Condonación"
       },
       "codes": {
@@ -308,9 +308,9 @@
       }
     },
     {
-      "key": "other+conflicting",
+      "key": "other+merger",
       "name": {
-        "en": "Conflicting",
+        "en": "Merger",
         "es": "Confusión"
       },
       "codes": {
@@ -388,7 +388,7 @@
       }
     },
     {
-      "key": "other+tbd",
+      "key": "other",
       "name": {
         "en": "To be defined",
         "es": "Por definir"

--- a/build/regimes/mx.json
+++ b/build/regimes/mx.json
@@ -338,9 +338,9 @@
       }
     },
     {
-      "key": "other+extinguishment",
+      "key": "other+satisfy-creditor",
       "name": {
-        "en": "Extinguishment of payment obligation",
+        "en": "To the creditor's satisfaction",
         "es": "A satisfacción del acreedor"
       },
       "codes": {

--- a/regimes/mx/README.md
+++ b/regimes/mx/README.md
@@ -62,7 +62,7 @@ The CFDI’s `FormaPago` field specifies an invoice's means of payment. The foll
 | 24 | Confusión | `other+merger` |
 | 25 | Remisión de deuda | `other+remission` |
 | 26 | Prescripción o caducidad | `other+expiration` |
-| 27 | A satisfacción del acreedor | `other+extinguishment` |
+| 27 | A satisfacción del acreedor | `other+satisfy-creditor` |
 | 28 | Tarjeta de débito | `card+debit` |
 | 29 | Tarjeta de servicios | `card+services` |
 | 30 | Aplicación de anticipos | `other+advance` |

--- a/regimes/mx/README.md
+++ b/regimes/mx/README.md
@@ -5,3 +5,67 @@ Mexico uses the CFDI (Comprobante Fiscal Digital por Internet) format for their 
 ## Public Documentation
 
 * [Formato de factura (Anexo 20)](http://omawww.sat.gob.mx/tramitesyservicios/Paginas/anexo_20.htm)
+
+
+## Local Codes
+
+### `UsoCFDI`
+
+The CFDI’s `UsoCFDI` field specifies how the invoice's recipient will use the invoice to deduce taxes for the expenditure made. The following table list all the supported values and how GOBL will map them from the invoice's tax tags:
+
+| Code | Name | GOBL Tax Tag |
+| --- | --- | --- |
+| G01 | Adquisición de mercancías | `use+goods-acquisition` |
+| G02 | Devoluciones, descuentos o bonificaciones | `use+returns` |
+| G03 | Gastos en general | `use+general-expenses` |
+| I01 | Construcciones | `use+construction` |
+| I02 | Mobiliario y equipo de oficina por inversiones | `use+office-equipment` |
+| I03 | Equipo de transporte | `use+transport-equipment` |
+| I04 | Equipo de computo y accesorios | `use+computer-equipment` |
+| I05 | Dados, troqueles, moldes, matrices y herramental | `use+manufacturing-tooling` |
+| I06 | Comunicaciones telefónicas | `use+telephone-comms` |
+| I07 | Comunicaciones satelitales | `use+satellite-comms` |
+| I08 | Otra maquinaria y equipo | `use+other-machinery` |
+| D01 | Honorarios médicos, dentales y gastos hospitalarios | `use+medical-expenses` |
+| D02 | Gastos médicos por incapacidad o discapacidad | `use+medical-expenses+disability` |
+| D03 | Gastos funerales | `use+funeral-expenses` |
+| D04 | Donativos | `use+donation` |
+| D05 | Intereses reales efectivamente pagados por créditos hipotecarios (casa habitación) | `use+mortgage-interest` |
+| D06 | Aportaciones voluntarias al SAR | `use+sar-contribution` |
+| D07 | Primas por seguros de gastos médicos | `use+medical-insurance` |
+| D08 | Gastos de transportación escolar obligatoria | `use+school-transportation` |
+| D09 | Depósitos en cuentas para el ahorro, primas que tengan como base planes de pensiones | `use+savings-deposit` |
+| D10 | Pagos por servicios educativos (colegiaturas) | `use+school-fees` |
+| S01 | Sin efectos fiscales | `use+no-tax-effects` |
+| CP01 | Pagos | `use+suplementary-payment` |
+| CN01 | Nómina | `use+payroll` |
+
+### `FormaPago`
+
+The CFDI’s `FormaPago` field specifies an invoice's means of payment. The following list list all the supported values and how GOBL will map them from the invoice's payment instructions key:
+
+| Code | Name | GOBL Payment Instructions Key |
+| --- | --- | --- |
+| 01 | Efectivo | `cash` |
+| 02 | Cheque nominativo | `cheque` |
+| 03 | Transferencia electrónica de fondos | `credit-transfer` |
+| 04 | Tarjeta de crédito | `card` |
+| 05 | Monedero electrónico | `online+wallet` |
+| 06 | Dinero electrónico | `online` |
+| 08 | Vales de despensa | `other+food-vouchers` |
+| 12 | Dación en pago | `other+in-kind` |
+| 13 | Pago por subrogación | `other+subrogation` |
+| 14 | Pago por consignación | `other+consignation` |
+| 15 | Condonación | `other+condonation` |
+| 17 | Compensación | `netting` |
+| 23 | Novación | `other+novation` |
+| 24 | Confusión | `other+conflicting` |
+| 25 | Remisión de deuda | `other+remission` |
+| 26 | Prescripción o caducidad | `other+expiration` |
+| 27 | A satisfacción del acreedor | `other+extinguishment` |
+| 28 | Tarjeta de débito | `card+debit` |
+| 29 | Tarjeta de servicios | `card+services` |
+| 30 | Aplicación de anticipos | `other+advance` |
+| 31 | Intermediario pagos | `other+intermediary` |
+| 99 | Por definir | `other+tbd` |
+

--- a/regimes/mx/README.md
+++ b/regimes/mx/README.md
@@ -52,14 +52,14 @@ The CFDI’s `FormaPago` field specifies an invoice's means of payment. The foll
 | 04 | Tarjeta de crédito | `card` |
 | 05 | Monedero electrónico | `online+wallet` |
 | 06 | Dinero electrónico | `online` |
-| 08 | Vales de despensa | `other+food-vouchers` |
+| 08 | Vales de despensa | `other+grocery-vouchers  ` |
 | 12 | Dación en pago | `other+in-kind` |
 | 13 | Pago por subrogación | `other+subrogation` |
-| 14 | Pago por consignación | `other+consignation` |
-| 15 | Condonación | `other+condonation` |
+| 14 | Pago por consignación | `other+consignment` |
+| 15 | Condonación | `other+debt-relief` |
 | 17 | Compensación | `netting` |
 | 23 | Novación | `other+novation` |
-| 24 | Confusión | `other+conflicting` |
+| 24 | Confusión | `other+merger` |
 | 25 | Remisión de deuda | `other+remission` |
 | 26 | Prescripción o caducidad | `other+expiration` |
 | 27 | A satisfacción del acreedor | `other+extinguishment` |
@@ -67,5 +67,5 @@ The CFDI’s `FormaPago` field specifies an invoice's means of payment. The foll
 | 29 | Tarjeta de servicios | `card+services` |
 | 30 | Aplicación de anticipos | `other+advance` |
 | 31 | Intermediario pagos | `other+intermediary` |
-| 99 | Por definir | `other+tbd` |
+| 99 | Por definir | `other` |
 

--- a/regimes/mx/invoice_validator.go
+++ b/regimes/mx/invoice_validator.go
@@ -48,7 +48,7 @@ func (v *invoiceValidator) validateScenarios() error {
 	ss := v.inv.ScenarioSummary()
 
 	if ss.Codes[KeySATUsoCFDI] == "" {
-		return errors.New("tax tags are missing or don’t map to a UsoCFDI code")
+		return errors.New("'use' tax tags is required")
 	}
 
 	return nil

--- a/regimes/mx/invoice_validator.go
+++ b/regimes/mx/invoice_validator.go
@@ -1,9 +1,12 @@
 package mx
 
 import (
+	"errors"
+
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/num"
 	"github.com/invopop/gobl/org"
+	"github.com/invopop/gobl/pay"
 	"github.com/invopop/validation"
 )
 
@@ -17,6 +20,10 @@ func validateInvoice(inv *bill.Invoice) error {
 }
 
 func (v *invoiceValidator) validate() error {
+	if err := v.validateScenarios(); err != nil {
+		return err
+	}
+
 	inv := v.inv
 	return validation.ValidateStruct(inv,
 		validation.Field(&inv.Customer,
@@ -30,7 +37,21 @@ func (v *invoiceValidator) validate() error {
 			),
 			validation.Skip, // Prevents each line's `ValidateWithContext` function from being called again.
 		),
+		validation.Field(&inv.Payment,
+			validation.Required,
+			validation.By(v.validPayment),
+		),
 	)
+}
+
+func (v *invoiceValidator) validateScenarios() error {
+	ss := v.inv.ScenarioSummary()
+
+	if ss.Codes[KeySATUsoCFDI] == "" {
+		return errors.New("tax tags are missing or don’t map to a UsoCFDI code")
+	}
+
+	return nil
 }
 
 func (v *invoiceValidator) validCustomer(value interface{}) error {
@@ -57,4 +78,39 @@ func (v *invoiceValidator) validLine(value interface{}) error {
 			validation.Skip, // Prevents each tax's `ValidateWithContext` function from being called again.
 		),
 	)
+}
+
+func (v *invoiceValidator) validPayment(value interface{}) error {
+	pay, _ := value.(*bill.Payment)
+	if pay == nil {
+		return nil
+	}
+	return validation.ValidateStruct(pay,
+		validation.Field(&pay.Instructions,
+			validation.Required,
+			validation.By(v.validatePayInstructions),
+		),
+	)
+}
+
+func (v *invoiceValidator) validatePayInstructions(value interface{}) error {
+	instr, _ := value.(*pay.Instructions)
+	if instr == nil {
+		return nil
+	}
+
+	return validation.ValidateStruct(instr,
+		validation.Field(&instr.Key, isValidPaymentMeanKey),
+	)
+}
+
+var isValidPaymentMeanKey = validation.In(validPaymentMeanKeys()...)
+
+func validPaymentMeanKeys() []interface{} {
+	keys := make([]interface{}, len(paymentMeansKeyDefinitions))
+	for i, keyDef := range paymentMeansKeyDefinitions {
+		keys[i] = keyDef.Key
+	}
+
+	return keys
 }

--- a/regimes/mx/invoice_validator_test.go
+++ b/regimes/mx/invoice_validator_test.go
@@ -126,13 +126,13 @@ func TestUsoCFDIScenarioValidation(t *testing.T) {
 	inv := validInvoice()
 
 	inv.Tax.Tags = make([]cbc.Key, 0)
-	assertValidationError(t, inv, "tax tags are missing or don’t map to a UsoCFDI code")
+	assertValidationError(t, inv, "'use' tax tags is required")
 
 	inv.Tax.Tags = nil
-	assertValidationError(t, inv, "tax tags are missing or don’t map to a UsoCFDI code")
+	assertValidationError(t, inv, "'use' tax tags is required")
 
 	inv.Tax = nil
-	assertValidationError(t, inv, "tax tags are missing or don’t map to a UsoCFDI code")
+	assertValidationError(t, inv, "'use' tax tags is required")
 }
 
 func assertValidationError(t *testing.T, inv *bill.Invoice, expected string) {

--- a/regimes/mx/mx.go
+++ b/regimes/mx/mx.go
@@ -3,6 +3,7 @@ package mx
 
 import (
 	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/currency"
 	"github.com/invopop/gobl/i18n"
 	"github.com/invopop/gobl/l10n"
@@ -14,6 +15,12 @@ func init() {
 	tax.RegisterRegime(New())
 }
 
+// Custom keys used typically in meta or codes information.
+const (
+	KeySATFormaPago cbc.Key = "sat-forma-pago"
+	KeySATUsoCFDI   cbc.Key = "sat-uso-cfdi"
+)
+
 // New provides the tax region definition
 func New() *tax.Regime {
 	return &tax.Regime{
@@ -23,9 +30,12 @@ func New() *tax.Regime {
 			i18n.EN: "Mexico",
 			i18n.ES: "México",
 		},
-		Validator:  Validate,
-		Calculator: Calculate,
-		Categories: taxCategories,
+		PaymentMeansKeys: paymentMeansKeyDefinitions, // pay.go
+		Validator:        Validate,
+		Calculator:       Calculate,
+		Tags:             invoiceTags,   // scenarios.go
+		Scenarios:        scenarios,     // scenarios.go
+		Categories:       taxCategories, // categories.go
 	}
 }
 

--- a/regimes/mx/pay.go
+++ b/regimes/mx/pay.go
@@ -1,0 +1,251 @@
+package mx
+
+import (
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/i18n"
+	"github.com/invopop/gobl/pay"
+	"github.com/invopop/gobl/tax"
+)
+
+// Regime Specific Payment Means Extension Keys
+const (
+	MeansKeyWallet        cbc.Key = "wallet"
+	MeansKeyFoodVouchers  cbc.Key = "food-vouchers"
+	MeansKeyInKind        cbc.Key = "in-kind"
+	MeansKeySubrogation   cbc.Key = "subrogation"
+	MeansKeyConsignation  cbc.Key = "consignation"
+	MeansKeyCondonation   cbc.Key = "condonation"
+	MeansKeyNovation      cbc.Key = "novation"
+	MeansKeyConflicting   cbc.Key = "conflicting"
+	MeansKeyRemission     cbc.Key = "remission"
+	MeansKeyExpiration    cbc.Key = "expiration"
+	MeansKeyExtingishment cbc.Key = "extinguishment"
+	MeansKeyDebit         cbc.Key = "debit"
+	MeansKeyServices      cbc.Key = "services"
+	MeansKeyAdvance       cbc.Key = "advance"
+	MeansKeyIntermediary  cbc.Key = "intermediary"
+	MeansKeyTBD           cbc.Key = "tbd"
+)
+
+var paymentMeansKeyDefinitions = []*tax.KeyDefinition{
+	{
+		Key: pay.MeansKeyCash,
+		Name: i18n.String{
+			i18n.EN: "Cash",
+			i18n.ES: "Efectivo",
+		},
+		Codes: cbc.CodeSet{
+			KeySATFormaPago: "01",
+		},
+	},
+	{
+		Key: pay.MeansKeyCheque,
+		Name: i18n.String{
+			i18n.EN: "Nominative cheque",
+			i18n.ES: "Cheque nominativo", // nolint:misspell
+		},
+		Codes: cbc.CodeSet{
+			KeySATFormaPago: "02",
+		},
+	},
+	{
+		Key: pay.MeansKeyCreditTransfer,
+		Name: i18n.String{
+			i18n.EN: "Electronic funds transfer",
+			i18n.ES: "Transferencia electrónica de fondos",
+		},
+		Codes: cbc.CodeSet{
+			KeySATFormaPago: "03",
+		},
+	},
+	{
+		Key: pay.MeansKeyCard,
+		Name: i18n.String{
+			i18n.EN: "Credit card",
+			i18n.ES: "Tarjeta de crédito",
+		},
+		Codes: cbc.CodeSet{
+			KeySATFormaPago: "04",
+		},
+	},
+	{
+		Key: pay.MeansKeyOnline.With(MeansKeyWallet),
+		Name: i18n.String{
+			i18n.EN: "Electronic wallet",
+			i18n.ES: "Monedero electrónico",
+		},
+		Codes: cbc.CodeSet{
+			KeySATFormaPago: "05",
+		},
+	},
+	{
+		Key: pay.MeansKeyOnline,
+		Name: i18n.String{
+			i18n.EN: "Online or electronic payment",
+			i18n.ES: "Dinero electrónico",
+		},
+		Codes: cbc.CodeSet{
+			KeySATFormaPago: "06",
+		},
+	},
+	{
+		Key: pay.MeansKeyOther.With(MeansKeyFoodVouchers),
+		Name: i18n.String{
+			i18n.EN: "Food vouchers",
+			i18n.ES: "Vales de despensa",
+		},
+		Codes: cbc.CodeSet{
+			KeySATFormaPago: "08",
+		},
+	},
+	{
+		Key: pay.MeansKeyOther.With(MeansKeyInKind),
+		Name: i18n.String{
+			i18n.EN: "Payment in kind",
+			i18n.ES: "Dación en pago",
+		},
+		Codes: cbc.CodeSet{
+			KeySATFormaPago: "12",
+		},
+	},
+	{
+		Key: pay.MeansKeyOther.With(MeansKeySubrogation),
+		Name: i18n.String{
+			i18n.EN: "Payment by subrogation",
+			i18n.ES: "Pago por subrogación",
+		},
+		Codes: cbc.CodeSet{
+			KeySATFormaPago: "13",
+		},
+	},
+	{
+		Key: pay.MeansKeyOther.With(MeansKeyConsignation),
+		Name: i18n.String{
+			i18n.EN: "Payment by consignation",
+			i18n.ES: "Pago por consignación",
+		},
+		Codes: cbc.CodeSet{
+			KeySATFormaPago: "14",
+		},
+	},
+	{
+		Key: pay.MeansKeyOther.With(MeansKeyCondonation),
+		Name: i18n.String{
+			i18n.EN: "Debt condonation",
+			i18n.ES: "Condonación",
+		},
+		Codes: cbc.CodeSet{
+			KeySATFormaPago: "15",
+		},
+	},
+	{
+		Key: pay.MeansKeyNetting,
+		Name: i18n.String{
+			i18n.EN: "Netting",
+			i18n.ES: "Compensación",
+		},
+		Codes: cbc.CodeSet{
+			KeySATFormaPago: "17",
+		},
+	},
+	{
+		Key: pay.MeansKeyOther.With(MeansKeyNovation),
+		Name: i18n.String{
+			i18n.EN: "Novation",
+			i18n.ES: "Novación",
+		},
+		Codes: cbc.CodeSet{
+			KeySATFormaPago: "23",
+		},
+	},
+	{
+		Key: pay.MeansKeyOther.With(MeansKeyConflicting),
+		Name: i18n.String{
+			i18n.EN: "Conflicting",
+			i18n.ES: "Confusión",
+		},
+		Codes: cbc.CodeSet{
+			KeySATFormaPago: "24",
+		},
+	},
+	{
+		Key: pay.MeansKeyOther.With(MeansKeyRemission),
+		Name: i18n.String{
+			i18n.EN: "Debt remission",
+			i18n.ES: "Remisión de deuda",
+		},
+		Codes: cbc.CodeSet{
+			KeySATFormaPago: "25",
+		},
+	},
+	{
+		Key: pay.MeansKeyOther.With(MeansKeyExpiration),
+		Name: i18n.String{
+			i18n.EN: "Expiration of payment obligation",
+			i18n.ES: "Prescripción o caducidad",
+		},
+		Codes: cbc.CodeSet{
+			KeySATFormaPago: "26",
+		},
+	},
+	{
+		Key: pay.MeansKeyOther.With(MeansKeyExtingishment),
+		Name: i18n.String{
+			i18n.EN: "Extinguishment of payment obligation",
+			i18n.ES: "A satisfacción del acreedor",
+		},
+		Codes: cbc.CodeSet{
+			KeySATFormaPago: "27",
+		},
+	},
+	{
+		Key: pay.MeansKeyCard.With(MeansKeyDebit),
+		Name: i18n.String{
+			i18n.EN: "Debit card",
+			i18n.ES: "Tarjeta de débito",
+		},
+		Codes: cbc.CodeSet{
+			KeySATFormaPago: "28",
+		},
+	},
+	{
+		Key: pay.MeansKeyCard.With(MeansKeyServices),
+		Name: i18n.String{
+			i18n.EN: "Services card",
+			i18n.ES: "Tarjeta de servicios",
+		},
+		Codes: cbc.CodeSet{
+			KeySATFormaPago: "29",
+		},
+	},
+	{
+		Key: pay.MeansKeyOther.With(MeansKeyAdvance),
+		Name: i18n.String{
+			i18n.EN: "Advance payment",
+			i18n.ES: "Aplicación de anticipos",
+		},
+		Codes: cbc.CodeSet{
+			KeySATFormaPago: "30",
+		},
+	},
+	{
+		Key: pay.MeansKeyOther.With(MeansKeyIntermediary),
+		Name: i18n.String{
+			i18n.EN: "Payment via intermediary",
+			i18n.ES: "Intermediario pagos",
+		},
+		Codes: cbc.CodeSet{
+			KeySATFormaPago: "31",
+		},
+	},
+	{
+		Key: pay.MeansKeyOther.With(MeansKeyTBD),
+		Name: i18n.String{
+			i18n.EN: "To be defined",
+			i18n.ES: "Por definir",
+		},
+		Codes: cbc.CodeSet{
+			KeySATFormaPago: "99",
+		},
+	},
+}

--- a/regimes/mx/pay.go
+++ b/regimes/mx/pay.go
@@ -19,7 +19,7 @@ const (
 	MeansKeyMerger          cbc.Key = "merger"
 	MeansKeyRemission       cbc.Key = "remission"
 	MeansKeyExpiration      cbc.Key = "expiration"
-	MeansKeyExtingishment   cbc.Key = "extinguishment"
+	MeansKeySatisfyCreditor cbc.Key = "satisfy-creditor"
 	MeansKeyDebit           cbc.Key = "debit"
 	MeansKeyServices        cbc.Key = "services"
 	MeansKeyAdvance         cbc.Key = "advance"
@@ -188,9 +188,9 @@ var paymentMeansKeyDefinitions = []*tax.KeyDefinition{
 		},
 	},
 	{
-		Key: pay.MeansKeyOther.With(MeansKeyExtingishment),
+		Key: pay.MeansKeyOther.With(MeansKeySatisfyCreditor),
 		Name: i18n.String{
-			i18n.EN: "Extinguishment of payment obligation",
+			i18n.EN: "To the creditor's satisfaction",
 			i18n.ES: "A satisfacción del acreedor",
 		},
 		Codes: cbc.CodeSet{

--- a/regimes/mx/pay.go
+++ b/regimes/mx/pay.go
@@ -9,22 +9,21 @@ import (
 
 // Regime Specific Payment Means Extension Keys
 const (
-	MeansKeyWallet        cbc.Key = "wallet"
-	MeansKeyFoodVouchers  cbc.Key = "food-vouchers"
-	MeansKeyInKind        cbc.Key = "in-kind"
-	MeansKeySubrogation   cbc.Key = "subrogation"
-	MeansKeyConsignation  cbc.Key = "consignation"
-	MeansKeyCondonation   cbc.Key = "condonation"
-	MeansKeyNovation      cbc.Key = "novation"
-	MeansKeyConflicting   cbc.Key = "conflicting"
-	MeansKeyRemission     cbc.Key = "remission"
-	MeansKeyExpiration    cbc.Key = "expiration"
-	MeansKeyExtingishment cbc.Key = "extinguishment"
-	MeansKeyDebit         cbc.Key = "debit"
-	MeansKeyServices      cbc.Key = "services"
-	MeansKeyAdvance       cbc.Key = "advance"
-	MeansKeyIntermediary  cbc.Key = "intermediary"
-	MeansKeyTBD           cbc.Key = "tbd"
+	MeansKeyWallet          cbc.Key = "wallet"
+	MeansKeyGroceryVouchers cbc.Key = "grocery-vouchers"
+	MeansKeyInKind          cbc.Key = "in-kind"
+	MeansKeySubrogation     cbc.Key = "subrogation"
+	MeansKeyConsignment     cbc.Key = "consignment"
+	MeansKeyDebtRelief      cbc.Key = "debt-relief"
+	MeansKeyNovation        cbc.Key = "novation"
+	MeansKeyMerger          cbc.Key = "merger"
+	MeansKeyRemission       cbc.Key = "remission"
+	MeansKeyExpiration      cbc.Key = "expiration"
+	MeansKeyExtingishment   cbc.Key = "extinguishment"
+	MeansKeyDebit           cbc.Key = "debit"
+	MeansKeyServices        cbc.Key = "services"
+	MeansKeyAdvance         cbc.Key = "advance"
+	MeansKeyIntermediary    cbc.Key = "intermediary"
 )
 
 var paymentMeansKeyDefinitions = []*tax.KeyDefinition{
@@ -89,9 +88,9 @@ var paymentMeansKeyDefinitions = []*tax.KeyDefinition{
 		},
 	},
 	{
-		Key: pay.MeansKeyOther.With(MeansKeyFoodVouchers),
+		Key: pay.MeansKeyOther.With(MeansKeyGroceryVouchers),
 		Name: i18n.String{
-			i18n.EN: "Food vouchers",
+			i18n.EN: "Grocery vouchers",
 			i18n.ES: "Vales de despensa",
 		},
 		Codes: cbc.CodeSet{
@@ -119,9 +118,9 @@ var paymentMeansKeyDefinitions = []*tax.KeyDefinition{
 		},
 	},
 	{
-		Key: pay.MeansKeyOther.With(MeansKeyConsignation),
+		Key: pay.MeansKeyOther.With(MeansKeyConsignment),
 		Name: i18n.String{
-			i18n.EN: "Payment by consignation",
+			i18n.EN: "Payment by consignment",
 			i18n.ES: "Pago por consignación",
 		},
 		Codes: cbc.CodeSet{
@@ -129,9 +128,9 @@ var paymentMeansKeyDefinitions = []*tax.KeyDefinition{
 		},
 	},
 	{
-		Key: pay.MeansKeyOther.With(MeansKeyCondonation),
+		Key: pay.MeansKeyOther.With(MeansKeyDebtRelief),
 		Name: i18n.String{
-			i18n.EN: "Debt condonation",
+			i18n.EN: "Debt relief",
 			i18n.ES: "Condonación",
 		},
 		Codes: cbc.CodeSet{
@@ -159,9 +158,9 @@ var paymentMeansKeyDefinitions = []*tax.KeyDefinition{
 		},
 	},
 	{
-		Key: pay.MeansKeyOther.With(MeansKeyConflicting),
+		Key: pay.MeansKeyOther.With(MeansKeyMerger),
 		Name: i18n.String{
-			i18n.EN: "Conflicting",
+			i18n.EN: "Merger",
 			i18n.ES: "Confusión",
 		},
 		Codes: cbc.CodeSet{
@@ -239,7 +238,7 @@ var paymentMeansKeyDefinitions = []*tax.KeyDefinition{
 		},
 	},
 	{
-		Key: pay.MeansKeyOther.With(MeansKeyTBD),
+		Key: pay.MeansKeyOther,
 		Name: i18n.String{
 			i18n.EN: "To be defined",
 			i18n.ES: "Por definir",

--- a/regimes/mx/scenarios.go
+++ b/regimes/mx/scenarios.go
@@ -1,0 +1,388 @@
+package mx
+
+import (
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/i18n"
+	"github.com/invopop/gobl/tax"
+)
+
+// Regime Specific Tags (UsoCFDI codes)
+const (
+	TagUse cbc.Key = "use" // UsoCFDI codes "namespace"
+
+	TagGoodsAcquisition     cbc.Key = "goods-acquisition"
+	TagReturns              cbc.Key = "returns"
+	TagGeneralExpenses      cbc.Key = "general-expenses"
+	TagConstruction         cbc.Key = "construction"
+	TagOfficeEquipment      cbc.Key = "office-equipment"
+	TagTransportEquipment   cbc.Key = "transport-equipment"
+	TagComputerEquipment    cbc.Key = "computer-equipment"
+	TagManufacturingTooling cbc.Key = "manufacturing-tooling"
+	TagTelephoneComms       cbc.Key = "telephone-comms"
+	TagSatelliteComms       cbc.Key = "satellite-comms"
+	TagOtherMachinery       cbc.Key = "other-machinery"
+	TagMedicalExpenses      cbc.Key = "medical-expenses"
+	TagDisability           cbc.Key = "disability"
+	TagFuneralExpenses      cbc.Key = "funeral-expenses"
+	TagDonation             cbc.Key = "donation"
+	TagMortgageInterest     cbc.Key = "mortgage-interest"
+	TagSARContribution      cbc.Key = "sar-contribution"
+	TagMedicalInsurance     cbc.Key = "medical-insurance"
+	TagSchoolTransportation cbc.Key = "school-transportation"
+	TagSavingsDeposit       cbc.Key = "savings-deposit"
+	TagSchoolFees           cbc.Key = "school-fees"
+	TagNoTaxEffects         cbc.Key = "no-tax-effects"
+	TagSuplementaryPayment  cbc.Key = "suplementary-payment"
+	TagPayroll              cbc.Key = "payroll"
+)
+
+var invoiceTags = []*tax.KeyDefinition{
+
+	{
+		Key: TagUse.With(TagGoodsAcquisition),
+		Name: i18n.String{
+			i18n.EN: "Acquisition of goods",
+			i18n.ES: "Adquisición de mercancías",
+		},
+	},
+	{
+		Key: TagUse.With(TagReturns),
+		Name: i18n.String{
+			i18n.EN: "Returns, discounts or rebates",
+			i18n.ES: "Devoluciones, descuentos o bonificaciones",
+		},
+	},
+	{
+		Key: TagUse.With(TagGeneralExpenses),
+		Name: i18n.String{
+			i18n.EN: "General expenses",
+			i18n.ES: "Gastos en general",
+		},
+	},
+	{
+		Key: TagUse.With(TagConstruction),
+		Name: i18n.String{
+			i18n.EN: "Construction",
+			i18n.ES: "Construcciones",
+		},
+	},
+	{
+		Key: TagUse.With(TagOfficeEquipment),
+		Name: i18n.String{
+			i18n.EN: "Office furniture and equipment as investmen",
+			i18n.ES: "Mobiliario y equipo de oficina por inversiones",
+		},
+	},
+	{
+		Key: TagUse.With(TagTransportEquipment),
+		Name: i18n.String{
+			i18n.EN: "Transport equipment",
+			i18n.ES: "Equipo de transporte",
+		},
+	},
+	{
+		Key: TagUse.With(TagComputerEquipment),
+		Name: i18n.String{
+			i18n.EN: "Computer equipment and accessories",
+			i18n.ES: "Equipo de computo y accesorios",
+		},
+	},
+	{
+		Key: TagUse.With(TagManufacturingTooling),
+		Name: i18n.String{
+			i18n.EN: "Dies, punches, molds, matrices and other toolin",
+			i18n.ES: "Dados, troqueles, moldes, matrices y herramental",
+		},
+	},
+	{
+		Key: TagUse.With(TagTelephoneComms),
+		Name: i18n.String{
+			i18n.EN: "Telephone communications",
+			i18n.ES: "Comunicaciones telefónicas",
+		},
+	},
+	{
+		Key: TagUse.With(TagSatelliteComms),
+		Name: i18n.String{
+			i18n.EN: "Satellite communications",
+			i18n.ES: "Comunicaciones satelitales",
+		},
+	},
+	{
+		Key: TagUse.With(TagOtherMachinery),
+		Name: i18n.String{
+			i18n.EN: "Other machinery and equipment",
+			i18n.ES: "Otra maquinaria y equipo",
+		},
+	},
+	{
+		Key: TagUse.With(TagMedicalExpenses),
+		Name: i18n.String{
+			i18n.EN: "Medical and dental fees and hospital expenses",
+			i18n.ES: "Honorarios médicos, dentales y gastos hospitalarios",
+		},
+	},
+	{
+		Key: TagUse.With(TagMedicalExpenses).With(TagDisability),
+		Name: i18n.String{
+			i18n.EN: "Medical expenses for disability or incapacity",
+			i18n.ES: "Gastos médicos por incapacidad o discapacidad",
+		},
+	},
+	{
+		Key: TagUse.With(TagFuneralExpenses),
+		Name: i18n.String{
+			i18n.EN: "Funeral expenses",
+			i18n.ES: "Gastos funerales",
+		},
+	},
+	{
+		Key: TagUse.With(TagDonation),
+		Name: i18n.String{
+			i18n.EN: "Donations",
+			i18n.ES: "Donativos",
+		},
+	},
+	{
+		Key: TagUse.With(TagMortgageInterest),
+		Name: i18n.String{
+			i18n.EN: "Interest actually paid on mortgage loans (housing)",
+			i18n.ES: "Intereses reales efectivamente pagados por créditos hipotecarios (casa habitación)",
+		},
+	},
+	{
+		Key: TagUse.With(TagSARContribution),
+		Name: i18n.String{
+			i18n.EN: "Voluntary contributions to the SAR",
+			i18n.ES: "Aportaciones voluntarias al SAR",
+		},
+	},
+	{
+		Key: TagUse.With(TagMedicalInsurance),
+		Name: i18n.String{
+			i18n.EN: "Medical insurance premiums",
+			i18n.ES: "Primas por seguros de gastos médicos",
+		},
+	},
+	{
+		Key: TagUse.With(TagSchoolTransportation),
+		Name: i18n.String{
+			i18n.EN: "Mandatory school transportation expenses",
+			i18n.ES: "Gastos de transportación escolar obligatoria",
+		},
+	},
+	{
+		Key: TagUse.With(TagSavingsDeposit),
+		Name: i18n.String{
+			i18n.EN: "Deposits in savings accounts, pension plans premiums",
+			i18n.ES: "Depósitos en cuentas para el ahorro, primas que tengan como base planes de pensiones",
+		},
+	},
+	{
+		Key: TagUse.With(TagSchoolFees),
+		Name: i18n.String{
+			i18n.EN: "Payments for educational services (school fees)",
+			i18n.ES: "Pagos por servicios educativos (colegiaturas)",
+		},
+	},
+	{
+		Key: TagUse.With(TagNoTaxEffects),
+		Name: i18n.String{
+			i18n.EN: "Without tax effects",
+			i18n.ES: "Sin efectos fiscales",
+		},
+	},
+	{
+		Key: TagUse.With(TagSuplementaryPayment),
+		Name: i18n.String{
+			i18n.EN: "Payments",
+			i18n.ES: "Pagos",
+		},
+	},
+	{
+		Key: TagUse.With(TagPayroll),
+		Name: i18n.String{
+			i18n.EN: "Payroll",
+			i18n.ES: "Nómina",
+		},
+	},
+}
+
+var scenarios = []*tax.ScenarioSet{
+	invoiceScenarios,
+}
+
+var invoiceScenarios = &tax.ScenarioSet{
+	Schema: bill.ShortSchemaInvoice,
+	List: []*tax.Scenario{
+
+		{
+			Tags: []cbc.Key{TagUse.With(TagGoodsAcquisition)},
+			Codes: cbc.CodeSet{
+				KeySATUsoCFDI: "G01",
+			},
+		},
+
+		{
+			Tags: []cbc.Key{TagUse.With(TagReturns)},
+			Codes: cbc.CodeSet{
+				KeySATUsoCFDI: "G02",
+			},
+		},
+
+		{
+			Tags: []cbc.Key{TagUse.With(TagGeneralExpenses)},
+			Codes: cbc.CodeSet{
+				KeySATUsoCFDI: "G03",
+			},
+		},
+
+		{
+			Tags: []cbc.Key{TagUse.With(TagConstruction)},
+			Codes: cbc.CodeSet{
+				KeySATUsoCFDI: "I01",
+			},
+		},
+
+		{
+			Tags: []cbc.Key{TagUse.With(TagOfficeEquipment)},
+			Codes: cbc.CodeSet{
+				KeySATUsoCFDI: "I02",
+			},
+		},
+
+		{
+			Tags: []cbc.Key{TagUse.With(TagTransportEquipment)},
+			Codes: cbc.CodeSet{
+				KeySATUsoCFDI: "I03",
+			},
+		},
+
+		{
+			Tags: []cbc.Key{TagUse.With(TagComputerEquipment)},
+			Codes: cbc.CodeSet{
+				KeySATUsoCFDI: "I04",
+			},
+		},
+
+		{
+			Tags: []cbc.Key{TagUse.With(TagManufacturingTooling)},
+			Codes: cbc.CodeSet{
+				KeySATUsoCFDI: "I05",
+			},
+		},
+
+		{
+			Tags: []cbc.Key{TagUse.With(TagTelephoneComms)},
+			Codes: cbc.CodeSet{
+				KeySATUsoCFDI: "I06",
+			},
+		},
+
+		{
+			Tags: []cbc.Key{TagUse.With(TagSatelliteComms)},
+			Codes: cbc.CodeSet{
+				KeySATUsoCFDI: "I07",
+			},
+		},
+
+		{
+			Tags: []cbc.Key{TagUse.With(TagOtherMachinery)},
+			Codes: cbc.CodeSet{
+				KeySATUsoCFDI: "I08",
+			},
+		},
+
+		{
+			Tags: []cbc.Key{TagUse.With(TagMedicalExpenses)},
+			Codes: cbc.CodeSet{
+				KeySATUsoCFDI: "D01",
+			},
+		},
+
+		{
+			Tags: []cbc.Key{TagUse.With(TagMedicalExpenses).With(TagDisability)},
+			Codes: cbc.CodeSet{
+				KeySATUsoCFDI: "D02",
+			},
+		},
+
+		{
+			Tags: []cbc.Key{TagUse.With(TagFuneralExpenses)},
+			Codes: cbc.CodeSet{
+				KeySATUsoCFDI: "D03",
+			},
+		},
+
+		{
+			Tags: []cbc.Key{TagUse.With(TagDonation)},
+			Codes: cbc.CodeSet{
+				KeySATUsoCFDI: "D04",
+			},
+		},
+
+		{
+			Tags: []cbc.Key{TagUse.With(TagMortgageInterest)},
+			Codes: cbc.CodeSet{
+				KeySATUsoCFDI: "D05",
+			},
+		},
+
+		{
+			Tags: []cbc.Key{TagUse.With(TagSARContribution)},
+			Codes: cbc.CodeSet{
+				KeySATUsoCFDI: "D06",
+			},
+		},
+
+		{
+			Tags: []cbc.Key{TagUse.With(TagMedicalInsurance)},
+			Codes: cbc.CodeSet{
+				KeySATUsoCFDI: "D07",
+			},
+		},
+
+		{
+			Tags: []cbc.Key{TagUse.With(TagSchoolTransportation)},
+			Codes: cbc.CodeSet{
+				KeySATUsoCFDI: "D08",
+			},
+		},
+
+		{
+			Tags: []cbc.Key{TagUse.With(TagSavingsDeposit)},
+			Codes: cbc.CodeSet{
+				KeySATUsoCFDI: "D09",
+			},
+		},
+
+		{
+			Tags: []cbc.Key{TagUse.With(TagSchoolFees)},
+			Codes: cbc.CodeSet{
+				KeySATUsoCFDI: "D10",
+			},
+		},
+
+		{
+			Tags: []cbc.Key{TagUse.With(TagNoTaxEffects)},
+			Codes: cbc.CodeSet{
+				KeySATUsoCFDI: "S01",
+			},
+		},
+
+		{
+			Tags: []cbc.Key{TagUse.With(TagSuplementaryPayment)},
+			Codes: cbc.CodeSet{
+				KeySATUsoCFDI: "CP01",
+			},
+		},
+
+		{
+			Tags: []cbc.Key{TagUse.With(TagPayroll)},
+			Codes: cbc.CodeSet{
+				KeySATUsoCFDI: "CN01",
+			},
+		},
+	},
+}

--- a/regimes/pt/README.md
+++ b/regimes/pt/README.md
@@ -13,7 +13,7 @@ Portugal doesn't have an e-invoicing format per se. Tax information is reported 
 
 ### `InvoiceType` (Tipo de documento)
 
-AT's `InvoiceType` (Tipo de document) specifies the type of a Portuguese tax document. The following table lists all the supported invoice types and how GOBL will map them with a combination of invoice type and tax tags:
+AT's `InvoiceType` (Tipo de documento) specifies the type of a Portuguese tax document. The following table lists all the supported invoice types and how GOBL will map them with a combination of invoice type and tax tags:
 
 | Code | Name | GOBL Type | GOBL Tax Tag |
 | --- | --- | --- | --- |


### PR DESCRIPTION
* Adds mapping codes from GOBL's payment instructions keys (i.e. payment means) to the CFDI's `FormaPago` field
* Adds mapping codes from GOBL's invoice tax tags (and scenarios) to the CFDI's `UsoCFDI` field
* Extracts and makes public a `TaxRegime` method that will be used by [the related changes](https://github.com/invopop/gobl.cfdi/pull/6) in `gobl.cfdi`
* Fixes a typo in PT's a README