### PR TITLE
Fuel account balance complement to MX regime

### DIFF
--- a/bill/invoice.go
+++ b/bill/invoice.go
@@ -469,14 +469,14 @@ func (inv *Invoice) calculate(r *tax.Regime, tID *tax.Identity) error {
 	t.round(zero)
 
 	// Complements
-	if err := calculateComplements(r, inv.Complements); err != nil {
+	if err := calculateComplements(inv.Complements); err != nil {
 		return validation.Errors{"complements": err}
 	}
 
 	return nil
 }
 
-func calculateComplements(r *tax.Regime, comps []*schema.Object) error {
+func calculateComplements(comps []*schema.Object) error {
 	for _, c := range comps {
 		if err := c.Calculate(); err != nil {
 			return err

--- a/bill/invoice.go
+++ b/bill/invoice.go
@@ -145,6 +145,8 @@ func (inv *Invoice) ValidateWithContext(ctx context.Context) error {
 
 		validation.Field(&inv.Notes),
 		validation.Field(&inv.Meta),
+
+		validation.Field(&inv.Complements, validation.Each()),
 	)
 	if err == nil {
 		err = r.ValidateObject(inv)
@@ -466,6 +468,20 @@ func (inv *Invoice) calculate(r *tax.Regime, tID *tax.Identity) error {
 
 	t.round(zero)
 
+	// Complements
+	if err := calculateComplements(r, inv.Complements); err != nil {
+		return validation.Errors{"complements": err}
+	}
+
+	return nil
+}
+
+func calculateComplements(r *tax.Regime, comps []*schema.Object) error {
+	for _, c := range comps {
+		if err := c.Calculate(); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/regimes/mx/examples/fuel-account-balance.yaml
+++ b/regimes/mx/examples/fuel-account-balance.yaml
@@ -1,0 +1,76 @@
+$schema: "https://gobl.org/draft-0/bill/invoice"
+issue_date: "2023-07-10"
+series: "TEST"
+code: "00002"
+supplier:
+  name: "ESCUELA KEMPER URGATE"
+  ext:
+    mx-cfdi-fiscal-regime: "601"
+  tax_id:
+    country: "MX"
+    code: "EKU9003173C9"
+    zone: "21000"
+customer:
+  name: "UNIVERSIDAD ROBOTICA ESPAÑOLA"
+  ext:
+    mx-cfdi-fiscal-regime: "601"
+    mx-cfdi-use: "G01"
+  tax_id:
+    country: "MX"
+    code: "URE180429TM6"
+    zone: "86991"
+lines:
+  - quantity: "1"
+    item:
+      name: "Comisión servicio de monedero electrónico"
+      price: "10.00"
+      ext:
+        mx-cfdi-prod-serv: "84141602"
+    taxes:
+      - cat: "VAT"
+        rate: "standard"
+payment:
+  terms:
+    notes: "Condiciones de pago"
+  instructions:
+    key: "online+wallet"
+complements:
+  - $schema: "https://gobl.org/draft-0/regimes/mx/fuel-account-balance"
+    account_number: "0123456789"
+    lines:
+      - e_wallet_id: "1234"
+        purchase_date_time: "2022-07-19T10:20:30"
+        vendor_tax_code: "RWT860605OF5"
+        service_station_code: "8171650"
+        quantity: "9.6613"
+        unit: "l"
+        fuel_type: "3"
+        fuel_name: "Diesel"
+        unit_price: "12.7428"
+        purchase_code: "2794668"
+        total: "123.11"
+        taxes:
+          - code: "IVA"
+            rate: "0.16"
+            amount: "19.70"
+          - code: "IEPS"
+            rate: "5.9195"
+            amount: "57.19"
+      - e_wallet_id: "1234"
+        purchase_date_time: "2022-08-19T10:20:30"
+        vendor_tax_code: "DJV320816JT1"
+        service_station_code: "8171667"
+        quantity: "9.68"
+        fuel_type: "1"
+        fuel_name: "Gasolina Magna"
+        unit_price: "12.709"
+        purchase_code: "2794669"
+        total: "123.02"
+        taxes:
+          - code: "IVA"
+            rate: "0.16"
+            amount: "19.68"
+          - code: "IEPS"
+            rate: "5.9195"
+            amount: "57.30"
+

--- a/regimes/mx/examples/fuel-account-balance.yaml
+++ b/regimes/mx/examples/fuel-account-balance.yaml
@@ -43,10 +43,11 @@ complements:
         vendor_tax_code: "RWT860605OF5"
         service_station_code: "8171650"
         quantity: "9.6613"
-        unit: "l"
-        fuel_type: "3"
-        fuel_name: "Diesel"
-        unit_price: "12.7428"
+        item:
+          unit: "l"
+          type: "3"
+          name: "Diesel"
+          price: "12.7428"
         purchase_code: "2794668"
         total: "123.11"
         taxes:
@@ -61,9 +62,10 @@ complements:
         vendor_tax_code: "DJV320816JT1"
         service_station_code: "8171667"
         quantity: "9.68"
-        fuel_type: "1"
-        fuel_name: "Gasolina Magna"
-        unit_price: "12.709"
+        item:
+          type: "1"
+          name: "Gasolina Magna"
+          price: "12.709"
         purchase_code: "2794669"
         total: "123.02"
         taxes:

--- a/regimes/mx/examples/out/fuel-account-balance.json
+++ b/regimes/mx/examples/out/fuel-account-balance.json
@@ -1,0 +1,155 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
+		"dig": {
+			"alg": "sha256",
+			"val": "c0a43b719859e1f656b6a3bf6cc500703f1536240a110522a7f3f7fbeb566ef4"
+		},
+		"draft": true
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"type": "standard",
+		"series": "TEST",
+		"code": "00002",
+		"issue_date": "2023-07-10",
+		"currency": "MXN",
+		"supplier": {
+			"name": "ESCUELA KEMPER URGATE",
+			"tax_id": {
+				"country": "MX",
+				"zone": "21000",
+				"code": "EKU9003173C9"
+			},
+			"ext": {
+				"mx-cfdi-fiscal-regime": "601"
+			}
+		},
+		"customer": {
+			"name": "UNIVERSIDAD ROBOTICA ESPAÑOLA",
+			"tax_id": {
+				"country": "MX",
+				"zone": "86991",
+				"code": "URE180429TM6"
+			},
+			"ext": {
+				"mx-cfdi-fiscal-regime": "601",
+				"mx-cfdi-use": "G01"
+			}
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "1",
+				"item": {
+					"name": "Comisión servicio de monedero electrónico",
+					"price": "10.00",
+					"ext": {
+						"mx-cfdi-prod-serv": "84141602"
+					}
+				},
+				"sum": "10.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"rate": "standard",
+						"percent": "16.0%"
+					}
+				],
+				"total": "10.00"
+			}
+		],
+		"payment": {
+			"terms": {
+				"notes": "Condiciones de pago"
+			},
+			"instructions": {
+				"key": "online+wallet"
+			}
+		},
+		"totals": {
+			"sum": "10.00",
+			"total": "10.00",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"base": "10.00",
+								"percent": "16.0%",
+								"amount": "1.60"
+							}
+						],
+						"amount": "1.60"
+					}
+				],
+				"sum": "1.60"
+			},
+			"tax": "1.60",
+			"total_with_tax": "11.60",
+			"payable": "11.60"
+		},
+		"complements": [
+			{
+				"$schema": "https://gobl.org/draft-0/regimes/mx/fuel-account-balance",
+				"account_number": "0123456789",
+				"subtotal": "246.13",
+				"total": "400.00",
+				"lines": [
+					{
+						"e_wallet_id": "1234",
+						"purchase_date_time": "2022-07-19T10:20:30",
+						"vendor_tax_code": "RWT860605OF5",
+						"service_station_code": "8171650",
+						"quantity": "9.661",
+						"fuel_type": "3",
+						"unit": "l",
+						"fuel_name": "Diesel",
+						"unit_price": "12.743",
+						"purchase_code": "2794668",
+						"total": "123.11",
+						"taxes": [
+							{
+								"code": "IVA",
+								"rate": "0.160000",
+								"amount": "19.70"
+							},
+							{
+								"code": "IEPS",
+								"rate": "5.919500",
+								"amount": "57.19"
+							}
+						]
+					},
+					{
+						"e_wallet_id": "1234",
+						"purchase_date_time": "2022-08-19T10:20:30",
+						"vendor_tax_code": "DJV320816JT1",
+						"service_station_code": "8171667",
+						"quantity": "9.680",
+						"fuel_type": "1",
+						"fuel_name": "Gasolina Magna",
+						"unit_price": "12.709",
+						"purchase_code": "2794669",
+						"total": "123.02",
+						"taxes": [
+							{
+								"code": "IVA",
+								"rate": "0.160000",
+								"amount": "19.68"
+							},
+							{
+								"code": "IEPS",
+								"rate": "5.919500",
+								"amount": "57.30"
+							}
+						]
+					}
+				]
+			}
+		]
+	}
+}

