### PR TITLE
Completing FR VAT rates, plus sources

### DIFF
--- a/.golangci.toml
+++ b/.golangci.toml
@@ -7,7 +7,7 @@ format = "colored-line-number"
 [linters]
 enable = [
     "gocyclo", "unconvert", "goimports", "unused", "unused",
-    "vetshadow", "misspell", "nakedret", "errcheck", "revive", "ineffassign",
+    "vetshadow", "nakedret", "errcheck", "revive", "ineffassign",
     "goconst", "vet", "unparam", "gofmt"
 ]
 

--- a/regimes/common/common.go
+++ b/regimes/common/common.go
@@ -16,7 +16,7 @@ const (
 	TaxCategoryGST cbc.Code = "GST" // Goods and Services Tax
 )
 
-// Most commonly used codes. Local regions may add their own rate codes.
+// Most commonly used keys. Local regions may add their own rate keys.
 const (
 	TaxRateExempt       cbc.Key = "exempt"
 	TaxRateZero         cbc.Key = "zero"
@@ -24,6 +24,7 @@ const (
 	TaxRateIntermediate cbc.Key = "intermediate"
 	TaxRateReduced      cbc.Key = "reduced"
 	TaxRateSuperReduced cbc.Key = "super-reduced"
+	TaxRateSpecial      cbc.Key = "special"
 )
 
 // Standard tax tags

--- a/regimes/fr/examples/out/invoice-fr-fr.json
+++ b/regimes/fr/examples/out/invoice-fr-fr.json
@@ -4,7 +4,7 @@
 		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
 		"dig": {
 			"alg": "sha256",
-			"val": "5b61832e7890d87f657af524f1a0e068aa06217a8967d724f821d9ea258c7371"
+			"val": "f65beda9e9bf89db3ec40b04b1a60a34e5bd227f59d0f5879e1c394a40b1ac68"
 		},
 		"draft": true
 	},
@@ -78,7 +78,7 @@
 					{
 						"cat": "VAT",
 						"rate": "standard",
-						"percent": "20.0%"
+						"percent": "20%"
 					}
 				],
 				"total": "1620.00"
@@ -95,7 +95,7 @@
 							{
 								"key": "standard",
 								"base": "1620.00",
-								"percent": "20.0%",
+								"percent": "20%",
 								"amount": "324.00"
 							}
 						],

--- a/regimes/fr/tax_categories.go
+++ b/regimes/fr/tax_categories.go
@@ -22,6 +22,15 @@ var taxCategories = []*tax.Category{
 			i18n.EN: "Value Added Tax",
 			i18n.FR: "Taxe sur la Valeur Ajoutée",
 		},
