### PR TITLE
Regime validation and better corrective messages

### DIFF
--- a/bill/invoice_correct.go
+++ b/bill/invoice_correct.go
@@ -169,7 +169,7 @@ func (inv *Invoice) Correct(opts ...cbc.Option) error {
 			inv.Type = InvoiceTypeCorrective
 			inv.Invert()
 		} else {
-			return errors.New("credit not supported by regime")
+			return errors.New("credit note not supported by regime")
 		}
 		inv.Payment.ResetAdvances()
 	} else if o.Debit {
@@ -179,13 +179,13 @@ func (inv *Invoice) Correct(opts ...cbc.Option) error {
 			inv.Type = InvoiceTypeDebitNote
 			inv.Empty()
 		} else {
-			return errors.New("debit not supported by regime")
+			return errors.New("debit note not supported by regime")
 		}
 	} else {
 		if r.Preceding.HasType(InvoiceTypeCorrective) {
 			inv.Type = InvoiceTypeCorrective
 		} else {
-			return errors.New("correction not supported by regime")
+			return fmt.Errorf("corrective invoice type not supported by regime, try credit or debit")
 		}
 	}
 

--- a/bill/invoice_correct_test.go
+++ b/bill/invoice_correct_test.go
@@ -44,7 +44,7 @@ func TestInvoiceCorrect(t *testing.T) {
 	i = testInvoiceESForCorrection(t)
 	err = i.Correct(bill.Debit, bill.WithReason("should fail"))
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "debit not supported")
+	assert.Contains(t, err.Error(), "debit note not supported by regime")
 
 	i = testInvoiceESForCorrection(t)
 	err = i.Correct()
@@ -90,7 +90,7 @@ func TestInvoiceCorrect(t *testing.T) {
 	i = testInvoiceCOForCorrection(t)
 	err = i.Correct(bill.WithStamps(stamps))
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "correction not supported by regime")
+	assert.Contains(t, err.Error(), "corrective invoice type not supported by regime, try credit or debit")
 
 	i = testInvoiceCOForCorrection(t)
 	err = i.Correct(bill.Credit, bill.WithStamps(stamps), bill.WithCorrectionMethod(co.CorrectionMethodKeyRevoked))

--- a/bill/payment.go
+++ b/bill/payment.go
@@ -6,6 +6,7 @@ import (
 	"github.com/invopop/gobl/num"
 	"github.com/invopop/gobl/org"
 	"github.com/invopop/gobl/pay"
+	"github.com/invopop/gobl/tax"
 	"github.com/invopop/validation"
 )
 
