### PR TITLE
Add main time zone to tax regimes

### DIFF
--- a/bill/invoice.go
+++ b/bill/invoice.go
@@ -314,12 +314,12 @@ func (inv *Invoice) prepareTagsAndScenarios() error {
 }
 
 func (inv *Invoice) calculate(r *tax.Regime, tID *tax.Identity) error {
+	if inv.IssueDate.IsZero() {
+		inv.IssueDate = cal.TodayIn(r.TimeLocation())
+	}
 	date := inv.ValueDate
 	if date == nil {
 		date = &inv.IssueDate
-	}
-	if date == nil {
-		return errors.New("issue date cannot be empty")
 	}
 
 	if inv.Currency == currency.CodeEmpty {

--- a/regimes/co/co.go
+++ b/regimes/co/co.go
@@ -36,6 +36,7 @@ func New() *tax.Regime {
 			i18n.EN: "Colombia",
 			i18n.ES: "Colombia",
 		},
+		TimeZone:         "America/Bogota",
 		Validator:        Validate,
 		Calculator:       Calculate,
 		IdentityTypeKeys: taxIdentityTypeDefs, // see tax_identity.go

--- a/regimes/es/es.go
+++ b/regimes/es/es.go
@@ -73,6 +73,7 @@ func New() *tax.Regime {
 			i18n.EN: "Spain",
 			i18n.ES: "España",
 		},
+		TimeZone:         "Europe/Madrid",
 		Zones:            zones,
 		Tags:             invoiceTags,
 		IdentityTypeKeys: taxIdentityTypeDefinitions,

--- a/regimes/fr/fr.go
+++ b/regimes/fr/fr.go
@@ -32,7 +32,8 @@ func New() *tax.Regime {
 			i18n.EN: "France",
 			i18n.FR: "La France",
 		},
-		Tags: invoiceTags,
+		TimeZone: "Europe/Paris",
+		Tags:     invoiceTags,
 		Scenarios: []*tax.ScenarioSet{
 			invoiceScenarios,
 		},

--- a/regimes/gb/gb.go
+++ b/regimes/gb/gb.go
@@ -27,6 +27,7 @@ func New() *tax.Regime {
 		Name: i18n.String{
 			i18n.EN: "United Kingdom",
 		},
+		TimeZone:   "Europe/London",
 		Validator:  Validate,
 		Calculator: Calculate,
 		Categories: taxCategories,

--- a/regimes/it/it.go
+++ b/regimes/it/it.go
@@ -34,6 +34,7 @@ func New() *tax.Regime {
 			i18n.EN: "Italy",
 			i18n.IT: "Italia",
 		},
+		TimeZone:         "Europe/Rome",
 		ChargeKeys:       chargeKeyDefinitions,       // charges.go
 		PaymentMeansKeys: paymentMeansKeyDefinitions, // pay.go
 		IdentityTypeKeys: taxIdentityTypeDefinitions, // tax_identity.go

--- a/regimes/mx/mx.go
+++ b/regimes/mx/mx.go
@@ -40,6 +40,7 @@ func New() *tax.Regime {
 			i18n.EN: "Mexico",
 			i18n.ES: "México",
 		},
+		TimeZone:         "America/Mexico_City",
 		Validator:        Validate,
 		Calculator:       Calculate,
 		PaymentMeansKeys: paymentMeansKeyDefinitions, // pay.go

--- a/regimes/nl/nl.go
+++ b/regimes/nl/nl.go
@@ -23,6 +23,7 @@ func New() *tax.Regime {
 			i18n.EN: "The Netherlands",
 			i18n.NL: "Nederland",
 		},
+		TimeZone:   "Europe/Amsterdam",
 		Validator:  Validate,
 		Calculator: Calculate,
 		Categories: []*tax.Category{

--- a/regimes/pt/pt.go
+++ b/regimes/pt/pt.go
@@ -62,6 +62,7 @@ func New() *tax.Regime {
 			i18n.EN: "Portugal",
 			i18n.PT: "Portugal",
 		},
+		TimeZone:   "Europe/Lisbon",
 		Zones:      zones,
 		Tags:       invoiceTags,
 		Scenarios:  scenarios,

--- a/regimes/us/us.go
+++ b/regimes/us/us.go
@@ -28,6 +28,7 @@ func New() *tax.Regime {
 		Name: i18n.String{
 			i18n.EN: "United States of America",
 		},
+		TimeZone:  "America/Chicago", // Around the middle
 		Validator: Validate,
 		Categories: []*tax.Category{
 			//

--- a/tax/regime_test.go
+++ b/tax/regime_test.go
@@ -1,0 +1,23 @@
+package tax_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/invopop/gobl/tax"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegimeTimeLocation(t *testing.T) {
+	r := new(tax.Regime)
+	r.TimeZone = "Europe/Amsterdam"
+	loc, err := time.LoadLocation("Europe/Amsterdam")
+	require.NoError(t, err)
+
+	assert.Equal(t, loc, r.TimeLocation())
+
+	r.TimeZone = "INVALID"
+	loc = r.TimeLocation()
+	assert.Equal(t, loc, time.UTC)
+}


### PR DESCRIPTION
* Assigns and validates a time zone for each tax regime.
* Uses the tax regime's time zone to assign an issue date when calculating an invoice if one was not already provided.