### PR TITLE
Adding Error wrapper for fields and messages

### DIFF
--- a/envelope_test.go
+++ b/envelope_test.go
@@ -403,7 +403,7 @@ func TestDocumentValidationOutput(t *testing.T) {
 	err = env.Validate()
 	data, err = json.Marshal(err)
 	require.NoError(t, err)
-	assert.Equal(t, `{"key":"validation","cause":{"doc":{"content":"cannot be blank"}}}`, string(data))
+	assert.Equal(t, `{"key":"validation","fields":{"doc":{"content":"cannot be blank"}}}`, string(data))
 }
 
 func TestEnvelopeVerify(t *testing.T) {

--- a/errors.go
+++ b/errors.go
@@ -118,6 +118,11 @@ func (e *Error) WithReason(msg string, a ...interface{}) *Error {
 	return ne
 }
 
+// Key provides the error's key.
+func (e *Error) Key() cbc.Key {
+	return e.key
+}
+
 // Fields returns the errors that are associated with specific fields
 // or nil if there are no field errors available.
 func (e *Error) Fields() FieldErrors {

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,94 @@
+package gobl_test
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/invopop/gobl"
+	"github.com/invopop/gobl/schema"
+	"github.com/invopop/validation"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestError(t *testing.T) {
+	// basic error
+	err := gobl.ErrNoDocument
+
+	assert.Equal(t, "no-document", err.Error())
+	assert.Equal(t, "", err.Message())
+	assert.Nil(t, err.Fields())
+	data, _ := json.Marshal(err)
+	assert.JSONEq(t, `{"key":"no-document"}`, string(data))
+	assert.True(t, err.Is(gobl.ErrNoDocument))
+
+	se := errors.New("simple error message")
+	err = gobl.ErrValidation.WithCause(se)
+	assert.Equal(t, "validation: simple error message", err.Error())
+	assert.Equal(t, "simple error message", err.Message())
+	data, _ = json.Marshal(err)
+	assert.JSONEq(t, `{"key":"validation","message":"simple error message"}`, string(data))
+
+	err2 := err.WithReason("overwrite message")
+	assert.Equal(t, "validation: simple error message", err.Error(), "do not modify original")
+	assert.Equal(t, "validation: overwrite message", err2.Error())
+	assert.Nil(t, err2.Fields())
+	assert.Equal(t, "overwrite message", err2.Message())
+	data, _ = json.Marshal(err2)
+	assert.JSONEq(t, `{"key":"validation","message":"overwrite message"}`, string(data))
+
+	err = gobl.ErrCalculation.WithCause(err2)
+	assert.Equal(t, "validation: overwrite message", err.Error())
+
+	ve := validation.Errors{
+		"field": errors.New("field error"),
+	}
+	err = gobl.ErrValidation.WithCause(ve)
+	assert.Equal(t, "validation: (field: field error.).", err.Error())
+	data, _ = json.Marshal(err)
+	assert.JSONEq(t, `{"key":"validation","fields":{"field":"field error"}}`, string(data))
+
+	// check nested error with Is
+	err = gobl.ErrValidation.WithCause(schema.ErrUnknownSchema)
+	assert.True(t, errors.Is(err, schema.ErrUnknownSchema))
+}
+
+func TestFieldErrors_Error(t *testing.T) {
+	errs := gobl.FieldErrors{
+		"B": errors.New("B1"),
+		"C": errors.New("C1"),
+		"A": errors.New("A1"),
+	}
+	assert.Equal(t, "A: A1; B: B1; C: C1.", errs.Error())
+
+	errs = gobl.FieldErrors{
+		"C": gobl.FieldErrors{
+			"B": errors.New("B1"),
+		},
+		"A": errors.New("A1"),
+	}
+	assert.Equal(t, "A: A1; C: (B: B1.).", errs.Error())
+
+	errs = gobl.FieldErrors{
+		"B": errors.New("B1"),
+	}
+	assert.Equal(t, "B: B1.", errs.Error())
+
+	errs = gobl.FieldErrors{}
+	assert.Equal(t, "", errs.Error())
+}
+
+func TestFieldErrors_MarshalJSON(t *testing.T) {
+	errs := gobl.FieldErrors{
+		"A": errors.New("A1"),
+		"B": gobl.FieldErrors{
+			"2": errors.New("B1"),
+		},
+		"C": validation.Errors{
+			"3": errors.New("C1"),
+		},
+	}
+	data, err := errs.MarshalJSON()
+	assert.Nil(t, err)
+	assert.Equal(t, `{"A":"A1","B":{"2":"B1"},"C":{"3":"C1"}}`, string(data))
+}

--- a/errors_test.go
+++ b/errors_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/invopop/gobl"
+	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/schema"
 	"github.com/invopop/validation"
 	"github.com/stretchr/testify/assert"
@@ -16,6 +17,7 @@ func TestError(t *testing.T) {
 	err := gobl.ErrNoDocument
 
 	assert.Equal(t, "no-document", err.Error())
+	assert.Equal(t, cbc.Key("no-document"), err.Key())
 	assert.Equal(t, "", err.Message())
 	assert.Nil(t, err.Fields())
 	data, _ := json.Marshal(err)

--- a/version.go
+++ b/version.go
@@ -8,7 +8,7 @@ import (
 type Version string
 
 // VERSION is the current version of the GOBL library.
-const VERSION Version = "v0.67.6"
+const VERSION Version = "v0.67.7"
 
 // Semver parses and returns semver
 func (v Version) Semver() *semver.Version {


### PR DESCRIPTION
* Migrating away from the "cause" field and instead moving to a more structured approach around "fields" which can be re-utilized if needed.
* Serialized `gobl.Error` now provides `key`, `message` if no fields available, and `fields` if there are specific field errors.