### PR TITLE
Save example output and compare

### DIFF
--- a/note/examples/out/message.json
+++ b/note/examples/out/message.json
@@ -1,0 +1,16 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
+		"dig": {
+			"alg": "sha256",
+			"val": "45ac3115c8569a1789e58af8d0dc91ef3baa1fb71daaf38f5aef94f82b4d0033"
+		},
+		"draft": true
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/note/message",
+		"title": "Test Message",
+		"content": "We hope you like this test message!"
+	}
+}

--- a/pay/terms.go
+++ b/pay/terms.go
@@ -16,7 +16,7 @@ import (
 // the contents of the document.
 type Terms struct {
 	// Type of terms to be applied.
-	Key cbc.Key `json:"key" jsonschema:"title=Key"`
+	Key cbc.Key `json:"key,omitempty" jsonschema:"title=Key"`
 	// Text detail of the chosen payment terms.
 	Detail string `json:"detail,omitempty" jsonschema:"title=Detail"`
 	// Set of dates for agreed payments.

--- a/regimes/co/examples/out/simple.json
+++ b/regimes/co/examples/out/simple.json
@@ -4,7 +4,7 @@
 		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
 		"dig": {
 			"alg": "sha256",
-			"val": "5fff065413fac95076f9ee278ee219b351da74f6251244aa7accc6f6a57ae471"
+			"val": "4f57dd43293a4c781a1d3a3456cbca2199315103cbc801fe5c8b3e059264791d"
 		},
 		"draft": true
 	},
@@ -71,7 +71,6 @@
 		],
 		"payment": {
 			"terms": {
-				"key": "",
 				"due_dates": [
 					{
 						"date": "2021-01-01",

--- a/regimes/co/examples/out/simple.json
+++ b/regimes/co/examples/out/simple.json
@@ -1,0 +1,108 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
+		"dig": {
+			"alg": "sha256",
+			"val": "5fff065413fac95076f9ee278ee219b351da74f6251244aa7accc6f6a57ae471"
+		},
+		"draft": true
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"series": "SETT",
+		"code": "1234",
+		"type": "standard",
+		"currency": "COP",
+		"issue_date": "2021-01-01",
+		"supplier": {
+			"name": "EXAMPLE SUPPLIER S.A.S.",
+			"tax_id": {
+				"country": "CO",
+				"zone": "11001",
+				"type": "tin",
+				"code": "9014514812"
+			}
+		},
+		"customer": {
+			"name": "EXAMPLE CUSTOMER S.A.S.",
+			"tax_id": {
+				"country": "CO",
+				"zone": "11001",
+				"type": "tin",
+				"code": "9014514805"
+			},
+			"addresses": [
+				{
+					"street": "CRA 8 113 31 OF 703",
+					"locality": "Bogotá, D.C.",
+					"region": "Bogotá",
+					"country": "CO"
+				}
+			],
+			"emails": [
+				{
+					"addr": "benito.ortiz@example.com"
+				}
+			],
+			"telephones": [
+				{
+					"num": "3114131811"
+				}
+			]
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "1",
+				"item": {
+					"name": "Servicios Mes de Julio 2022",
+					"price": "200000.00"
+				},
+				"sum": "200000.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"percent": "19%"
+					}
+				],
+				"total": "200000.00"
+			}
+		],
+		"payment": {
+			"terms": {
+				"key": "",
+				"due_dates": [
+					{
+						"date": "2021-01-01",
+						"amount": "238000.00",
+						"percent": "100%"
+					}
+				]
+			}
+		},
+		"totals": {
+			"sum": "200000.00",
+			"total": "200000.00",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"base": "200000.00",
+								"percent": "19%",
+								"amount": "38000.00"
+							}
+						],
+						"amount": "38000.00"
+					}
+				],
+				"sum": "38000.00"
+			},
+			"tax": "38000.00",
+			"total_with_tax": "238000.00",
+			"payable": "238000.00"
+		}
+	}
+}

