### PR TITLE
Credit notes (and stamps) to MX

### DIFF
--- a/regimes/mx/examples/credit-note.yaml
+++ b/regimes/mx/examples/credit-note.yaml
@@ -1,0 +1,44 @@
+$schema: https://gobl.org/draft-0/bill/invoice
+issue_date: "2023-05-29"
+type: credit-note
+series: CN
+code: "0003"
+currency: MXN
+tax:
+  tags:
+  - use+goods-acquisition
+preceding:
+- code: "0010"
+  stamps:
+  - prv: sat-uuid
+    val: 1fac4464-1111-0000-1111-cd37179db12e
+supplier:
+  name: ESCUELA KEMPER URGATE
+  tax_id:
+    country: MX
+    zone: "26015"
+    code: EKU9003173C9
+customer:
+  name: UNIVERSIDAD ROBOTICA ESPAÑOLA
+  tax_id:
+    country: MX
+    zone: "65000"
+    code: URE180429TM6
+lines:
+- quantity: "2"
+  item:
+    name: Cigarros
+    identities:
+    - type: SAT
+      code: "50211502"
+    price: "100.1010"
+    unit: piece
+  taxes:
+  - cat: VAT
+    rate: standard
+  total: "200.2020"
+payment:
+  terms:
+    notes: Pago a 30 días.
+  instructions:
+    key: credit-transfer

--- a/regimes/mx/examples/out/credit-note.json
+++ b/regimes/mx/examples/out/credit-note.json
@@ -1,0 +1,109 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
+		"dig": {
+			"alg": "sha256",
+			"val": "b27227e309bd4ddfaf76c36fdcb13974e1e8d699e055d9a75d63c3bd87836e90"
+		},
+		"draft": true
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"series": "CN",
+		"code": "0003",
+		"type": "credit-note",
+		"currency": "MXN",
+		"tax": {
+			"tags": [
+				"use+goods-acquisition"
+			]
+		},
+		"preceding": [
+			{
+				"code": "0010",
+				"stamps": [
+					{
+						"prv": "sat-uuid",
+						"val": "1fac4464-1111-0000-1111-cd37179db12e"
+					}
+				]
+			}
+		],
+		"issue_date": "2023-05-29",
+		"supplier": {
+			"name": "ESCUELA KEMPER URGATE",
+			"tax_id": {
+				"country": "MX",
+				"zone": "26015",
+				"code": "EKU9003173C9"
+			}
+		},
+		"customer": {
+			"name": "UNIVERSIDAD ROBOTICA ESPAÑOLA",
+			"tax_id": {
+				"country": "MX",
+				"zone": "65000",
+				"code": "URE180429TM6"
+			}
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "2",
+				"item": {
+					"name": "Cigarros",
+					"identities": [
+						{
+							"type": "SAT",
+							"code": "50211502"
+						}
+					],
+					"price": "100.1010",
+					"unit": "piece"
+				},
+				"sum": "200.2020",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"rate": "standard",
+						"percent": "16.0%"
+					}
+				],
+				"total": "200.2020"
+			}
+		],
+		"payment": {
+			"terms": {
+				"notes": "Pago a 30 días."
+			},
+			"instructions": {
+				"key": "credit-transfer"
+			}
+		},
+		"totals": {
+			"sum": "200.2020",
+			"total": "200.20",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"base": "200.2020",
+								"percent": "16.0%",
+								"amount": "32.0323"
+							}
+						],
+						"amount": "32.0323"
+					}
+				],
+				"sum": "32.0323"
+			},
+			"tax": "32.03",
+			"total_with_tax": "232.23",
+			"payable": "232.23"
+		}
+	}
+}

--- a/regimes/mx/mx.go
+++ b/regimes/mx/mx.go
@@ -18,10 +18,17 @@ func init() {
 
 // Custom keys used typically in meta or codes information.
 const (
-	KeySATFormaPago cbc.Key = "sat-forma-pago" // for mapping to c_FormaPago’s codes
-	KeySATUsoCFDI   cbc.Key = "sat-uso-cfdi"   // for mapping to c_UsoCFDI’s codes
+	KeySATFormaPago         cbc.Key = "sat-forma-pago"          // for mapping to c_FormaPago’s codes
+	KeySATTipoDeComprobante cbc.Key = "sat-tipo-de-comprobante" // for mapping to c_TipoDeComprobante’s codes
+	KeySATTipoRelacion      cbc.Key = "sat-tipo-relacion"       // for mapping to c_TipoRelacion’s codes
+	KeySATUsoCFDI           cbc.Key = "sat-uso-cfdi"            // for mapping to c_UsoCFDI’s codes
 
 	IdentityTypeSAT cbc.Code = "SAT" // for custom codes mapped from identities (e.g. c_ClaveProdServ’s codes)
+)
+
+// SAT official codes to include in stamps.
+const (
+	StampProviderSATUUID cbc.Key = "sat-uuid" // a.k.a. Folio Fiscal
 )
 
 // New provides the tax region definition
@@ -33,12 +40,13 @@ func New() *tax.Regime {
 			i18n.EN: "Mexico",
 			i18n.ES: "México",
 		},
-		PaymentMeansKeys: paymentMeansKeyDefinitions, // pay.go
 		Validator:        Validate,
 		Calculator:       Calculate,
-		Tags:             invoiceTags,   // scenarios.go
-		Scenarios:        scenarios,     // scenarios.go
-		Categories:       taxCategories, // categories.go
+		PaymentMeansKeys: paymentMeansKeyDefinitions, // pay.go
+		Tags:             invoiceTags,                // scenarios.go
+		Scenarios:        scenarios,                  // scenarios.go
+		Categories:       taxCategories,              // categories.go
+		Preceding:        precedingDefinitions,       // preceding.go
 	}
 }
 

--- a/regimes/mx/preceding.go
+++ b/regimes/mx/preceding.go
@@ -1,0 +1,16 @@
+package mx
+
+import (
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/tax"
+)
+
+var precedingDefinitions = &tax.PrecedingDefinitions{
+	Types: []cbc.Key{
+		bill.InvoiceTypeCreditNote,
+	},
+	Stamps: []cbc.Key{
+		StampProviderSATUUID,
+	},
+}

--- a/regimes/mx/scenarios.go
+++ b/regimes/mx/scenarios.go
@@ -216,7 +216,22 @@ var scenarios = []*tax.ScenarioSet{
 var invoiceScenarios = &tax.ScenarioSet{
 	Schema: bill.ShortSchemaInvoice,
 	List: []*tax.Scenario{
+		// TipoDeComprobante / TipoRelacion
+		{
+			Types: []cbc.Key{bill.InvoiceTypeStandard},
+			Codes: cbc.CodeSet{
+				KeySATTipoDeComprobante: "I",
+			},
+		},
+		{
+			Types: []cbc.Key{bill.InvoiceTypeCreditNote},
+			Codes: cbc.CodeSet{
+				KeySATTipoDeComprobante: "E",
+				KeySATTipoRelacion:      "01",
+			},
+		},
 
+		// UsoCFDI
 		{
 			Tags: []cbc.Key{TagUse.With(TagGoodsAcquisition)},
 			Codes: cbc.CodeSet{


### PR DESCRIPTION
* Adds SAT UUID Stamp key to be linked from preceding credit notes
* Uses scenarios to map the invoice type to the fields `TipoRelacion` and `TipoDeComprobante`
* Adds preceding definitions to produce credit notes from invoices
* Implements related validations