### PR TITLE
VAT always required in Italy

### DIFF
--- a/regimes/it/invoice_validator.go
+++ b/regimes/it/invoice_validator.go
@@ -128,6 +128,7 @@ func validateLine(value interface{}) error {
 	}
 	return validation.ValidateStruct(v,
 		validation.Field(&v.Taxes,
+			tax.SetHasCategory(tax.CategoryVAT),
 			validation.Each(
 				validation.By(validateLineTax),
 				validation.Skip,

--- a/regimes/it/invoice_validator_test.go
+++ b/regimes/it/invoice_validator_test.go
@@ -140,3 +140,18 @@ func TestRetainedTaxesValidation(t *testing.T) {
 	require.NoError(t, inv.Calculate())
 	require.NoError(t, inv.Validate())
 }
+
+func TestInvoiceLineTaxes(t *testing.T) {
+	inv := testInvoiceStandard(t)
+	inv.Lines = append(inv.Lines, &bill.Line{
+		Quantity: num.MakeAmount(10, 0),
+		Item: &org.Item{
+			Name:  "Test Item",
+			Price: num.MakeAmount(10000, 2),
+		},
+		// No taxes!
+	})
+	require.NoError(t, inv.Calculate())
+	err := inv.Validate()
+	require.EqualError(t, err, "lines: (1: (taxes: missing category VAT.).).")
+}

--- a/tax/set.go
+++ b/tax/set.go
@@ -200,3 +200,25 @@ func (s Set) Rate(cat cbc.Code) cbc.Key {
 	}
 	return ""
 }
+
+type setValidation struct {
+	categories []cbc.Code
+}
+
+// SetHasCategory validates that the set contains the given category.
+func SetHasCategory(categories ...cbc.Code) validation.Rule {
+	return &setValidation{categories: categories}
+}
+
+func (sv *setValidation) Validate(value interface{}) error {
+	s, ok := value.(Set)
+	if !ok {
+		return nil
+	}
+	for _, c := range sv.categories {
+		if s.Get(c) == nil {
+			return fmt.Errorf("missing category %s", c.String())
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
* Quick test to ensure that invoice lines in Italy always have VAT defined, even if exempt.