--- a/regimes/es/examples/out/invoice-es-es-freelance.json
+++ b/regimes/es/examples/out/invoice-es-es-freelance.json
@@ -1,0 +1,137 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
+		"dig": {
+			"alg": "sha256",
+			"val": "f1d54d434ba07ddd90f33d711f6a6725a80228f80cd831f11fcaa21357796571"
+		},
+		"draft": true
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"code": "SAMPLE-001",
+		"type": "standard",
+		"currency": "EUR",
+		"issue_date": "2022-02-01",
+		"supplier": {
+			"name": "MªF. Services",
+			"tax_id": {
+				"country": "ES",
+				"code": "58384285G"
+			},
+			"people": [
+				{
+					"name": {
+						"given": "MARIA FRANCISCA",
+						"surname": "MONTERO",
+						"surname2": "ESTEBAN"
+					}
+				}
+			],
+			"addresses": [
+				{
+					"num": "9",
+					"street": "CAMÍ MADRID",
+					"locality": "CANENA",
+					"region": "JAÉN",
+					"code": "23480",
+					"country": "ES"
+				}
+			],
+			"emails": [
+				{
+					"addr": "billing@example.com"
+				}
+			]
+		},
+		"customer": {
+			"name": "Sample Consumer",
+			"tax_id": {
+				"country": "ES",
+				"code": "54387763P"
+			}
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "20",
+				"item": {
+					"name": "Development services",
+					"price": "90.00",
+					"unit": "h"
+				},
+				"sum": "1800.00",
+				"discounts": [
+					{
+						"percent": "10%",
+						"amount": "180.00",
+						"reason": "Special discount"
+					}
+				],
+				"taxes": [
+					{
+						"cat": "VAT",
+						"rate": "standard",
+						"percent": "21.0%"
+					},
+					{
+						"cat": "IRPF",
+						"percent": "15.0%"
+					}
+				],
+				"total": "1620.00"
+			}
+		],
+		"payment": {
+			"terms": {
+				"key": "instant"
+			},
+			"instructions": {
+				"key": "credit-transfer",
+				"credit_transfer": [
+					{
+						"iban": "ES06 0128 0011 3901 0008 1391",
+						"name": "Bankinter"
+					}
+				]
+			}
+		},
+		"totals": {
+			"sum": "1620.00",
+			"total": "1620.00",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"base": "1620.00",
+								"percent": "21.0%",
+								"amount": "340.20"
+							}
+						],
+						"amount": "340.20"
+					},
+					{
+						"code": "IRPF",
+						"retained": true,
+						"rates": [
+							{
+								"base": "1620.00",
+								"percent": "15.0%",
+								"amount": "243.00"
+							}
+						],
+						"amount": "243.00"
+					}
+				],
+				"sum": "97.20"
+			},
+			"tax": "97.20",
+			"total_with_tax": "1717.20",
+			"payable": "1717.20"
+		}
+	}
+}

--- a/regimes/es/examples/out/invoice-es-es-vateqs-provider.json
+++ b/regimes/es/examples/out/invoice-es-es-vateqs-provider.json
@@ -1,0 +1,168 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
+		"dig": {
+			"alg": "sha256",
+			"val": "be3f4ef1fe594f569535d860a7b85ba7e2fb0ee70d4deed9cf9c5761faa1e446"
+		},
+		"draft": true
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"code": "SAMPLE-001",
+		"type": "standard",
+		"currency": "EUR",
+		"tax": {
+			"prices_include": "VAT"
+		},
+		"issue_date": "2022-02-01",
+		"supplier": {
+			"name": "Provide One S.L.",
+			"tax_id": {
+				"country": "ES",
+				"code": "B98602642"
+			},
+			"addresses": [
+				{
+					"num": "42",
+					"street": "Calle Pradillo",
+					"locality": "Madrid",
+					"region": "Madrid",
+					"code": "28002",
+					"country": "ES"
+				}
+			],
+			"emails": [
+				{
+					"addr": "billing@example.com"
+				}
+			]
+		},
+		"customer": {
+			"name": "Simple Goods Store",
+			"tax_id": {
+				"country": "ES",
+				"code": "54387763P"
+			},
+			"addresses": [
+				{
+					"num": "43",
+					"street": "Calle Mayor",
+					"locality": "Madrid",
+					"region": "Madrid",
+					"code": "28003"
+				}
+			]
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "10",
+				"item": {
+					"name": "Mugs from provider",
+					"price": "10.00"
+				},
+				"sum": "100.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"rate": "standard+eqs",
+						"percent": "21.0%",
+						"surcharge": "5.2%"
+					}
+				],
+				"total": "100.00"
+			},
+			{
+				"i": 2,
+				"quantity": "1",
+				"item": {
+					"name": "Delivery Costs",
+					"price": "10.00"
+				},
+				"sum": "10.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"rate": "standard",
+						"percent": "21.0%"
+					}
+				],
+				"total": "10.00"
+			}
+		],
+		"payment": {
+			"terms": {
+				"key": "due-date",
+				"due_dates": [
+					{
+						"date": "2021-10-30",
+						"amount": "45.72",
+						"percent": "40%"
+					},
+					{
+						"date": "2021-11-30",
+						"amount": "68.58",
+						"percent": "60%"
+					}
+				]
+			},
+			"advances": [
+				{
+					"date": "2021-09-01",
+					"desc": "Deposit paid upfront",
+					"amount": "25.00"
+				}
+			],
+			"instructions": {
+				"key": "credit-transfer",
+				"credit_transfer": [
+					{
+						"iban": "ES06 0128 0011 3901 0008 1391",
+						"bic": "BKBKESMMXXX",
+						"name": "Bankinter"
+					}
+				]
+			}
+		},
+		"totals": {
+			"sum": "110.00",
+			"tax_included": "19.09",
+			"total": "90.91",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard+eqs",
+								"base": "82.6446",
+								"percent": "21.0%",
+								"surcharge": {
+									"percent": "5.2%",
+									"amount": "4.2975"
+								},
+								"amount": "17.3554"
+							},
+							{
+								"key": "standard",
+								"base": "8.2645",
+								"percent": "21.0%",
+								"amount": "1.7355"
+							}
+						],
+						"amount": "19.0909",
+						"surcharge": "4.2975"
+					}
+				],
+				"sum": "23.3884"
+			},
+			"tax": "23.39",
+			"total_with_tax": "114.30",
+			"payable": "114.30",
+			"advance": "25.00",
+			"due": "89.30"
+		}
+	}
+}

