### PR TITLE
Completely replace ProdServ identity type with key

### DIFF
--- a/regimes/mx/item.go
+++ b/regimes/mx/item.go
@@ -42,7 +42,7 @@ func validItemIdentities(value interface{}) error {
 
 func normalizeItem(item *org.Item) error {
 	for _, id := range item.Identities {
-		if id.Type == IdentityTypeSAT && itemIdentityNormalizableCodeRegexp.MatchString(string(id.Code)) {
+		if id.Key == IdentityKeyCFDIProdServ && itemIdentityNormalizableCodeRegexp.MatchString(string(id.Code)) {
 			id.Code = id.Code + "00"
 		}
 	}

--- a/regimes/mx/item_test.go
+++ b/regimes/mx/item_test.go
@@ -89,7 +89,7 @@ func TestItemIdentityNormalization(t *testing.T) {
 		},
 	}
 	for _, ts := range tests {
-		item := &org.Item{Identities: []*org.Identity{{Code: ts.Code, Type: "SAT"}}}
+		item := &org.Item{Identities: []*org.Identity{{Code: ts.Code, Key: mx.IdentityKeyCFDIProdServ}}}
 		err := r.CalculateObject(item)
 		assert.NoError(t, err)
 		assert.Equal(t, ts.Expected, item.Identities[0].Code)

--- a/regimes/mx/mx.go
+++ b/regimes/mx/mx.go
@@ -21,8 +21,6 @@ const (
 	KeySATFormaPago         cbc.Key = "sat-forma-pago"          // for mapping to c_FormaPago’s codes
 	KeySATTipoDeComprobante cbc.Key = "sat-tipo-de-comprobante" // for mapping to c_TipoDeComprobante’s codes
 	KeySATTipoRelacion      cbc.Key = "sat-tipo-relacion"       // for mapping to c_TipoRelacion’s codes
-
-	IdentityTypeSAT cbc.Code = "SAT" // for custom codes mapped from identities (e.g. c_ClaveProdServ’s codes)
 )
 
 // SAT official codes to include in stamps.


### PR DESCRIPTION
* Replaces a stray use of the the "SAT" identity type with the new "mx-cfdi-prod-serv" identity key
* Addresses the feedback given [here](https://github.com/invopop/gobl/pull/183#discussion_r1297218585) and [here](https://github.com/invopop/gobl/pull/183#discussion_r1297220505)