--- a/regimes/mx/examples/out/fuel-account-balance.json
+++ b/regimes/mx/examples/out/fuel-account-balance.json
@@ -4,7 +4,7 @@
 		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
 		"dig": {
 			"alg": "sha256",
-			"val": "c0a43b719859e1f656b6a3bf6cc500703f1536240a110522a7f3f7fbeb566ef4"
+			"val": "1451d94f4ab432342eb1cf5721e978ff88bf45a90835c0538a917b58b9d59224"
 		},
 		"draft": true
 	},
@@ -105,10 +105,12 @@
 						"vendor_tax_code": "RWT860605OF5",
 						"service_station_code": "8171650",
 						"quantity": "9.661",
-						"fuel_type": "3",
-						"unit": "l",
-						"fuel_name": "Diesel",
-						"unit_price": "12.743",
+						"item": {
+							"type": "3",
+							"unit": "l",
+							"name": "Diesel",
+							"price": "12.743"
+						},
 						"purchase_code": "2794668",
 						"total": "123.11",
 						"taxes": [
@@ -130,9 +132,11 @@
 						"vendor_tax_code": "DJV320816JT1",
 						"service_station_code": "8171667",
 						"quantity": "9.680",
-						"fuel_type": "1",
-						"fuel_name": "Gasolina Magna",
-						"unit_price": "12.709",
+						"item": {
+							"type": "1",
+							"name": "Gasolina Magna",
+							"price": "12.709"
+						},
 						"purchase_code": "2794669",
 						"total": "123.02",
 						"taxes": [

--- a/regimes/mx/fuel_account_balance.go
+++ b/regimes/mx/fuel_account_balance.go
@@ -95,62 +95,48 @@ func (fab *FuelAccountBalance) Validate() error {
 		),
 		validation.Field(&fab.Subtotal, validation.Required),
 		validation.Field(&fab.Total, validation.Required),
-		validation.Field(&fab.Lines,
-			validation.Required,
-			validation.Each(validation.By(validateFuelAccountLine)),
-		),
+		validation.Field(&fab.Lines, validation.Required),
 	)
 }
 
