### PR TITLE
Line quantity and item price validation for PT

### DIFF
--- a/regimes/pt/invoice_validator_test.go
+++ b/regimes/pt/invoice_validator_test.go
@@ -1,0 +1,68 @@
+package pt_test
+
+import (
+	"testing"
+
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/cal"
+	"github.com/invopop/gobl/num"
+	"github.com/invopop/gobl/org"
+	"github.com/invopop/gobl/tax"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func validInvoice() *bill.Invoice {
+	return &bill.Invoice{
+		Supplier: &org.Party{
+			TaxID: &tax.Identity{
+				Code:    "123456789",
+				Country: "PT",
+			},
+			Name: "Test Supplier",
+		},
+		Customer: &org.Party{
+			Name: "Test Customer",
+		},
+		Code:      "INV/1",
+		Currency:  "EUR",
+		IssueDate: cal.MakeDate(2023, 1, 1),
+		Lines: []*bill.Line{
+			{
+				Quantity: num.MakeAmount(1, 0),
+				Item: &org.Item{
+					Name: "Test Item",
+				},
+				Taxes: tax.Set{
+					{
+						Category: "VAT",
+						Rate:     "standard",
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestValidInvoice(t *testing.T) {
+	inv := validInvoice()
+	require.NoError(t, inv.Calculate())
+	require.NoError(t, inv.Validate())
+}
+
+func TestLineValidation(t *testing.T) {
+	inv := validInvoice()
+	inv.Lines[0].Quantity = num.MakeAmount(-1, 0)
+	assertValidationError(t, inv, "lines: (0: (quantity: must be no less than 0.).)")
+
+	inv = validInvoice()
+	inv.Lines[0].Item.Price = num.MakeAmount(-1, 0)
+	assertValidationError(t, inv, "lines: (0: (item: (price: must be no less than 0.).).)")
+}
+
+func assertValidationError(t *testing.T, inv *bill.Invoice, expected string) {
+	require.NoError(t, inv.Calculate())
+	err := inv.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), expected)
+}


### PR DESCRIPTION
* Validates PT invoice lines to have a non-negative item price and quantity, as required by the AT.
* Reference: `Quantity` and `UnitPrice` in [SAF-T PT XSD](https://info.portaldasfinancas.gov.pt/apps/saft-pt04/saftpt1.04_01.xsd).