### PR TITLE
Support for signature and header verification

### DIFF
--- a/envelope.go
+++ b/envelope.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"strconv"
 
 	"github.com/invopop/validation"
 
@@ -63,6 +65,58 @@ func (e *Envelope) Validate() error {
 	return e.ValidateWithContext(context.Background())
 }
 
+// Verify checks the envelope's signatures to ensure the headers they contain
+// still matches with the current headers. If a list of public keys are provided,
+// they will be used to ensure that the signatures we're signed by at least
+// one of them. If no keys are provided, only the contents will be checked.
+func (e *Envelope) Verify(keys ...*dsig.PublicKey) error {
+	if e.Head == nil || e.Head.Draft {
+		return errors.New("cannot verify draft document")
+	}
+	if len(e.Signatures) == 0 {
+		return errors.New("no signatures to verify")
+	}
+
+	ve := make(validation.Errors)
+	for i, s := range e.Signatures {
+		if err := e.verifySignature(keys, s); err != nil {
+			ve[strconv.Itoa(i)] = err
+		}
+	}
+	if len(ve) > 0 {
+		return ErrValidation.WithCause(validation.Errors{
+			"signatures": ve,
+		})
+	}
+
+	return nil
+}
+
+func (e *Envelope) verifySignature(keys []*dsig.PublicKey, s *dsig.Signature) error {
+	if len(keys) == 0 {
+		// no keys provided, only check the contents
+		h := new(head.Header)
+		if err := s.UnsafePayload(h); err != nil {
+			return errors.New("invalid signature payload")
+		}
+		if !e.Head.Contains(h) {
+			return errors.New("header mismatch")
+		}
+		return nil
+	}
+	for _, k := range keys {
+		h := new(head.Header)
+		if err := s.VerifyPayload(k, h); err != nil {
+			continue
+		}
+		if e.Head.Contains(h) {
+			return nil
+		}
+		return errors.New("header mismatch")
+	}
+	return errors.New("no key match found")
+}
+
 // ValidateWithContext ensures that the envelope contains everything it should to be considered valid GoBL.
 func (e *Envelope) ValidateWithContext(ctx context.Context) error {
 	ctx = context.WithValue(ctx, internal.KeyDraft, e.Head != nil && e.Head.Draft)
@@ -70,7 +124,12 @@ func (e *Envelope) ValidateWithContext(ctx context.Context) error {
 		validation.Field(&e.Schema, validation.Required),
 		validation.Field(&e.Head, validation.Required),
 		validation.Field(&e.Document, validation.Required), // this will also check payload
-		validation.Field(&e.Signatures, validation.When(e.Head == nil || e.Head.Draft, validation.Empty)),
+		validation.Field(&e.Signatures,
+			validation.When(
+				e.Head == nil || e.Head.Draft,
+				validation.Empty,
+			),
+		),
 	)
 	if err != nil {
 		return err

--- a/head/header.go
+++ b/head/header.go
@@ -66,3 +66,49 @@ func (h *Header) ValidateWithContext(ctx context.Context) error {
 func (h *Header) AddStamp(s *Stamp) {
 	h.Stamps = AddStamp(h.Stamps, s)
 }
+
+// Contains compares the provided header to ensure that all the fields
+// and properties are contained within the base header. Only a subset of
+// the most important fields are compared.
+func (h *Header) Contains(h2 *Header) bool {
+	if h.UUID.String() != h2.UUID.String() {
+		return false
+	}
+	if h2.Digest != nil && h.Digest.String() != h2.Digest.String() {
+		return false
+	}
+	for _, s2 := range h2.Stamps {
+		match := false
+		for _, s := range h.Stamps {
+			if s.Provider == s2.Provider && s.Value == s2.Value {
+				match = true
+				break
+			}
+		}
+		if !match {
+			return false
+		}
+	}
+	for _, t2 := range h2.Tags {
+		match := false
+		for _, t := range h.Tags {
+			if t == t2 {
+				match = true
+				break
+			}
+		}
+		if !match {
+			return false
+		}
+	}
+	for k2, v2 := range h2.Meta {
+		v, ok := h.Meta[k2]
+		if !ok || v != v2 {
+			return false
+		}
+	}
+	if h2.Notes != "" && h2.Notes != h.Notes {
+		return false
+	}
+	return true // all comparisons have passed!
+}

--- a/head/header_test.go
+++ b/head/header_test.go
@@ -3,6 +3,7 @@ package head_test
 import (
 	"testing"
 
+	"github.com/invopop/gobl/dsig"
 	"github.com/invopop/gobl/head"
 	"github.com/stretchr/testify/assert"
 )
@@ -28,4 +29,62 @@ func TestHeaderAddStamp(t *testing.T) {
 	h.AddStamp(&head.Stamp{Provider: "bar", Value: "bax"})
 	assert.Len(t, h.Stamps, 2)
 	assert.Equal(t, "bax", h.Stamps[1].Value)
+}
+
+func TestHeaderContains(t *testing.T) {
+	h1 := head.NewHeader()
+	h2 := head.NewHeader()
+
+	// UUID
+	assert.False(t, h1.Contains(h2))
+	h2.UUID = h1.UUID
+	assert.True(t, h1.Contains(h2))
+
+	// Digest
+	h1.Digest = dsig.NewSHA256Digest([]byte("testing"))
+	h2.Digest = dsig.NewSHA256Digest([]byte("testing 2"))
+	assert.False(t, h1.Contains(h2))
+	h2.Digest = h1.Digest
+	assert.True(t, h1.Contains(h2))
+
+	// Stamps
+	h1.AddStamp(&head.Stamp{Provider: "foo", Value: "bar"})
+	h1.AddStamp(&head.Stamp{Provider: "foo2", Value: "bar"})
+	assert.True(t, h1.Contains(h2))
+	h2.AddStamp(&head.Stamp{Provider: "foo", Value: "bar"})
+	assert.True(t, h1.Contains(h2))
+	h2.AddStamp(&head.Stamp{Provider: "foo2", Value: "bar"})
+	assert.True(t, h1.Contains(h2))
+	h2.AddStamp(&head.Stamp{Provider: "foo3", Value: "bar"})
+	assert.False(t, h1.Contains(h2))
+	h1.AddStamp(&head.Stamp{Provider: "foo3", Value: "bar"})
+	assert.True(t, h1.Contains(h2))
+
+	// Tags
+	h1.Tags = append(h1.Tags, "foo")
+	assert.True(t, h1.Contains(h2))
+	h2.Tags = append(h2.Tags, "foo")
+	assert.True(t, h1.Contains(h2))
+	h2.Tags = append(h2.Tags, "foo2")
+	assert.False(t, h1.Contains(h2))
+	h1.Tags = append(h1.Tags, "foo2")
+	assert.True(t, h1.Contains(h2))
+
+	// Meta
+	h1.Meta["foo"] = "bar"
+	assert.True(t, h1.Contains(h2))
+	h2.Meta["foo"] = "bar"
+	assert.True(t, h1.Contains(h2))
+	h2.Meta["foo2"] = "bar"
+	assert.False(t, h1.Contains(h2))
+	h1.Meta["foo2"] = "bar"
+	assert.True(t, h1.Contains(h2))
+
+	// Notes
+	h1.Notes = "test notes"
+	assert.True(t, h1.Contains(h2))
+	h2.Notes = "bad notes"
+	assert.False(t, h1.Contains(h2))
+	h2.Notes = h1.Notes
+	assert.True(t, h1.Contains(h2))
 }


### PR DESCRIPTION
* Adds a "Verify" method to the envelope that makes it easier to check an optional list of keys against the signatures used to sign the document.
* `head.Header` now has a "Contains" method that facilitates testing if the current header includes all the fields from the provided header.