+		Sources: []*tax.Source{
+			{
+				Title: i18n.String{
+					i18n.EN: "What are the current VAT rates in France and in the European Union?",
+					i18n.FR: "Quels sont les taux de TVA en vigueur en France et dans l'Union européenne?",
+				},
+				URL: "https://www.economie.gouv.fr/cedef/taux-tva-france-et-union-europeenne",
+			},
+		},
 		Retained: false,
 		Rates: []*tax.Rate{
 			{
@@ -38,12 +47,68 @@ var taxCategories = []*tax.Category{
 			{
 				Key: common.TaxRateStandard,
 				Name: i18n.String{
-					i18n.EN: "Standard Rate",
+					i18n.EN: "Standard rate",
+					i18n.FR: "Taux normal",
+				},
+				Desc: i18n.String{
+					i18n.EN: "For the majority of sales of goods and services: it applies to all products or services for which no other rate is expressly provided.",
+					i18n.FR: "Pour la majorité des ventes de biens et des prestations de services : il s'applique à tous les produits ou services pour lesquels aucun autre taux n'est expressément prévu.",
 				},
 				Values: []*tax.RateValue{
 					{
 						Since:   cal.NewDate(2011, 1, 4),
-						Percent: num.MakePercentage(200, 3),
+						Percent: num.MakePercentage(20, 2),
+					},
+				},
+			},
+			{
+				Key: common.TaxRateIntermediate,
+				Name: i18n.String{
+					i18n.EN: "Intermediate rate",
+					i18n.FR: "Taux intermédiaire",
+				},
+				Desc: i18n.String{
+					i18n.EN: "Applicable in particular to unprocessed agricultural products, firewood, housing improvement works which do not benefit from the 5.5% rate, to certain accommodation and camping services, to fairs and exhibitions, fairground games and rides, to entrance fees to museums, zoos, monuments, to passenger transport, to the processing of waste, restoration.",
+					i18n.FR: "Notamment applicable aux produits agricoles non transformés, au bois de chauffage, aux travaux d'amélioration du logement qui ne bénéficient pas du taux de 5,5%, à certaines prestations de logement et de camping, aux foires et salons, jeux et manèges forains, aux droits d'entrée des musées, zoo, monuments, aux transports de voyageurs, au traitement des déchets, à la restauration.",
+				},
+				Values: []*tax.RateValue{
+					{
+						Since:   cal.NewDate(2014, 1, 1),
+						Percent: num.MakePercentage(10, 2),
+					},
+				},
+			},
+			{
+				Key: common.TaxRateReduced,
+				Name: i18n.String{
+					i18n.EN: "Reduced rate",
+					i18n.FR: "Taux réduit",
+				},
+				Desc: i18n.String{
+					i18n.EN: "Concerns most food products, feminine hygiene protection products, equipment and services for the disabled, books on any medium, gas and electricity subscriptions, supply of heat from renewable energies, supply of meals in school canteens, ticketing for live shows and cinemas, certain imports and deliveries of works of art, improvement works the energy quality of housing, social or emergency housing, home ownership.",
+					i18n.FR: "Concerne l'essentiel des produits alimentaires, les produits de protection hygiénique féminine, équipements et services pour handicapés, livres sur tout support, abonnements gaz et électricité, fourniture de chaleur issue d’énergies renouvelables, fourniture de repas dans les cantines scolaires, billeterie de spectacle vivant et de cinéma, certaines importations et livraisons d'œuvres d'art, travaux d’amélioration de la qualité énergétique des logements, logements sociaux ou d'urgence, accession à la propriété.",
+				},
+				Values: []*tax.RateValue{
+					{
+						Since:   cal.NewDate(2014, 1, 1),
+						Percent: num.MakePercentage(55, 3),
+					},
+				},
+			},
+			{
+				Key: common.TaxRateSpecial,
+				Name: i18n.String{
+					i18n.EN: "Special rate",
+					i18n.FR: "Taux particulier",
+				},
+				Desc: i18n.String{
+					i18n.EN: "Reserved for medicines reimbursable by social security, sales of live animals for slaughter and charcuterie to non-taxable persons, the television license fee, certain shows and press publications registered with the Joint Commission for Publications and Press Agencies.",
+					i18n.FR: "Réservé aux médicaments remboursables par la sécurité sociale, aux ventes d’animaux vivants de boucherie et de charcuterie à des non assujettis, à la redevance télévision, à certains spectacles et aux publications de presse inscrites à la Commission paritaire des publications et agences de presse.",
+				},
+				Values: []*tax.RateValue{
+					{
+						Since:   cal.NewDate(2014, 1, 1),
+						Percent: num.MakePercentage(21, 3),
 					},
 				},
 			},

--- a/regimes/pt/examples/out/credit-note.json
+++ b/regimes/pt/examples/out/credit-note.json
@@ -10,8 +10,9 @@
 	},
 	"doc": {
 		"$schema": "https://gobl.org/draft-0/bill/invoice",
-		"code": "",
 		"type": "credit-note",
+		"code": "",
+		"issue_date": "2023-01-30",
 		"currency": "EUR",
 		"preceding": [
 			{
@@ -19,7 +20,6 @@
 				"issue_date": "2023-01-20"
 			}
 		],
-		"issue_date": "2023-01-30",
 		"supplier": {
 			"uuid": "9de7584f-ea5c-42a7-b159-5e4c6a280a5c",
 			"name": "Hotelzinho",

--- a/regimes/pt/examples/out/invoice.json
+++ b/regimes/pt/examples/out/invoice.json
@@ -10,10 +10,10 @@
 	},
 	"doc": {
 		"$schema": "https://gobl.org/draft-0/bill/invoice",
-		"code": "",
 		"type": "standard",
-		"currency": "EUR",
+		"code": "",
 		"issue_date": "2023-01-30",
+		"currency": "EUR",
 		"supplier": {
 			"uuid": "9de7584f-ea5c-42a7-b159-5e4c6a280a5c",
 			"name": "Hotelzinho",


### PR DESCRIPTION
* France now has complete VAT rates.
* Added a `Source` model to the tax category so that we can start adding more structured data, such as official sources.