### PR TITLE
Retained and other MX taxes

### DIFF
--- a/regimes/mx/examples/out/retentions.json
+++ b/regimes/mx/examples/out/retentions.json
@@ -1,0 +1,128 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
+		"dig": {
+			"alg": "sha256",
+			"val": "ae61650449eed123ec5d12375d41b1232915acde7c4a8fec08b8b801edd8a09b"
+		},
+		"draft": true
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"type": "standard",
+		"series": "TEST",
+		"code": "00001",
+		"issue_date": "2023-07-10",
+		"currency": "MXN",
+		"supplier": {
+			"name": "KARLA FUENTE NOLASCO",
+			"tax_id": {
+				"country": "MX",
+				"zone": "01160",
+				"code": "FUNK671228PH6"
+			},
+			"ext": {
+				"mx-cfdi-fiscal-regime": "612"
+			}
+		},
+		"customer": {
+			"name": "UNIVERSIDAD ROBOTICA ESPAÑOLA",
+			"tax_id": {
+				"country": "MX",
+				"zone": "86991",
+				"code": "URE180429TM6"
+			},
+			"ext": {
+				"mx-cfdi-fiscal-regime": "601",
+				"mx-cfdi-use": "G01"
+			}
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "1",
+				"item": {
+					"name": "Honorarios de notario",
+					"price": "1230.00",
+					"ext": {
+						"mx-cfdi-prod-serv": "80121603"
+					}
+				},
+				"sum": "1230.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"rate": "standard",
+						"percent": "16.0%"
+					},
+					{
+						"cat": "RVAT",
+						"percent": "10.6667%"
+					},
+					{
+						"cat": "ISR",
+						"percent": "10.00%"
+					}
+				],
+				"total": "1230.00"
+			}
+		],
+		"payment": {
+			"terms": {
+				"notes": "Condiciones de pago"
+			},
+			"instructions": {
+				"key": "credit-transfer"
+			}
+		},
+		"totals": {
+			"sum": "1230.00",
+			"total": "1230.00",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"base": "1230.00",
+								"percent": "16.0%",
+								"amount": "196.80"
+							}
+						],
+						"amount": "196.80"
+					},
+					{
+						"code": "RVAT",
+						"retained": true,
+						"rates": [
+							{
+								"base": "1230.00",
+								"percent": "10.6667%",
+								"amount": "131.20"
+							}
+						],
+						"amount": "131.20"
+					},
+					{
+						"code": "ISR",
+						"retained": true,
+						"rates": [
+							{
+								"base": "1230.00",
+								"percent": "10.00%",
+								"amount": "123.00"
+							}
+						],
+						"amount": "123.00"
+					}
+				],
+				"sum": "-57.40"
+			},
+			"tax": "-57.40",
+			"total_with_tax": "1172.60",
+			"payable": "1172.60"
+		}
+	}
+}

--- a/regimes/mx/examples/retentions.yaml
+++ b/regimes/mx/examples/retentions.yaml
@@ -1,0 +1,40 @@
+$schema: "https://gobl.org/draft-0/bill/invoice"
+issue_date: "2023-07-10"
+series: "TEST"
+code: "00001"
+supplier:
+  name: "KARLA FUENTE NOLASCO"
+  ext:
+    mx-cfdi-fiscal-regime: "612"
+  tax_id:
+    country: "MX"
+    code: "FUNK671228PH6"
+    zone: "01160"
+customer:
+  name: "UNIVERSIDAD ROBOTICA ESPAÑOLA"
+  ext:
+    mx-cfdi-fiscal-regime: "601"
+    mx-cfdi-use: "G01"
+  tax_id:
+    country: "MX"
+    code: "URE180429TM6"
+    zone: "86991"
+lines:
+  - quantity: "1"
+    item:
+      name: "Honorarios de notario"
+      price: "1230.00"
+      ext:
+        mx-cfdi-prod-serv: "80121603"
+    taxes:
+      - cat: "VAT"
+        rate: "standard"
+      - cat: "RVAT"
+        percent: "10.6667%"
+      - cat: "ISR"
+        percent: "10.00%"
+payment:
+  terms:
+    notes: "Condiciones de pago"
+  instructions:
+    key: "credit-transfer"