@@ -23,7 +24,7 @@ type Payment struct {
 
 // ValidateWithContext checks to make sure the payment data looks good
 func (p *Payment) ValidateWithContext(ctx context.Context) error {
-	return validation.ValidateStructWithContext(ctx, p,
+	return tax.ValidateStructWithRegime(ctx, p,
 		validation.Field(&p.Payee),
 		validation.Field(&p.Terms),
 		validation.Field(&p.Advances),

--- a/build/build.go
+++ b/build/build.go
@@ -1,6 +1,10 @@
+// Package build is used to embed the generated regimes and schemas.
 package build
 
 import "embed"
 
 //go:embed regimes schemas
+
+// Content contains the generated regimes and schemes
+// ready to serve as an embed.FS.
 var Content embed.FS

--- a/build/build.go
+++ b/build/build.go
@@ -1,0 +1,6 @@
+package build
+
+import "embed"
+
+//go:embed regimes schemas
+var Content embed.FS

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/invopop/gobl
 
-go 1.14
+go 1.16
 
 require (
 	cloud.google.com/go v0.110.2

--- a/org/address.go
+++ b/org/address.go
@@ -46,19 +46,6 @@ type Address struct {
 	Meta cbc.Meta `json:"meta,omitempty" jsonschema:"title=Meta"`
 }
 
-// Coordinates describes an exact geographical location in the world. We provide support
-// for a set of different options beyond regular latitude and longitude.
-type Coordinates struct {
-	// Decimal latitude coordinate.
-	Latitude float64 `json:"lat,omitempty" jsonschema:"title=Latitude"`
-	// Decimal longitude coordinate.
-	Longitude float64 `json:"lon,omitempty" jsonschema:"title=Longitude"`
-	// Text coordinates compose of three words.
-	W3W string `json:"w3w,omitempty" jsonschema:"title=What 3 Words"`
-	// Single string coordinate based on geohash standard.
-	Geohash string `json:"geohash,omitempty" jsonschema:"title=Geohash"`
-}
-
 // Validate checks that an address looks okay.
 func (a *Address) Validate() error {
 	return a.ValidateWithContext(context.Background())

--- a/org/address.go
+++ b/org/address.go
@@ -1,8 +1,11 @@
 package org
 
 import (
+	"context"
+
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/l10n"
+	"github.com/invopop/gobl/tax"
 	"github.com/invopop/gobl/uuid"
 	"github.com/invopop/validation"
 )
@@ -58,7 +61,12 @@ type Coordinates struct {
 
 // Validate checks that an address looks okay.
 func (a *Address) Validate() error {
-	return validation.ValidateStruct(a,
+	return a.ValidateWithContext(context.Background())
+}
+
+// ValidateWithContext checks that an address looks okay in the given context.
+func (a *Address) ValidateWithContext(ctx context.Context) error {
+	return tax.ValidateStructWithRegime(ctx, a,
 		validation.Field(&a.UUID),
 		validation.Field(&a.Locality, validation.Required),
 		validation.Field(&a.Country),

--- a/org/coordinates.go
+++ b/org/coordinates.go
@@ -1,0 +1,50 @@
+package org
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/invopop/gobl/tax"
+	"github.com/invopop/validation"
+)
+
+// RegexpPatternW3W is a regular expression that matches a what3words address.
+var RegexpPatternW3W = "^/*(?:(?:\\p{L}\\p{M}*)+[.｡。･・︒។։။۔።।](?:\\p{L}\\p{M}*)+[.｡。･・︒។։။۔።।](?:\\p{L}\\p{M}*)+|(?:\\p{L}\\p{M}*)+([\u0020\u00A0](?:\\p{L}\\p{M}*)+){1,3}[.｡。･・︒។։။۔።।](?:\\p{L}\\p{M}*)+([\u0020\u00A0](?:\\p{L}\\p{M}*)+){1,3}[.｡。･・︒។։။۔።।](?:\\p{L}\\p{M}*)+([\u0020\u00A0](?:\\p{L}\\p{M}*)+){1,3})$"
+
+var regexpW3W = regexp.MustCompile(RegexpPatternW3W)
+
+// Coordinates describes an exact geographical location in the world. We provide support
+// for a set of different options beyond regular latitude and longitude.
+type Coordinates struct {
+	// Decimal latitude coordinate.
+	Latitude *float64 `json:"lat,omitempty" jsonschema:"title=Latitude"`
+	// Decimal longitude coordinate.
+	Longitude *float64 `json:"lon,omitempty" jsonschema:"title=Longitude"`
+	// What 3 Words text coordinates.
+	W3W string `json:"w3w,omitempty" jsonschema:"title=What 3 Words"`
+	// Single string coordinate based on geohash standard.
+	Geohash string `json:"geohash,omitempty" jsonschema:"title=Geohash"`
+}
+
+// Validate checks that coordinates look okay.
+func (c *Coordinates) Validate() error {
+	return c.ValidateWithContext(context.Background())
+}
+
+// ValidateWithContext checks that coordinates look okay in the given context.
+func (c *Coordinates) ValidateWithContext(ctx context.Context) error {
+	return tax.ValidateStructWithRegime(ctx, c,
+		validation.Field(&c.Latitude, validation.Min(-90.0), validation.Max(90.0)),
+		validation.Field(&c.Longitude, validation.Min(-180.0), validation.Max(180.0)),
+		validation.Field(&c.W3W, validation.Match(regexpW3W)),
+	)
+}
+
+// LatLon provides the Latitude and Longitude values as a pair,
+// or 0, 0 if the coordinates are not set.
+func (c *Coordinates) LatLon() (float64, float64) {
+	if c == nil || c.Latitude == nil || c.Longitude == nil {
+		return 0, 0
+	}
+	return *c.Latitude, *c.Longitude
+}

--- a/org/coordinates_test.go
+++ b/org/coordinates_test.go
@@ -1,0 +1,83 @@
+package org_test
+
+import (
+	"testing"
+
+	"github.com/invopop/gobl/org"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCoordinates(t *testing.T) {
+	// Use a table to test coordinate use-cases
+	tests := []struct {
+		name string
+		c    *org.Coordinates
+		err  string
+	}{
+		{
+			name: "empty",
+			c:    &org.Coordinates{},
+		},
+		{
+			name: "valid w3w",
+			c: &org.Coordinates{
+				W3W: "speak.duck.green",
+			},
+		},
+		{
+			name: "invalid w3w",
+			c: &org.Coordinates{
+				W3W: "speak.duck",
+			},
+			err: "w3w: must be in a valid format.",
+		},
+		{
+			name: "invalid w3w",
+			c: &org.Coordinates{
+				W3W: "speak.duck.green.green",
+			},
+			err: "w3w: must be in a valid format.",
+		},
+		{
+			name: "valid coords",
+			c: &org.Coordinates{
+				Latitude:  newFloat64(40.416775),
+				Longitude: newFloat64(-3.703790),
+			},
+		},
+		{
+			name: "invalid latitude",
+			c: &org.Coordinates{
+				Latitude:  newFloat64(140.416775),
+				Longitude: newFloat64(-3.703790),
+			},
+			err: "lat: must be no greater than 90",
+		},
+		{
+			name: "invalid longitude",
+			c: &org.Coordinates{
+				Latitude:  newFloat64(40.416775),
+				Longitude: newFloat64(-300.703790),
+			},
+			err: "lon: must be no less than -180",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.c.Validate()
+			if tt.err != "" {
+				if assert.Error(t, err) {
+					assert.Contains(t, err.Error(), tt.err)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+
+}
+
+func newFloat64(f float64) *float64 {
+	return &f
+}

--- a/org/email.go
+++ b/org/email.go
@@ -1,0 +1,35 @@
+package org
+
+import (
+	"context"
+
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/tax"
+	"github.com/invopop/gobl/uuid"
+	"github.com/invopop/validation"
+	"github.com/invopop/validation/is"
+)
+
+// Email describes the electronic mailing details.
+type Email struct {
+	// Unique identity code
+	UUID *uuid.UUID `json:"uuid,omitempty"`
+	// Identifier for the email.
+	Label string `json:"label,omitempty" jsonschema:"title=Label"`
+	// Electronic mailing address.
+	Address string `json:"addr" jsonschema:"title=Address"`
+	// Additional fields.
+	Meta cbc.Meta `json:"meta,omitempty" jsonschema:"title=Meta"`
+}
+
+// Validate ensures email address looks valid.
+func (e *Email) Validate() error {
+	return e.ValidateWithContext(context.Background())
+}
+
+// ValidateWithContext ensures email address looks valid inside the provided context.
+func (e *Email) ValidateWithContext(ctx context.Context) error {
+	return tax.ValidateStructWithRegime(ctx, e,
+		validation.Field(&e.Address, validation.Required, is.EmailFormat),
+	)
+}

--- a/org/identity.go
+++ b/org/identity.go
@@ -1,6 +1,8 @@
 package org
 
 import (
+	"context"
+
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/uuid"
 	"github.com/invopop/validation"
@@ -21,7 +23,12 @@ type Identity struct {
 
 // Validate ensures the identity looks valid.
 func (i *Identity) Validate() error {
-	return validation.ValidateStruct(i,
+	return i.ValidateWithContext(context.Background())
+}
+
+// ValidateWithContext ensures the identity looks valid inside the provided context.
+func (i *Identity) ValidateWithContext(ctx context.Context) error {
+	return validation.ValidateStructWithContext(ctx, i,
 		validation.Field(&i.Label),
 		validation.Field(&i.Type),
 		validation.Field(&i.Code, validation.Required),

--- a/org/identity.go
+++ b/org/identity.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/tax"
 	"github.com/invopop/gobl/uuid"
 	"github.com/invopop/validation"
 )
@@ -28,7 +29,7 @@ func (i *Identity) Validate() error {
 
 // ValidateWithContext ensures the identity looks valid inside the provided context.
 func (i *Identity) ValidateWithContext(ctx context.Context) error {
-	return validation.ValidateStructWithContext(ctx, i,
+	return tax.ValidateStructWithRegime(ctx, i,
 		validation.Field(&i.Label),
 		validation.Field(&i.Type),
 		validation.Field(&i.Code, validation.Required),

--- a/org/image.go
+++ b/org/image.go
@@ -1,7 +1,10 @@
 package org
 
 import (
+	"context"
+
 	"github.com/invopop/gobl/dsig"
+	"github.com/invopop/gobl/tax"
 	"github.com/invopop/gobl/uuid"
 	"github.com/invopop/validation"
 	"github.com/invopop/validation/is"
@@ -37,7 +40,12 @@ type Image struct {
 
 // Validate ensures the details on the image look okay.
 func (i *Image) Validate() error {
-	return validation.ValidateStruct(i,
+	return i.ValidateWithContext(context.Background())
+}
+
+// ValidateWithContext ensures the details on the image look okay inside the provided context.
+func (i *Image) ValidateWithContext(ctx context.Context) error {
+	return tax.ValidateStructWithRegime(ctx, i,
 		validation.Field(&i.UUID),
 		validation.Field(&i.URL, is.URL),
 		validation.Field(&i.Height, validation.Min(1), validation.Max(2048)),

--- a/org/inbox.go
+++ b/org/inbox.go
@@ -1,7 +1,10 @@
 package org
 
 import (
+	"context"
+
 	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/tax"
 	"github.com/invopop/gobl/uuid"
 	"github.com/invopop/validation"
 )
@@ -28,7 +31,12 @@ type Inbox struct {
 
 // Validate ensures the inbox's fields look good.
 func (i *Inbox) Validate() error {
-	return validation.ValidateStruct(i,
+	return i.ValidateWithContext(context.Background())
+}
+
+// ValidateWithContext ensures the inbox's fields look good inside the provided context.
+func (i *Inbox) ValidateWithContext(ctx context.Context) error {
+	return tax.ValidateStructWithRegime(ctx, i,
 		validation.Field(&i.UUID),
 		validation.Field(&i.Key, validation.Required),
 		validation.Field(&i.Role),

--- a/org/item.go
+++ b/org/item.go
@@ -1,9 +1,13 @@
 package org
 
 import (
+	"context"
+
 	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/currency"
 	"github.com/invopop/gobl/l10n"
 	"github.com/invopop/gobl/num"
+	"github.com/invopop/gobl/tax"
 	"github.com/invopop/gobl/uuid"
 
 	"github.com/invopop/validation"
@@ -32,7 +36,7 @@ type Item struct {
 	// Detailed description
 	Description string `json:"desc,omitempty"`
 	// Currency used for the item's price.
-	Currency string `json:"currency,omitempty" jsonschema:"title=Currency"`
+	Currency currency.Code `json:"currency,omitempty" jsonschema:"title=Currency"`
 	// Base price of a single unit to be sold.
 	Price num.Amount `json:"price" jsonschema:"title=Price"`
 	// Unit of measure.
@@ -43,13 +47,19 @@ type Item struct {
 	Meta cbc.Meta `json:"meta,omitempty" jsonschema:"title=Meta"`
 }
 
-// Validate checks that an address looks okay.
+// Validate checks that the Item looks okay.
 func (i *Item) Validate() error {
-	return validation.ValidateStruct(i,
+	return i.ValidateWithContext(context.Background())
+}
+
+// ValidateWithContext checks that the Item looks okay inside the provided context.
+func (i *Item) ValidateWithContext(ctx context.Context) error {
+	return tax.ValidateStructWithRegime(ctx, i,
 		validation.Field(&i.UUID),
 		validation.Field(&i.Key),
 		validation.Field(&i.Name, validation.Required),
 		validation.Field(&i.Identities),
+		validation.Field(&i.Currency),
 		validation.Field(&i.Price, validation.Required),
 		validation.Field(&i.Unit),
 		validation.Field(&i.Origin),

--- a/org/name.go
+++ b/org/name.go
@@ -1,0 +1,49 @@
+package org
+
+import (
+	"context"
+
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/tax"
+	"github.com/invopop/gobl/uuid"
+	"github.com/invopop/validation"
+)
+
+// Name represents what a human is called. This is a complex subject, see this
+// w3 article for some insights:
+// https://www.w3.org/International/questions/qa-personal-names
+type Name struct {
+	// Unique identity code
+	UUID *uuid.UUID `json:"uuid,omitempty" jsonschema:"title=UUID"`
+	// What the person would like to be called
+	Alias string `json:"alias,omitempty" jsonschema:"title=Alias"`
+	// Additional prefix to add to name, like Mrs. or Mr.
+	Prefix string `json:"prefix,omitempty" jsonschema:"title=Prefix"`
+	// Person's given or first name
+	Given string `json:"given" jsonschema:"title=Given"`
+	// Middle names or initials
+	Middle string `json:"middle,omitempty" jsonschema:"title=Middle"`
+	// Second or Family name.
+	Surname string `json:"surname" jsonschema:"title=Surname"`
+	// Additional second of family name.
+	Surname2 string `json:"surname2,omitempty" jsonschema:"title=Second Surname"`
+	// Titles to include after the name.
+	Suffix string `json:"suffix,omitempty" jsonschema:"title=Suffix"`
+	// Any additional useful data.
+	Meta cbc.Meta `json:"meta,omitempty" jsonschema:"title=Meta"`
+}
+
+// Validate ensures the name looks valid.
+func (n *Name) Validate() error {
+	return n.ValidateWithContext(context.Background())
+}
+
+// ValidateWithContext ensures the name looks valid inside the provided context.
+func (n *Name) ValidateWithContext(ctx context.Context) error {
+	return tax.ValidateStructWithRegime(ctx, n,
+		validation.Field(&n.UUID),
+		validation.Field(&n.Given, validation.Required),
+		validation.Field(&n.Surname, validation.Required),
+		validation.Field(&n.Meta),
+	)
+}

--- a/org/org.go
+++ b/org/org.go
@@ -18,5 +18,6 @@ func init() {
 		Registration{},
 		Telephone{},
 		Unit(""),
+		Website{},
 	)
 }

--- a/org/party.go
+++ b/org/party.go
@@ -1,6 +1,8 @@
 package org
 
 import (
+	"context"
+
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/currency"
 	"github.com/invopop/gobl/num"
@@ -15,14 +17,14 @@ import (
 type Party struct {
 	// Unique identity code
 	UUID *uuid.UUID `json:"uuid,omitempty" jsonschema:"title=UUID"`
-	// The entity's legal ID code used for tax purposes. They may have other numbers, but we're only interested in those valid for tax purposes.
-	TaxID *tax.Identity `json:"tax_id,omitempty" jsonschema:"title=Tax Identity"`
-	// Set of codes used to identify the party in other systems.
-	Identities []*Identity `json:"identities,omitempty" jsonschema:"title=Identities"`
 	// Legal name or representation of the organization.
 	Name string `json:"name" jsonschema:"title=Name"`
 	// Alternate short name.
 	Alias string `json:"alias,omitempty" jsonschema:"title=Alias"`
+	// The entity's legal ID code used for tax purposes. They may have other numbers, but we're only interested in those valid for tax purposes.
+	TaxID *tax.Identity `json:"tax_id,omitempty" jsonschema:"title=Tax Identity"`
+	// Set of codes used to identify the party in other systems.
+	Identities []*Identity `json:"identities,omitempty" jsonschema:"title=Identities"`
 	// Details of physical people who represent the party.
 	People []*Person `json:"people,omitempty" jsonschema:"title=People"`
 	// Digital inboxes used for forwarding electronic versions of documents
@@ -154,15 +156,24 @@ func (p *Party) Calculate() error {
 
 // Validate is used to check the party's data meets minimum expectations.
 func (p *Party) Validate() error {
-	return validation.ValidateStruct(p,
+	return p.ValidateWithContext(context.Background())
+}
+
+// ValidateWithContext is used to check the party's data meets minimum expectations.
+func (p *Party) ValidateWithContext(ctx context.Context) error {
+	return tax.ValidateStructWithRegime(ctx, p,
 		validation.Field(&p.Name, validation.Required),
 		validation.Field(&p.TaxID),
 		validation.Field(&p.Identities),
 		validation.Field(&p.People),
+		validation.Field(&p.Inboxes),
+		validation.Field(&p.Addresses),
 		validation.Field(&p.Emails),
-		validation.Field(&p.Telephones),
-		validation.Field(&p.Logos),
 		validation.Field(&p.Websites),
+		validation.Field(&p.Telephones),
+		validation.Field(&p.Registration),
+		validation.Field(&p.Logos),
+		validation.Field(&p.Meta),
 	)
 }
 

--- a/org/party.go
+++ b/org/party.go
@@ -4,13 +4,10 @@ import (
 	"context"
 
 	"github.com/invopop/gobl/cbc"
-	"github.com/invopop/gobl/currency"
-	"github.com/invopop/gobl/num"
 	"github.com/invopop/gobl/tax"
 	"github.com/invopop/gobl/uuid"
 
 	"github.com/invopop/validation"
-	"github.com/invopop/validation/is"
 )
 
 // Party represents a person or business entity.
@@ -43,99 +40,6 @@ type Party struct {
 	Logos []*Image `json:"logos,omitempty" jsonschema:"title=Logos"`
 	// Any additional semi-structured information that does not fit into the rest of the party.
 	Meta cbc.Meta `json:"meta,omitempty" jsonschema:"title=Meta"`
-}
-
-// Person represents a human, and how to contact them electronically.
-type Person struct {
-	// Unique identity code
-	UUID *uuid.UUID `json:"uuid,omitempty" jsonschema:"title=UUID"`
-	// Complete details on the name of the person
-	Name Name `json:"name" jsonschema:"title=Name"`
-	// What they do within an organization
-	Role string `json:"role,omitempty" jsonschema:"title=Role"`
-	// Electronic mail addresses that belong to the person.
-	Emails []*Email `json:"emails,omitempty" jsonschema:"title=Email Addresses"`
-	// Regular phone or mobile numbers
-	Telephones []*Telephone `json:"telephones,omitempty" jsonschema:"title=Telephone Numbers"`
-	// Avatars provider links to images or photos or the person.
-	Avatars []*Image `json:"avatars,omitempty" jsonschema:"title=Avatars"`
-	// Data about the data.
-	Meta cbc.Meta `json:"meta,omitempty" jsonschema:"title=Meta"`
-}
-
-// Name represents what a human is called. This is a complex subject, see this
-// w3 article for some insights:
-// https://www.w3.org/International/questions/qa-personal-names
-type Name struct {
-	// Unique identity code
-	UUID *uuid.UUID `json:"uuid,omitempty" jsonschema:"title=UUID"`
-	// What the person would like to be called
-	Alias string `json:"alias,omitempty" jsonschema:"title=Alias"`
-	// Additional prefix to add to name, like Mrs. or Mr.
-	Prefix string `json:"prefix,omitempty" jsonschema:"title=Prefix"`
-	// Person's given or first name
-	Given string `json:"given" jsonschema:"title=Given"`
-	// Middle names or initials
-	Middle string `json:"middle,omitempty" jsonschema:"title=Middle"`
-	// Second or Family name.
-	Surname string `json:"surname" jsonschema:"title=Surname"`
-	// Additional second of family name.
-	Surname2 string `json:"surname2,omitempty" jsonschema:"title=Second Surname"`
-	// Titles to include after the name.
-	Suffix string `json:"suffix,omitempty" jsonschema:"title=Suffix"`
-	// Any additional useful data.
-	Meta cbc.Meta `json:"meta,omitempty" jsonschema:"title=Meta"`
-}
-
-// Email describes the electronic mailing details.
-type Email struct {
-	// Unique identity code
-	UUID *uuid.UUID `json:"uuid,omitempty"`
-	// Identifier for the email.
-	Label string `json:"label,omitempty" jsonschema:"title=Label"`
-	// Electronic mailing address.
-	Address string `json:"addr" jsonschema:"title=Address"`
-	// Additional fields.
-	Meta cbc.Meta `json:"meta,omitempty" jsonschema:"title=Meta"`
-}
-
-// Telephone describes what is expected for a telephone number.
-type Telephone struct {
-	// Unique identity code
-	UUID *uuid.UUID `json:"uuid,omitempty" jsonschema:"title=UUID"`
-	// Identifier for this number.
-	Label string `json:"label,omitempty" jsonschema:"title=Label"`
-	// The number to be dialed in ITU E.164 international format.
-	Number string `json:"num" jsonschema:"title=Number"`
-}
-
-// Website describes what is expected for a web address.
-type Website struct {
-	// Unique identity code
-	UUID *uuid.UUID `json:"uuid,omitempty" jsonschema:"title=UUID"`
-	// Identifier for this number.
-	Label string `json:"label,omitempty" jsonschema:"title=Label"`
-	// Title of the website to help distinguish between this and other links.
-	Title string `json:"title,omitempty" jsonschema:"title=Title"`
-	// URL for the website.
-	URL string `json:"url" jsonschema:"title=URL,format=uri"`
-}
-
-// Registration is used in countries that require additional information to be associated
-// with a company usually related to a specific registration office.
-// The definition found here is based on the details required for spain.
-// If your country requires additional fields, please let us know.
-type Registration struct {
-	UUID     *uuid.UUID    `json:"uuid,omitempty" jsonschema:"title=UUID"`
-	Capital  *num.Amount   `json:"capital,omitempty" jsonschema:"title=Capital"`
-	Currency currency.Code `json:"currency,omitempty" jsonschema:"title=Currency"`
-	Office   string        `json:"office,omitempty" jsonschema:"title=Office"`
-	Book     string        `json:"book,omitempty" jsonschema:"title=Book"`
-	Volume   string        `json:"volume,omitempty" jsonschema:"title=Volume"`
-	Sheet    string        `json:"sheet,omitempty" jsonschema:"title=Sheet"`
-	Section  string        `json:"section,omitempty" jsonschema:"title=Section"`
-	Page     string        `json:"page,omitempty" jsonschema:"title=Page"`
-	Entry    string        `json:"entry,omitempty" jsonschema:"title=Entry"`
 }
 
 // Calculate performs any calculations required on the Party or
@@ -174,26 +78,5 @@ func (p *Party) ValidateWithContext(ctx context.Context) error {
 		validation.Field(&p.Registration),
 		validation.Field(&p.Logos),
 		validation.Field(&p.Meta),
-	)
-}
-
-// Validate ensures email address looks valid.
-func (e *Email) Validate() error {
-	return validation.ValidateStruct(e,
-		validation.Field(&e.Address, validation.Required, is.EmailFormat),
-	)
-}
-
-// Validate checks the telephone objects number to ensure it looks correct.
-func (t *Telephone) Validate() error {
-	return validation.ValidateStruct(t,
-		validation.Field(&t.Number, validation.Required, is.E164),
-	)
-}
-
-// Validate checks the telephone objects number to ensure it looks correct.
-func (w *Website) Validate() error {
-	return validation.ValidateStruct(w,
-		validation.Field(&w.URL, validation.Required, is.URL),
 	)
 }

--- a/org/person.go
+++ b/org/person.go
@@ -1,0 +1,45 @@
+package org
+
+import (
+	"context"
+
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/tax"
+	"github.com/invopop/gobl/uuid"
+	"github.com/invopop/validation"
+)
+
+// Person represents a human, and how to contact them electronically.
+type Person struct {
+	// Unique identity code
+	UUID *uuid.UUID `json:"uuid,omitempty" jsonschema:"title=UUID"`
+	// Complete details on the name of the person
+	Name Name `json:"name" jsonschema:"title=Name"`
+	// What they do within an organization
+	Role string `json:"role,omitempty" jsonschema:"title=Role"`
+	// Electronic mail addresses that belong to the person.
+	Emails []*Email `json:"emails,omitempty" jsonschema:"title=Email Addresses"`
+	// Regular phone or mobile numbers
+	Telephones []*Telephone `json:"telephones,omitempty" jsonschema:"title=Telephone Numbers"`
+	// Avatars provider links to images or photos or the person.
+	Avatars []*Image `json:"avatars,omitempty" jsonschema:"title=Avatars"`
+	// Data about the data.
+	Meta cbc.Meta `json:"meta,omitempty" jsonschema:"title=Meta"`
+}
+
+// Validate validates the person.
+func (p *Person) Validate() error {
+	return p.ValidateWithContext(context.Background())
+}
+
+// ValidateWithContext validates the person with the given context.
+func (p *Person) ValidateWithContext(ctx context.Context) error {
+	return tax.ValidateStructWithRegime(ctx, p,
+		validation.Field(&p.UUID),
+		validation.Field(&p.Name, validation.Required),
+		validation.Field(&p.Emails),
+		validation.Field(&p.Telephones),
+		validation.Field(&p.Avatars),
+		validation.Field(&p.Meta),
+	)
+}

--- a/org/registration.go
+++ b/org/registration.go
@@ -1,0 +1,49 @@
+package org
+
+import (
+	"context"
+
+	"github.com/invopop/gobl/currency"
+	"github.com/invopop/gobl/num"
+	"github.com/invopop/gobl/tax"
+	"github.com/invopop/gobl/uuid"
+	"github.com/invopop/validation"
+)
+
+// Registration is used in countries that require additional information to be associated
+// with a company usually related to a specific registration office.
+// The definition found here is based on the details required for spain.
+// If your country requires additional fields, please let us know.
+type Registration struct {
+	UUID     *uuid.UUID    `json:"uuid,omitempty" jsonschema:"title=UUID"`
+	Capital  *num.Amount   `json:"capital,omitempty" jsonschema:"title=Capital"`
+	Currency currency.Code `json:"currency,omitempty" jsonschema:"title=Currency"`
+	Office   string        `json:"office,omitempty" jsonschema:"title=Office"`
+	Book     string        `json:"book,omitempty" jsonschema:"title=Book"`
+	Volume   string        `json:"volume,omitempty" jsonschema:"title=Volume"`
+	Sheet    string        `json:"sheet,omitempty" jsonschema:"title=Sheet"`
+	Section  string        `json:"section,omitempty" jsonschema:"title=Section"`
+	Page     string        `json:"page,omitempty" jsonschema:"title=Page"`
+	Entry    string        `json:"entry,omitempty" jsonschema:"title=Entry"`
+}
+
+// Validate ensures the registration looks valid.
+func (r *Registration) Validate() error {
+	return r.ValidateWithContext(context.Background())
+}
+
+// ValidateWithContext ensures the registration looks valid inside the provided context.
+func (r *Registration) ValidateWithContext(ctx context.Context) error {
+	return tax.ValidateStructWithRegime(ctx, r,
+		validation.Field(&r.UUID),
+		validation.Field(&r.Capital),
+		validation.Field(&r.Currency),
+		validation.Field(&r.Office),
+		validation.Field(&r.Book),
+		validation.Field(&r.Volume),
+		validation.Field(&r.Sheet),
+		validation.Field(&r.Section),
+		validation.Field(&r.Page),
+		validation.Field(&r.Entry),
+	)
+}

--- a/org/telephone.go
+++ b/org/telephone.go
@@ -1,0 +1,33 @@
+package org
+
+import (
+	"context"
+
+	"github.com/invopop/gobl/tax"
+	"github.com/invopop/gobl/uuid"
+	"github.com/invopop/validation"
+	"github.com/invopop/validation/is"
+)
+
+// Telephone describes what is expected for a telephone number.
+type Telephone struct {
+	// Unique identity code
+	UUID *uuid.UUID `json:"uuid,omitempty" jsonschema:"title=UUID"`
+	// Identifier for this number.
+	Label string `json:"label,omitempty" jsonschema:"title=Label"`
+	// The number to be dialed in ITU E.164 international format.
+	Number string `json:"num" jsonschema:"title=Number"`
+}
+
+// Validate checks the telephone objects number to ensure it looks correct.
+func (t *Telephone) Validate() error {
+	return t.ValidateWithContext(context.Background())
+}
+
+// ValidateWithContext checks the telephone objects number to ensure it looks correct inside the provided context.
+func (t *Telephone) ValidateWithContext(ctx context.Context) error {
+	return tax.ValidateStructWithRegime(ctx, t,
+		validation.Field(&t.UUID),
+		validation.Field(&t.Number, validation.Required, is.E164),
+	)
+}

--- a/org/website.go
+++ b/org/website.go
@@ -1,0 +1,34 @@
+package org
+
+import (
+	"context"
+
+	"github.com/invopop/gobl/tax"
+	"github.com/invopop/gobl/uuid"
+	"github.com/invopop/validation"
+	"github.com/invopop/validation/is"
+)
+
+// Website describes what is expected for a web address.
+type Website struct {
+	// Unique identity code
+	UUID *uuid.UUID `json:"uuid,omitempty" jsonschema:"title=UUID"`
+	// Identifier for this number.
+	Label string `json:"label,omitempty" jsonschema:"title=Label"`
+	// Title of the website to help distinguish between this and other links.
+	Title string `json:"title,omitempty" jsonschema:"title=Title"`
+	// URL for the website.
+	URL string `json:"url" jsonschema:"title=URL,format=uri"`
+}
+
+// Validate checks the website objects URL to ensure it looks correct.
+func (w *Website) Validate() error {
+	return w.ValidateWithContext(context.Background())
+}
+
+// ValidateWithContext checks the website objects URL to ensure it looks correct inside the provided context.
+func (w *Website) ValidateWithContext(ctx context.Context) error {
+	return tax.ValidateStructWithRegime(ctx, w,
+		validation.Field(&w.URL, validation.Required, is.URL),
+	)
+}

--- a/pay/advance.go
+++ b/pay/advance.go
@@ -44,15 +44,11 @@ func (a *Advance) Validate() error {
 
 // ValidateWithContext checks the advance looks okay inside the context.
 func (a *Advance) ValidateWithContext(ctx context.Context) error {
-	err := validation.ValidateStructWithContext(ctx, a,
+	return tax.ValidateStructWithRegime(ctx, a,
 		validation.Field(&a.Amount, validation.Required),
 		validation.Field(&a.Key, HasValidMeansKey),
 		validation.Field(&a.Description, validation.Required),
 	)
-	if err == nil {
-		err = tax.ValidateInRegime(ctx, a)
-	}
-	return err
 }
 
 // CalculateFrom will update the amount using the rate of the provided

--- a/pay/instructions.go
+++ b/pay/instructions.go
@@ -100,16 +100,12 @@ func (i *Instructions) Validate() error {
 
 // ValidateWithContext ensures the fields provided in the instructions are valid.
 func (i *Instructions) ValidateWithContext(ctx context.Context) error {
-	err := validation.ValidateStructWithContext(ctx, i,
+	return tax.ValidateStructWithRegime(ctx, i,
 		validation.Field(&i.Key, validation.Required, HasValidMeansKey),
 		validation.Field(&i.CreditTransfer),
 		validation.Field(&i.DirectDebit),
 		validation.Field(&i.Online),
 	)
-	if err == nil {
-		err = tax.ValidateInRegime(ctx, i)
-	}
-	return err
 }
 
 // JSONSchemaExtend extends the JSONSchema for the Instructions type.

--- a/pay/terms.go
+++ b/pay/terms.go
@@ -1,10 +1,13 @@
 package pay
 
 import (
+	"context"
+
 	"github.com/invopop/gobl/cal"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/currency"
 	"github.com/invopop/gobl/num"
+	"github.com/invopop/gobl/tax"
 	"github.com/invopop/jsonschema"
 	"github.com/invopop/validation"
 )
@@ -107,7 +110,12 @@ func (t *Terms) CalculateDues(sum num.Amount) {
 
 // Validate ensures that the terms contain everything required.
 func (t *Terms) Validate() error {
-	return validation.ValidateStruct(t,
+	return t.ValidateWithContext(context.Background())
+}
+
+// ValidateWithContext ensures that the terms contain everything required.
+func (t *Terms) ValidateWithContext(ctx context.Context) error {
+	return tax.ValidateStructWithRegime(ctx, t,
 		validation.Field(&t.Key, isValidTermKey),
 		validation.Field(&t.DueDates),
 	)

--- a/regimes/es/examples/invoice-es-es-vateqs-provider.yaml
+++ b/regimes/es/examples/invoice-es-es-vateqs-provider.yaml
@@ -28,6 +28,7 @@ customer:
   addresses:
     - num: "43"
       street: "Calle Mayor"
+      locality: "Madrid"
       region: "Madrid"
       code: "28003"
 

--- a/regimes/es/examples/invoice-es-es-vateqs-retailer.yaml
+++ b/regimes/es/examples/invoice-es-es-vateqs-retailer.yaml
@@ -15,6 +15,7 @@ supplier:
   addresses:
     - num: "43"
       street: "Calle Mayor"
+      locality: "Madrid"
       region: "Madrid"
       code: "28003"
 

--- a/tax/regime.go
+++ b/tax/regime.go
@@ -312,6 +312,16 @@ func ValidateInRegime(ctx context.Context, obj interface{}) error {
 	return r.ValidateObject(obj)
 }
 
+// ValidateStructWithRegime wraps around the standard validation.ValidateStructWithContext
+// method to add an additional check for the tax regime.
+func ValidateStructWithRegime(ctx context.Context, obj interface{}, fields ...*validation.FieldRules) error {
+	// First run regular validation
+	if err := validation.ValidateStructWithContext(ctx, obj, fields...); err != nil {
+		return err
+	}
+	return ValidateInRegime(ctx, obj)
+}
+
 // Validate ensures that the zone looks correct.
 func (z *Zone) Validate() error {
 	err := validation.ValidateStruct(z,


### PR DESCRIPTION
Replaces #166.

* Improving correction error messages
* Fixing validation bug for Party Addresses.
* Added `tax.ValidateStructWithRegime` method to make it easy to validate more types of object inside the context of a regime.