### PR TITLE
Clean up tax categories

### DIFF
--- a/data/regimes/pl.json
+++ b/data/regimes/pl.json
@@ -89,30 +89,42 @@
       ]
     },
     {
-      "key": "pl-ksef-vat-zero",
+      "key": "pl-ksef-vat-region",
       "name": {
-        "en": "Zero VAT Extensions for KSeF"
+        "en": "Region VAT Extensions for KSeF"
       },
-      "keys": [
+      "codes": [
         {
-          "key": "wdt",
+          "code": "EU",
           "name": {
-            "en": "WDT",
-            "pl": "WDT"
+            "en": "EU",
+            "pl": "EU"
+          },
+          "desc": {
+            "en": "Intra-EU Transactions",
+            "pl": "Transakcje wewnątrzwspólnotowe"
           }
         },
         {
-          "key": "domestic",
+          "code": "domestic",
           "name": {
             "en": "Domestic",
             "pl": "Krajowy"
+          },
+          "desc": {
+            "en": "Domestic trade",
+            "pl": "Handel wewnątrzkrajowy."
           }
         },
         {
-          "key": "export",
+          "code": "non-EU",
           "name": {
-            "en": "Export",
-            "pl": "Eksport"
+            "en": "non-EU",
+            "pl": "Poza UE"
+          },
+          "desc": {
+            "en": "Trading with countries outside the EU",
+            "pl": "Handel z krajami z poza Unii Europejskiej"
           }
         }
       ]
@@ -428,7 +440,7 @@
             }
           ],
           "extensions": [
-            "pl-ksef-vat-zero"
+            "pl-ksef-vat-region"
           ]
         },
         {
@@ -445,8 +457,24 @@
             "en": "Special Rate",
             "pl": "Stawka Specjalna"
           },
+          "values": [
+            {
+              "percent": "4.0%"
+            }
+          ],
           "extensions": [
             "pl-ksef-vat-special"
+          ]
+        },
+        {
+          "key": "np",
+          "name": {
+            "en": "Not pursuant",
+            "pl": "Niepodlegające opodatkowaniu"
+          },
+          "exempt": true,
+          "extensions": [
+            "pl-ksef-vat-region"
           ]
         }
       ]

--- a/regimes/pl/examples/invoice-tax-exempt.yaml
+++ b/regimes/pl/examples/invoice-tax-exempt.yaml
@@ -1,0 +1,42 @@
+$schema: "https://gobl.org/draft-0/bill/invoice"
+currency: "PLN"
+issue_date: "2023-12-20"
+code: "SAMPLE-001"
+
+supplier:
+  tax_id:
+    country: "PL"
+    code: "9876543210"
+  name: "Provide One S.L."
+  emails:
+    - addr: "billing@example.com"
+  addresses:
+    - num: "42"
+      street: "Calle Pradillo"
+      locality: "Madrid"
+      region: "Madrid"
+      code: "00-015"
+      country: "PL"
+
+customer:
+  tax_id:
+    country: "PL"
+    code: "1234567788"
+  name: "Sample Consumer"
+  addresses:
+    - num: "43"
+      street: "Calle Pradillo"
+      locality: "Madrid"
+      region: "Madrid"
+      code: "00-015"
+      country: "PL"
+
+lines:
+  - quantity: 1
+    item:
+      name: "Development services"
+      price: "1.00"
+      unit: "h"
+    taxes:
+      - cat: VAT
+        rate: exempt

--- a/regimes/pl/examples/invoice-tax-not-applicable.yaml
+++ b/regimes/pl/examples/invoice-tax-not-applicable.yaml
@@ -1,0 +1,42 @@
+$schema: "https://gobl.org/draft-0/bill/invoice"
+currency: "PLN"
+issue_date: "2023-12-20"
+code: "SAMPLE-001"
+
+supplier:
+  tax_id:
+    country: "PL"
+    code: "9876543210"
+  name: "Provide One S.L."
+  emails:
+    - addr: "billing@example.com"
+  addresses:
+    - num: "42"
+      street: "Calle Pradillo"
+      locality: "Madrid"
+      region: "Madrid"
+      code: "00-015"
+      country: "PL"
+
+customer:
+  tax_id:
+    country: "PL"
+    code: "1234567788"
+  name: "Sample Consumer"
+  addresses:
+    - num: "43"
+      street: "Calle Pradillo"
+      locality: "Madrid"
+      region: "Madrid"
+      code: "00-015"
+      country: "PL"
+
+lines:
+  - quantity: 1
+    item:
+      name: "Development services"
+      price: "1.00"
+      unit: "h"
+    taxes:
+      - cat: VAT
+        rate: np

