### PR TITLE
Ensure structured errors are accessible in errors + advance payment details

### DIFF
--- a/bill/outlay.go
+++ b/bill/outlay.go
@@ -50,7 +50,7 @@ func (o *Outlay) Validate() error {
 // UnmarshalJSON helps migrate the desc field to description.
 func (o *Outlay) UnmarshalJSON(data []byte) error {
 	type Alias Outlay
-	aux := &struct {
+	aux := struct {
 		Desc string `json:"desc"`
 		*Alias
 	}{

--- a/dsig/digest.go
+++ b/dsig/digest.go
@@ -39,10 +39,10 @@ func (d *Digest) Validate() error {
 // digest object. This will fail if the algorithms are different.
 func (d *Digest) Equals(d2 *Digest) error {
 	if d.Algorithm != d2.Algorithm {
-		return errors.New("digest algorithm mismatch")
+		return errors.New("algorithm mismatch")
 	}
 	if d.Value != d2.Value {
-		return errors.New("digest mismatch")
+		return errors.New("mismatch")
 	}
 	return nil
 }

--- a/envelope_test.go
+++ b/envelope_test.go
@@ -209,7 +209,7 @@ func TestEnvelopeValidate(t *testing.T) {
 			env: func() *gobl.Envelope {
 				return &gobl.Envelope{}
 			},
-			want: "$schema: cannot be blank; doc: cannot be blank; head: cannot be blank.",
+			want: "validation: ($schema: cannot be blank; doc: cannot be blank; head: cannot be blank.).",
 		},
 		{
 			name: "missing message body, draft",
@@ -219,7 +219,7 @@ func TestEnvelopeValidate(t *testing.T) {
 				require.NoError(t, env.Insert(&note.Message{}))
 				return env
 			},
-			want: "doc: (content: cannot be blank.).",
+			want: "validation: (doc: (content: cannot be blank.).).",
 		},
 		{
 			name: "missing sig, draft",
@@ -249,7 +249,7 @@ func TestEnvelopeValidate(t *testing.T) {
 				msg.Content = "bar"
 				return env
 			},
-			want: "document: digest mismatch",
+			want: "digest: mismatch",
 		},
 	}
 
@@ -279,7 +279,7 @@ func TestEnvelopeSign(t *testing.T) {
 		require.NoError(t, env.Insert(&note.Message{})) // missing msg content
 		err := env.Sign(testKey)
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "validation: doc: (content: cannot be blank.).")
+		assert.Contains(t, err.Error(), "validation: (doc: (content: cannot be blank.).).")
 	})
 	t.Run("sign valid document", func(t *testing.T) {
 		env := gobl.NewEnvelope()
@@ -385,6 +385,25 @@ func TestDocumentValidation(t *testing.T) {
 		// Double check to make sure validation working
 		assert.Contains(t, err.Error(), "issue_date: required")
 	}
+}
+
+func TestDocumentValidationOutput(t *testing.T) {
+	msg := &note.Message{}
+
+	doc, err := schema.NewObject(msg)
+	require.NoError(t, err)
+
+	err = doc.Validate()
+	data, err := json.Marshal(err)
+	require.NoError(t, err)
+	assert.Equal(t, `{"content":"cannot be blank"}`, string(data))
+
+	env := gobl.NewEnvelope()
+	require.NoError(t, env.Insert(msg))
+	err = env.Validate()
+	data, err = json.Marshal(err)
+	require.NoError(t, err)
+	assert.Equal(t, `{"key":"validation","cause":{"doc":{"content":"cannot be blank"}}}`, string(data))
 }
 
 func TestEnvelopeVerify(t *testing.T) {

--- a/pay/advance.go
+++ b/pay/advance.go
@@ -74,7 +74,7 @@ func (a *Advance) CalculateFrom(totalWithTax num.Amount) {
 // UnmarshalJSON helps migrate the desc field to description.
 func (a *Advance) UnmarshalJSON(data []byte) error {
 	type Alias Advance
-	aux := &struct {
+	aux := struct {
 		Desc string `json:"desc,omitempty"`
 		*Alias
 	}{

--- a/pay/advance.go
+++ b/pay/advance.go
@@ -36,6 +36,12 @@ type Advance struct {
 	Amount num.Amount `json:"amount" jsonschema:"title=Amount"`
 	// If different from the parent document's base currency.
 	Currency currency.Code `json:"currency,omitempty" jsonschema:"title=Currency"`
+	// Details of the payment that was made via a credit or debit card.
+	Card *Card `json:"card,omitempty" jsonschema:"title=Card"`
+	// Details about how the payment was made by credit (bank) transfer.
+	CreditTransfer *CreditTransfer `json:"credit_transfer,omitempty" jsonschema:"title=Credit Transfer"`
+	// Additional details useful for the parties involved.
+	Meta cbc.Meta `json:"meta,omitempty" jsonschema:"title=Meta"`
 }
 
 // Validate checks the advance looks okay
@@ -49,6 +55,11 @@ func (a *Advance) ValidateWithContext(ctx context.Context) error {
 		validation.Field(&a.Amount, validation.Required),
 		validation.Field(&a.Key, HasValidMeansKey),
 		validation.Field(&a.Description, validation.Required),
+		validation.Field(&a.Percent),
+		validation.Field(&a.Amount),
+		validation.Field(&a.Card),
+		validation.Field(&a.CreditTransfer),
+		validation.Field(&a.Meta),
 	)
 }
 

--- a/tax/set.go
+++ b/tax/set.go
@@ -133,7 +133,7 @@ func (c *Combo) prepare(r *Regime, zone l10n.Code, date cal.Date) error {
 // the rate field.
 func (c *Combo) UnmarshalJSON(data []byte) error {
 	type Alias Combo
-	aux := &struct {
+	aux := struct {
 		*Alias
 		Tags []cbc.Key `json:"tags"`
 	}{


### PR DESCRIPTION
* Refactor of errors to try and ensure structured responses are always included.
* Tagged along here we also have support for adding card and transfer details to advanced payments.