### PR TITLE
Correction Option Schema support

### DIFF
--- a/bill/invoice_correct_test.go
+++ b/bill/invoice_correct_test.go
@@ -1,8 +1,10 @@
 package bill_test
 
 import (
+	"encoding/json"
 	"testing"
 
+	"github.com/iancoleman/orderedmap"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cal"
 	"github.com/invopop/gobl/cbc"
@@ -14,6 +16,7 @@ import (
 	"github.com/invopop/gobl/regimes/common"
 	"github.com/invopop/gobl/regimes/es"
 	"github.com/invopop/gobl/tax"
+	"github.com/invopop/jsonschema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -139,6 +142,30 @@ func TestCorrectWithOptions(t *testing.T) {
 	assert.Equal(t, pre.IssueDate, cal.NewDate(2022, 6, 13))
 	assert.Equal(t, pre.Reason, "test refund")
 	assert.Equal(t, i.Totals.Payable.String(), "-900.00")
+}
+
+func TestCorrectionOptionsSchema(t *testing.T) {
+	inv := testInvoiceESForCorrection(t)
+	out, err := inv.CorrectionOptionsSchema()
+	require.NoError(t, err)
+
+	schema, ok := out.(*jsonschema.Schema)
+	require.True(t, ok)
+
+	assert.Len(t, schema.Properties.Keys(), 7)
+
+	mtd, ok := schema.Properties.Get("method")
+	require.True(t, ok)
+	pm := mtd.(orderedmap.OrderedMap)
+	assert.Len(t, pm.Keys(), 4)
+
+	exp := `{"$ref":"https://gobl.org/draft-0/cbc/key","title":"Method","description":"Correction method as defined by the tax regime.","oneOf":[{"const":"complete","title":"Complete"},{"const":"partial","title":"Corrected items only"},{"const":"discount","title":"Bulk deal in a given period"},{"const":"authorized","title":"Authorized by the Tax Agency"}]`
+
+	data, err := json.Marshal(pm)
+	require.NoError(t, err)
+	if !assert.JSONEq(t, exp, string(data)) {
+		t.Log(string(data))
+	}
 }
 
 func TestCorrectWithData(t *testing.T) {

--- a/bill/invoice_correct_test.go
+++ b/bill/invoice_correct_test.go
@@ -152,20 +152,24 @@ func TestCorrectionOptionsSchema(t *testing.T) {
 	schema, ok := out.(*jsonschema.Schema)
 	require.True(t, ok)
 
-	assert.Len(t, schema.Properties.Keys(), 7)
+	cos := schema.Definitions["CorrectionOptions"]
+	assert.Len(t, cos.Properties.Keys(), 7)
 
-	mtd, ok := schema.Properties.Get("method")
+	mtd, ok := cos.Properties.Get("method")
 	require.True(t, ok)
 	pm := mtd.(orderedmap.OrderedMap)
 	assert.Len(t, pm.Keys(), 4)
 
 	exp := `{"$ref":"https://gobl.org/draft-0/cbc/key","title":"Method","description":"Correction method as defined by the tax regime.","oneOf":[{"const":"complete","title":"Complete"},{"const":"partial","title":"Corrected items only"},{"const":"discount","title":"Bulk deal in a given period"},{"const":"authorized","title":"Authorized by the Tax Agency"}]}`
-
 	data, err := json.Marshal(pm)
 	require.NoError(t, err)
 	if !assert.JSONEq(t, exp, string(data)) {
 		t.Log(string(data))
 	}
+
+	data, err = json.Marshal(schema)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"$id":"https://gobl.org/draft-0/bill/correction-options?tax_regime=es"`)
 }
 
 func TestCorrectWithData(t *testing.T) {

--- a/bill/invoice_correct_test.go
+++ b/bill/invoice_correct_test.go
@@ -159,7 +159,7 @@ func TestCorrectionOptionsSchema(t *testing.T) {
 	pm := mtd.(orderedmap.OrderedMap)
 	assert.Len(t, pm.Keys(), 4)
 
-	exp := `{"$ref":"https://gobl.org/draft-0/cbc/key","title":"Method","description":"Correction method as defined by the tax regime.","oneOf":[{"const":"complete","title":"Complete"},{"const":"partial","title":"Corrected items only"},{"const":"discount","title":"Bulk deal in a given period"},{"const":"authorized","title":"Authorized by the Tax Agency"}]`
+	exp := `{"$ref":"https://gobl.org/draft-0/cbc/key","title":"Method","description":"Correction method as defined by the tax regime.","oneOf":[{"const":"complete","title":"Complete"},{"const":"partial","title":"Corrected items only"},{"const":"discount","title":"Bulk deal in a given period"},{"const":"authorized","title":"Authorized by the Tax Agency"}]}`
 
 	data, err := json.Marshal(pm)
 	require.NoError(t, err)

--- a/build/regimes/co.json
+++ b/build/regimes/co.json
@@ -14741,7 +14741,10 @@
       "methods": [
         {
           "key": "partial",
-          "name": null,
+          "name": {
+            "en": "Partial refund",
+            "es": "Devolución parcial"
+          },
           "desc": {
             "en": "Partial refund of part of the goods or services.",
             "es": "Devolución de parte de los bienes; no aceptación de partes del servicio."
@@ -14752,7 +14755,10 @@
         },
         {
           "key": "revoked",
-          "name": null,
+          "name": {
+            "en": "Revoked",
+            "es": "Anulación"
+          },
           "desc": {
             "en": "Previous document has been completely cancelled.",
             "es": "Anulación de la factura anterior."
@@ -14763,7 +14769,10 @@
         },
         {
           "key": "discount",
-          "name": null,
+          "name": {
+            "en": "Discount",
+            "es": "Descuento"
+          },
           "desc": {
             "en": "Partial or total discount.",
             "es": "Rebaja o descuento parcial o total."
@@ -14774,10 +14783,13 @@
         },
         {
           "key": "price-adjustment",
-          "name": null,
+          "name": {
+            "en": "Adjustment",
+            "es": "Ajuste"
+          },
           "desc": {
-            "en": "Ajuste de precio.",
-            "es": "Price adjustment."
+            "en": "Price adjustment.",
+            "es": "Ajuste de precio."
           },
           "map": {
             "dian": "4"

--- a/envelope.go
+++ b/envelope.go
@@ -216,3 +216,17 @@ func (e *Envelope) Correct(opts ...schema.Option) (*Envelope, error) {
 	// Create a completely new envelope with a new set of data.
 	return Envelop(nd)
 }
+
+// CorrectionOptionsSchema will attempt to provide a corrective options JSON Schema
+// that can be used to generate a JSON object to send when correcting a document.
+// If none are available, the result will be nil.
+func (e *Envelope) CorrectionOptionsSchema() (interface{}, error) {
+	if e.Document == nil {
+		return nil, ErrNoDocument
+	}
+	opts, err := e.Document.CorrectionOptionsSchema()
+	if err != nil {
+		return nil, err
+	}
+	return opts, nil
+}

--- a/i18n/string.go
+++ b/i18n/string.go
@@ -9,12 +9,17 @@ const (
 // String provides a simple map of locales to texts.
 type String map[Lang]string
 
-// String provides a single string from the map using the
-// language requested or resorting to the default.
-func (s String) String(lang Lang) string {
+// In provides a single string from the map using the
+// language requested or resorts to the default.
+func (s String) In(lang Lang) string {
 	if v, ok := s[lang]; ok {
 		return v
 	}
+	return s.String()
+}
+
+// String returns the default language string or first entry found.
+func (s String) String() string {
 	if v, ok := s[defaultLanguage]; ok {
 		return v
 	}
@@ -22,6 +27,11 @@ func (s String) String(lang Lang) string {
 		return v // provide first entry
 	}
 	return ""
+}
+
+// IsEmpty returns true if the string map is empty.
+func (s String) IsEmpty() bool {
+	return len(s) == 0
 }
 
 // JSONSchema returns the json schema definition

--- a/i18n/string_test.go
+++ b/i18n/string_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/invopop/gobl/i18n"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestI18nString(t *testing.T) {
@@ -12,20 +13,14 @@ func TestI18nString(t *testing.T) {
 		"es": "Prueba",
 	}
 
-	if x := s.String("en"); x != "Test" {
-		t.Errorf("Unexpected string result: %v", x)
-	}
-	if x := s.String("es"); x != "Prueba" {
-		t.Errorf("Unexpected string result: %v", x)
-	}
-	if x := s.String("fo"); x != "Test" {
-		t.Errorf("Unexpected string result: %v", x)
-	}
+	assert.Equal(t, "Test", s.In("en"))
+	assert.Equal(t, "Prueba", s.In("es"))
+	assert.Equal(t, "Test", s.In("fo"))
+	assert.Equal(t, "Test", s.String())
 
 	snd := i18n.String{
 		i18n.AA: "Foo",
 	}
-	if x := snd.String("en"); x != "Foo" {
-		t.Errorf("Unexpected string result: %v", x)
-	}
+	assert.Equal(t, "Foo", snd.In("en"))
+	assert.Equal(t, "Foo", snd.String())
 }

--- a/regimes/co/corrections.go
+++ b/regimes/co/corrections.go
@@ -19,6 +19,10 @@ const (
 var correctionMethodList = []*tax.KeyDefinition{
 	{
 		Key: CorrectionMethodKeyPartial,
+		Name: i18n.String{
+			i18n.EN: "Partial refund",
+			i18n.ES: "Devolución parcial",
+		},
 		Desc: i18n.String{
 			i18n.EN: "Partial refund of part of the goods or services.",
 			i18n.ES: "Devolución de parte de los bienes; no aceptación de partes del servicio.",
@@ -29,6 +33,10 @@ var correctionMethodList = []*tax.KeyDefinition{
 	},
 	{
 		Key: CorrectionMethodKeyRevoked,
+		Name: i18n.String{
+			i18n.EN: "Revoked",
+			i18n.ES: "Anulación",
+		},
 		Desc: i18n.String{
 			i18n.EN: "Previous document has been completely cancelled.",
 			i18n.ES: "Anulación de la factura anterior.",
@@ -39,6 +47,10 @@ var correctionMethodList = []*tax.KeyDefinition{
 	},
 	{
 		Key: CorrectionMethodKeyDiscount,
+		Name: i18n.String{
+			i18n.EN: "Discount",
+			i18n.ES: "Descuento",
+		},
 		Desc: i18n.String{
 			i18n.EN: "Partial or total discount.",
 			i18n.ES: "Rebaja o descuento parcial o total.",
@@ -49,9 +61,13 @@ var correctionMethodList = []*tax.KeyDefinition{
 	},
 	{
 		Key: CorrectionMethodKeyPriceAdjustment,
+		Name: i18n.String{
+			i18n.EN: "Adjustment",
+			i18n.ES: "Ajuste",
+		},
 		Desc: i18n.String{
-			i18n.EN: "Ajuste de precio.",
-			i18n.ES: "Price adjustment.",
+			i18n.EN: "Price adjustment.",
+			i18n.ES: "Ajuste de precio.",
 		},
 		Map: cbc.CodeMap{
 			KeyDIAN: "4",

--- a/regimes/co/tax_identity.go
+++ b/regimes/co/tax_identity.go
@@ -210,8 +210,8 @@ func normalizePartyWithTaxIdentity(p *org.Party) error {
 				return nil
 			}
 			a := p.Addresses[0]
-			a.Locality = z.Locality.String(i18n.ES)
-			a.Region = z.Region.String(i18n.ES)
+			a.Locality = z.Locality.In(i18n.ES)
+			a.Region = z.Region.In(i18n.ES)
 		}
 	}
 	return nil

--- a/schema/object.go
+++ b/schema/object.go
@@ -42,6 +42,7 @@ type Calculable interface {
 // corrected.
 type Correctable interface {
 	Correct(...Option) error
+	CorrectionOptionsSchema() (interface{}, error)
 }
 
 // NewObject instantiates an Object wrapper around the provided payload.
@@ -105,6 +106,20 @@ func (d *Object) Correct(opts ...Option) error {
 		return err
 	}
 	return nil
+}
+
+// CorrectionOptionsSchema provides a schema with the correction options available
+// for the schema, if available.
+func (d *Object) CorrectionOptionsSchema() (interface{}, error) {
+	pl, ok := d.payload.(Correctable)
+	if !ok {
+		return nil, nil
+	}
+	res, err := pl.CorrectionOptionsSchema()
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
 }
 
 // Insert places the provided object inside the document and looks up the schema

--- a/tax/regime.go
+++ b/tax/regime.go
@@ -254,6 +254,11 @@ type CodeDefinition struct {
 	Desc i18n.String `json:"desc,omitempty" jsonschema:"title=Description"`
 }
 
+// Code provides a unique code for this tax regime based on the country.
+func (r *Regime) Code() cbc.Code {
+	return cbc.Code(r.Country)
+}
+
 // ValidateObject performs validation on the provided object in the context
 // of the regime.
 func (r *Regime) ValidateObject(value interface{}) error {

--- a/version.go
+++ b/version.go
@@ -8,7 +8,7 @@ import (
 type Version string
 
 // VERSION is the current version of the GOBL library.
-const VERSION Version = "v0.58.0"
+const VERSION Version = "v0.58.1"
 
 // Semver parses and returns semver
 func (v Version) Semver() *semver.Version {


### PR DESCRIPTION
* Opens up a new method `CorrectionOptionsSchema` that will generate a schema that can be used to dynamically load the available correction options for a given document.
* Initially only supports invoices.