### PR TITLE
Update Tax ID validations in CO

### DIFF
--- a/regimes/co/invoices_test.go
+++ b/regimes/co/invoices_test.go
@@ -142,7 +142,16 @@ func TestBasicInvoiceValidation(t *testing.T) {
 
 	inv = baseInvoice()
 	inv.Customer.TaxID.Type = co.TaxIdentityTypeCitizen
-	inv.Customer.TaxID.Code = "100100100"
+	inv.Customer.TaxID.Code = co.TaxCodeFinalCustomer
+	inv.Customer.TaxID.Zone = ""
+	require.NoError(t, inv.Calculate())
+	err = inv.Validate()
+	assert.NoError(t, err)
+
+	inv = baseInvoice()
+	inv.Customer.TaxID.Country = l10n.ES
+	inv.Customer.TaxID.Code = "A13180492"
+	inv.Customer.TaxID.Type = co.TaxIdentityTypeForeign
 	inv.Customer.TaxID.Zone = ""
 	require.NoError(t, inv.Calculate())
 	err = inv.Validate()

--- a/regimes/co/tax_identity.go
+++ b/regimes/co/tax_identity.go
@@ -25,6 +25,8 @@ const (
 	TaxIdentityTypeForeigner  cbc.Key = "foreigner"
 	TaxIdentityTypePEP        cbc.Key = "pep"
 	TaxIdentityTypeNUIP       cbc.Key = "nuip"
+
+	TaxCodeFinalCustomer cbc.Code = "222222222222"
 )
 
 var (
@@ -177,12 +179,19 @@ func validateTaxIdentity(tID *tax.Identity) error {
 			),
 		),
 		validation.Field(&tID.Zone,
-			validation.When(tID.Type.In(TaxIdentityTypeTIN),
+			validation.When(!isFinalCustomer(tID),
 				validation.Required,
 				tax.ZoneIn(zones),
 			),
 		),
 	)
+}
+
+func isFinalCustomer(tID *tax.Identity) bool {
+	if tID == nil {
+		return false
+	}
+	return tID.Type == TaxIdentityTypeCitizen && tID.Code == TaxCodeFinalCustomer
 }
 
 // normalizeTaxIdentity will remove any whitespace or separation characters from
@@ -265,3 +274,15 @@ func validateDigits(code, check cbc.Code) error {
 
 	return nil
 }
+
+func taxIdentityTypeKeys() []interface{} {
+	keys := make([]interface{}, len(taxIdentityTypeDefs))
+	i := 0
+	for _, v := range taxIdentityTypeDefs {
+		keys[i] = v.Key
+		i++
+	}
+	return keys
+}
+
+var isValidTaxIdentityTypeKey = validation.In(taxIdentityTypeKeys()...)

--- a/regimes/co/tax_identity_test.go
+++ b/regimes/co/tax_identity_test.go
@@ -113,9 +113,9 @@ func TestValidateTaxIdentity(t *testing.T) {
 			err:  "code: cannot be blank",
 		},
 		{
-			name: "missing zone for citizen",
+			name: "missing zone for final customer",
 			typ:  co.TaxIdentityTypeCitizen,
-			code: "100100100",
+			code: co.TaxCodeFinalCustomer,
 			zone: "",
 			err:  "",
 		},


### PR DESCRIPTION
* Ensure all the Tax ID validations previously done in the provider are now in GOBL (related to https://github.com/invopop/plemsi/pull/51)
* Validate the Tax ID properly for foreign customers