### PR TITLE
Automatically determine accuracy based on line quantity

### DIFF
--- a/num/amount.go
+++ b/num/amount.go
@@ -254,6 +254,12 @@ func (a Amount) MinimalString() string {
 	return strings.TrimSuffix(s, ".")
 }
 
+// Float64 provides the amount as a float64 value which should be used
+// with caution!
+func (a Amount) Float64() float64 {
+	return float64(a.value) / float64(intPow(10, a.exp))
+}
+
 // MarshalText provides the byte value of the amount. See also the
 // String() method.
 // We always add quotes around values as number representations do not

--- a/num/amount_test.go
+++ b/num/amount_test.go
@@ -187,6 +187,11 @@ func TestAmountMinimalString(t *testing.T) {
 	assert.Equal(t, "123000", a.MinimalString())
 }
 
+func TestAmountFloat64(t *testing.T) {
+	a := num.MakeAmount(123123, 3)
+	assert.Equal(t, 123.123, a.Float64())
+}
+
 func TestAmountRescale(t *testing.T) {
 	a := num.MakeAmount(123456, 2)
 	r := a.Rescale(2)


### PR DESCRIPTION
* Removed option to define accuracy when removing taxes from prices that include tax.
* Accuracy now determined automatically from the "size" (Log base 10) of the quantity.