### PR TITLE
Establish consistent usage of 'desc' in public models

### DIFF
--- a/bill/outlay.go
+++ b/bill/outlay.go
@@ -47,8 +47,8 @@ func (o *Outlay) Validate() error {
 	)
 }
 
-// JSONUnmarshal helps migrate the desc field to description.
-func (o *Outlay) JSONUnmarshal(data []byte) error {
+// UnmarshalJSON helps migrate the desc field to description.
+func (o *Outlay) UnmarshalJSON(data []byte) error {
 	type Alias Outlay
 	aux := &struct {
 		Desc string `json:"desc"`

--- a/bill/outlay_test.go
+++ b/bill/outlay_test.go
@@ -8,6 +8,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestOutlayUnmarshal(t *testing.T) {
+	o := new(Outlay)
+	err := o.JSONUnmarshal([]byte(`{"desc":"foo"}`))
+	require.NoError(t, err)
+	assert.Equal(t, "foo", o.Description)
+}
+
 func TestOutlayTotals(t *testing.T) {
 	os := []*Outlay{
 		{

--- a/bill/outlay_test.go
+++ b/bill/outlay_test.go
@@ -1,6 +1,7 @@
 package bill
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/invopop/gobl/num"
@@ -10,7 +11,7 @@ import (
 
 func TestOutlayUnmarshal(t *testing.T) {
 	o := new(Outlay)
-	err := o.JSONUnmarshal([]byte(`{"desc":"foo"}`))
+	err := json.Unmarshal([]byte(`{"desc":"foo"}`), o)
 	require.NoError(t, err)
 	assert.Equal(t, "foo", o.Description)
 }

--- a/data/schemas/bill/invoice.json
+++ b/data/schemas/bill/invoice.json
@@ -614,7 +614,7 @@
           "title": "Series",
           "description": "Series of the outlay invoice."
         },
-        "desc": {
+        "description": {
           "type": "string",
           "title": "Description",
           "description": "Details on what the outlay was."
@@ -633,7 +633,7 @@
       "type": "object",
       "required": [
         "i",
-        "desc",
+        "description",
         "amount"
       ],
       "description": "Outlay represents a reimbursable expense that was paid for by the supplier and invoiced separately by the third party directly to the customer."

--- a/data/schemas/org/item.json
+++ b/data/schemas/org/item.json
@@ -32,9 +32,10 @@
           "title": "Identities",
           "description": "List of additional codes, IDs, or SKUs which can be used to identify the item. They should be agreed upon between supplier and customer."
         },
-        "desc": {
+        "description": {
           "type": "string",
-          "description": "Detailed description"
+          "title": "Description",
+          "description": "Detailed description of the item."
         },
         "currency": {
           "$ref": "https://gobl.org/draft-0/currency/code",

--- a/data/schemas/pay/advance.json
+++ b/data/schemas/pay/advance.json
@@ -96,7 +96,7 @@
           "title": "Grant",
           "description": "If this \"advance\" payment has come from a public grant or subsidy, set this to true."
         },
-        "desc": {
+        "description": {
           "type": "string",
           "title": "Description",
           "description": "Details about the advance."
@@ -119,7 +119,7 @@
       },
       "type": "object",
       "required": [
-        "desc",
+        "description",
         "amount"
       ],
       "description": "Advance represents a single payment that has been made already, such as a deposit on an intent to purchase, or as credit from a previous invoice which was later corrected or cancelled."

--- a/org/item.go
+++ b/org/item.go
@@ -33,8 +33,8 @@ type Item struct {
 	Name string `json:"name"`
 	// List of additional codes, IDs, or SKUs which can be used to identify the item. They should be agreed upon between supplier and customer.
 	Identities []*Identity `json:"identities,omitempty" jsonschema:"title=Identities"`
-	// Detailed description
-	Description string `json:"desc,omitempty"`
+	// Detailed description of the item.
+	Description string `json:"description,omitempty" jsonschema:"title=Description"`
 	// Currency used for the item's price.
 	Currency currency.Code `json:"currency,omitempty" jsonschema:"title=Currency"`
 	// Base price of a single unit to be sold.

--- a/pay/advance.go
+++ b/pay/advance.go
@@ -60,8 +60,8 @@ func (a *Advance) CalculateFrom(totalWithTax num.Amount) {
 	}
 }
 
-// JSONUnmarshal helps migrate the desc field to description.
-func (a *Advance) JSONUnmarshal(data []byte) error {
+// UnmarshalJSON helps migrate the desc field to description.
+func (a *Advance) UnmarshalJSON(data []byte) error {
 	type Alias Advance
 	aux := &struct {
 		Desc string `json:"desc,omitempty"`

--- a/pay/advance_test.go
+++ b/pay/advance_test.go
@@ -1,6 +1,7 @@
 package pay_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/invopop/gobl/pay"
@@ -10,7 +11,7 @@ import (
 
 func TestAdvanceUnmarshal(t *testing.T) {
 	a := new(pay.Advance)
-	err := a.JSONUnmarshal([]byte(`{"desc":"foo"}`))
+	err := json.Unmarshal([]byte(`{"desc":"foo"}`), a)
 	require.NoError(t, err)
 	assert.Equal(t, "foo", a.Description)
 }

--- a/pay/advance_test.go
+++ b/pay/advance_test.go
@@ -1,0 +1,16 @@
+package pay_test
+
+import (
+	"testing"
+
+	"github.com/invopop/gobl/pay"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAdvanceUnmarshal(t *testing.T) {
+	a := new(pay.Advance)
+	err := a.JSONUnmarshal([]byte(`{"desc":"foo"}`))
+	require.NoError(t, err)
+	assert.Equal(t, "foo", a.Description)
+}

--- a/regimes/co/examples/out/simplified.json
+++ b/regimes/co/examples/out/simplified.json
@@ -4,7 +4,7 @@
 		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
 		"dig": {
 			"alg": "sha256",
-			"val": "2346991aab5ee704bd2b0ad14a06260aaf81fa7baca32c2bcd211cbc177aa6a2"
+			"val": "f23f62eb0cf68db88a55bd391e5410bfba7bf06c24e1a7a863191346b07b644c"
 		},
 		"draft": true
 	},
@@ -50,7 +50,7 @@
 		"payment": {
 			"advances": [
 				{
-					"desc": "Prepaid",
+					"description": "Prepaid",
 					"percent": "100%",
 					"amount": "238000.00"
 				}

--- a/regimes/es/examples/out/invoice-es-es-vateqs-provider.json
+++ b/regimes/es/examples/out/invoice-es-es-vateqs-provider.json
@@ -4,7 +4,7 @@
 		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
 		"dig": {
 			"alg": "sha256",
-			"val": "72e81bc4530fcd56154953690b56d170d3de5109a833642876e1dc33399f8d6e"
+			"val": "43f53d3728f1840ae9a652d616a7af90f827a937e375e9bf68d2e5d61c986ddc"
 		},
 		"draft": true
 	},
@@ -111,7 +111,7 @@
 			"advances": [
 				{
 					"date": "2021-09-01",
-					"desc": "Deposit paid upfront",
+					"description": "Deposit paid upfront",
 					"amount": "25.00"
 				}
 			],

--- a/regimes/mx/examples/out/prepaid-invoice.json
+++ b/regimes/mx/examples/out/prepaid-invoice.json
@@ -4,7 +4,7 @@
 		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
 		"dig": {
 			"alg": "sha256",
-			"val": "d8defb2c2e8f823f3ee18d3b75516cd38532f735a6f2635ceb7950af3fa7c150"
+			"val": "e87b2b2acf012c7fa3b9d9eda0046943b173b98ce47fa9bd27144f27b157b1b0"
 		},
 		"draft": true
 	},
@@ -94,13 +94,13 @@
 			"advances": [
 				{
 					"key": "cash",
-					"desc": "Anticipo",
+					"description": "Anticipo",
 					"percent": "10.0%",
 					"amount": "2.20"
 				},
 				{
 					"key": "card",
-					"desc": "Saldo",
+					"description": "Saldo",
 					"percent": "90.0%",
 					"amount": "19.84"
 				}


### PR DESCRIPTION
* Removing usage of `"desc"` property name in favour of `"description"` which is used more widely throughout GOBL and is consistent with JSON Schema definitions.