### PR TITLE
Rename Calculate to Normalize

### DIFF
--- a/bill/charges.go
+++ b/bill/charges.go
@@ -93,7 +93,7 @@ func (m *Charge) removeIncludedTaxes(cat cbc.Code, accuracy uint32) *Charge {
 	return &m2
 }
 
-func calculateCharges(zero, sum num.Amount, charges []*Charge) *num.Amount {
+func normalizeCharges(zero, sum num.Amount, charges []*Charge) *num.Amount {
 	if len(charges) == 0 {
 		return nil
 	}

--- a/bill/charges_test.go
+++ b/bill/charges_test.go
@@ -21,7 +21,7 @@ func TestChargeTotals(t *testing.T) {
 	}
 	zero := num.MakeAmount(0, 2)
 	base := num.MakeAmount(30000, 2)
-	sum := calculateCharges(zero, base, ls)
+	sum := normalizeCharges(zero, base, ls)
 	require.NotNil(t, sum)
 	assert.Equal(t, 1, ls[0].Index)
 	assert.Equal(t, 2, ls[1].Index)
@@ -32,6 +32,6 @@ func TestChargeTotals(t *testing.T) {
 	assert.Equal(t, "60.00", ls[1].Amount.String())
 
 	ls = []*Charge{}
-	sum = calculateCharges(zero, base, ls)
+	sum = normalizeCharges(zero, base, ls)
 	assert.Nil(t, sum)
 }

--- a/bill/discounts.go
+++ b/bill/discounts.go
@@ -93,7 +93,7 @@ func (m *Discount) removeIncludedTaxes(cat cbc.Code, accuracy uint32) *Discount 
 	return &m2
 }
 
-func calculateDiscounts(zero, sum num.Amount, discounts []*Discount) *num.Amount {
+func normalizeDiscounts(zero, sum num.Amount, discounts []*Discount) *num.Amount {
 	if len(discounts) == 0 {
 		return nil
 	}

--- a/bill/discounts_test.go
+++ b/bill/discounts_test.go
@@ -21,7 +21,7 @@ func TestDiscountTotals(t *testing.T) {
 	}
 	zero := num.MakeAmount(0, 2)
 	base := num.MakeAmount(30000, 2)
-	sum := calculateDiscounts(zero, base, ls)
+	sum := normalizeDiscounts(zero, base, ls)
 	require.NotNil(t, sum)
 	assert.Equal(t, 1, ls[0].Index)
 	assert.Equal(t, 2, ls[1].Index)
@@ -32,6 +32,6 @@ func TestDiscountTotals(t *testing.T) {
 	assert.Equal(t, "60.00", ls[1].Amount.String())
 
 	ls = []*Discount{}
-	sum = calculateDiscounts(zero, base, ls)
+	sum = normalizeDiscounts(zero, base, ls)
 	assert.Nil(t, sum)
 }

--- a/bill/invoice_correct.go
+++ b/bill/invoice_correct.go
@@ -209,8 +209,8 @@ func (inv *Invoice) Correct(opts ...cbc.Option) error {
 	// Replace all previous preceding data
 	inv.Preceding = []*Preceding{pre}
 
-	// Running a Calculate feels a bit out of place, but not performing
+	// Running a Normalize feels a bit out of place, but not performing
 	// this operation on the corrected invoice results in potentially
 	// conflicting or incomplete data.
-	return inv.Calculate()
+	return inv.Normalize()
 }

--- a/bill/line.go
+++ b/bill/line.go
@@ -64,8 +64,8 @@ func (l *Line) ValidateWithContext(ctx context.Context) error {
 	)
 }
 
-// calculate figures out the totals according to quantity and discounts.
-func (l *Line) calculate(zero num.Amount) {
+// normalize figures out the totals according to quantity and discounts.
+func (l *Line) normalize(zero num.Amount) {
 	if l.Item == nil {
 		return
 	}
@@ -73,7 +73,7 @@ func (l *Line) calculate(zero num.Amount) {
 	// Ensure the Price precision is set correctly according to the currency
 	l.Item.Price = l.Item.Price.MatchPrecision(zero)
 
-	// Calculate the line sum and total
+	// Normalize the line sum and total
 	l.Sum = l.Item.Price.Multiply(l.Quantity)
 	l.Total = l.Sum
 
@@ -138,11 +138,11 @@ func (l *Line) removeIncludedTaxes(cat cbc.Code) *Line {
 	return &l2
 }
 
-func calculateLines(zero num.Amount, lines []*Line) num.Amount {
+func normalizeLines(zero num.Amount, lines []*Line) num.Amount {
 	sum := zero
 	for i, l := range lines {
 		l.Index = i + 1
-		l.calculate(zero)
+		l.normalize(zero)
 		sum = sum.MatchPrecision(l.Total)
 		sum = sum.Add(l.Total)
 	}

--- a/bill/outlay.go
+++ b/bill/outlay.go
@@ -45,7 +45,7 @@ func (o *Outlay) Validate() error {
 	)
 }
 
-func calculateOutlays(zero num.Amount, outlays []*Outlay) *num.Amount {
+func normalizeOutlays(zero num.Amount, outlays []*Outlay) *num.Amount {
 	if len(outlays) == 0 {
 		return nil
 	}

--- a/bill/outlay_test.go
+++ b/bill/outlay_test.go
@@ -20,7 +20,7 @@ func TestOutlayTotals(t *testing.T) {
 		},
 	}
 	zero := num.MakeAmount(0, 2)
-	sum := calculateOutlays(zero, os)
+	sum := normalizeOutlays(zero, os)
 	require.NotNil(t, sum)
 	assert.Equal(t, 1, os[0].Index)
 	assert.Equal(t, 2, os[1].Index)
@@ -28,6 +28,6 @@ func TestOutlayTotals(t *testing.T) {
 	assert.Equal(t, "200.00", os[1].Amount.String())
 
 	os = []*Outlay{}
-	sum = calculateOutlays(zero, os)
+	sum = normalizeOutlays(zero, os)
 	assert.Nil(t, sum)
 }

--- a/bill/payment.go
+++ b/bill/payment.go
@@ -40,9 +40,9 @@ func (p *Payment) ResetAdvances() {
 	p.Advances = make([]*pay.Advance, 0)
 }
 
-func (p *Payment) calculateAdvances(zero num.Amount, totalWithTax num.Amount) {
+func (p *Payment) normalizeAdvances(zero num.Amount, totalWithTax num.Amount) {
 	for _, a := range p.Advances {
-		a.CalculateFrom(totalWithTax)
+		a.NormalizeFrom(totalWithTax)
 		a.Amount = a.Amount.MatchPrecision(zero)
 	}
 }

--- a/bill/payment_test.go
+++ b/bill/payment_test.go
@@ -19,7 +19,7 @@ func TestPaymentCalculations(t *testing.T) {
 			},
 		},
 	}
-	p.calculateAdvances(zero, total)
+	p.normalizeAdvances(zero, total)
 	assert.Equal(t, "20.00", p.Advances[0].Amount.String())
 
 	p = &Payment{
@@ -31,7 +31,7 @@ func TestPaymentCalculations(t *testing.T) {
 		},
 	}
 	assert.Equal(t, "10", p.Advances[0].Amount.String())
-	p.calculateAdvances(zero, total)
+	p.normalizeAdvances(zero, total)
 	assert.Equal(t, "10.00", p.Advances[0].Amount.String())
 
 	p = &Payment{
@@ -46,7 +46,7 @@ func TestPaymentCalculations(t *testing.T) {
 			},
 		},
 	}
-	p.calculateAdvances(zero, total)
+	p.normalizeAdvances(zero, total)
 	sum := p.totalAdvance(zero)
 	assert.Equal(t, "30.00", sum.String())
 }

--- a/document.go
+++ b/document.go
@@ -24,10 +24,10 @@ type Document struct {
 	payload interface{}
 }
 
-// Calculable defines the methods expected of a document payload that contains a `Calculate`
-// method to be used to perform any additional calculations.
-type Calculable interface {
-	Calculate() error
+// Normalizable defines the methods expected of a document payload that contains a `Normalize`
+// method to be used to perform any additional data normalization and calculations.
+type Normalizable interface {
+	Normalize() error
 }
 
 // Correctable defines the expected interface of a document that can be
@@ -71,14 +71,21 @@ func (d *Document) Instance() interface{} {
 	return d.payload
 }
 
-// Calculate will attempt to run the calculation method on the
+// Normalize will attempt to run the normalization method on the
 // document payload.
-func (d *Document) Calculate() error {
-	pl, ok := d.payload.(Calculable)
+func (d *Document) Normalize() error {
+	pl, ok := d.payload.(Normalizable)
 	if !ok {
 		return nil
 	}
-	return pl.Calculate()
+	return pl.Normalize()
+}
+
+// Calculate wraps around the Normalize method.
+//
+// Deprecated: use the Normalize method instead.
+func (d *Document) Calculate() error {
+	return d.Normalize()
 }
 
 // Validate checks to ensure the document has everything it needs

--- a/document_test.go
+++ b/document_test.go
@@ -75,7 +75,7 @@ func TestDocumentValidation(t *testing.T) {
 
 	inv := doc.Instance().(*bill.Invoice)
 	inv.Code = "" // blank, which will not be accepted if not a draft
-	require.NoError(t, doc.Calculate())
+	require.NoError(t, doc.Normalize())
 	assert.NoError(t, doc.Validate())
 	inv.IssueDate = cal.Date{}
 	err = doc.Validate()

--- a/envelope.go
+++ b/envelope.go
@@ -109,7 +109,7 @@ func (e *Envelope) Sign(key *dsig.PrivateKey) error {
 }
 
 // Insert takes the provided document and inserts it into this
-// envelope. Calculate will be called automatically.
+// envelope. Normalize will be called automatically.
 func (e *Envelope) Insert(doc interface{}) error {
 	if e.Head == nil {
 		return ErrInternal.WithErrorf("missing head")
@@ -128,18 +128,26 @@ func (e *Envelope) Insert(doc interface{}) error {
 		}
 	}
 
-	if err := e.calculate(); err != nil {
+	if err := e.normalize(); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-// Calculate is used to perform calculations on the envelope's
-// document contents to ensure everything looks correct.
-// Headers will be refreshed to ensure they have the latest valid
-// digest.
+// Calculate will perform any normalization and calculation methods on the
+// envelope and document to ensure the basic data is correct.
+//
+// Deprecated: use the Normalize method instead.
 func (e *Envelope) Calculate() error {
+	return e.Normalize()
+}
+
+// Normalize is used to normalize the envelope and document data alongside
+// any calculations required to complete the data.
+// Headers will also be refreshed to ensure they have the latest valid
+// digest data.
+func (e *Envelope) Normalize() error {
 	if e.Document == nil {
 		return ErrNoDocument
 	}
@@ -147,15 +155,15 @@ func (e *Envelope) Calculate() error {
 		return ErrNoDocument
 	}
 
-	return e.calculate()
+	return e.normalize()
 }
 
-func (e *Envelope) calculate() error {
+func (e *Envelope) normalize() error {
 	// Always set our schema version
 	e.Schema = EnvelopeSchema
 
 	// arm doors and cross check
-	if err := e.Document.Calculate(); err != nil {
+	if err := e.Document.Normalize(); err != nil {
 		return ErrCalculation.WithCause(err)
 	}
 

--- a/envelope_test.go
+++ b/envelope_test.go
@@ -127,14 +127,14 @@ func TestEnvelopeInsert(t *testing.T) {
 	})
 }
 
-func TestEnvelopeCalculate(t *testing.T) {
+func TestEnvelopeNormalize(t *testing.T) {
 	m := new(note.Message)
 	m.Content = testMessageContent
 
 	t.Run("basics", func(t *testing.T) {
 		e := gobl.NewEnvelope()
 		require.NoError(t, e.Insert(m))
-		err := e.Calculate()
+		err := e.Normalize()
 		assert.NoError(t, err)
 	})
 
@@ -142,14 +142,14 @@ func TestEnvelopeCalculate(t *testing.T) {
 		e := gobl.NewEnvelope()
 		require.NoError(t, e.Insert(m))
 		e.Head.AddStamp(&cbc.Stamp{Provider: cbc.Key("test"), Value: "test"})
-		err := e.Calculate()
+		err := e.Normalize()
 		assert.NoError(t, err)
 		assert.NotEmpty(t, e.Head.Stamps)
 		e.Head.Draft = true
 		err = e.Validate()
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "stamps: must be blank.")
-		err = e.Calculate()
+		err = e.Normalize()
 		assert.NoError(t, err)
 		assert.Len(t, e.Head.Stamps, 1)
 		/*
@@ -169,7 +169,7 @@ func TestEnvelopeComplete(t *testing.T) {
 	err = yaml.Unmarshal(data, e)
 	require.NoError(t, err)
 
-	err = e.Calculate()
+	err = e.Normalize()
 	require.NoError(t, err)
 
 	inv, ok := e.Extract().(*bill.Invoice)
@@ -182,13 +182,13 @@ func TestEnvelopeComplete(t *testing.T) {
 func TestEnvelopeCompleteErrors(t *testing.T) {
 	t.Run("missing document", func(t *testing.T) {
 		e := new(gobl.Envelope)
-		err := e.Calculate()
+		err := e.Normalize()
 		assert.Error(t, err)
 		assert.ErrorIs(t, err, gobl.ErrNoDocument)
 	})
 	t.Run("missing document payload", func(t *testing.T) {
 		e := gobl.NewEnvelope()
-		err := e.Calculate()
+		err := e.Normalize()
 		assert.Error(t, err)
 		assert.ErrorIs(t, err, gobl.ErrNoDocument)
 	})
@@ -294,7 +294,7 @@ func TestEnvelopeCorrect(t *testing.T) {
 		require.NoError(t, err)
 		err = yaml.Unmarshal(data, env)
 		require.NoError(t, err)
-		require.NoError(t, env.Calculate())
+		require.NoError(t, env.Normalize())
 
 		_, err = env.Correct()
 		require.NoError(t, err)

--- a/examples_test.go
+++ b/examples_test.go
@@ -62,7 +62,7 @@ func processFile(t *testing.T, path string) error {
 		if err := yaml.Unmarshal(data, env); err != nil {
 			return fmt.Errorf("invalid contents: %w", err)
 		}
-		if err := env.Calculate(); err != nil {
+		if err := env.Normalize(); err != nil {
 			return fmt.Errorf("failed to complete: %w", err)
 		}
 	} else {

--- a/org/party.go
+++ b/org/party.go
@@ -42,20 +42,20 @@ type Party struct {
 	Meta cbc.Meta `json:"meta,omitempty" jsonschema:"title=Meta"`
 }
 
-// Calculate performs any calculations required on the Party or
+// Normalize performs any calculations required on the Party or
 // it's properties, like the tax identity.
-func (p *Party) Calculate() error {
+func (p *Party) Normalize() error {
 	if p.TaxID == nil {
 		return nil
 	}
-	if err := p.TaxID.Calculate(); err != nil {
+	if err := p.TaxID.Normalize(); err != nil {
 		return err
 	}
 	r := p.TaxID.Regime()
 	if r == nil {
 		return nil // nothing to do here
 	}
-	return r.CalculateObject(p)
+	return r.NormalizeObject(p)
 }
 
 // Validate is used to check the party's data meets minimum expectations.

--- a/org/party_test.go
+++ b/org/party_test.go
@@ -23,7 +23,7 @@ func TestEmailValidation(t *testing.T) {
 	assert.EqualError(t, invalid.Validate(), "addr: must be a valid email address.")
 }
 
-func TestPartyCalculate(t *testing.T) {
+func TestPartyNormalize(t *testing.T) {
 	party := org.Party{
 		Name: "Invopop",
 		TaxID: &tax.Identity{
@@ -31,7 +31,7 @@ func TestPartyCalculate(t *testing.T) {
 			Code:    "423 429 12.G",
 		},
 	}
-	assert.NoError(t, party.Calculate())
+	assert.NoError(t, party.Normalize())
 	assert.Equal(t, l10n.ES, party.TaxID.Country)
 	assert.Equal(t, "ES42342912G", party.TaxID.String())
 
@@ -42,5 +42,5 @@ func TestPartyCalculate(t *testing.T) {
 			Code:    "423 429 12.G",
 		},
 	}
-	assert.NoError(t, party.Calculate(), "unknown entry should not cause problem")
+	assert.NoError(t, party.Normalize(), "unknown entry should not cause problem")
 }

--- a/pay/advance.go
+++ b/pay/advance.go
@@ -51,9 +51,9 @@ func (a *Advance) ValidateWithContext(ctx context.Context) error {
 	)
 }
 
-// CalculateFrom will update the amount using the rate of the provided
+// NormalizeFrom will update the amount using the rate of the provided
 // total, if defined.
-func (a *Advance) CalculateFrom(totalWithTax num.Amount) {
+func (a *Advance) NormalizeFrom(totalWithTax num.Amount) {
 	if a.Percent != nil {
 		a.Amount = a.Percent.Of(totalWithTax)
 	}

--- a/pay/terms.go
+++ b/pay/terms.go
@@ -95,9 +95,9 @@ func (t *Terms) UNTDID4279() cbc.Code {
 	return cbc.CodeEmpty
 }
 
-// CalculateDues goes through each DueDate. If it has a percentage
+// NormalizeDues goes through each DueDate. If it has a percentage
 // value set, it'll be used to calculate the amount.
-func (t *Terms) CalculateDues(zero num.Amount, sum num.Amount) {
+func (t *Terms) NormalizeDues(zero num.Amount, sum num.Amount) {
 	if t == nil {
 		return
 	}

--- a/pay/terms_test.go
+++ b/pay/terms_test.go
@@ -29,11 +29,11 @@ func TestTermsValidation(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestTermsCalculateDues(t *testing.T) {
+func TestTermsNormalizeDues(t *testing.T) {
 	sum := num.MakeAmount(10000, 2)
 	var terms *Terms
 	zero := num.MakeAmount(0, 2)
-	terms.CalculateDues(zero, sum) // Should not panic
+	terms.NormalizeDues(zero, sum) // Should not panic
 	terms = new(Terms)
 	terms.DueDates = []*DueDate{
 		{
@@ -45,7 +45,7 @@ func TestTermsCalculateDues(t *testing.T) {
 			Percent: num.NewPercentage(60, 2),
 		},
 	}
-	terms.CalculateDues(zero, sum)
+	terms.NormalizeDues(zero, sum)
 
 	assert.Equal(t, num.MakeAmount(4000, 2), terms.DueDates[0].Amount)
 	assert.Equal(t, num.MakeAmount(6000, 2), terms.DueDates[1].Amount)
@@ -56,6 +56,6 @@ func TestTermsCalculateDues(t *testing.T) {
 			Amount: num.MakeAmount(40, 0),
 		},
 	}
-	terms.CalculateDues(zero, sum)
+	terms.NormalizeDues(zero, sum)
 	assert.Equal(t, "40.00", terms.DueDates[0].Amount.String(), "should normalize amounts for currency")
 }

--- a/regimes/co/co.go
+++ b/regimes/co/co.go
@@ -37,7 +37,7 @@ func New() *tax.Regime {
 			i18n.ES: "Colombia",
 		},
 		Validator:        Validate,
-		Calculator:       Calculate,
+		Normalizer:       Normalize,
 		IdentityTypeKeys: taxIdentityTypeDefs, // see tax_identity.go
 		Zones:            zones,               // see zones.go
 		Preceding: &tax.PrecedingDefinitions{ // see preceding.go
@@ -64,8 +64,8 @@ func Validate(doc interface{}) error {
 	return nil
 }
 
-// Calculate will attempt to clean the object passed to it.
-func Calculate(doc interface{}) error {
+// Normalize will attempt to clean the object passed to it.
+func Normalize(doc interface{}) error {
 	switch obj := doc.(type) {
 	case *tax.Identity:
 		return normalizeTaxIdentity(obj)

--- a/regimes/co/invoices_test.go
+++ b/regimes/co/invoices_test.go
@@ -115,7 +115,7 @@ func creditNote() *bill.Invoice {
 
 func TestBasicInvoiceValidation(t *testing.T) {
 	inv := baseInvoice()
-	require.NoError(t, inv.Calculate())
+	require.NoError(t, inv.Normalize())
 	assert.Equal(t, inv.Type, bill.InvoiceTypeStandard)
 	require.NoError(t, inv.Validate())
 	assert.Equal(t, inv.Supplier.Addresses[0].Locality, "Bogotá, D.C.")
@@ -135,7 +135,7 @@ func TestBasicInvoiceValidation(t *testing.T) {
 
 	inv = baseInvoice()
 	inv.Supplier.TaxID.Type = co.TaxIdentityTypeCitizen
-	require.NoError(t, inv.Calculate())
+	require.NoError(t, inv.Normalize())
 	err = inv.Validate()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "supplier: (tax_id: (type: must be a valid value.).).")
@@ -144,7 +144,7 @@ func TestBasicInvoiceValidation(t *testing.T) {
 	inv.Customer.TaxID.Type = co.TaxIdentityTypeCitizen
 	inv.Customer.TaxID.Code = "100100100"
 	inv.Customer.TaxID.Zone = ""
-	require.NoError(t, inv.Calculate())
+	require.NoError(t, inv.Normalize())
 	err = inv.Validate()
 	assert.NoError(t, err)
 }
@@ -152,7 +152,7 @@ func TestBasicInvoiceValidation(t *testing.T) {
 func TestBasicCreditNoteValidation(t *testing.T) {
 	inv := creditNote()
 	inv.Preceding[0].Reason = "Correcting an error"
-	err := inv.Calculate()
+	err := inv.Normalize()
 	require.NoError(t, err)
 	err = inv.Validate()
 	assert.NoError(t, err)

--- a/regimes/co/tax_identity_test.go
+++ b/regimes/co/tax_identity_test.go
@@ -14,12 +14,12 @@ import (
 
 func TestNormalizeTaxIdentity(t *testing.T) {
 	tID := &tax.Identity{Country: l10n.CO, Code: "901.458.652-7"}
-	err := co.Calculate(tID)
+	err := co.Normalize(tID)
 	require.NoError(t, err)
 	assert.Equal(t, co.TaxIdentityTypeTIN, tID.Type, "autoassign type")
 
 	tID = &tax.Identity{Country: l10n.CO, Type: co.TaxIdentityTypeCivil, Code: "XX"}
-	err = co.Calculate(tID)
+	err = co.Normalize(tID)
 	require.NoError(t, err)
 	assert.Equal(t, co.TaxIdentityTypeCivil, tID.Type, "copy type")
 
@@ -48,7 +48,7 @@ func TestNormalizeTaxIdentity(t *testing.T) {
 	}
 	for _, ts := range tests {
 		tID := &tax.Identity{Country: l10n.CO, Code: ts.Code}
-		err := co.Calculate(tID)
+		err := co.Normalize(tID)
 		assert.NoError(t, err)
 		assert.Equal(t, ts.Expected, tID.Code)
 	}
@@ -68,7 +68,7 @@ func TestNormalizeParty(t *testing.T) {
 			},
 		},
 	}
-	err := co.Calculate(p)
+	err := co.Normalize(p)
 	assert.NoError(t, err)
 	assert.Equal(t, p.Addresses[0].Locality, "Bogotá, D.C.")
 	assert.Equal(t, p.Addresses[0].Region, "Bogotá")
@@ -86,7 +86,7 @@ func TestNormalizeParty(t *testing.T) {
 			},
 		},
 	}
-	err = co.Calculate(p)
+	err = co.Normalize(p)
 	require.NoError(t, err)
 	err = co.Validate(p)
 	assert.NoError(t, err)

--- a/regimes/es/es.go
+++ b/regimes/es/es.go
@@ -79,7 +79,7 @@ func New() *tax.Regime {
 		Categories:       taxCategories,
 		ItemKeys:         itemKeyDefinitions, // items.go
 		Validator:        Validate,
-		Calculator:       Calculate,
+		Normalizer:       Normalize,
 		Scenarios: []*tax.ScenarioSet{
 			invoiceScenarios,
 		},
@@ -104,8 +104,8 @@ func Validate(doc interface{}) error {
 	return nil
 }
 
-// Calculate will perform any regime specific calculations.
-func Calculate(doc interface{}) error {
+// Normalize will perform any regime specific calculations.
+func Normalize(doc interface{}) error {
 	switch obj := doc.(type) {
 	case *tax.Identity:
 		return normalizeTaxIdentity(obj)

--- a/regimes/es/scenarios_test.go
+++ b/regimes/es/scenarios_test.go
@@ -108,7 +108,7 @@ func testInvoiceSimplified(t *testing.T) *bill.Invoice {
 
 func TestInvoiceDocumentScenarios(t *testing.T) {
 	i := testInvoiceStandard(t)
-	require.NoError(t, i.Calculate())
+	require.NoError(t, i.Normalize())
 	assert.Len(t, i.Notes, 0)
 
 	ss := i.ScenarioSummary()
@@ -117,12 +117,12 @@ func TestInvoiceDocumentScenarios(t *testing.T) {
 
 	i = testInvoiceStandard(t)
 	i.Tax.Tags = []cbc.Key{es.TagTravelAgency}
-	require.NoError(t, i.Calculate())
+	require.NoError(t, i.Normalize())
 	assert.Len(t, i.Notes, 1)
 	assert.Equal(t, i.Notes[0].Src, es.TagTravelAgency)
 	assert.Equal(t, i.Notes[0].Text, "Régimen especial de las agencias de viajes.")
 
 	i = testInvoiceSimplified(t)
-	require.NoError(t, i.Calculate())
+	require.NoError(t, i.Normalize())
 	require.NoError(t, i.Validate())
 }

--- a/regimes/es/tax_identity.go
+++ b/regimes/es/tax_identity.go
@@ -250,7 +250,7 @@ func verifyOrgCodeMatches(m map[string]string) error {
 		}
 	}
 
-	// Calculate check digit
+	// Normalize check digit
 	cdc := (10 - (sumEven+sumOdd)%10) % 10
 
 	// Extract digit to compare against

--- a/regimes/es/tax_identity_test.go
+++ b/regimes/es/tax_identity_test.go
@@ -39,7 +39,7 @@ func TestNormalizeTaxIdentity(t *testing.T) {
 	}
 	for _, ts := range tests {
 		tID := &tax.Identity{Country: l10n.ES, Code: ts.Code}
-		err := r.CalculateObject(tID)
+		err := r.NormalizeObject(tID)
 		assert.NoError(t, err)
 		assert.Equal(t, ts.Expected, tID.Code)
 	}

--- a/regimes/fr/fr.go
+++ b/regimes/fr/fr.go
@@ -44,7 +44,7 @@ func New() *tax.Regime {
 			},
 		},
 		Validator:  Validate,
-		Calculator: Calculate,
+		Normalizer: Normalize,
 		Categories: taxCategories,
 	}
 }
@@ -58,8 +58,8 @@ func Validate(doc interface{}) error {
 	return nil
 }
 
-// Calculate will attempt to clean the object passed to it.
-func Calculate(doc interface{}) error {
+// Normalize will attempt to clean the object passed to it.
+func Normalize(doc interface{}) error {
 	switch obj := doc.(type) {
 	case *tax.Identity:
 		return normalizeTaxIdentity(obj)

--- a/regimes/fr/tax_identity_test.go
+++ b/regimes/fr/tax_identity_test.go
@@ -39,7 +39,7 @@ func TestNormalizeTaxIdentity(t *testing.T) {
 	}
 	for _, ts := range tests {
 		tID := &tax.Identity{Country: l10n.FR, Code: ts.Code}
-		err := r.CalculateObject(tID)
+		err := r.NormalizeObject(tID)
 		assert.NoError(t, err)
 		assert.Equal(t, ts.Expected, tID.Code)
 	}

--- a/regimes/gb/gb.go
+++ b/regimes/gb/gb.go
@@ -28,7 +28,7 @@ func New() *tax.Regime {
 			i18n.EN: "United Kingdom",
 		},
 		Validator:  Validate,
-		Calculator: Calculate,
+		Normalizer: Normalize,
 		Categories: taxCategories,
 	}
 }
@@ -44,8 +44,8 @@ func Validate(doc interface{}) error {
 	return nil
 }
 
-// Calculate will attempt to clean the object passed to it.
-func Calculate(doc interface{}) error {
+// Normalize will attempt to clean the object passed to it.
+func Normalize(doc interface{}) error {
 	switch obj := doc.(type) {
 	case *tax.Identity:
 		return common.NormalizeTaxIdentity(obj)

--- a/regimes/it/invoice_validator_test.go
+++ b/regimes/it/invoice_validator_test.go
@@ -86,7 +86,7 @@ func testInvoiceStandard(t *testing.T) *bill.Invoice {
 
 func TestInvoiceValidation(t *testing.T) {
 	inv := testInvoiceStandard(t)
-	require.NoError(t, inv.Calculate())
+	require.NoError(t, inv.Normalize())
 	require.NoError(t, inv.Validate())
 }
 
@@ -97,7 +97,7 @@ func TestCustomerValidation(t *testing.T) {
 		Type:    it.TaxIdentityTypeIndividual,
 		Code:    "RSSGNN60R30H501U",
 	}
-	require.NoError(t, inv.Calculate())
+	require.NoError(t, inv.Normalize())
 	require.NoError(t, inv.Validate())
 
 }
@@ -109,7 +109,7 @@ func TestSupplierValidation(t *testing.T) {
 		Type:    it.TaxIdentityTypeIndividual,
 		Code:    "RSSGNN60R30H501U",
 	}
-	require.NoError(t, inv.Calculate())
+	require.NoError(t, inv.Normalize())
 	err := inv.Validate()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "type: must be a valid value")
@@ -121,7 +121,7 @@ func TestRetainedTaxesValidation(t *testing.T) {
 		Category: "IRPEF",
 		Percent:  num.NewPercentage(20, 2),
 	})
-	require.NoError(t, inv.Calculate())
+	require.NoError(t, inv.Normalize())
 	err := inv.Validate()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "lines: (0: (taxes: 1: rate: cannot be blank..).).")
@@ -132,6 +132,6 @@ func TestRetainedTaxesValidation(t *testing.T) {
 		Rate:     cbc.Key("self-employed-habitual"),
 		Percent:  num.NewPercentage(20, 2),
 	})
-	require.NoError(t, inv.Calculate())
+	require.NoError(t, inv.Normalize())
 	require.NoError(t, inv.Validate())
 }

--- a/regimes/it/it.go
+++ b/regimes/it/it.go
@@ -40,7 +40,7 @@ func New() *tax.Regime {
 		Tags:             invoiceTags,
 		Scenarios:        scenarios, // scenarios.go
 		Validator:        Validate,
-		Calculator:       Calculate,
+		Normalizer:       Normalize,
 		Zones:            zones,      // zones.go
 		Categories:       categories, // categories.go
 	}
@@ -61,8 +61,8 @@ func Validate(doc interface{}) error {
 	return nil
 }
 
-// Calculate will perform any regime specific calculations.
-func Calculate(doc interface{}) error {
+// Normalize will perform any regime specific calculations.
+func Normalize(doc interface{}) error {
 	switch obj := doc.(type) {
 	case *tax.Identity:
 		return normalizeTaxIdentity(obj)

--- a/regimes/it/pay_test.go
+++ b/regimes/it/pay_test.go
@@ -23,7 +23,7 @@ func TestPayInstructionsValidation(t *testing.T) {
 			},
 		},
 	}
-	require.NoError(t, inv.Calculate())
+	require.NoError(t, inv.Normalize())
 	err := inv.Validate()
 	require.NoError(t, err)
 
@@ -36,7 +36,7 @@ func TestPayInstructionsValidation(t *testing.T) {
 			},
 		},
 	}
-	require.NoError(t, inv.Calculate())
+	require.NoError(t, inv.Normalize())
 	err = inv.Validate()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "key: must be a valid value")

--- a/regimes/it/tax_identity_test.go
+++ b/regimes/it/tax_identity_test.go
@@ -34,7 +34,7 @@ func TestNormalizeTaxIdentity(t *testing.T) {
 	}
 	for _, ts := range tests {
 		tID := &tax.Identity{Country: l10n.IT, Code: ts.code}
-		err := it.Calculate(tID)
+		err := it.Normalize(tID)
 		assert.NoError(t, err)
 		assert.Equal(t, ts.expected, tID.Code)
 	}

--- a/regimes/mx/invoice_validator_test.go
+++ b/regimes/mx/invoice_validator_test.go
@@ -74,7 +74,7 @@ func validInvoice() *bill.Invoice {
 
 func TestValidInvoice(t *testing.T) {
 	inv := validInvoice()
-	require.NoError(t, inv.Calculate())
+	require.NoError(t, inv.Normalize())
 	require.NoError(t, inv.Validate())
 }
 
@@ -156,7 +156,7 @@ func TestUsoCFDIScenarioValidation(t *testing.T) {
 }
 
 func assertValidationError(t *testing.T, inv *bill.Invoice, expected string) {
-	require.NoError(t, inv.Calculate())
+	require.NoError(t, inv.Normalize())
 	err := inv.Validate()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), expected)

--- a/regimes/mx/item_test.go
+++ b/regimes/mx/item_test.go
@@ -90,7 +90,7 @@ func TestItemIdentityNormalization(t *testing.T) {
 	}
 	for _, ts := range tests {
 		item := &org.Item{Identities: []*org.Identity{{Code: ts.Code, Type: "SAT"}}}
-		err := r.CalculateObject(item)
+		err := r.NormalizeObject(item)
 		assert.NoError(t, err)
 		assert.Equal(t, ts.Expected, item.Identities[0].Code)
 	}

--- a/regimes/mx/mx.go
+++ b/regimes/mx/mx.go
@@ -35,7 +35,7 @@ func New() *tax.Regime {
 		},
 		PaymentMeansKeys: paymentMeansKeyDefinitions, // pay.go
 		Validator:        Validate,
-		Calculator:       Calculate,
+		Normalizer:       Normalize,
 		Tags:             invoiceTags,   // scenarios.go
 		Scenarios:        scenarios,     // scenarios.go
 		Categories:       taxCategories, // categories.go
@@ -55,8 +55,8 @@ func Validate(doc interface{}) error {
 	return nil
 }
 
-// Calculate performs regime specific calculations.
-func Calculate(doc interface{}) error {
+// Normalize performs regime specific calculations.
+func Normalize(doc interface{}) error {
 	switch obj := doc.(type) {
 	case *tax.Identity:
 		return common.NormalizeTaxIdentity(obj)

--- a/regimes/mx/tax_identity_test.go
+++ b/regimes/mx/tax_identity_test.go
@@ -31,7 +31,7 @@ func TestTaxIdentityNormalization(t *testing.T) {
 	}
 	for _, ts := range tests {
 		tID := &tax.Identity{Country: l10n.MX, Code: ts.Code}
-		err := r.CalculateObject(tID)
+		err := r.NormalizeObject(tID)
 		assert.NoError(t, err)
 		assert.Equal(t, ts.Expected, tID.Code)
 	}

--- a/regimes/nl/nl.go
+++ b/regimes/nl/nl.go
@@ -24,7 +24,7 @@ func New() *tax.Regime {
 			i18n.NL: "Nederland",
 		},
 		Validator:  Validate,
-		Calculator: Calculate,
+		Normalizer: Normalize,
 		Categories: []*tax.Category{
 			//
 			// VAT
@@ -93,8 +93,8 @@ func Validate(doc interface{}) error {
 	return nil
 }
 
-// Calculate performs region specific calculations on the document.
-func Calculate(doc interface{}) error {
+// Normalize performs region specific calculations on the document.
+func Normalize(doc interface{}) error {
 	switch obj := doc.(type) {
 	case *tax.Identity:
 		return NormalizeTaxIdentity(obj)

--- a/regimes/pt/invoice_validator_test.go
+++ b/regimes/pt/invoice_validator_test.go
@@ -46,7 +46,7 @@ func validInvoice() *bill.Invoice {
 
 func TestValidInvoice(t *testing.T) {
 	inv := validInvoice()
-	require.NoError(t, inv.Calculate())
+	require.NoError(t, inv.Normalize())
 	require.NoError(t, inv.Validate())
 }
 
@@ -61,7 +61,7 @@ func TestLineValidation(t *testing.T) {
 }
 
 func assertValidationError(t *testing.T, inv *bill.Invoice, expected string) {
-	require.NoError(t, inv.Calculate())
+	require.NoError(t, inv.Normalize())
 	err := inv.Validate()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), expected)

--- a/regimes/pt/pt.go
+++ b/regimes/pt/pt.go
@@ -66,7 +66,7 @@ func New() *tax.Regime {
 		Tags:       invoiceTags,
 		Scenarios:  scenarios,
 		Validator:  Validate,
-		Calculator: Calculate,
+		Normalizer: Normalize,
 		Preceding: &tax.PrecedingDefinitions{
 			Types: []cbc.Key{
 				bill.InvoiceTypeCreditNote,
@@ -87,8 +87,8 @@ func Validate(doc interface{}) error {
 	return nil
 }
 
-// Calculate will attempt to clean the object passed to it.
-func Calculate(doc interface{}) error {
+// Normalize will attempt to clean the object passed to it.
+func Normalize(doc interface{}) error {
 	switch obj := doc.(type) {
 	case *tax.Identity:
 		return normalizeTaxIdentity(obj)

--- a/regimes/pt/tax_code_test.go
+++ b/regimes/pt/tax_code_test.go
@@ -34,7 +34,7 @@ func TestNormalizeTaxIdentity(t *testing.T) {
 	}
 	for _, ts := range tests {
 		tID := &tax.Identity{Country: l10n.PT, Code: ts.Code}
-		err := pt.Calculate(tID)
+		err := pt.Normalize(tID)
 		assert.NoError(t, err)
 		assert.Equal(t, ts.Expected, tID.Code)
 	}

--- a/tax/identity.go
+++ b/tax/identity.go
@@ -79,12 +79,12 @@ func (id *Identity) Regime() *Regime {
 	return regimes.For(id.Country, id.Zone)
 }
 
-// Calculate will attempt to perform a regional tax normalization
+// Normalize will attempt to perform a regional tax normalization
 // on the tax identity.
-func (id *Identity) Calculate() error {
+func (id *Identity) Normalize() error {
 	r := id.Regime()
 	if r != nil {
-		return r.CalculateObject(id)
+		return r.NormalizeObject(id)
 	}
 	return nil
 }

--- a/tax/identity_test.go
+++ b/tax/identity_test.go
@@ -34,7 +34,7 @@ func TestTaxIdentity(t *testing.T) {
 		Country: l10n.ES,
 		Code:    "  x315-7928 m",
 	}
-	err = tID.Calculate()
+	err = tID.Normalize()
 	assert.NoError(t, err)
 	assert.Equal(t, tID.Code.String(), "X3157928M")
 }

--- a/tax/regime.go
+++ b/tax/regime.go
@@ -69,10 +69,10 @@ type Regime struct {
 	// Validator is a method to use to validate a document in a given region.
 	Validator func(doc interface{}) error `json:"-"`
 
-	// Calculator is used to performs regime specific calculations on data,
+	// Normalizer is used to performs regime specific calculations on data,
 	// including any normalization that might need to take place such as
 	// with tax codes and removing white-space.
-	Calculator func(doc interface{}) error `json:"-"`
+	Normalizer func(doc interface{}) error `json:"-"`
 }
 
 // Zone represents an area inside a country, like a province
@@ -203,11 +203,11 @@ func (r *Regime) ValidateObject(obj interface{}) error {
 	return nil
 }
 
-// CalculateObject performs any regime specific calculations on the provided
+// NormalizeObject performs any regime specific calculations on the provided
 // object.
-func (r *Regime) CalculateObject(obj interface{}) error {
-	if r.Calculator != nil {
-		return r.Calculator(obj)
+func (r *Regime) NormalizeObject(obj interface{}) error {
+	if r.Normalizer != nil {
+		return r.Normalizer(obj)
 	}
 	return nil
 }

--- a/tax/totals_test.go
+++ b/tax/totals_test.go
@@ -30,7 +30,7 @@ func (tl *taxableLine) GetTotal() num.Amount {
 	return tl.amount
 }
 
-func TestTotalCalculate(t *testing.T) {
+func TestTotalNormalize(t *testing.T) {
 	spain := es.New()
 	portugal := pt.New()
 	italy := it.New()


### PR DESCRIPTION
* Quickly experimenting renaming Calculate into Normalize which more accurately describes the intent.