--- a/regimes/pl/examples/invoice-taxi.yaml
+++ b/regimes/pl/examples/invoice-taxi.yaml
@@ -1,0 +1,42 @@
+$schema: "https://gobl.org/draft-0/bill/invoice"
+currency: "PLN"
+issue_date: "2023-12-20"
+code: "SAMPLE-001"
+
+supplier:
+  tax_id:
+    country: "PL"
+    code: "9876543210"
+  name: "Provide One S.L."
+  emails:
+    - addr: "billing@example.com"
+  addresses:
+    - num: "42"
+      street: "Calle Pradillo"
+      locality: "Madrid"
+      region: "Madrid"
+      code: "00-015"
+      country: "PL"
+
+customer:
+  tax_id:
+    country: "PL"
+    code: "1234567788"
+  name: "Sample Consumer"
+  addresses:
+    - num: "43"
+      street: "Calle Pradillo"
+      locality: "Madrid"
+      region: "Madrid"
+      code: "00-015"
+      country: "PL"
+
+lines:
+  - quantity: 1
+    item:
+      name: "Transport service"
+      price: "1.00"
+      unit: "trip"
+    taxes:
+      - cat: VAT
+        rate: special

--- a/regimes/pl/examples/invoice-zero.yaml
+++ b/regimes/pl/examples/invoice-zero.yaml
@@ -1,0 +1,42 @@
+$schema: "https://gobl.org/draft-0/bill/invoice"
+currency: "PLN"
+issue_date: "2023-12-20"
+code: "SAMPLE-001"
+
+supplier:
+  tax_id:
+    country: "PL"
+    code: "9876543210"
+  name: "Provide One S.L."
+  emails:
+    - addr: "billing@example.com"
+  addresses:
+    - num: "42"
+      street: "Calle Pradillo"
+      locality: "Madrid"
+      region: "Madrid"
+      code: "00-015"
+      country: "PL"
+
+customer:
+  tax_id:
+    country: "PL"
+    code: "1234567788"
+  name: "Sample Consumer"
+  addresses:
+    - num: "43"
+      street: "Calle Pradillo"
+      locality: "Madrid"
+      region: "Madrid"
+      code: "00-015"
+      country: "PL"
+
+lines:
+  - quantity: 1
+    item:
+      name: "Transport of computer equipment for educational institutions"
+      price: "1.00"
+      unit: "trip"
+    taxes:
+      - cat: VAT
+        rate: zero

--- a/regimes/pl/examples/out/invoice-tax-exempt.json
+++ b/regimes/pl/examples/out/invoice-tax-exempt.json
@@ -1,0 +1,99 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "2198b2c0-00b4-11ef-a729-52f0b4d06139",
+		"dig": {
+			"alg": "sha256",
+			"val": "481fcf5c2a1dd733b368318359b9df03aa09cef17925c12e3c59f8b8723011c4"
+		},
+		"draft": true
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"type": "standard",
+		"code": "SAMPLE-001",
+		"issue_date": "2023-12-20",
+		"currency": "PLN",
+		"supplier": {
+			"name": "Provide One S.L.",
+			"tax_id": {
+				"country": "PL",
+				"code": "9876543210"
+			},
+			"addresses": [
+				{
+					"num": "42",
+					"street": "Calle Pradillo",
+					"locality": "Madrid",
+					"region": "Madrid",
+					"code": "00-015",
+					"country": "PL"
+				}
+			],
+			"emails": [
+				{
+					"addr": "billing@example.com"
+				}
+			]
+		},
+		"customer": {
+			"name": "Sample Consumer",
+			"tax_id": {
+				"country": "PL",
+				"code": "1234567788"
+			},
+			"addresses": [
+				{
+					"num": "43",
+					"street": "Calle Pradillo",
+					"locality": "Madrid",
+					"region": "Madrid",
+					"code": "00-015",
+					"country": "PL"
+				}
+			]
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "1",
+				"item": {
+					"name": "Development services",
+					"price": "1.00",
+					"unit": "h"
+				},
+				"sum": "1.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"rate": "exempt"
+					}
+				],
+				"total": "1.00"
+			}
+		],
+		"totals": {
+			"sum": "1.00",
+			"total": "1.00",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "exempt",
+								"base": "1.00",
+								"amount": "0.00"
+							}
+						],
+						"amount": "0.00"
+					}
+				],
+				"sum": "0.00"
+			},
+			"tax": "0.00",
+			"total_with_tax": "1.00",
+			"payable": "1.00"
+		}
+	}
+}