--- a/regimes/es/examples/out/invoice-es-es-vateqs-retailer.json
+++ b/regimes/es/examples/out/invoice-es-es-vateqs-retailer.json
@@ -1,0 +1,87 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
+		"dig": {
+			"alg": "sha256",
+			"val": "e12bfa758ae6fa0678f4e6e58a882fba4427f9f099bdfbb542fdb00a04e240cb"
+		},
+		"draft": true
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"code": "SAMPLE-001",
+		"type": "standard",
+		"currency": "EUR",
+		"tax": {
+			"prices_include": "VAT",
+			"tags": [
+				"simplified"
+			]
+		},
+		"issue_date": "2022-02-01",
+		"supplier": {
+			"name": "Simple Goods Store",
+			"tax_id": {
+				"country": "ES",
+				"code": "54387763P"
+			},
+			"addresses": [
+				{
+					"num": "43",
+					"street": "Calle Mayor",
+					"locality": "Madrid",
+					"region": "Madrid",
+					"code": "28003"
+				}
+			]
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "10",
+				"item": {
+					"name": "Mugs from provider",
+					"price": "16.00",
+					"meta": {
+						"source": "provider"
+					}
+				},
+				"sum": "160.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"rate": "standard",
+						"percent": "21.0%"
+					}
+				],
+				"total": "160.00"
+			}
+		],
+		"totals": {
+			"sum": "160.00",
+			"tax_included": "27.77",
+			"total": "132.23",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"base": "132.2314",
+								"percent": "21.0%",
+								"amount": "27.7686"
+							}
+						],
+						"amount": "27.7686"
+					}
+				],
+				"sum": "27.7686"
+			},
+			"tax": "27.77",
+			"total_with_tax": "160.00",
+			"payable": "160.00"
+		}
+	}
+}

--- a/regimes/es/examples/out/invoice-es-es.env.json
+++ b/regimes/es/examples/out/invoice-es-es.env.json
@@ -1,0 +1,90 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
+		"dig": {
+			"alg": "sha256",
+			"val": "690b45d7d13ea3cc32b9b71bd1d08d55bcc13782974ca7a2a65b553d380515bd"
+		},
+		"draft": true
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"code": "SAMPLE-001",
+		"type": "standard",
+		"currency": "EUR",
+		"issue_date": "2022-02-01",
+		"supplier": {
+			"name": "Provide One S.L.",
+			"tax_id": {
+				"country": "ES",
+				"code": "B98602642"
+			},
+			"addresses": [
+				{
+					"num": "42",
+					"street": "Calle Pradillo",
+					"locality": "Madrid",
+					"region": "Madrid",
+					"code": "28002",
+					"country": "ES"
+				}
+			],
+			"emails": [
+				{
+					"addr": "billing@example.com"
+				}
+			]
+		},
+		"customer": {
+			"name": "Sample Consumer",
+			"tax_id": {
+				"country": "ES",
+				"code": "54387763P"
+			}
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "10",
+				"item": {
+					"name": "Item being purchased",
+					"price": "100.00"
+				},
+				"sum": "1000.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"rate": "standard",
+						"percent": "21.0%"
+					}
+				],
+				"total": "1000.00"
+			}
+		],
+		"totals": {
+			"sum": "1000.00",
+			"total": "1000.00",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"base": "1000.00",
+								"percent": "21.0%",
+								"amount": "210.00"
+							}
+						],
+						"amount": "210.00"
+					}
+				],
+				"sum": "210.00"
+			},
+			"tax": "210.00",
+			"total_with_tax": "1210.00",
+			"payable": "1210.00"
+		}
+	}
+}

