### PR TITLE
Date arithmetic support

### DIFF
--- a/cal/date.go
+++ b/cal/date.go
@@ -49,6 +49,13 @@ func TodayIn(loc *time.Location) Date {
 	}
 }
 
+// DateOf returns the Date in which a time occurs in the time's location.
+func DateOf(t time.Time) Date {
+	return Date{
+		civil.DateOf(t),
+	}
+}
+
 // Validate ensures the the date object looks valid.
 func (d Date) Validate() error {
 	if d.IsZero() {
@@ -64,6 +71,25 @@ func (d Date) Validate() error {
 func (d *Date) Clone() *Date {
 	d2 := *d
 	return &d2
+}
+
+// Time returns a time object for the date.
+func (d Date) Time() time.Time {
+	return d.TimeIn(time.UTC)
+}
+
+// TimeIn returns a time object for the date in the given location which
+// may be important when considering timezones and arithmetic.
+func (d Date) TimeIn(loc *time.Location) time.Time {
+	return time.Date(d.Year, d.Month, d.Day, 0, 0, 0, 0, loc)
+}
+
+// Add returns a new date with the given number of years, months and days.
+// This uses the time package to do the arithmetic.
+func (d Date) Add(years, months, days int) Date {
+	t := d.Time()
+	t = t.AddDate(years, months, days)
+	return DateOf(t)
 }
 
 // UnmarshalJSON is used to parse a date from json and ensures that

--- a/cal/date_test.go
+++ b/cal/date_test.go
@@ -133,3 +133,34 @@ func TestDateClone(t *testing.T) {
 	d = cal.MakeDate(2021, time.May, 27)
 	assert.NotEqual(t, d.String(), d2.String())
 }
+
+func TestDateTime(t *testing.T) {
+	d := cal.MakeDate(2023, time.July, 28)
+	dt := d.Time()
+	assert.Equal(t, "2023-07-28 00:00:00 +0000 UTC", dt.String())
+
+	dp := cal.NewDate(2023, time.July, 28)
+	dt = dp.Time()
+	assert.Equal(t, "2023-07-28 00:00:00 +0000 UTC", dt.String())
+
+	loc, err := time.LoadLocation("Europe/Madrid")
+	require.NoError(t, err)
+	dt = d.TimeIn(loc)
+	assert.Equal(t, "2023-07-28 00:00:00 +0200 CEST", dt.String())
+}
+
+func TestDateOf(t *testing.T) {
+	x := time.Date(2023, time.July, 28, 0, 0, 0, 0, time.UTC)
+	d := cal.DateOf(x)
+	assert.Equal(t, "2023-07-28", d.String())
+}
+
+func TestDateAdd(t *testing.T) {
+	d := cal.MakeDate(2023, time.July, 28)
+	d2 := d.Add(0, 1, 5)
+	assert.Equal(t, "2023-09-02", d2.String())
+
+	d = cal.MakeDate(2023, time.July, 1)
+	d2 = d.Add(0, 1, -1) // last day of month
+	assert.Equal(t, "2023-07-31", d2.String())
+}


### PR DESCRIPTION
* `cal.Date` now has `Time` and `TimeIn` methods to help converting to time.
* Added an `Add` method that uses go's time package to do date arithmetic.