--- a/regimes/pl/examples/out/invoice-tax-not-applicable.json
+++ b/regimes/pl/examples/out/invoice-tax-not-applicable.json
@@ -1,0 +1,99 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "e060a49c-00b4-11ef-9596-52f0b4d06139",
+		"dig": {
+			"alg": "sha256",
+			"val": "dbfa6fa5b7e0c15a787974337459c744a357aa1ab8dac9460e8100e777128158"
+		},
+		"draft": true
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"type": "standard",
+		"code": "SAMPLE-001",
+		"issue_date": "2023-12-20",
+		"currency": "PLN",
+		"supplier": {
+			"name": "Provide One S.L.",
+			"tax_id": {
+				"country": "PL",
+				"code": "9876543210"
+			},
+			"addresses": [
+				{
+					"num": "42",
+					"street": "Calle Pradillo",
+					"locality": "Madrid",
+					"region": "Madrid",
+					"code": "00-015",
+					"country": "PL"
+				}
+			],
+			"emails": [
+				{
+					"addr": "billing@example.com"
+				}
+			]
+		},
+		"customer": {
+			"name": "Sample Consumer",
+			"tax_id": {
+				"country": "PL",
+				"code": "1234567788"
+			},
+			"addresses": [
+				{
+					"num": "43",
+					"street": "Calle Pradillo",
+					"locality": "Madrid",
+					"region": "Madrid",
+					"code": "00-015",
+					"country": "PL"
+				}
+			]
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "1",
+				"item": {
+					"name": "Development services",
+					"price": "1.00",
+					"unit": "h"
+				},
+				"sum": "1.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"rate": "np"
+					}
+				],
+				"total": "1.00"
+			}
+		],
+		"totals": {
+			"sum": "1.00",
+			"total": "1.00",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "np",
+								"base": "1.00",
+								"amount": "0.00"
+							}
+						],
+						"amount": "0.00"
+					}
+				],
+				"sum": "0.00"
+			},
+			"tax": "0.00",
+			"total_with_tax": "1.00",
+			"payable": "1.00"
+		}
+	}
+}

--- a/regimes/pl/examples/out/invoice-taxi.json
+++ b/regimes/pl/examples/out/invoice-taxi.json
@@ -1,0 +1,101 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "f2b1ec78-00b4-11ef-8c13-52f0b4d06139",
+		"dig": {
+			"alg": "sha256",
+			"val": "8a137d24a0395bfb0d01bb987e8ed3175dc73305e49e9cee9d2c34b382983d3b"
+		},
+		"draft": true
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"type": "standard",
+		"code": "SAMPLE-001",
+		"issue_date": "2023-12-20",
+		"currency": "PLN",
+		"supplier": {
+			"name": "Provide One S.L.",
+			"tax_id": {
+				"country": "PL",
+				"code": "9876543210"
+			},
+			"addresses": [
+				{
+					"num": "42",
+					"street": "Calle Pradillo",
+					"locality": "Madrid",
+					"region": "Madrid",
+					"code": "00-015",
+					"country": "PL"
+				}
+			],
+			"emails": [
+				{
+					"addr": "billing@example.com"
+				}
+			]
+		},
+		"customer": {
+			"name": "Sample Consumer",
+			"tax_id": {
+				"country": "PL",
+				"code": "1234567788"
+			},
+			"addresses": [
+				{
+					"num": "43",
+					"street": "Calle Pradillo",
+					"locality": "Madrid",
+					"region": "Madrid",
+					"code": "00-015",
+					"country": "PL"
+				}
+			]
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "1",
+				"item": {
+					"name": "Transport service",
+					"price": "1.00",
+					"unit": "trip"
+				},
+				"sum": "1.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"rate": "special",
+						"percent": "4.0%"
+					}
+				],
+				"total": "1.00"
+			}
+		],
+		"totals": {
+			"sum": "1.00",
+			"total": "1.00",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "special",
+								"base": "1.00",
+								"percent": "4.0%",
+								"amount": "0.04"
+							}
+						],
+						"amount": "0.04"
+					}
+				],
+				"sum": "0.04"
+			},
+			"tax": "0.04",
+			"total_with_tax": "1.04",
+			"payable": "1.04"
+		}
+	}
+}