--- a/regimes/es/examples/out/invoice-es-es.json
+++ b/regimes/es/examples/out/invoice-es-es.json
@@ -1,0 +1,121 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
+		"dig": {
+			"alg": "sha256",
+			"val": "506978043814863e52aab1d9f8097b5bb65f5e5f9572356027b9bc715381e922"
+		},
+		"draft": true
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"code": "SAMPLE-001",
+		"type": "standard",
+		"currency": "EUR",
+		"issue_date": "2022-02-01",
+		"supplier": {
+			"name": "Provide One S.L.",
+			"tax_id": {
+				"country": "ES",
+				"code": "B98602642"
+			},
+			"addresses": [
+				{
+					"num": "42",
+					"street": "Calle Pradillo",
+					"locality": "Madrid",
+					"region": "Madrid",
+					"code": "28002",
+					"country": "ES"
+				}
+			],
+			"emails": [
+				{
+					"addr": "billing@example.com"
+				}
+			]
+		},
+		"customer": {
+			"name": "Sample Consumer",
+			"tax_id": {
+				"country": "ES",
+				"code": "54387763P"
+			}
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "20",
+				"item": {
+					"name": "Development services",
+					"price": "90.00",
+					"unit": "h"
+				},
+				"sum": "1800.00",
+				"discounts": [
+					{
+						"percent": "10%",
+						"amount": "180.00",
+						"reason": "Special discount"
+					}
+				],
+				"taxes": [
+					{
+						"cat": "VAT",
+						"rate": "standard",
+						"percent": "21.0%"
+					}
+				],
+				"total": "1620.00"
+			},
+			{
+				"i": 2,
+				"quantity": "1",
+				"item": {
+					"name": "Financial service",
+					"price": "10.00"
+				},
+				"sum": "10.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"rate": "zero",
+						"percent": "0.0%"
+					}
+				],
+				"total": "10.00"
+			}
+		],
+		"totals": {
+			"sum": "1630.00",
+			"total": "1630.00",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"base": "1620.00",
+								"percent": "21.0%",
+								"amount": "340.20"
+							},
+							{
+								"key": "zero",
+								"base": "10.00",
+								"percent": "0.0%",
+								"amount": "0.00"
+							}
+						],
+						"amount": "340.20"
+					}
+				],
+				"sum": "340.20"
+			},
+			"tax": "340.20",
+			"total_with_tax": "1970.20",
+			"payable": "1970.20"
+		}
+	}
+}

--- a/regimes/es/examples/out/invoice-es-nl-b2b.json
+++ b/regimes/es/examples/out/invoice-es-nl-b2b.json
@@ -1,0 +1,125 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
+		"dig": {
+			"alg": "sha256",
+			"val": "e7ecd9dd17dfb68facd7ad474b2fcfc7f5497f05b8a71e8fa4e26d5c0f6ecbc2"
+		},
+		"draft": true
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"code": "SAMPLE-X-002",
+		"type": "standard",
+		"currency": "EUR",
+		"tax": {
+			"prices_include": "VAT",
+			"tags": [
+				"reverse-charge"
+			]
+		},
+		"issue_date": "2022-02-01",
+		"supplier": {
+			"name": "Provide One S.L.",
+			"tax_id": {
+				"country": "ES",
+				"code": "B98602642"
+			},
+			"addresses": [
+				{
+					"num": "42",
+					"street": "Calle Pradillo",
+					"locality": "Madrid",
+					"region": "Madrid",
+					"code": "28002",
+					"country": "ES"
+				}
+			],
+			"emails": [
+				{
+					"addr": "billing@example.com"
+				}
+			]
+		},
+		"customer": {
+			"name": "Sample Consumer",
+			"tax_id": {
+				"country": "NL",
+				"code": "000099995B57"
+			}
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "10",
+				"item": {
+					"name": "Services exported",
+					"price": "20.00",
+					"unit": "day"
+				},
+				"sum": "200.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"rate": "standard",
+						"percent": "21.0%"
+					}
+				],
+				"total": "200.00"
+			},
+			{
+				"i": 2,
+				"quantity": "50",
+				"item": {
+					"name": "Branded Mugs",
+					"price": "7.50",
+					"meta": {
+						"product": "goods"
+					}
+				},
+				"sum": "375.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"rate": "standard",
+						"percent": "21.0%"
+					}
+				],
+				"total": "375.00"
+			}
+		],
+		"totals": {
+			"sum": "575.00",
+			"tax_included": "99.79",
+			"total": "475.21",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"base": "475.2067",
+								"percent": "21.0%",
+								"amount": "99.7934"
+							}
+						],
+						"amount": "99.7934"
+					}
+				],
+				"sum": "99.7934"
+			},
+			"tax": "0.00",
+			"total_with_tax": "475.21",
+			"payable": "475.21"
+		},
+		"notes": [
+			{
+				"key": "legal",
+				"src": "reverse-charge",
+				"text": "Reverse Charge / Inversión del sujeto pasivo."
+			}
+		]
+	}
+}

