### PR TITLE
Normalizing ExtMap, Stamps, and others to remove empty rows

### DIFF
--- a/bill/line.go
+++ b/bill/line.go
@@ -72,9 +72,13 @@ func (l *Line) calculate(r *tax.Regime, zero num.Amount) error {
 	if l.Item == nil {
 		return nil
 	}
-
 	if err := r.CalculateObject(l); err != nil {
 		return err
+	}
+
+	// Ensure Item looks good
+	if err := l.Item.Calculate(); err != nil { // Normalizes
+		return validation.Errors{"item": err}
 	}
 	if err := r.CalculateObject(l.Item); err != nil {
 		return validation.Errors{"item": err}

--- a/bill/preceding.go
+++ b/bill/preceding.go
@@ -42,6 +42,16 @@ func (p *Preceding) Validate() error {
 	return p.ValidateWithContext(context.Background())
 }
 
+// Calculate tries to normalize the preceding data
+func (p *Preceding) Calculate() error {
+	if p == nil {
+		return nil
+	}
+	p.Stamps = head.NormalizeStamps(p.Stamps)
+	p.Ext = tax.NormalizeExtMap(p.Ext)
+	return nil
+}
+
 // ValidateWithContext ensures the preceding details look okay
 func (p *Preceding) ValidateWithContext(ctx context.Context) error {
 	return validation.ValidateStructWithContext(ctx, p,

--- a/head/stamps.go
+++ b/head/stamps.go
@@ -69,3 +69,22 @@ func AddStamp(in []*Stamp, s *Stamp) []*Stamp {
 	}
 	return append(in, s)
 }
+
+// NormalizeStamps will try to clean the stamps by removing rows with empty
+// providers or values. If empty, the function will return nil.
+func NormalizeStamps(in []*Stamp) []*Stamp {
+	if in == nil {
+		return nil
+	}
+	out := make([]*Stamp, 0)
+	for _, v := range in {
+		if v.Value == "" || v.Provider == "" {
+			continue
+		}
+		out = append(out, v)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}

--- a/head/stamps_test.go
+++ b/head/stamps_test.go
@@ -59,3 +59,36 @@ func TestAddStamp(t *testing.T) {
 	assert.Len(t, st.Stamps, 1)
 	assert.Equal(t, "new value", st.Stamps[0].Value)
 }
+
+func TestNormalizeStamp(t *testing.T) {
+	st := head.NormalizeStamps(nil)
+	assert.Nil(t, st)
+
+	st = []*head.Stamp{}
+	st2 := head.NormalizeStamps(st)
+	assert.Nil(t, st2)
+	assert.Len(t, st2, 0)
+
+	st = []*head.Stamp{
+		{
+			Provider: "foo",
+			Value:    "",
+		},
+	}
+	st = head.NormalizeStamps(st)
+	assert.Len(t, st, 0)
+
+	st = []*head.Stamp{
+		{
+			Provider: "foo",
+			Value:    "bar",
+		},
+		{
+			Provider: "foo2",
+			Value:    "",
+		},
+	}
+	st = head.NormalizeStamps(st)
+	assert.Len(t, st, 1)
+	assert.Equal(t, "bar", st[0].Value)
+}

--- a/org/item.go
+++ b/org/item.go
@@ -54,6 +54,12 @@ func (i *Item) Validate() error {
 	return i.ValidateWithContext(context.Background())
 }
 
+// Calculate performs any required calculations on the Item.
+func (i *Item) Calculate() error {
+	i.Ext = tax.NormalizeExtMap(i.Ext)
+	return nil
+}
+
 // ValidateWithContext checks that the Item looks okay inside the provided context.
 func (i *Item) ValidateWithContext(ctx context.Context) error {
 	return tax.ValidateStructWithRegime(ctx, i,

--- a/org/party.go
+++ b/org/party.go
@@ -47,6 +47,11 @@ type Party struct {
 // Calculate performs any calculations required on the Party or
 // it's properties, like the tax identity.
 func (p *Party) Calculate() error {
+	if p == nil {
+		return nil
+	}
+	p.UUID = uuid.Normalize(p.UUID)
+	p.Ext = tax.NormalizeExtMap(p.Ext)
 	if p.TaxID == nil {
 		return nil
 	}

--- a/regimes/es/examples/credit-note-es-es-tbai.yaml
+++ b/regimes/es/examples/credit-note-es-es-tbai.yaml
@@ -12,6 +12,7 @@ preceding:
     issue_date: "2022-01-10"
     ext:
       es-tbai-correction: "R2"
+      es-facturae-correction: "" # empty
 
 supplier:
   tax_id:

--- a/regimes/es/examples/invoice-es-es.yaml
+++ b/regimes/es/examples/invoice-es-es.yaml
@@ -19,6 +19,7 @@ supplier:
       country: "ES"
 
 customer:
+  uuid: "00000000-0000-0000-0000-000000000000" # should be removed
   tax_id:
     country: "ES"
     code: "54387763P"

--- a/tax/ext.go
+++ b/tax/ext.go
@@ -77,6 +77,25 @@ func (em ExtMap) Equals(other ExtMap) bool {
 	return true
 }
 
+// NormalizeExtMap will try to clean the extension map removing empty values
+// and will potentially return a nil if there only keys with no values.
+func NormalizeExtMap(em map[cbc.Key]cbc.KeyOrCode) ExtMap {
+	if em == nil {
+		return nil
+	}
+	nem := make(ExtMap)
+	for k, v := range em {
+		if v == "" {
+			continue
+		}
+		nem[k] = v
+	}
+	if len(nem) == 0 {
+		return nil
+	}
+	return nem
+}
+
 // ExtMapHas returns a validation rule that ensures the extension map's
 // keys match those provided.
 func ExtMapHas(keys ...cbc.Key) validation.Rule {

--- a/tax/ext_test.go
+++ b/tax/ext_test.go
@@ -1,0 +1,31 @@
+package tax_test
+
+import (
+	"testing"
+
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/tax"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizeExtMap(t *testing.T) {
+	var em tax.ExtMap
+
+	em2 := tax.NormalizeExtMap(em)
+	assert.Nil(t, em2)
+
+	em = tax.ExtMap{
+		"key": "",
+	}
+	em2 = tax.NormalizeExtMap(em)
+	assert.Nil(t, em2)
+
+	em = tax.ExtMap{
+		"key": "foo",
+		"bar": "",
+	}
+	em2 = tax.NormalizeExtMap(em)
+	assert.NotNil(t, em2)
+	assert.Len(t, em2, 1)
+	assert.Equal(t, cbc.KeyOrCode("foo"), em2["key"])
+}

--- a/tax/set.go
+++ b/tax/set.go
@@ -76,6 +76,15 @@ func (c *Combo) ValidateWithContext(ctx context.Context) error {
 	return r.ValidateObject(c)
 }
 
+// NormalizeCombo tries to normalize the data inside the tax combo.
+func NormalizeCombo(c *Combo) *Combo {
+	if c == nil {
+		return nil
+	}
+	c.Ext = NormalizeExtMap(c.Ext)
+	return c
+}
+
 func combineExtKeys(cat *Category, rate *Rate) []cbc.Key {
 	keys := make([]cbc.Key, 0)
 	if cat != nil {
@@ -146,6 +155,26 @@ func (c *Combo) UnmarshalJSON(data []byte) error {
 		c.Rate = aux.Tags[0]
 	}
 	return nil
+}
+
+// NormalizeSet tries to normalize the tax set by normalizing combos
+// and returning nil if empty.
+func NormalizeSet(s Set) Set {
+	if s == nil {
+		return nil
+	}
+	ns := make(Set, 0)
+	for _, c := range s {
+		c = NormalizeCombo(c)
+		if c == nil {
+			continue
+		}
+		ns = append(ns, c)
+	}
+	if len(ns) == 0 {
+		return nil
+	}
+	return ns
 }
 
 // ValidateWithContext ensures the set of tax combos looks correct

--- a/tax/set_test.go
+++ b/tax/set_test.go
@@ -271,3 +271,45 @@ func TestComboUnmarshal(t *testing.T) {
 	assert.Equal(t, c.Category, cbc.Code("VAT"))
 	assert.Equal(t, c.Rate, cbc.Key("standard"))
 }
+
+func TestNormalizeSet(t *testing.T) {
+	s := tax.NormalizeSet(nil)
+	assert.Nil(t, s)
+
+	s = tax.Set{
+		{
+			Category: "VAT",
+			Rate:     "standard",
+		},
+		{
+			Category: "IRPF",
+			Rate:     "pro",
+		},
+	}
+	s = tax.NormalizeSet(s)
+	assert.Equal(t, s[0].Category, cbc.Code("VAT"))
+	assert.Equal(t, s[1].Category, cbc.Code("IRPF"))
+
+	s = tax.Set{
+		{
+			Category: "VAT",
+			Rate:     "standard",
+			Ext: tax.ExtMap{
+				es.ExtKeyFacturaECorrection: "",
+			},
+		},
+		nil,
+	}
+	assert.NotNil(t, s[0].Ext)
+	assert.Len(t, s, 2)
+	s = tax.NormalizeSet(s)
+	assert.Nil(t, s[0].Ext)
+	assert.Len(t, s, 1)
+
+	s = tax.Set{
+		nil,
+	}
+	assert.Len(t, s, 1)
+	s = tax.NormalizeSet(s)
+	assert.Nil(t, s)
+}

--- a/uuid/uuid.go
+++ b/uuid/uuid.go
@@ -108,6 +108,18 @@ func NodeID() string {
 	return fmt.Sprintf("%x", uuid.NodeID())
 }
 
+// Normalize looks at the provided UUID and tries to return a consistent
+// value, which may be nil. Only works with pointers to UUID.
+func Normalize(u *UUID) *UUID {
+	if u == nil {
+		return nil
+	}
+	if u.IsZero() {
+		return nil
+	}
+	return u
+}
+
 // JSONSchema returns the jsonschema schema object for the UUID.
 func (UUID) JSONSchema() *jsonschema.Schema {
 	return &jsonschema.Schema{

--- a/uuid/uuid_test.go
+++ b/uuid/uuid_test.go
@@ -47,6 +47,22 @@ func TestUUIDIsZero(t *testing.T) {
 	assert.False(t, u1.IsZero())
 }
 
+func TestNormalizeUUID(t *testing.T) {
+	var u *uuid.UUID
+	u2 := uuid.Normalize(u)
+	assert.Nil(t, u2)
+
+	u = &uuid.UUID{}
+	assert.Equal(t, "00000000-0000-0000-0000-000000000000", u.String())
+
+	u2 = uuid.Normalize(u)
+	assert.Nil(t, u2)
+
+	u3 := uuid.MustParse("03907310-8daa-11eb-8dcd-0242ac130003")
+	u2 = uuid.Normalize(&u3)
+	assert.Equal(t, u3.String(), u2.String())
+}
+
 func TestUUIDJSON(t *testing.T) {
 	v1s := "03907310-8daa-11eb-8dcd-0242ac130003"
 	type testJSON struct {


### PR DESCRIPTION
* ExtMap values are now normalized, removing any empty values.
* Stamps also normalized
* UUID in `org.Party` is now cleaning UUID.