--- a/regimes/pl/examples/out/invoice-zero.json
+++ b/regimes/pl/examples/out/invoice-zero.json
@@ -1,0 +1,101 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "2a943e2a-00b5-11ef-815a-52f0b4d06139",
+		"dig": {
+			"alg": "sha256",
+			"val": "5a35a7e0497b07e40aeecc41953cede39d62019448ad14fcbeb3741b1b6b14dc"
+		},
+		"draft": true
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"type": "standard",
+		"code": "SAMPLE-001",
+		"issue_date": "2023-12-20",
+		"currency": "PLN",
+		"supplier": {
+			"name": "Provide One S.L.",
+			"tax_id": {
+				"country": "PL",
+				"code": "9876543210"
+			},
+			"addresses": [
+				{
+					"num": "42",
+					"street": "Calle Pradillo",
+					"locality": "Madrid",
+					"region": "Madrid",
+					"code": "00-015",
+					"country": "PL"
+				}
+			],
+			"emails": [
+				{
+					"addr": "billing@example.com"
+				}
+			]
+		},
+		"customer": {
+			"name": "Sample Consumer",
+			"tax_id": {
+				"country": "PL",
+				"code": "1234567788"
+			},
+			"addresses": [
+				{
+					"num": "43",
+					"street": "Calle Pradillo",
+					"locality": "Madrid",
+					"region": "Madrid",
+					"code": "00-015",
+					"country": "PL"
+				}
+			]
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "1",
+				"item": {
+					"name": "Transport of computer equipment for educational institutions",
+					"price": "1.00",
+					"unit": "trip"
+				},
+				"sum": "1.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"rate": "zero",
+						"percent": "0.0%"
+					}
+				],
+				"total": "1.00"
+			}
+		],
+		"totals": {
+			"sum": "1.00",
+			"total": "1.00",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "zero",
+								"base": "1.00",
+								"percent": "0.0%",
+								"amount": "0.00"
+							}
+						],
+						"amount": "0.00"
+					}
+				],
+				"sum": "0.00"
+			},
+			"tax": "0.00",
+			"total_with_tax": "1.00",
+			"payable": "1.00"
+		}
+	}
+}

--- a/regimes/pl/extensions.go
+++ b/regimes/pl/extensions.go
@@ -7,7 +7,6 @@ import (
 
 // Regime extension codes for local electronic formats.
 const (
-	ExtKeyKSeFVATZero       = "pl-ksef-vat-zero"
 	ExtKeyKSeFVATSpecial    = "pl-ksef-vat-special"
 	ExtKeyKSeFEffectiveDate = "pl-ksef-effective-date"
 )
@@ -30,38 +29,6 @@ var extensionKeys = []*cbc.KeyDefinition{
 					i18n.EN: "Special flat rate for taxi drivers.",
 					i18n.PL: "Specjalna stawka ryczałtu dla taksówkarzy.",
 				},
-			},
-		},
-	},
-	{
-		Key: ExtKeyKSeFVATZero,
-		Name: i18n.String{
-			i18n.EN: "Zero VAT Extensions for KSeF",
-		},
-		Keys: []*cbc.KeyDefinition{
-			{
-				Key: "wdt",
-				Name: i18n.String{
-					i18n.EN: "WDT",
-					i18n.PL: "WDT",
-				},
-				// TODO: description required
-			},
-			{
-				Key: "domestic",
-				Name: i18n.String{
-					i18n.EN: "Domestic",
-					i18n.PL: "Krajowy",
-				},
-				// TODO: description required
-			},
-			{
-				Key: "export",
-				Name: i18n.String{
-					i18n.EN: "Export",
-					i18n.PL: "Eksport",
-				},
-				// TODO: description required
 			},
 		},
 	},

