### PR TITLE
Custom formatting for negative numbers

### DIFF
--- a/num/formatter_test.go
+++ b/num/formatter_test.go
@@ -46,6 +46,18 @@ func TestFormatterAmount(t *testing.T) {
 			exp:  "1,234,567.89",
 		},
 		{
+			name: "no unit: negative millions",
+			f:    num.MakeFormatter(".", ","),
+			amt:  num.MakeAmount(-123456789, 2),
+			exp:  "-1,234,567.89",
+		},
+		{
+			name: "no unit: negative millions with negative format",
+			f:    num.MakeFormatter(".", ",").WithNegativeTemplate("(%n)%u"),
+			amt:  num.MakeAmount(-123456789, 2),
+			exp:  "(1,234,567.89)",
+		},
+		{
 			name: "with unit default format zero",
 			f:    num.MakeFormatter(".", ",").WithUnit("%"),
 			amt:  num.MakeAmount(0, 2),
@@ -82,6 +94,18 @@ func TestFormatterAmount(t *testing.T) {
 			f:    num.MakeFormatter(",", ".").WithUnit("€").WithTemplate("%n %u"),
 			amt:  num.MakeAmount(123456789, 2),
 			exp:  "1.234.567,89 €",
+		},
+		{
+			name: "with custom negative template format millions",
+			f:    num.MakeFormatter(",", ".").WithUnit("€").WithTemplate("%n %u"),
+			amt:  num.MakeAmount(-123456789, 2),
+			exp:  "-1.234.567,89 €",
+		},
+		{
+			name: "with custom negative template format millions",
+			f:    num.MakeFormatter(",", ".").WithUnit("€").WithTemplate("%n %u").WithNegativeTemplate("(%n) %u"),
+			amt:  num.MakeAmount(-123456789, 2),
+			exp:  "(1.234.567,89) €",
 		},
 		{
 			name: "with custom template format millions",

--- a/num/percentage_test.go
+++ b/num/percentage_test.go
@@ -1,37 +1,42 @@
 package num_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/invopop/gobl/num"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPercentage(t *testing.T) {
 	p := num.MakePercentage(1600, 4)
-	if p.Value() != 1600 {
-		t.Errorf("unexpected value, got: %v", p.Value())
-	}
+	assert.Equal(t, int64(1600), p.Value())
 	p2 := num.MakePercentage(1600, 4)
-	if p.Value() != 1600 {
-		t.Errorf("unexpected value, got: %v", p.Value())
-	}
-	if !p.Equals(p2) {
-		t.Errorf("expected percentages to be the same")
-	}
+	assert.True(t, p.Equals(p2))
+	pp := num.NewPercentage(1600, 4)
+	assert.Equal(t, "16.00%", pp.String())
+	assert.True(t, pp.Equals(p2))
+	assert.True(t, p2.Equals(*pp))
 }
 
 func TestPercentageFromString(t *testing.T) {
-	p, err := num.PercentageFromString("16.0%")
-	if err != nil {
-		t.Errorf("did not expect error: %v", err.Error())
-	}
-	if p.Value() != 160 {
-		t.Errorf("unexpected value from string, got: %v", p.Value())
-	}
-	if p.Exp() != 3 {
-		t.Errorf("unexpected exponential value, got: %v", p.Exp())
-	}
+	p, err := num.PercentageFromString("")
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), p.Value())
+
+	p, err = num.PercentageFromString("16.0%")
+	require.NoError(t, err)
+	assert.Equal(t, int64(160), p.Value())
+	assert.Equal(t, uint32(3), p.Exp())
+
+	_, err = num.PercentageFromString("bad")
+	assert.ErrorContains(t, err, "invalid major number 'bad', strconv.ParseInt: parsing \"bad\": invalid syntax")
+
+	p, err = num.PercentageFromString("0.160")
+	require.NoError(t, err)
+	assert.Equal(t, int64(160), p.Value())
+	assert.Equal(t, uint32(3), p.Exp())
 }
 
 func TestPercentageString(t *testing.T) {
@@ -93,4 +98,82 @@ func TestPercentageInvert(t *testing.T) {
 	p := num.MakePercentage(160, 3)
 	x := p.Invert()
 	assert.Equal(t, "-16.0%", x.String())
+}
+
+func TestPercentageIsZero(t *testing.T) {
+	p := num.MakePercentage(0, 0)
+	assert.True(t, p.IsZero())
+	p = num.MakePercentage(160, 0)
+	assert.False(t, p.IsZero())
+	p = num.MakePercentage(-160, 0)
+	assert.False(t, p.IsZero())
+}
+
+func TestPercentageIsNegative(t *testing.T) {
+	p := num.MakePercentage(-160, 0)
+	assert.True(t, p.IsNegative())
+	p = num.MakePercentage(160, 0)
+	assert.False(t, p.IsNegative())
+	p = num.MakePercentage(0, 0)
+	assert.False(t, p.IsNegative())
+}
+
+func TestPercentageIsPositive(t *testing.T) {
+	p := num.MakePercentage(160, 0)
+	assert.True(t, p.IsPositive())
+	p = num.MakePercentage(-160, 0)
+	assert.False(t, p.IsPositive())
+	p = num.MakePercentage(0, 0)
+	assert.False(t, p.IsPositive())
+}
+
+func TestPercentageUnmarshalJSONBasic(t *testing.T) {
+	d := []byte(`{"percent":"16.0%"}`)
+	o := struct {
+		Percent num.Percentage
+	}{}
+	require.NoError(t, json.Unmarshal(d, &o))
+	assert.Equal(t, 0, o.Percent.Compare(num.MakePercentage(160, 3)))
+
+	d = []byte(`{"percent":0.10}`)
+	require.NoError(t, json.Unmarshal(d, &o))
+	assert.Equal(t, int64(10), o.Percent.Value())
+	assert.Equal(t, uint32(2), o.Percent.Exp())
+
+	o.Percent = num.MakePercentage(0, 0)
+	d = []byte(`{"percent":null}`)
+	require.NoError(t, json.Unmarshal(d, &o))
+	assert.Equal(t, int64(0), o.Percent.Value())
+
+	d = []byte(`{"percent":"bad"}`)
+	require.ErrorContains(t, json.Unmarshal(d, &o), "invalid major number 'bad', strconv.ParseInt: parsing \"bad\": invalid syntax")
+}
+
+func TestPercentageUnmarshalJSONPointer(t *testing.T) {
+	d := []byte(`{"percent":"16.0%"}`)
+	o := struct {
+		Percent *num.Percentage
+	}{}
+	require.NoError(t, json.Unmarshal(d, &o))
+	assert.Equal(t, 0, o.Percent.Compare(num.MakePercentage(160, 3)))
+	d = []byte(`{"percent":null}`)
+	require.NoError(t, json.Unmarshal(d, &o))
+	assert.Nil(t, o.Percent)
+
+	d = []byte(`{"percent":"bad"}`)
+	require.ErrorContains(t, json.Unmarshal(d, &o), "invalid major number 'bad', strconv.ParseInt: parsing \"bad\": invalid syntax")
+}
+
+func TestPercentageMarshalJSON(t *testing.T) {
+	o := struct {
+		Percent num.Percentage `json:"percent"`
+	}{
+		Percent: num.MakePercentage(160, 3),
+	}
+	d, err := json.Marshal(o)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	de := []byte(`{"percent":"16.0%"}`)
+	assert.Equal(t, de, d)
 }

--- a/num/validation.go
+++ b/num/validation.go
@@ -64,7 +64,7 @@ func interfaceToAmount(val interface{}) Amount {
 	case Amount:
 		return a
 	case Percentage:
-		return a.Amount
+		return a.amount
 	default:
 		return Amount{}
 	}


### PR DESCRIPTION
* Fixes bugs when formatting negative numbers
* `num.Formatter` now allows for a `NegativeTemplate` property to be able to output `-10.20` as `(10.20)` for example.
* Added more tests around numbers in general.
* `num.Percentage` no longer extends `num.Amount`, instead it defines its own methods and provides an `Amount()` method that will respond with the factored percentage value, i.e. if the percentage is `16.0%`, the `Amount()` method will provide `16.0`.