--- a/regimes/es/examples/out/invoice-es-nl-digital-b2c.json
+++ b/regimes/es/examples/out/invoice-es-nl-digital-b2c.json
@@ -1,0 +1,94 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
+		"dig": {
+			"alg": "sha256",
+			"val": "06b5812258b4ea63f20b385f7de2035f03dbef9d45621d92721dd4f6043e5945"
+		},
+		"draft": true
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"code": "SAMPLE-X-002",
+		"type": "standard",
+		"currency": "EUR",
+		"tax": {
+			"tags": [
+				"customer-rates"
+			]
+		},
+		"issue_date": "2022-02-01",
+		"supplier": {
+			"name": "Provide One S.L.",
+			"tax_id": {
+				"country": "ES",
+				"code": "B98602642"
+			},
+			"addresses": [
+				{
+					"num": "42",
+					"street": "Calle Pradillo",
+					"locality": "Madrid",
+					"region": "Madrid",
+					"code": "28002",
+					"country": "ES"
+				}
+			],
+			"emails": [
+				{
+					"addr": "billing@example.com"
+				}
+			]
+		},
+		"customer": {
+			"name": "Sample Consumer",
+			"tax_id": {
+				"country": "NL"
+			}
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "10",
+				"item": {
+					"name": "Services exported",
+					"price": "100.00"
+				},
+				"sum": "1000.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"rate": "standard",
+						"percent": "21.0%"
+					}
+				],
+				"total": "1000.00"
+			}
+		],
+		"totals": {
+			"sum": "1000.00",
+			"total": "1000.00",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"base": "1000.00",
+								"percent": "21.0%",
+								"amount": "210.00"
+							}
+						],
+						"amount": "210.00"
+					}
+				],
+				"sum": "210.00"
+			},
+			"tax": "210.00",
+			"total_with_tax": "1210.00",
+			"payable": "1210.00"
+		}
+	}
+}

--- a/regimes/fr/examples/out/invoice-fr-fr.json
+++ b/regimes/fr/examples/out/invoice-fr-fr.json
@@ -1,0 +1,112 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
+		"dig": {
+			"alg": "sha256",
+			"val": "5b61832e7890d87f657af524f1a0e068aa06217a8967d724f821d9ea258c7371"
+		},
+		"draft": true
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"series": "SAMPLE",
+		"code": "001",
+		"type": "standard",
+		"currency": "EUR",
+		"issue_date": "2022-02-01",
+		"supplier": {
+			"name": "Provide One Inc.",
+			"tax_id": {
+				"country": "FR",
+				"code": "44732829320"
+			},
+			"addresses": [
+				{
+					"num": "42",
+					"street": "Calle Pradillo",
+					"locality": "Madrid",
+					"region": "Madrid",
+					"code": "28002",
+					"country": "ES"
+				}
+			],
+			"emails": [
+				{
+					"addr": "billing@example.com"
+				}
+			]
+		},
+		"customer": {
+			"name": "Sample Consumer",
+			"tax_id": {
+				"country": "FR",
+				"code": "39356000000"
+			},
+			"addresses": [
+				{
+					"num": "1",
+					"street": "Rue Sundacsakn",
+					"locality": "Saint-Germain-En-Laye",
+					"code": "75050"
+				}
+			],
+			"emails": [
+				{
+					"addr": "email@sample.com"
+				}
+			]
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "20",
+				"item": {
+					"name": "Development services",
+					"price": "90.00",
+					"unit": "h"
+				},
+				"sum": "1800.00",
+				"discounts": [
+					{
+						"percent": "10%",
+						"amount": "180.00",
+						"reason": "Special discount"
+					}
+				],
+				"taxes": [
+					{
+						"cat": "VAT",
+						"rate": "standard",
+						"percent": "20.0%"
+					}
+				],
+				"total": "1620.00"
+			}
+		],
+		"totals": {
+			"sum": "1620.00",
+			"total": "1620.00",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"base": "1620.00",
+								"percent": "20.0%",
+								"amount": "324.00"
+							}
+						],
+						"amount": "324.00"
+					}
+				],
+				"sum": "324.00"
+			},
+			"tax": "324.00",
+			"total_with_tax": "1944.00",
+			"payable": "1944.00"
+		}
+	}
+}

--- a/regimes/it/examples/freelance.json
+++ b/regimes/it/examples/freelance.json
@@ -80,7 +80,7 @@
         {
           "cat": "IRPEF",
           "percent": "20.0%",
-          "tags": ["self-employed-habitual"]
+          "rate": "self-employed-habitual"
         }
       ],
       "sum": "1800.00",
@@ -97,8 +97,7 @@
       "taxes": [
         {
           "cat": "VAT",
-          "rate": "zero",
-          "tags": ["not-subject+other"]
+          "rate": "not-subject+other"
         }
       ],
       "sum": "100.00",

--- a/regimes/it/examples/hotel.json
+++ b/regimes/it/examples/hotel.json
@@ -65,10 +65,7 @@
       "taxes": [
         {
           "cat": "VAT",
-          "rate": "zero",
-          "tags": [
-            "excluded"
-          ]
+          "rate": "excluded"
         }
       ],
       "sum": "1.00",