--- a/regimes/pl/tax_categories.go
+++ b/regimes/pl/tax_categories.go
@@ -10,8 +10,7 @@ import (
 
 // Tax rates specific to Poland.
 const (
-	TaxRateNotPursuant       cbc.Key = "np"
-	TaxRateNotPursuantArt100 cbc.Key = "np-art100sec1point4"
+	TaxRateNotPursuant cbc.Key = "np"
 )
 
 var taxCategories = []*tax.Category{
@@ -89,9 +88,6 @@ var taxCategories = []*tax.Category{
 						Percent: num.MakePercentage(0, 3),
 					},
 				},
-				Extensions: []cbc.Key{
-					ExtKeyKSeFVATZero,
-				},
 			},
 			{
 				Key: tax.RateExempt,
@@ -99,8 +95,7 @@ var taxCategories = []*tax.Category{
 					i18n.EN: "Exempt",
 					i18n.PL: "Zwolnione",
 				},
-				Exempt:     true,
-				Extensions: []cbc.Key{},
+				Exempt: true,
 			},
 			{
 				Key: tax.RateSpecial,
@@ -111,27 +106,20 @@ var taxCategories = []*tax.Category{
 				Extensions: []cbc.Key{
 					ExtKeyKSeFVATSpecial,
 				},
+				Values: []*tax.RateValue{
+					{
+						Percent: num.MakePercentage(40, 3),
+					},
+				},
 			},
-
-			/*
-				 * Still working on refactoring these...
-				{
-					Key: TaxRateNotPursuant,
-					Name: i18n.String{
-						i18n.EN: "Not pursuant, pursuant to art100 section 1 point4",
-						i18n.PL: "Niepodlegające opodatkowaniu na postawie wyłączeniem art100 sekcja 1 punkt 4",
-					},
-					Exempt: true,
+			{
+				Key: TaxRateNotPursuant,
+				Name: i18n.String{
+					i18n.EN: "Not pursuant",
+					i18n.PL: "Niepodlegające opodatkowaniu",
 				},
-				{
-					Key: TaxRateNotPursuantArt100,
-					Name: i18n.String{
-						i18n.EN: "Not pursuant excluding art100 section 1 point4",
-						i18n.PL: "Niepodlegające opodatkowaniu z wyłączeniem art100 sekcja 1 punkt 4",
-					},
-					Exempt: true,
-				},
-			*/
+				Exempt: true,
+			},
 		},
 	},
 }


### PR DESCRIPTION
### Dependencies
This PR is a dependency for https://github.com/invopop/gobl.ksef/pull/14

## Pull Request Summary
To handle additional tax categories we need to clean up tax categories and extensions. We want to handle tax categories for:
```
standard                      - tax.RateStandard
reduced                       - tax.RateReduced
super reduced                 - tax.RateSuperReduced
taxi                          - tax.RateSpecial + ExtKeyKSeFVATSpecial{taxi}
inside Poland 0%              - tax.RateZero
inside EU 0%                  - tax.RateZero
outside EU 0%                 - tax.RateZero
tax exempt                    - tax.RateExempt
tax not applicable outside EU - TaxRateNotPursuant
tax not applicable inside EU  - TaxRateNotPursuant

Additional values to determine which case it is will be determined in the gobl.ksef package
```

## When do we use the zero tax rate
The regulations indicate situations in which a business entity may apply a 0% VAT rate for sales. It is essential for the seller to be an active VAT taxpayer. The 0% rate does not mean exemption from taxation. Sales made with a 0% VAT rate are still considered taxable. Despite no tax due, sales at a zero VAT rate should be reported in the VAT declaration. The 0% rate can be applied, among others, for the following activities:
- Intra-Community Supply of Goods (ICS),
- export of goods,
- services related to maritime and air transport.

## When do we use the tax exempt tax rate
The "ZW" VAT invoice is used by entrepreneurs who are not active VAT taxpayers, are exempt from taxation on goods and services on a subjective basis, or are active VAT taxpayers who provide VAT-exempt services. The "ZW" VAT invoice used by entrepreneurs for the sale of goods or services rendered does not allow for the deduction of VAT on purchases covered by "ZW". Activities exempt from tax include, for example:
- delivery of own agricultural products,
- educational services,
- social assistance services,
- financial and insurance intermediary services,
- services related to sports and physical education.

## When do we use the tax not applicable tax rate
The entrepreneur who includes the annotation "NP" in the field corresponding to the VAT rate on the invoice indicates that the sale to which the entry refers is not subject to taxation in Poland. The designation "NP" is an abbreviation for the phrase "not subject to." This situation occurs, for example, in the case of entrepreneurs who provide services related to export for foreign customers. Taxation will occur in the buyer's country. The "NP" annotation allows for the settlement of VAT on purchases covered by the entry.