--- a/regimes/mx/mx.go
+++ b/regimes/mx/mx.go
@@ -28,6 +28,7 @@ const (
 	KeySATFormaPago         cbc.Key = "sat-forma-pago"          // for mapping to c_FormaPago’s codes
 	KeySATTipoDeComprobante cbc.Key = "sat-tipo-de-comprobante" // for mapping to c_TipoDeComprobante’s codes
 	KeySATTipoRelacion      cbc.Key = "sat-tipo-relacion"       // for mapping to c_TipoRelacion’s codes
+	KeySATImpuesto          cbc.Key = "sat-impuesto"            // for mapping to c_Impuesto’s codes
 )
 
 // SAT official codes to include in stamps.

--- a/regimes/mx/tax_categories.go
+++ b/regimes/mx/tax_categories.go
@@ -8,12 +8,23 @@ import (
 	"github.com/invopop/gobl/tax"
 )
 
-// Tax rates specific to Mexico.
+// Local tax categories
+const (
+	TaxCategoryRVAT  cbc.Code = "RVAT"  // IVA (Retenido)
+	TaxCategoryIEPS  cbc.Code = "IEPS"  // Impuesto Especial sobre Producción y Servicios
+	TaxCategoryRIEPS cbc.Code = "RIEPS" // Impuesto Especial sobre Producción y Servicios (Retenido)
+	TaxCategoryISR   cbc.Code = "ISR"   // Impuesto Sobre la Renta
+)
+
+// Local tax rates
 const (
 	TaxRateExempt cbc.Key = "exempt"
 )
 
 var taxCategories = []*tax.Category{
+	//
+	// IVA
+	//
 	{
 		Code: common.TaxCategoryVAT,
 		Name: i18n.String{
@@ -71,5 +82,78 @@ var taxCategories = []*tax.Category{
 				Exempt: true,
 			},
 		},
+		Map: cbc.CodeMap{KeySATImpuesto: "002"},
+	},
+
+	//
+	// IVA (Retenido)
+	//
+	{
+		Code: TaxCategoryRVAT,
+		Name: i18n.String{
+			i18n.EN: "Retained VAT",
+			i18n.ES: "IVA Retenido",
+		},
+		Title: i18n.String{
+			i18n.EN: "Retained Value Added Tax",
+			i18n.ES: "Impuesto al Valor Agregado Retenido",
+		},
+		Retained: true,
+		Rates:    []*tax.Rate{},
+		Map:      cbc.CodeMap{KeySATImpuesto: "002"},
+	},
+
+	//
+	// IEPS
+	//
+	{
+		Code: TaxCategoryIEPS,
+		Name: i18n.String{
+			i18n.EN: "IEPS",
+			i18n.ES: "IEPS",
+		},
+		Title: i18n.String{
+			i18n.EN: "Special Tax on Production and Services",
+			i18n.ES: "Impuesto Especial sobre Producción y Servicios",
+		},
+		Retained: false,
+		Rates:    []*tax.Rate{},
+		Map:      cbc.CodeMap{KeySATImpuesto: "003"},
+	},
+
+	//
+	// IEPS (Retenido)
+	//
+	{
+		Code: TaxCategoryRIEPS,
+		Name: i18n.String{
+			i18n.EN: "Retained IEPS",
+			i18n.ES: "IEPS Retenido",
+		},
+		Title: i18n.String{
+			i18n.EN: "Retained Special Tax on Production and Services",
+			i18n.ES: "Impuesto Especial sobre Producción y Servicios Retenido",
+		},
+		Retained: true,
+		Rates:    []*tax.Rate{},
+		Map:      cbc.CodeMap{KeySATImpuesto: "003"},
+	},
+
+	//
+	// ISR
+	//
+	{
+		Code: TaxCategoryISR,
+		Name: i18n.String{
+			i18n.EN: "ISR",
+			i18n.ES: "ISR",
+		},
+		Title: i18n.String{
+			i18n.EN: "Income Tax",
+			i18n.ES: "Impuesto Sobre la Renta",
+		},
+		Retained: true,
+		Rates:    []*tax.Rate{},
+		Map:      cbc.CodeMap{KeySATImpuesto: "001"},
 	},
 }


### PR DESCRIPTION
* This PR completes the tax categories allowed in Mexico with: Retained VAT, ISR (only retained) and IEPS (both regular and retained versions)
* Related to https://github.com/invopop/gobl.cfdi/pull/17