--- a/regimes/it/examples/out/freelance.json
+++ b/regimes/it/examples/out/freelance.json
@@ -1,0 +1,165 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
+		"dig": {
+			"alg": "sha256",
+			"val": "be0d3110e56c1813eca6b7fd17c0d2a6300c3bcba77351a04a658725f0544dae"
+		},
+		"draft": true
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"series": "SAMPLE",
+		"code": "001",
+		"type": "standard",
+		"currency": "EUR",
+		"tax": {
+			"tags": [
+				"freelance"
+			]
+		},
+		"issue_date": "2023-03-02",
+		"supplier": {
+			"name": "MªF. Services",
+			"tax_id": {
+				"country": "IT",
+				"code": "12345678903"
+			},
+			"people": [
+				{
+					"name": {
+						"given": "MARIA FRANCISCA",
+						"surname": "MONTERO",
+						"surname2": "ESTEBAN"
+					}
+				}
+			],
+			"addresses": [
+				{
+					"num": "9",
+					"street": "VIA DI TORREVECCHIA",
+					"locality": "ROMA",
+					"region": "RM",
+					"code": "23480",
+					"country": "IT"
+				}
+			],
+			"emails": [
+				{
+					"addr": "billing@example.com"
+				}
+			]
+		},
+		"customer": {
+			"name": "David Bowie",
+			"tax_id": {
+				"country": "IT",
+				"code": "13029381004"
+			},
+			"addresses": [
+				{
+					"num": "1",
+					"street": "Via del Corso",
+					"locality": "Roma",
+					"region": "RM",
+					"code": "00100",
+					"country": "IT"
+				}
+			]
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "20",
+				"item": {
+					"name": "Development services",
+					"price": "90.00",
+					"unit": "h"
+				},
+				"sum": "1800.00",
+				"discounts": [
+					{
+						"percent": "10%",
+						"amount": "180.00",
+						"reason": "Special discount"
+					}
+				],
+				"taxes": [
+					{
+						"cat": "VAT",
+						"rate": "standard",
+						"percent": "22.0%"
+					},
+					{
+						"cat": "IRPEF",
+						"rate": "self-employed-habitual",
+						"percent": "20.0%"
+					}
+				],
+				"total": "1620.00"
+			},
+			{
+				"i": 2,
+				"quantity": "1",
+				"item": {
+					"name": "Zero test",
+					"price": "100.00",
+					"unit": "h"
+				},
+				"sum": "100.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"rate": "zero",
+						"percent": "0.0%"
+					}
+				],
+				"total": "100.00"
+			}
+		],
+		"totals": {
+			"sum": "1720.00",
+			"total": "1720.00",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"base": "1620.00",
+								"percent": "22.0%",
+								"amount": "356.40"
+							},
+							{
+								"key": "zero",
+								"base": "100.00",
+								"percent": "0.0%",
+								"amount": "0.00"
+							}
+						],
+						"amount": "356.40"
+					},
+					{
+						"code": "IRPEF",
+						"retained": true,
+						"rates": [
+							{
+								"key": "self-employed-habitual",
+								"base": "1620.00",
+								"percent": "20.0%",
+								"amount": "324.00"
+							}
+						],
+						"amount": "324.00"
+					}
+				],
+				"sum": "32.40"
+			},
+			"tax": "32.40",
+			"total_with_tax": "1752.40",
+			"payable": "1752.40"
+		}
+	}
+}

--- a/regimes/it/examples/out/freelance.json
+++ b/regimes/it/examples/out/freelance.json
@@ -4,7 +4,7 @@
 		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
 		"dig": {
 			"alg": "sha256",
-			"val": "be0d3110e56c1813eca6b7fd17c0d2a6300c3bcba77351a04a658725f0544dae"
+			"val": "a8e521dd42014ad7e4e930c02eac591704ed748048c38961841710956f197221"
 		},
 		"draft": true
 	},
@@ -111,8 +111,7 @@
 				"taxes": [
 					{
 						"cat": "VAT",
-						"rate": "zero",
-						"percent": "0.0%"
+						"rate": "not-subject+other"
 					}
 				],
 				"total": "100.00"
@@ -133,9 +132,8 @@
 								"amount": "356.40"
 							},
 							{
-								"key": "zero",
+								"key": "not-subject+other",
 								"base": "100.00",
-								"percent": "0.0%",
 								"amount": "0.00"
 							}
 						],

--- a/regimes/it/examples/out/hotel.json
+++ b/regimes/it/examples/out/hotel.json
@@ -4,7 +4,7 @@
 		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
 		"dig": {
 			"alg": "sha256",
-			"val": "315f83a516a4ca1efc18c8d31878c61a2ddcccd6dd9218e825950ccf3d4ab8c8"
+			"val": "cf6c5c8927bb5a7c42a674fe3d7afb26e4cd7e08189a1541babe8e47bf10f08a"
 		},
 		"draft": true
 	},
@@ -76,8 +76,7 @@
 				"taxes": [
 					{
 						"cat": "VAT",
-						"rate": "zero",
-						"percent": "0.0%"
+						"rate": "excluded"
 					}
 				],
 				"total": "1.00"
