### PR TITLE
Tax regime docs improvements

### DIFF
--- a/regimes/co/README.md
+++ b/regimes/co/README.md
@@ -1,5 +1,7 @@
 # 🇨🇴 GOBL Colombia Tax Regime
 
+Example CO GOBL files can be found in the [`examples`](./examples) (YAML uncalculated documents) and [`examples/out`](./examples/out) (JSON calculated envelopes) subdirectories.
+
 ## Zones
 
 Colombia requires zones to be defined in supplier and customer party's tax identity.

--- a/regimes/es/README.md
+++ b/regimes/es/README.md
@@ -1,2 +1,3 @@
 # 🇪🇸 GOBL Spain Tax Regime
 
+Example ES GOBL files can be found in the [`examples`](./examples) (YAML uncalculated documents) and [`examples/out`](./examples/out) (JSON calculated envelopes) subdirectories.

--- a/regimes/fr/README.md
+++ b/regimes/fr/README.md
@@ -1,5 +1,7 @@
 # 🇫🇷 GOBL France Tax Regime
 
+Example FR GOBL files can be found in the [`examples`](./examples) (YAML uncalculated documents) and [`examples/out`](./examples/out) (JSON calculated envelopes) subdirectories.
+
 ## Tax IDs
 
 France has three main company IDs which are all very closely related and may be included on Invoice documents:

--- a/regimes/it/README.md
+++ b/regimes/it/README.md
@@ -2,6 +2,8 @@
 
 Italy uses the FatturaPA format for their e-invoicing system.
 
+Example IT GOBL files can be found in the [`examples`](./examples) (YAML uncalculated documents) and [`examples/out`](./examples/out) (JSON calculated envelopes) subdirectories.
+
 ## Public Documentations
 
 ### FatturaPA

