### PR TITLE
MX Discounts

### DIFF
--- a/regimes/mx/examples/invoice.yaml
+++ b/regimes/mx/examples/invoice.yaml
@@ -25,6 +25,8 @@ lines:
       identities:
         - type: "SAT"
           code: "84141602"
+    discounts:
+      - percent: "10.0%"
     taxes:
       - cat: "VAT"
         rate: "standard"

--- a/regimes/mx/examples/out/invoice.json
+++ b/regimes/mx/examples/out/invoice.json
@@ -4,7 +4,7 @@
 		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
 		"dig": {
 			"alg": "sha256",
-			"val": "dd1adab216bd9fbe9a5a5964c997dd45e56a6f0b4b4b5db85b2b165f68872942"
+			"val": "fc163aa40798b593ecfe3c97546d82f25e2b2e4d88e0da0204db5cbf25b3fe58"
 		},
 		"draft": true
 	},
@@ -51,6 +51,12 @@
 					"price": "10.00"
 				},
 				"sum": "10.00",
+				"discounts": [
+					{
+						"percent": "10.0%",
+						"amount": "1.00"
+					}
+				],
 				"taxes": [
 					{
 						"cat": "VAT",
@@ -58,7 +64,7 @@
 						"percent": "16.0%"
 					}
 				],
-				"total": "10.00"
+				"total": "9.00"
 			},
 			{
 				"i": 2,
@@ -94,8 +100,8 @@
 			}
 		},
 		"totals": {
-			"sum": "20.00",
-			"total": "20.00",
+			"sum": "19.00",
+			"total": "19.00",
 			"taxes": {
 				"categories": [
 					{
@@ -103,19 +109,19 @@
 						"rates": [
 							{
 								"key": "standard",
-								"base": "20.00",
+								"base": "19.00",
 								"percent": "16.0%",
-								"amount": "3.20"
+								"amount": "3.04"
 							}
 						],
-						"amount": "3.20"
+						"amount": "3.04"
 					}
 				],
-				"sum": "3.20"
+				"sum": "3.04"
 			},
-			"tax": "3.20",
-			"total_with_tax": "23.20",
-			"payable": "23.20"
+			"tax": "3.04",
+			"total_with_tax": "22.04",
+			"payable": "22.04"
 		}
 	}
 }

--- a/regimes/mx/invoice_validator.go
+++ b/regimes/mx/invoice_validator.go
@@ -51,6 +51,9 @@ func (v *invoiceValidator) validate() error {
 			validation.By(v.validPrecedingList),
 			validation.Each(validation.By(v.validPrecedingEntry)),
 		),
+		validation.Field(&inv.Discounts,
+			validation.Empty.Error("the SAT doesn't allow discounts at invoice level. Use line discounts instead."),
+		),
 	)
 }
 

--- a/regimes/mx/invoice_validator_test.go
+++ b/regimes/mx/invoice_validator_test.go
@@ -178,6 +178,17 @@ func TestPrecedingValidation(t *testing.T) {
 	require.NoError(t, inv.Validate())
 }
 
+func TestInvoiceDiscountValidation(t *testing.T) {
+	inv := validInvoice()
+
+	inv.Discounts = []*bill.Discount{
+		{
+			Percent: num.NewPercentage(20, 2),
+		},
+	}
+	assertValidationError(t, inv, "discounts: the SAT doesn't allow discounts at invoice level")
+}
+
 func assertValidationError(t *testing.T, inv *bill.Invoice, expected string) {
 	require.NoError(t, inv.Calculate())
 	err := inv.Validate()


### PR DESCRIPTION
* Validates that invoice-level discounts aren't provided (since they aren't allowed by the SAT)
* Adds a line-level discount to the invoice example
* Related to: https://github.com/invopop/gobl.cfdi/pull/11