### PR TITLE
Use minimum accuracy when removing tax

### DIFF
--- a/bill/invoice.go
+++ b/bill/invoice.go
@@ -209,6 +209,8 @@ func (inv *Invoice) Calculate() error {
 // RemoveIncludedTaxes is a special function that will go through all prices which may include
 // the tax included in the invoice, and remove them.
 //
+// Be sure to run the Calculate method on the results!
+//
 // To do this we need to figure out the "accuracy" or precision to use when removing the included
 // taxes so that we can avoid rounding errors. By default we add a single decimal place to all
 // numbers, but in the case of line items we take the length (Log 10) of the *quantity*.

--- a/bill/invoice_test.go
+++ b/bill/invoice_test.go
@@ -64,19 +64,83 @@ func TestRemoveIncludedTax(t *testing.T) {
 	require.NoError(t, i.Calculate())
 
 	i2 := i.RemoveIncludedTaxes()
+	require.NoError(t, i2.Calculate())
 
 	assert.Equal(t, "1000.00", i.Lines[0].Item.Price.String())
 
 	assert.Empty(t, i2.Tax.PricesInclude)
 	l0 := i2.Lines[0]
-	assert.Equal(t, "826.446", l0.Item.Price.String())
-	assert.Equal(t, "826.446", l0.Sum.String())
-	assert.Equal(t, "826.446", l0.Sum.String())
-	assert.Equal(t, "82.645", l0.Discounts[0].Amount.String())
-	assert.Equal(t, "743.802", l0.Total.String())
+	assert.Equal(t, "826.4463", l0.Item.Price.String())
+	assert.Equal(t, "826.4463", l0.Sum.String())
+	assert.Equal(t, "826.4463", l0.Sum.String())
+	assert.Equal(t, "82.6446", l0.Discounts[0].Amount.String())
+	assert.Equal(t, "743.8017", l0.Total.String())
 
 	assert.Equal(t, "743.80", i2.Totals.Total.String())
 	assert.Equal(t, "900.00", i2.Totals.Payable.String())
+}
+
+func TestRemoveIncludedTax2(t *testing.T) {
+	i := &bill.Invoice{
+		Code: "123TEST",
+		Tax: &bill.Tax{
+			PricesInclude: common.TaxCategoryVAT,
+		},
+		Supplier: &org.Party{
+			TaxID: &tax.Identity{
+				Country: l10n.ES,
+				Code:    "B98602642",
+			},
+		},
+		Customer: &org.Party{
+			TaxID: &tax.Identity{
+				Country: l10n.ES,
+				Code:    "54387763P",
+			},
+		},
+		IssueDate: cal.MakeDate(2022, 6, 13),
+		Lines: []*bill.Line{
+			{
+				Quantity: num.MakeAmount(1, 0),
+				Item: &org.Item{
+					Name:  "Item",
+					Price: num.MakeAmount(4320, 2),
+				},
+				Taxes: tax.Set{
+					{
+						Category: "VAT",
+						Percent:  num.NewPercentage(6, 2),
+					},
+				},
+			},
+			{
+				Quantity: num.MakeAmount(1, 0),
+				Item: &org.Item{
+					Name:  "Item 2",
+					Price: num.MakeAmount(259, 2),
+				},
+			},
+			{
+				Quantity: num.MakeAmount(1, 0),
+				Item: &org.Item{
+					Name:  "Item 3",
+					Price: num.MakeAmount(300, 2),
+				},
+			},
+		},
+	}
+
+	require.NoError(t, i.Calculate())
+
+	i2 := i.RemoveIncludedTaxes()
+	require.NoError(t, i2.Calculate())
+	l0 := i2.Lines[0]
+	assert.Equal(t, "40.7547", l0.Item.Price.String())
+	assert.Equal(t, "40.7547", l0.Total.String())
+
+	assert.Equal(t, "46.34", i2.Totals.Total.String())
+	assert.Equal(t, "2.45", i2.Totals.Tax.String())
+	assert.Equal(t, "48.79", i2.Totals.Payable.String())
 }
 
 func TestRemoveIncludedTaxQuantity(t *testing.T) {
@@ -124,14 +188,14 @@ func TestRemoveIncludedTaxQuantity(t *testing.T) {
 	require.NoError(t, i.Calculate())
 
 	i2 := i.RemoveIncludedTaxes()
+	require.NoError(t, i2.Calculate())
 
 	assert.Empty(t, i2.Tax.PricesInclude)
 	l0 := i2.Lines[0]
 	assert.Equal(t, "8.26446", l0.Item.Price.String())
-	assert.Equal(t, "826.44628", l0.Sum.String())
-	assert.Equal(t, "826.44628", l0.Sum.String())
-	assert.Equal(t, "82.64463", l0.Discounts[0].Amount.String())
-	assert.Equal(t, "743.80165", l0.Total.String())
+	assert.Equal(t, "826.44600", l0.Sum.String())
+	assert.Equal(t, "82.64460", l0.Discounts[0].Amount.String())
+	assert.Equal(t, "743.80140", l0.Total.String())
 	assert.Equal(t, "10.00", i.Lines[0].Item.Price.String())
 
 	assert.Equal(t, "743.80", i2.Totals.Total.String())
@@ -201,8 +265,8 @@ func TestRemoveIncludedTaxDeep(t *testing.T) {
 	assert.Equal(t, "48.84906", l0.Item.Price.String()) // note extra digit!
 	assert.Equal(t, "17781.05784", l0.Sum.String())
 	l1 := i2.Lines[1]
-	assert.Equal(t, "49.132", l1.Item.Price.String())
-	assert.Equal(t, "49.132", l1.Sum.String())
+	assert.Equal(t, "49.1321", l1.Item.Price.String())
+	assert.Equal(t, "49.1321", l1.Sum.String())
 
 	assert.Equal(t, "17830.19", i2.Totals.Total.String())
 	assert.Equal(t, "18900.00", i2.Totals.Payable.String())

--- a/bill/line.go
+++ b/bill/line.go
@@ -100,6 +100,9 @@ func (l *Line) removeIncludedTaxes(cat cbc.Code) *Line {
 
 	// adjust the accuracy according to the line's quantity
 	ql := math.Log10(l2.Quantity.Float64()) + 1 // length of number
+	if ql < 2 {
+		ql = 2 // minimum accuracy
+	}
 	accuracy := uint32(ql)
 
 	l2i.Price = l2i.Price.Upscale(accuracy).Remove(*rate.Percent)

--- a/version.go
+++ b/version.go
@@ -8,7 +8,7 @@ import (
 type Version string
 
 // VERSION is the current version of the GOBL library.
-const VERSION Version = "v0.51.3"
+const VERSION Version = "v0.51.4"
 
 // Semver parses and returns semver
 func (v Version) Semver() *semver.Version {


### PR DESCRIPTION
* Fixing tax removal by setting minimum accuracy.
* Forcing tests to recalculate correctly.