-func validateFuelAccountLine(value interface{}) error {
-	line, _ := value.(*FuelAccountLine)
-	if line == nil {
-		return nil
-	}
-
-	return validation.ValidateStruct(line,
-		validation.Field(&line.EWalletID, validation.Required),
-		validation.Field(&line.PurchaseDateTime, cal.DateTimeNotZero()),
-		validation.Field(&line.VendorTaxCode,
+// Validate ensures that the line's data is valid.
+func (fal *FuelAccountLine) Validate() error {
+	return validation.ValidateStruct(fal,
+		validation.Field(&fal.EWalletID, validation.Required),
+		validation.Field(&fal.PurchaseDateTime, cal.DateTimeNotZero()),
+		validation.Field(&fal.VendorTaxCode,
 			validation.Required,
 			validation.By(validateTaxCode),
 		),
-		validation.Field(&line.ServiceStationCode,
+		validation.Field(&fal.ServiceStationCode,
 			validation.Required,
 			validation.Length(1, 20),
 		),
-		validation.Field(&line.Quantity, num.Positive),
-		validation.Field(&line.FuelType, validation.Required),
-		validation.Field(&line.FuelName,
+		validation.Field(&fal.Quantity, num.Positive),
+		validation.Field(&fal.FuelType, validation.Required),
+		validation.Field(&fal.FuelName,
 			validation.Required,
 			validation.Length(1, 300),
 		),
-		validation.Field(&line.PurchaseCode,
+		validation.Field(&fal.PurchaseCode,
 			validation.Required,
 			validation.Length(1, 50),
 		),
-		validation.Field(&line.UnitPrice, num.Positive),
-		validation.Field(&line.Total, isValidLineTotal(line)),
-		validation.Field(&line.Taxes,
-			validation.Required,
-			validation.Each(validation.By(validateFuelAccountTax)),
-		),
+		validation.Field(&fal.UnitPrice, num.Positive),
+		validation.Field(&fal.Total, isValidLineTotal(fal)),
+		validation.Field(&fal.Taxes, validation.Required),
 	)
 }
 
-func validateFuelAccountTax(value interface{}) error {
-	tax, _ := value.(*FuelAccountTax)
-	if tax == nil {
-		return nil
-	}
-
-	return validation.ValidateStruct(tax,
-		validation.Field(&tax.Code,
+// Validate ensures that the tax's data is valid.
+func (fat *FuelAccountTax) Validate() error {
+	return validation.ValidateStruct(fat,
+		validation.Field(&fat.Code,
 			validation.Required,
 			validation.In(validTaxCodes...),
 		),
-		validation.Field(&tax.Rate, num.Positive),
-		validation.Field(&tax.Amount, num.Positive),
+		validation.Field(&fat.Rate, num.Positive),
+		validation.Field(&fat.Amount, num.Positive),
 	)
 }
 

--- a/regimes/mx/fuel_account_balance.go
+++ b/regimes/mx/fuel_account_balance.go
@@ -8,14 +8,23 @@ import (
 	"github.com/invopop/validation"
 )
 
+// Constants for the precision of complement's amounts
 const (
 	FuelAccountInterimPrecision = 3
 	FuelAccountFinalPrecision   = 2
 	FuelAccountRatePrecision    = 6
+)
 
+// Constants for the complement's allowed tax codes
+const (
 	FuelAccountTaxCodeVAT  = cbc.Code("IVA")
 	FuelAccountTaxCodeIEPS = cbc.Code("IEPS")
 )
+
+var validTaxCodes = []interface{}{
+	FuelAccountTaxCodeVAT,
+	FuelAccountTaxCodeIEPS,
+}
 
 // FuelAccountBalance carries the data to produce a CFDI's "Complemento de
 // Estado de Cuenta de Combustibles para Monederos Electrónicos" (version 1.2
@@ -77,6 +86,7 @@ type FuelAccountTax struct {
 	Amount num.Amount `json:"amount" jsonschema:"title=Amount"`
 }
 
+// Validate ensures that the complement's data is valid.
 func (comp *FuelAccountBalance) Validate() error {
 	return validation.ValidateStruct(comp,
 		validation.Field(&comp.AccountNumber,
@@ -128,11 +138,6 @@ func validateFuelAccountLine(value interface{}) error {
 	)
 }
 
-var validTaxCodes = []interface{}{
-	FuelAccountTaxCodeVAT,
-	FuelAccountTaxCodeIEPS,
-}
-
 func validateFuelAccountTax(value interface{}) error {
 	tax, _ := value.(*FuelAccountTax)
 	if tax == nil {
@@ -155,6 +160,7 @@ func isValidLineTotal(line *FuelAccountLine) validation.Rule {
 	return validation.In(expected).Error("must be quantity x unit_price")
 }
 
+// Calculate performs the complement's calculations and normalisations.
 func (comp *FuelAccountBalance) Calculate() error {
 	var subtotal, taxtotal num.Amount
 

--- a/regimes/mx/fuel_account_balance.go
+++ b/regimes/mx/fuel_account_balance.go
@@ -1,0 +1,182 @@
+package mx
+
+import (
+	"github.com/invopop/gobl/cal"
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/num"
+	"github.com/invopop/gobl/org"
+	"github.com/invopop/validation"
+)
+
+const (
+	FuelAccountInterimPrecision = 3
+	FuelAccountFinalPrecision   = 2
+	FuelAccountRatePrecision    = 6
+
+	FuelAccountTaxCodeVAT  = cbc.Code("IVA")
+	FuelAccountTaxCodeIEPS = cbc.Code("IEPS")
+)
+
+// FuelAccountBalance carries the data to produce a CFDI's "Complemento de
+// Estado de Cuenta de Combustibles para Monederos Electrónicos" (version 1.2
+// revision B) providing detailed information about fuel purchases made with
+// electronic wallets. In Mexico, e-wallet suppliers are required to report this
+// complementary information in the invoices they issue to their customers.
+//
+// This struct maps to the `EstadoDeCuentaCombustible` root node in the CFDI's
+// complement.
+type FuelAccountBalance struct {
+	// Customer's account number (maps to `NumeroDeCuenta`).
+	AccountNumber string `json:"account_number" jsonschema:"title=Account Number"`
+	// Sum of all line totals (i.e. taxes not included) (calculated, maps to `SubTotal`).
+	Subtotal num.Amount `json:"subtotal" jsonschema:"title=Subtotal" jsonschema_extras:"calculated=true"`
+	// Grand total after taxes have been applied (calculated, maps to `Total`).
+	Total num.Amount `json:"total" jsonschema:"title=Total" jsonschema_extras:"calculated=true"`
+	// List of fuel purchases made with the customer's e-wallets (maps to `Conceptos`).
+	Lines []*FuelAccountLine `json:"lines" jsonschema:"title=Lines"`
+}
+
+// FuelAccountLine represents a single fuel purchase made with an e-wallet
+// issued by the invoice's supplier. It maps to one
+// `ConceptoEstadoDeCuentaCombustible` node in the CFDI's complement.
+type FuelAccountLine struct {
+	// Identifier of the e-wallet used to make the purchase (maps to `Identificador`).
+	EWalletID cbc.Code `json:"e_wallet_id" jsonschema:"title=E-wallet Identifier"`
+	// Date and time of the purchase (maps to `Fecha`).
+	PurchaseDateTime cal.DateTime `json:"purchase_date_time" jsonschema:"title=Purchase Date and Time"`
+	// Tax Identity Code of the fuel's vendor (maps to `Rfc`)
+	VendorTaxCode cbc.Code `json:"vendor_tax_code" jsonschema:"title=Vendor's Tax Identity Code"`
+	// Code of the service station where the purchase was made (maps to `ClaveEstacion`).
+	ServiceStationCode cbc.Code `json:"service_station_code" jsonschema:"title=Service Station Code"`
+	// Amount of fuel units purchased (maps to `Cantidad`)
+	Quantity num.Amount `json:"quantity" jsonschema:"title=Quantity"`
+	// Type of fuel (one of `c_ClaveTipoCombustible` codes, maps to `TipoCombustible`).
+	FuelType cbc.Code `json:"fuel_type" jsonschema:"title=Fuel Type"`
+	// Reference unit of measure used in the price and the quantity (maps to `Unidad`).
+	Unit org.Unit `json:"unit,omitempty" jsonschema:"title=Unit"`
+	// Name of the fuel (maps to `NombreCombustible`).
+	FuelName string `json:"fuel_name" jsonschema:"title=Fuel Name"`
+	// Base price of a single unit of the fuel without taxes (maps to `ValorUnitario`).
+	UnitPrice num.Amount `json:"unit_price" jsonschema:"title=Unit Price"`
+	// Identifier of the purchase (maps to `FolioOperacion`).
+	PurchaseCode cbc.Code `json:"purchase_code" jsonschema:"title=Purchase Code"`
+	// Result of quantity multiplied by the unit price (maps to `Importe`).
+	Total num.Amount `json:"total" jsonschema:"title=Total"`
+	// Map of taxes applied to the purchase (maps to `Traslados`).
+	Taxes []*FuelAccountTax `json:"taxes" jsonschema:"title=Taxes"`
+}
+
+// FuelAccountTax represents a single tax applied to a fuel purchase. It maps to
+// one `Traslado` node in the CFDI's complement.
+type FuelAccountTax struct {
+	// Code that identifies the tax ("IVA" or "IEPS", maps to `Impuesto`)
+	Code cbc.Code `json:"code" jsonschema:"title=Code"`
+	// Rate applicable to either the line total (tasa) or the line quantity (cuota) (maps to `TasaOCuota`).
+	Rate num.Amount `json:"rate" jsonschema:"title=Rate"`
+	// Total amount of the tax once the rate has been applied (maps to `Importe`).
+	Amount num.Amount `json:"amount" jsonschema:"title=Amount"`
+}
+
+func (comp *FuelAccountBalance) Validate() error {
+	return validation.ValidateStruct(comp,
+		validation.Field(&comp.AccountNumber,
+			validation.Required,
+			validation.Length(1, 50),
+		),
+		validation.Field(&comp.Subtotal, validation.Required),
+		validation.Field(&comp.Total, validation.Required),
+		validation.Field(&comp.Lines,
+			validation.Required,
+			validation.Each(validation.By(validateFuelAccountLine)),
+		),
+	)
+}
+
+func validateFuelAccountLine(value interface{}) error {
+	line, _ := value.(*FuelAccountLine)
+	if line == nil {
+		return nil
+	}
+
+	return validation.ValidateStruct(line,
+		validation.Field(&line.EWalletID, validation.Required),
+		validation.Field(&line.PurchaseDateTime, cal.DateTimeNotZero()),
+		validation.Field(&line.VendorTaxCode,
+			validation.Required,
+			validation.By(validateTaxCode),
+		),
+		validation.Field(&line.ServiceStationCode,
+			validation.Required,
+			validation.Length(1, 20),
+		),
+		validation.Field(&line.Quantity, num.Positive),
+		validation.Field(&line.FuelType, validation.Required),
+		validation.Field(&line.FuelName,
+			validation.Required,
+			validation.Length(1, 300),
+		),
+		validation.Field(&line.PurchaseCode,
+			validation.Required,
+			validation.Length(1, 50),
+		),
+		validation.Field(&line.UnitPrice, num.Positive),
+		validation.Field(&line.Total, isValidLineTotal(line)),
+		validation.Field(&line.Taxes,
+			validation.Required,
+			validation.Each(validation.By(validateFuelAccountTax)),
+		),
+	)
+}
+
+var validTaxCodes = []interface{}{
+	FuelAccountTaxCodeVAT,
+	FuelAccountTaxCodeIEPS,
+}
+
+func validateFuelAccountTax(value interface{}) error {
+	tax, _ := value.(*FuelAccountTax)
+	if tax == nil {
+		return nil
+	}
+
+	return validation.ValidateStruct(tax,
+		validation.Field(&tax.Code,
+			validation.Required,
+			validation.In(validTaxCodes...),
+		),
+		validation.Field(&tax.Rate, num.Positive),
+		validation.Field(&tax.Amount, num.Positive),
+	)
+}
+
+func isValidLineTotal(line *FuelAccountLine) validation.Rule {
+	expected := line.Quantity.Multiply(line.UnitPrice).Rescale(2)
+
+	return validation.In(expected).Error("must be quantity x unit_price")
+}
+
+func (comp *FuelAccountBalance) Calculate() error {
+	var subtotal, taxtotal num.Amount
+
+	for _, line := range comp.Lines {
+		// Normalise amounts to the expected precision
+		line.Quantity = line.Quantity.Rescale(FuelAccountInterimPrecision)
+		line.UnitPrice = line.UnitPrice.Rescale(FuelAccountInterimPrecision)
+		line.Total = line.Total.Rescale(FuelAccountFinalPrecision)
+
+		subtotal = line.Total.Add(subtotal)
+
+		for _, tax := range line.Taxes {
+			// Normalise amounts to the expected precision
+			tax.Rate = tax.Rate.Rescale(FuelAccountRatePrecision)
+			tax.Amount = tax.Amount.Rescale(FuelAccountFinalPrecision)
+
+			taxtotal = tax.Amount.Add(taxtotal)
+		}
+	}
+
+	comp.Subtotal = subtotal.Rescale(FuelAccountFinalPrecision)
+	comp.Total = subtotal.Add(taxtotal).Rescale(FuelAccountFinalPrecision)
+
+	return nil
+}

--- a/regimes/mx/fuel_account_balance.go
+++ b/regimes/mx/fuel_account_balance.go
@@ -87,15 +87,15 @@ type FuelAccountTax struct {
 }
 
 // Validate ensures that the complement's data is valid.
-func (comp *FuelAccountBalance) Validate() error {
-	return validation.ValidateStruct(comp,
-		validation.Field(&comp.AccountNumber,
+func (fab *FuelAccountBalance) Validate() error {
+	return validation.ValidateStruct(fab,
+		validation.Field(&fab.AccountNumber,
 			validation.Required,
 			validation.Length(1, 50),
 		),
-		validation.Field(&comp.Subtotal, validation.Required),
-		validation.Field(&comp.Total, validation.Required),
-		validation.Field(&comp.Lines,
+		validation.Field(&fab.Subtotal, validation.Required),
+		validation.Field(&fab.Total, validation.Required),
+		validation.Field(&fab.Lines,
 			validation.Required,
 			validation.Each(validation.By(validateFuelAccountLine)),
 		),
@@ -161,28 +161,28 @@ func isValidLineTotal(line *FuelAccountLine) validation.Rule {
 }
 
 // Calculate performs the complement's calculations and normalisations.
-func (comp *FuelAccountBalance) Calculate() error {
+func (fab *FuelAccountBalance) Calculate() error {
 	var subtotal, taxtotal num.Amount
 
-	for _, line := range comp.Lines {
+	for _, l := range fab.Lines {
 		// Normalise amounts to the expected precision
-		line.Quantity = line.Quantity.Rescale(FuelAccountInterimPrecision)
-		line.UnitPrice = line.UnitPrice.Rescale(FuelAccountInterimPrecision)
-		line.Total = line.Total.Rescale(FuelAccountFinalPrecision)
+		l.Quantity = l.Quantity.Rescale(FuelAccountInterimPrecision)
+		l.UnitPrice = l.UnitPrice.Rescale(FuelAccountInterimPrecision)
+		l.Total = l.Total.Rescale(FuelAccountFinalPrecision)
 
-		subtotal = line.Total.Add(subtotal)
+		subtotal = l.Total.Add(subtotal)
 
-		for _, tax := range line.Taxes {
+		for _, t := range l.Taxes {
 			// Normalise amounts to the expected precision
-			tax.Rate = tax.Rate.Rescale(FuelAccountRatePrecision)
-			tax.Amount = tax.Amount.Rescale(FuelAccountFinalPrecision)
+			t.Rate = t.Rate.Rescale(FuelAccountRatePrecision)
+			t.Amount = t.Amount.Rescale(FuelAccountFinalPrecision)
 
-			taxtotal = tax.Amount.Add(taxtotal)
+			taxtotal = t.Amount.Add(taxtotal)
 		}
 	}
 
-	comp.Subtotal = subtotal.Rescale(FuelAccountFinalPrecision)
-	comp.Total = subtotal.Add(taxtotal).Rescale(FuelAccountFinalPrecision)
+	fab.Subtotal = subtotal.Rescale(FuelAccountFinalPrecision)
+	fab.Total = subtotal.Add(taxtotal).Rescale(FuelAccountFinalPrecision)
 
 	return nil
 }

--- a/regimes/mx/fuel_account_balance.go
+++ b/regimes/mx/fuel_account_balance.go
@@ -21,7 +21,8 @@ const (
 	FuelAccountTaxCodeIEPS = cbc.Code("IEPS")
 )
 
-var validTaxCodes = []interface{}{
+// FuelAccountValidTaxCodes lists of the complement's allowed tax codes
+var FuelAccountValidTaxCodes = []interface{}{
 	FuelAccountTaxCodeVAT,
 	FuelAccountTaxCodeIEPS,
 }
@@ -149,7 +150,7 @@ func (fat *FuelAccountTax) Validate() error {
 	return validation.ValidateStruct(fat,
 		validation.Field(&fat.Code,
 			validation.Required,
-			validation.In(validTaxCodes...),
+			validation.In(FuelAccountValidTaxCodes...),
 		),
 		validation.Field(&fat.Rate, num.Positive),
 		validation.Field(&fat.Amount, num.Positive),

--- a/regimes/mx/fuel_account_balance_test.go
+++ b/regimes/mx/fuel_account_balance_test.go
@@ -10,9 +10,9 @@ import (
 )
 
 func TestInvalidComplement(t *testing.T) {
-	comp := &mx.FuelAccountBalance{}
+	fab := &mx.FuelAccountBalance{}
 
-	err := comp.Validate()
+	err := fab.Validate()
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "account_number: cannot be blank")
@@ -20,9 +20,9 @@ func TestInvalidComplement(t *testing.T) {
 }
 
 func TestInvalidLine(t *testing.T) {
-	comp := &mx.FuelAccountBalance{Lines: []*mx.FuelAccountLine{{}}}
+	fab := &mx.FuelAccountBalance{Lines: []*mx.FuelAccountLine{{}}}
 
-	err := comp.Validate()
+	err := fab.Validate()
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "e_wallet_id: cannot be blank")
@@ -36,11 +36,11 @@ func TestInvalidLine(t *testing.T) {
 	assert.Contains(t, err.Error(), "unit_price: must be greater than 0")
 	assert.Contains(t, err.Error(), "taxes: cannot be blank")
 
-	comp.Lines[0].VendorTaxCode = "1234"
-	comp.Lines[0].Quantity = num.MakeAmount(1, 0)
-	comp.Lines[0].UnitPrice = num.MakeAmount(1, 0)
+	fab.Lines[0].VendorTaxCode = "1234"
+	fab.Lines[0].Quantity = num.MakeAmount(1, 0)
+	fab.Lines[0].UnitPrice = num.MakeAmount(1, 0)
 
-	err = comp.Validate()
+	err = fab.Validate()
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "vendor_tax_code: invalid tax identity code")
@@ -48,27 +48,27 @@ func TestInvalidLine(t *testing.T) {
 }
 
 func TestInvalidTax(t *testing.T) {
-	comp := &mx.FuelAccountBalance{Lines: []*mx.FuelAccountLine{
+	fab := &mx.FuelAccountBalance{Lines: []*mx.FuelAccountLine{
 		{Taxes: []*mx.FuelAccountTax{{}}}},
 	}
 
-	err := comp.Validate()
+	err := fab.Validate()
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "code: cannot be blank")
 	assert.Contains(t, err.Error(), "rate: must be greater than 0")
 	assert.Contains(t, err.Error(), "amount: must be greater than 0")
 
-	comp.Lines[0].Taxes[0].Code = "IRPF"
+	fab.Lines[0].Taxes[0].Code = "IRPF"
 
-	err = comp.Validate()
+	err = fab.Validate()
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "code: must be a valid value")
 }
 
 func TestCalculate(t *testing.T) {
-	comp := &mx.FuelAccountBalance{
+	fab := &mx.FuelAccountBalance{
 		Lines: []*mx.FuelAccountLine{
 			{
 				Quantity:  num.MakeAmount(11, 1),
@@ -92,16 +92,16 @@ func TestCalculate(t *testing.T) {
 		},
 	}
 
-	err := comp.Calculate()
+	err := fab.Calculate()
 
 	require.NoError(t, err)
-	assert.Equal(t, num.MakeAmount(20001, 2), comp.Subtotal)
-	assert.Equal(t, num.MakeAmount(24337, 2), comp.Total)
+	assert.Equal(t, num.MakeAmount(20001, 2), fab.Subtotal)
+	assert.Equal(t, num.MakeAmount(24337, 2), fab.Total)
 
-	assert.Equal(t, num.MakeAmount(1100, 3), comp.Lines[0].Quantity)
-	assert.Equal(t, num.MakeAmount(90910, 3), comp.Lines[0].UnitPrice)
-	assert.Equal(t, num.MakeAmount(10000, 2), comp.Lines[0].Total)
+	assert.Equal(t, num.MakeAmount(1100, 3), fab.Lines[0].Quantity)
+	assert.Equal(t, num.MakeAmount(90910, 3), fab.Lines[0].UnitPrice)
+	assert.Equal(t, num.MakeAmount(10000, 2), fab.Lines[0].Total)
 
-	assert.Equal(t, num.MakeAmount(160000, 6), comp.Lines[0].Taxes[0].Rate)
-	assert.Equal(t, num.MakeAmount(1600, 2), comp.Lines[0].Taxes[0].Amount)
+	assert.Equal(t, num.MakeAmount(160000, 6), fab.Lines[0].Taxes[0].Rate)
+	assert.Equal(t, num.MakeAmount(1600, 2), fab.Lines[0].Taxes[0].Amount)
 }

--- a/regimes/mx/fuel_account_balance_test.go
+++ b/regimes/mx/fuel_account_balance_test.go
@@ -1,0 +1,107 @@
+package mx_test
+
+import (
+	"testing"
+
+	"github.com/invopop/gobl/num"
+	"github.com/invopop/gobl/regimes/mx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInvalidComplement(t *testing.T) {
+	comp := &mx.FuelAccountBalance{}
+
+	err := comp.Validate()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "account_number: cannot be blank")
+	assert.Contains(t, err.Error(), "lines: cannot be blank")
+}
+
+func TestInvalidLine(t *testing.T) {
+	comp := &mx.FuelAccountBalance{Lines: []*mx.FuelAccountLine{{}}}
+
+	err := comp.Validate()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "e_wallet_id: cannot be blank")
+	assert.Contains(t, err.Error(), "purchase_date_time: required")
+	assert.Contains(t, err.Error(), "vendor_tax_code: cannot be blank")
+	assert.Contains(t, err.Error(), "service_station_code: cannot be blank")
+	assert.Contains(t, err.Error(), "quantity: must be greater than 0")
+	assert.Contains(t, err.Error(), "fuel_type: cannot be blank")
+	assert.Contains(t, err.Error(), "fuel_name: cannot be blank")
+	assert.Contains(t, err.Error(), "purchase_code: cannot be blank")
+	assert.Contains(t, err.Error(), "unit_price: must be greater than 0")
+	assert.Contains(t, err.Error(), "taxes: cannot be blank")
+
+	comp.Lines[0].VendorTaxCode = "1234"
+	comp.Lines[0].Quantity = num.MakeAmount(1, 0)
+	comp.Lines[0].UnitPrice = num.MakeAmount(1, 0)
+
+	err = comp.Validate()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "vendor_tax_code: invalid tax identity code")
+	assert.Contains(t, err.Error(), "total: must be quantity x unit_price")
+}
+
+func TestInvalidTax(t *testing.T) {
+	comp := &mx.FuelAccountBalance{Lines: []*mx.FuelAccountLine{
+		{Taxes: []*mx.FuelAccountTax{{}}}},
+	}
+
+	err := comp.Validate()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "code: cannot be blank")
+	assert.Contains(t, err.Error(), "rate: must be greater than 0")
+	assert.Contains(t, err.Error(), "amount: must be greater than 0")
+
+	comp.Lines[0].Taxes[0].Code = "IRPF"
+
+	err = comp.Validate()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "code: must be a valid value")
+}
+
+func TestCalculate(t *testing.T) {
+	comp := &mx.FuelAccountBalance{
+		Lines: []*mx.FuelAccountLine{
+			{
+				Quantity:  num.MakeAmount(11, 1),
+				UnitPrice: num.MakeAmount(9091, 2),
+				Total:     num.MakeAmount(100, 0),
+				Taxes: []*mx.FuelAccountTax{
+					{
+						Rate:   num.MakeAmount(16, 2),
+						Amount: num.MakeAmount(16, 0),
+					},
+					{Amount: num.MakeAmount(56789, 4)},
+				},
+			},
+			{
+				Total: num.MakeAmount(100009, 3),
+				Taxes: []*mx.FuelAccountTax{
+					{Amount: num.MakeAmount(16, 0)},
+					{Amount: num.MakeAmount(56789, 4)},
+				},
+			},
+		},
+	}
+
+	err := comp.Calculate()
+
+	require.NoError(t, err)
+	assert.Equal(t, num.MakeAmount(20001, 2), comp.Subtotal)
+	assert.Equal(t, num.MakeAmount(24337, 2), comp.Total)
+
+	assert.Equal(t, num.MakeAmount(1100, 3), comp.Lines[0].Quantity)
+	assert.Equal(t, num.MakeAmount(90910, 3), comp.Lines[0].UnitPrice)
+	assert.Equal(t, num.MakeAmount(10000, 2), comp.Lines[0].Total)
+
+	assert.Equal(t, num.MakeAmount(160000, 6), comp.Lines[0].Taxes[0].Rate)
+	assert.Equal(t, num.MakeAmount(1600, 2), comp.Lines[0].Taxes[0].Amount)
+}

--- a/regimes/mx/mx.go
+++ b/regimes/mx/mx.go
@@ -9,11 +9,15 @@ import (
 	"github.com/invopop/gobl/l10n"
 	"github.com/invopop/gobl/org"
 	"github.com/invopop/gobl/regimes/common"
+	"github.com/invopop/gobl/schema"
 	"github.com/invopop/gobl/tax"
 )
 
 func init() {
 	tax.RegisterRegime(New())
+
+	// MX GOBL Schema Complements
+	schema.Register(schema.GOBL.Add("regimes/mx"), FuelAccountBalance{})
 }
 
 // Custom keys used typically in meta or codes information.


### PR DESCRIPTION
* Adds fuel account balance complement to MX regime used to generate the CFDI "EstadoDeCuentaCombustible" complement.
* Supersedes and applies the feedback discussed in #192.
* The GOBL complements maps one by one to every node and field of the CFDI complement.
* Implements validations according to the constrains of the the EstadoDeCuentaCombustible spec.
* Normalises all the amounts to the precisions (2, 3 or 6 decimals) specified in the EstadoDeCuentaCombustible spec.
* Calculates the grand subtotal and grand subtotal
* There are no line-level calculations as those must be calculated earlier when each fuel purchase was made by the purchase supplier.