@@ -110,10 +109,9 @@
 						"code": "VAT",
 						"rates": [
 							{
-								"key": "zero",
-								"base": "1.0000",
-								"percent": "0.0%",
-								"amount": "0.0000"
+								"key": "excluded",
+								"base": "1.00",
+								"amount": "0.00"
 							},
 							{
 								"key": "intermediate",

--- a/regimes/it/examples/out/hotel.json
+++ b/regimes/it/examples/out/hotel.json
@@ -1,0 +1,135 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
+		"dig": {
+			"alg": "sha256",
+			"val": "315f83a516a4ca1efc18c8d31878c61a2ddcccd6dd9218e825950ccf3d4ab8c8"
+		},
+		"draft": true
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"series": "SAMPLE",
+		"code": "002",
+		"type": "standard",
+		"currency": "EUR",
+		"tax": {
+			"prices_include": "VAT"
+		},
+		"issue_date": "2023-05-21",
+		"supplier": {
+			"name": "Hotel California",
+			"tax_id": {
+				"country": "IT",
+				"code": "12345678903"
+			},
+			"addresses": [
+				{
+					"num": "102",
+					"street": "Via California",
+					"locality": "Palermo",
+					"region": "PA",
+					"code": "33213",
+					"country": "IT"
+				}
+			],
+			"registration": {
+				"capital": "50000.00",
+				"currency": "EUR",
+				"office": "RM",
+				"entry": "123456"
+			}
+		},
+		"customer": {
+			"name": "Mela S.r.l.",
+			"tax_id": {
+				"country": "IT",
+				"code": "13029381004"
+			},
+			"inboxes": [
+				{
+					"key": "codice-destinatario",
+					"code": "M5UXCR5"
+				}
+			],
+			"addresses": [
+				{
+					"num": "23",
+					"street": "Via dei Mille",
+					"locality": "Firenze",
+					"region": "FI",
+					"code": "00100",
+					"country": "IT"
+				}
+			]
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "1",
+				"item": {
+					"name": "Tassa di Soggiorno",
+					"price": "1.00"
+				},
+				"sum": "1.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"rate": "zero",
+						"percent": "0.0%"
+					}
+				],
+				"total": "1.00"
+			},
+			{
+				"i": 2,
+				"quantity": "1",
+				"item": {
+					"name": "Camera Matrimoniale",
+					"price": "125.00"
+				},
+				"sum": "125.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"rate": "intermediate",
+						"percent": "10.0%"
+					}
+				],
+				"total": "125.00"
+			}
+		],
+		"totals": {
+			"sum": "126.00",
+			"tax_included": "11.36",
+			"total": "114.64",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "zero",
+								"base": "1.0000",
+								"percent": "0.0%",
+								"amount": "0.0000"
+							},
+							{
+								"key": "intermediate",
+								"base": "113.6364",
+								"percent": "10.0%",
+								"amount": "11.3636"
+							}
+						],
+						"amount": "11.3636"
+					}
+				],
+				"sum": "11.3636"
+			},
+			"tax": "11.36",
+			"total_with_tax": "126.00",
+			"payable": "126.00"
+		}
+	}
+}

--- a/regimes/mx/examples/invoice.yaml
+++ b/regimes/mx/examples/invoice.yaml
@@ -1,0 +1,46 @@
+$schema: "https://gobl.org/draft-0/bill/invoice"
+issue_date: "2023-07-10"
+series: "TEST"
+code: "00001"
+tax:
+  tags:
+    - "use+no-tax-effects"
+supplier:
+  name: "ESCUELA KEMPER URGATE"
+  tax_id:
+    country: "MX"
+    code: "EKU9003173C9"
+    zone: "21000"
+customer:
+  name: "UNIVERSIDAD ROBOTICA ESPAÑOLA"
+  tax_id:
+    country: "MX"
+    code: "URE180429TM6"
+    zone: "86991"
+lines:
+  - quantity: "1"
+    item:
+      name: "Cobro por tarjetas"
+      price: "10.00"
+      identities:
+        - type: "SAT"
+          code: "84141602"
+    taxes:
+      - cat: "VAT"
+        rate: "standard"
+  - quantity: "1"
+    item:
+      name: "Porcentaje sobre GMV"
+      price: "10.00"
+      unit: "service"
+      identities:
+        - type: "SAT"
+          code: "80141628"
+    taxes:
+      - cat: "VAT"
+        rate: "standard"
+payment:
+  terms:
+    notes: "Condiciones de pago"
+  instructions:
+    key: "online+wallet"

--- a/regimes/mx/examples/out/invoice.json
+++ b/regimes/mx/examples/out/invoice.json
@@ -4,7 +4,7 @@
 		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
 		"dig": {
 			"alg": "sha256",
-			"val": "82ee8f55fada51c77988d7a0c109930d9811de948c7316afed9f96e4bf2cd48f"
+			"val": "dd1adab216bd9fbe9a5a5964c997dd45e56a6f0b4b4b5db85b2b165f68872942"
 		},
 		"draft": true
 	},
