### PR TITLE
Validate presence of supplier address in IT regime

### DIFF
--- a/regimes/it/invoice_validator.go
+++ b/regimes/it/invoice_validator.go
@@ -63,7 +63,8 @@ func (v *invoiceValidator) supplier(value interface{}) error {
 			tax.IdentityTypeIn(TaxIdentityTypeBusiness, TaxIdentityTypeGovernment),
 		),
 		validation.Field(&supplier.Addresses,
-			validation.By(validateAddress),
+			validation.Required,
+			validation.Each(validation.By(validateAddress)),
 		),
 		validation.Field(&supplier.Registration,
 			validation.By(validateRegistration),
@@ -95,7 +96,7 @@ func (v *invoiceValidator) customer(value interface{}) error {
 			validation.When(
 				isItalianParty(customer),
 				// TODO: address not required for simplified invoices
-				validation.By(validateAddress),
+				validation.Each(validation.By(validateAddress)),
 			),
 		),
 	)
@@ -109,15 +110,14 @@ func isItalianParty(party *org.Party) bool {
 }
 
 func validateAddress(value interface{}) error {
-	v, ok := value.([]*org.Address)
+	v, ok := value.(*org.Address)
 	if v == nil || !ok {
 		return nil
 	}
 	// Post code and street in addition to the locality are required in Italian invoices.
-	address := v[0]
-	return validation.ValidateStruct(address,
-		validation.Field(&address.Street, validation.Required),
-		validation.Field(&address.Code, validation.Required),
+	return validation.ValidateStruct(v,
+		validation.Field(&v.Street, validation.Required),
+		validation.Field(&v.Code, validation.Required),
 	)
 }
 

--- a/regimes/it/invoice_validator_test.go
+++ b/regimes/it/invoice_validator_test.go
@@ -117,6 +117,15 @@ func TestSupplierValidation(t *testing.T) {
 	assert.Contains(t, err.Error(), "type: must be a valid value")
 }
 
+func TestSupplierAddressesValidation(t *testing.T) {
+	inv := testInvoiceStandard(t)
+	inv.Supplier.Addresses = nil
+	require.NoError(t, inv.Calculate())
+	err := inv.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "addresses: cannot be blank.")
+}
+
 func TestRetainedTaxesValidation(t *testing.T) {
 	inv := testInvoiceStandard(t)
 	inv.Lines[0].Taxes = append(inv.Lines[0].Taxes, &tax.Combo{


### PR DESCRIPTION
* Adds validation for the presence of a supplier address that will later be used to populate the `condense_prestatore.sede` field in FaturraPA.
* Prevents a crash happening when an empty array of addresses were given in a party

This was causing these error in production:

![image](https://github.com/invopop/gobl/assets/856/fb6699a7-e299-4451-96ff-2a919e3d6df1)

Reference from the FatturaPA docs:

![image](https://github.com/invopop/gobl/assets/856/39323cdb-d431-45ca-a3c2-e154f40d1cee)
