### PR TITLE
Add stamps for KSeF QR code

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,6 @@ github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/
 github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+xBAnxjb1X5vnTw=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190911031432-227b76d455e7/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-golang.org/x/crypto v0.9.0 h1:LF6fAI+IutBocDJ2OT0Q1g8plpYljMZ4+lty+dsqw3g=
-golang.org/x/crypto v0.9.0/go.mod h1:yrmDGqONDYtNj3tH8X9dzUun2m2lzPa9ngI6/RUPGR0=
 golang.org/x/crypto v0.17.0 h1:r8bRNjWL3GshPW3gkd+RpvzWrZAwPS49OmTGZ/uhM4k=
 golang.org/x/crypto v0.17.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=

--- a/regimes/pl/pl.go
+++ b/regimes/pl/pl.go
@@ -13,7 +13,9 @@ import (
 
 // KSeF official codes to include.
 const (
-	StampProviderKSeF cbc.Key = "ksef-id"
+	StampProviderKSeF     cbc.Key = "ksef-id"
+	StampProviderKSeFHash cbc.Key = "ksef-hash"
+	StampProviderKSeFQR   cbc.Key = "ksef-qr"
 )
 
 func init() {


### PR DESCRIPTION
As a requirement for PDF invoices in Poland we need to add a QR code. The QR code is created using the KSeF id and a hash of the invoice.