--- a/regimes/mx/README.md
+++ b/regimes/mx/README.md
@@ -8,6 +8,38 @@ Example MX GOBL files can be found in the [`examples`](./examples) (YAML uncalcu
 
 - [Formato de factura (Anexo 20)](http://omawww.sat.gob.mx/tramitesyservicios/Paginas/anexo_20.htm)
 
+## Zones
+
+In Mexican GOBL documents, the supplier and customer addresses are optional, however the parties’ tax identity zones must be included and contain the fiscal address’ postal code of each party. The supplier’s tax identity zone will map to the `LugarExpedicion` (Place of issue) CFDI field, and the customer’s one will map to the `DomicilioFiscalReceptor` (Recipient Fiscal Address) field in the CFDI.
+
+### Example
+
+The following example will set `21000` as the `LugarExpedicion` of the CFDI and `86991` as the `DomicilioFiscalReceptor`:
+
+```js
+{
+  "$schema": "https://gobl.org/draft-0/bill/invoice",
+  // [...]
+  "supplier": {
+    "name": "ESCUELA KEMPER URGATE",
+    "tax_id": {
+      "country": "MX",
+      "zone": "21000",
+      "code": "EKU9003173C9"
+    },
+    // [...]
+  },
+  "customer": {
+    "name": "UNIVERSIDAD ROBOTICA ESPAÑOLA",
+    "tax_id": {
+      "country": "MX",
+      "zone": "86991",
+      "code": "URE180429TM6"
+    },
+  // [...]
+}
+```
+
 ## Local Codes
 
 Mexican invoices as defined in the CFDI specification must include a set of specific codes that will either need to be known in advance by the supplier or requested from the customer during their purchase process.

--- a/regimes/mx/README.md
+++ b/regimes/mx/README.md
@@ -2,6 +2,8 @@
 
 Mexico uses the CFDI (Comprobante Fiscal Digital por Internet) format for their e-invoicing system.
 
+Example MX GOBL files can be found in the [`examples`](./examples) (YAML uncalculated documents) and [`examples/out`](./examples/out) (JSON calculated envelopes) subdirectories.
+
 ## Public Documentation
 
 - [Formato de factura (Anexo 20)](http://omawww.sat.gob.mx/tramitesyservicios/Paginas/anexo_20.htm)

--- a/regimes/mx/README.md
+++ b/regimes/mx/README.md
@@ -20,7 +20,7 @@ Every Supplier and Customer in a Mexican invoice must be associated with a fisca
 
 In GOBL the `mx-cfdi-fiscal-regime` identity key is used alongside the value expected by the SAT.
 
-### Example
+#### Example
 
 The following example will associate the supplier with the `601` fiscal regime code:
 

--- a/regimes/pt/README.md
+++ b/regimes/pt/README.md
@@ -2,6 +2,8 @@
 
 Portugal doesn't have an e-invoicing format per se. Tax information is reported electronically to the AT (Autoridade Tributária e Aduaneira) either periodically in batches via a SAF-T (PT) report or individually in real time via a web service.
 
+Example PT GOBL files can be found in the [`examples`](./examples) (YAML uncalculated documents) and [`examples/out`](./examples/out) (JSON calculated envelopes) subdirectories.
+
 ## Public Documentation
 
 * [Portaria n.o 302/2016 – SAF-T Data Structure & Taxonomies](https://info.portaldasfinancas.gov.pt/pt/informacao_fiscal/legislacao/diplomas_legislativos/Documents/Portaria_302_2016.pdf)

--- a/regimes/pt/examples/credit-note.yaml
+++ b/regimes/pt/examples/credit-note.yaml
@@ -1,0 +1,29 @@
+$schema: https://gobl.org/draft-0/bill/invoice
+type: credit-note
+currency: EUR
+preceding:
+- code: SEQ/333
+  issue_date: '2023-01-20'
+issue_date: '2023-01-30'
+supplier:
+  uuid: 9de7584f-ea5c-42a7-b159-5e4c6a280a5c
+  tax_id:
+    country: PT
+    code: '545259045'
+  name: Hotelzinho
+  addresses:
+  - street: Rua do Hotelzinho
+    code: 1000-000
+    locality: Lisboa
+customer:
+  name: Maria Santos Silva
+lines:
+- i: 1
+  quantity: 1
+  item:
+    name: Noite em quarto duplo
+    price: '200.00'
+  taxes:
+  - cat: VAT
+    rate: standard
+  total: '0'

--- a/regimes/pt/examples/invoice.yaml
+++ b/regimes/pt/examples/invoice.yaml
@@ -1,0 +1,26 @@
+$schema: https://gobl.org/draft-0/bill/invoice
+type: standard
+currency: EUR
+issue_date: '2023-01-30'
+supplier:
+  uuid: 9de7584f-ea5c-42a7-b159-5e4c6a280a5c
+  tax_id:
+    country: PT
+    code: '545259045'
+  name: Hotelzinho
+  addresses:
+  - street: Rua do Hotelzinho
+    code: 1000-000
+    locality: Lisboa
+customer:
+  name: Maria Santos Silva
+lines:
+- i: 1
+  quantity: 1
+  item:
+    name: Noite em quarto duplo
+    price: 100.00
+  sum: 100.00
+  taxes:
+  - cat: VAT
+    rate: standard

--- a/regimes/pt/examples/out/credit-note.json
+++ b/regimes/pt/examples/out/credit-note.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "https://gobl.org/draft-0/envelope",
+  "head": {
+    "uuid": "6b915452-40f0-11ee-b0c2-e6a7901137ed",
+    "dig": {
+      "alg": "sha256",
+      "val": "ae7f4128e7316c57015fe4eb9cb3286e44c4e2df1f64170470f0bff134dd062a"
+    },
+    "draft": true
+  },
+  "doc": {
+    "$schema": "https://gobl.org/draft-0/bill/invoice",
+    "code": "",
+    "type": "credit-note",
+    "currency": "EUR",
+    "preceding": [
+      {
+        "code": "SEQ/333",
+        "issue_date": "2023-01-20"
+      }
+    ],
+    "issue_date": "2023-01-30",
+    "supplier": {
+      "uuid": "9de7584f-ea5c-42a7-b159-5e4c6a280a5c",
+      "name": "Hotelzinho",
+      "tax_id": {
+        "country": "PT",
+        "code": "545259045"
+      },
+      "addresses": [
+        {
+          "street": "Rua do Hotelzinho",
+          "locality": "Lisboa",
+          "code": "1000-000"
+        }
+      ]
+    },
+    "customer": {
+      "name": "Maria Santos Silva"
+    },
+    "lines": [
+      {
+        "i": 1,
+        "quantity": "1",
+        "item": {
+          "name": "Noite em quarto duplo",
+          "price": "200.00"
+        },
+        "sum": "200.00",
+        "taxes": [
+          {
+            "cat": "VAT",
+            "rate": "standard",
+            "percent": "23.0%"
+          }
+        ],
+        "total": "200.00"
+      }
+    ],
+    "totals": {
+      "sum": "200.00",
+      "total": "200.00",
+      "taxes": {
+        "categories": [
+          {
+            "code": "VAT",
+            "rates": [
+              {
+                "key": "standard",
+                "base": "200.00",
+                "percent": "23.0%",
+                "amount": "46.00"
+              }
+            ],
+            "amount": "46.00"
+          }
+        ],
+        "sum": "46.00"
+      },
+      "tax": "46.00",
+      "total_with_tax": "246.00",
+      "payable": "246.00"
+    }
+  }
+}

--- a/regimes/pt/examples/out/invoice.json
+++ b/regimes/pt/examples/out/invoice.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "https://gobl.org/draft-0/envelope",
+  "head": {
+    "uuid": "077cf1c3-40f0-11ee-a053-e6a7901137ed",
+    "dig": {
+      "alg": "sha256",
+      "val": "7178de3cac39eb507ab0b6965523e67a1731142ba384bfaef42dd1c3fac681da"
+    },
+    "draft": true
+  },
+  "doc": {
+    "$schema": "https://gobl.org/draft-0/bill/invoice",
+    "code": "",
+    "type": "standard",
+    "currency": "EUR",
+    "issue_date": "2023-01-30",
+    "supplier": {
+      "uuid": "9de7584f-ea5c-42a7-b159-5e4c6a280a5c",
+      "name": "Hotelzinho",
+      "tax_id": {
+        "country": "PT",
+        "code": "545259045"
+      },
+      "addresses": [
+        {
+          "street": "Rua do Hotelzinho",
+          "locality": "Lisboa",
+          "code": "1000-000"
+        }
+      ]
+    },
+    "customer": {
+      "name": "Maria Santos Silva"
+    },
+    "lines": [
+      {
+        "i": 1,
+        "quantity": "1",
+        "item": {
+          "name": "Noite em quarto duplo",
+          "price": "100.00"
+        },
+        "sum": "100.00",
+        "taxes": [
+          {
+            "cat": "VAT",
+            "rate": "standard",
+            "percent": "23.0%"
+          }
+        ],
+        "total": "100.00"
+      }
+    ],
+    "totals": {
+      "sum": "100.00",
+      "total": "100.00",
+      "taxes": {
+        "categories": [
+          {
+            "code": "VAT",
+            "rates": [
+              {
+                "key": "standard",
+                "base": "100.00",
+                "percent": "23.0%",
+                "amount": "23.00"
+              }
+            ],
+            "amount": "23.00"
+          }
+        ],
+        "sum": "23.00"
+      },
+      "tax": "23.00",
+      "total_with_tax": "123.00",
+      "payable": "123.00"
+    }
+  }
+}

--- a/regimes/us/README.md
+++ b/regimes/us/README.md
@@ -1,1 +1,3 @@
 # 🇺🇸 GOBL United States of America Tax Regime
+
+Example US GOBL files can be found in the [`examples`](./examples) (YAML uncalculated documents) and [`examples/out`](./examples/out) (JSON calculated envelopes) subdirectories.


### PR DESCRIPTION
* Adds a reference to each tax regime examples directly in the README for better discoverability
* Documents the use of tax identity zones in Mexico GOBL documents