### PR TITLE
Tax ID Zone included in JSON, but no longer valid

### DIFF
--- a/data/schemas/tax/identity.json
+++ b/data/schemas/tax/identity.json
@@ -29,6 +29,11 @@
           "$ref": "https://gobl.org/draft-0/cbc/meta",
           "title": "Meta",
           "description": "Additional details that may be required."
+        },
+        "zone": {
+          "$ref": "https://gobl.org/draft-0/l10n/code",
+          "title": "Zone",
+          "description": "DEPRECATED. Zone was removed 2024-03-14 in favour of using tax tags\nand extensions with local data when required. Maintained here to support\ndata migration."
         }
       },
       "type": "object",

--- a/regimes/es/examples/credit-note-es-es-tbai.yaml
+++ b/regimes/es/examples/credit-note-es-es-tbai.yaml
@@ -20,7 +20,6 @@ preceding:
 supplier:
   tax_id:
     country: "ES"
-    zone: "BI"
     code: "B98602642"
   name: "Provide One S.L."
   emails:

--- a/regimes/es/tax_identity.go
+++ b/regimes/es/tax_identity.go
@@ -156,7 +156,7 @@ func normalizeTaxIdentity(tID *tax.Identity) error {
 	if err := common.NormalizeTaxIdentity(tID); err != nil {
 		return err
 	}
-	// Removethe Zone
+	// Remove the Zone
 	tID.Zone = ""
 	return nil
 }

--- a/regimes/es/tax_identity.go
+++ b/regimes/es/tax_identity.go
@@ -153,7 +153,12 @@ func validateTaxCode(value interface{}) error {
 // uppercase. It'll also remove the "ES" part at beginning if present such as required
 // for EU VIES system which is redundant and not used in the validation process.
 func normalizeTaxIdentity(tID *tax.Identity) error {
-	return common.NormalizeTaxIdentity(tID)
+	if err := common.NormalizeTaxIdentity(tID); err != nil {
+		return err
+	}
+	// Removethe Zone
+	tID.Zone = ""
+	return nil
 }
 
 // DetermineTaxCodeType takes a valid code and determines the type. If the code

--- a/regimes/es/tax_identity_test.go
+++ b/regimes/es/tax_identity_test.go
@@ -45,6 +45,14 @@ func TestNormalizeTaxIdentity(t *testing.T) {
 	}
 }
 
+func TestNormalizeTaxIdentityZone(t *testing.T) {
+	r := es.New()
+	tID := &tax.Identity{Country: l10n.ES, Code: "93471790C", Zone: "XX"}
+	err := r.CalculateObject(tID)
+	assert.NoError(t, err)
+	assert.Empty(t, tID.Zone)
+}
+
 func TestValidateTaxIdentity(t *testing.T) {
 	tests := []struct {
 		Code     cbc.Code

--- a/tax/identity.go
+++ b/tax/identity.go
@@ -34,9 +34,10 @@ type Identity struct {
 	// Additional details that may be required.
 	Meta cbc.Meta `json:"meta,omitempty" jsonschema:"title=Meta"`
 
-	// Zone was removed 2024-03-14 in favour of using tax tags
-	// and extensions with local data when required.
-	Zone l10n.Code `json:"-"`
+	// DEPRECATED. Zone was removed 2024-03-14 in favour of using tax tags
+	// and extensions with local data when required. Maintained here to support
+	// data migration.
+	Zone l10n.Code `json:"zone,omitempty" jsonschema:"title=Zone"`
 }
 
 // Standard error responses to be used by regimes.
@@ -95,7 +96,7 @@ func (id *Identity) Validate() error {
 	err := validation.ValidateStruct(id,
 		validation.Field(&id.UUID),
 		validation.Field(&id.Country, validation.Required),
-		validation.Field(&id.Zone),
+		validation.Field(&id.Zone, validation.Empty),
 		validation.Field(&id.Type),
 		validation.Field(&id.Code),
 		validation.Field(&id.Meta),

--- a/tax/identity.go
+++ b/tax/identity.go
@@ -1,7 +1,6 @@
 package tax
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -108,23 +107,6 @@ func (id *Identity) Validate() error {
 	if r != nil {
 		return r.ValidateObject(id)
 	}
-	return nil
-}
-
-// UnmarshalJSON parses the JSON and will extract any old fields
-// from data that will be migrated away.
-func (id *Identity) UnmarshalJSON(data []byte) error {
-	type Alias Identity
-	aux := &struct {
-		Zone l10n.Code `json:"zone"`
-		*Alias
-	}{
-		Alias: (*Alias)(id),
-	}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	id.Zone = aux.Zone
 	return nil
 }
 

--- a/tax/identity_test.go
+++ b/tax/identity_test.go
@@ -1,7 +1,6 @@
 package tax_test
 
 import (
-	"encoding/json"
 	"testing"
 
 	_ "github.com/invopop/gobl" // load all mods
@@ -9,7 +8,6 @@ import (
 	"github.com/invopop/gobl/tax"
 	"github.com/invopop/validation"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestTaxIdentity(t *testing.T) {
@@ -58,20 +56,4 @@ func TestValidationRules(t *testing.T) {
 	}
 	err := validation.Validate(tID, tax.RequireIdentityType)
 	assert.Error(t, err)
-
-}
-
-func TestIdentityUnmarshalJSON(t *testing.T) {
-	// Unmarshal should store the zone, but not return it
-	data := []byte(`{"country":"CO","code":"9014514805","zone":"11001"}`)
-	tID := &tax.Identity{}
-	err := tID.UnmarshalJSON(data)
-	require.NoError(t, err)
-	assert.Equal(t, tID.Country, l10n.CO)
-	assert.Equal(t, tID.Code.String(), "9014514805")
-	assert.Equal(t, tID.Zone.String(), "11001")
-
-	out, err := json.Marshal(tID)
-	require.NoError(t, err)
-	assert.Equal(t, string(out), `{"country":"CO","code":"9014514805"}`)
 }

--- a/tax/identity_test.go
+++ b/tax/identity_test.go
@@ -34,6 +34,16 @@ func TestTaxIdentity(t *testing.T) {
 
 	tID = &tax.Identity{
 		Country: l10n.ES,
+		Code:    "X3157928M",
+		Zone:    "XX",
+	}
+	err = tID.Validate()
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "zone: must be blank.")
+	}
+
+	tID = &tax.Identity{
+		Country: l10n.ES,
 		Code:    "  x315-7928 m",
 	}
 	err = tID.Calculate()

--- a/version.go
+++ b/version.go
@@ -8,7 +8,7 @@ import (
 type Version string
 
 // VERSION is the current version of the GOBL library.
-const VERSION Version = "v0.69.1"
+const VERSION Version = "v0.70.0"
 
 // Semver parses and returns semver
 func (v Version) Semver() *semver.Version {


### PR DESCRIPTION
* The Tax ID Zone field has now returned to the JSON Schema, but with a deprecated message and with a validation check that ensures it is blank.
* The Zone will still be loaded in older documents, but they'll need to be migrated in order to validate.