@@ -87,7 +87,6 @@
 		],
 		"payment": {
 			"terms": {
-				"key": "",
 				"notes": "Condiciones de pago"
 			},
 			"instructions": {

--- a/regimes/mx/examples/out/invoice.json
+++ b/regimes/mx/examples/out/invoice.json
@@ -1,0 +1,122 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
+		"dig": {
+			"alg": "sha256",
+			"val": "82ee8f55fada51c77988d7a0c109930d9811de948c7316afed9f96e4bf2cd48f"
+		},
+		"draft": true
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"series": "TEST",
+		"code": "00001",
+		"type": "standard",
+		"currency": "MXN",
+		"tax": {
+			"tags": [
+				"use+no-tax-effects"
+			]
+		},
+		"issue_date": "2023-07-10",
+		"supplier": {
+			"name": "ESCUELA KEMPER URGATE",
+			"tax_id": {
+				"country": "MX",
+				"zone": "21000",
+				"code": "EKU9003173C9"
+			}
+		},
+		"customer": {
+			"name": "UNIVERSIDAD ROBOTICA ESPAÑOLA",
+			"tax_id": {
+				"country": "MX",
+				"zone": "86991",
+				"code": "URE180429TM6"
+			}
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "1",
+				"item": {
+					"name": "Cobro por tarjetas",
+					"identities": [
+						{
+							"type": "SAT",
+							"code": "84141602"
+						}
+					],
+					"price": "10.00"
+				},
+				"sum": "10.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"rate": "standard",
+						"percent": "16.0%"
+					}
+				],
+				"total": "10.00"
+			},
+			{
+				"i": 2,
+				"quantity": "1",
+				"item": {
+					"name": "Porcentaje sobre GMV",
+					"identities": [
+						{
+							"type": "SAT",
+							"code": "80141628"
+						}
+					],
+					"price": "10.00",
+					"unit": "service"
+				},
+				"sum": "10.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"rate": "standard",
+						"percent": "16.0%"
+					}
+				],
+				"total": "10.00"
+			}
+		],
+		"payment": {
+			"terms": {
+				"key": "",
+				"notes": "Condiciones de pago"
+			},
+			"instructions": {
+				"key": "online+wallet"
+			}
+		},
+		"totals": {
+			"sum": "20.00",
+			"total": "20.00",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"base": "20.00",
+								"percent": "16.0%",
+								"amount": "3.20"
+							}
+						],
+						"amount": "3.20"
+					}
+				],
+				"sum": "3.20"
+			},
+			"tax": "3.20",
+			"total_with_tax": "23.20",
+			"payable": "23.20"
+		}
+	}
+}

--- a/regimes/us/examples/out/invoice-us-us.json
+++ b/regimes/us/examples/out/invoice-us-us.json
@@ -1,0 +1,101 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
+		"dig": {
+			"alg": "sha256",
+			"val": "2f42c17792ca424df809c674ff0fa4101e69581473bbe8e9b27b93d42314c6c2"
+		},
+		"draft": true
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"series": "SAMPLE",
+		"code": "001",
+		"type": "standard",
+		"currency": "USD",
+		"tax": {
+			"prices_include": "ST"
+		},
+		"issue_date": "2023-04-21",
+		"supplier": {
+			"name": "Provide One Inc.",
+			"tax_id": {
+				"country": "US"
+			},
+			"addresses": [
+				{
+					"num": "16",
+					"street": "Jessie Street",
+					"locality": "San Francisco",
+					"region": "CA",
+					"code": "94105",
+					"country": "US"
+				}
+			],
+			"emails": [
+				{
+					"addr": "billing@provideone.com"
+				}
+			]
+		},
+		"customer": {
+			"name": "Sample Consumer",
+			"emails": [
+				{
+					"addr": "email@sample.com"
+				}
+			]
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "20",
+				"item": {
+					"name": "Development services",
+					"price": "90.00",
+					"unit": "h"
+				},
+				"sum": "1800.00",
+				"discounts": [
+					{
+						"percent": "10%",
+						"amount": "180.00",
+						"reason": "Special discount"
+					}
+				],
+				"taxes": [
+					{
+						"cat": "ST",
+						"percent": "8.5%"
+					}
+				],
+				"total": "1620.00"
+			}
+		],
+		"totals": {
+			"sum": "1620.00",
+			"tax_included": "126.91",
+			"total": "1493.09",
+			"taxes": {
+				"categories": [
+					{
+						"code": "ST",
+						"rates": [
+							{
+								"base": "1493.0876",
+								"percent": "8.5%",
+								"amount": "126.9124"
+							}
+						],
+						"amount": "126.9124"
+					}
+				],
+				"sum": "126.9124"
+			},
+			"tax": "126.91",
+			"total_with_tax": "1620.00",
+			"payable": "1620.00"
+		}
+	}
+}


### PR DESCRIPTION
* This makes the example documents easier to test against.
* Any differences between the existing generated envelope and a new one, will cause an error that a human will need to review and run the tests with the `--update` flag.
* Hopefully this will make it easier to detect any unexpected consequences of changes.