### PR TITLE
UUID: moving to v7 and parse fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Added
 
-- Additional UUID validation rules: `IsV6`, `Isv7`, `HasTimestamp`, and `Timeless`.
+- Additional UUID validation rules: `Valid`, `IsV6`, `Isv7`, `HasTimestamp`, and `Timeless`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,21 @@ All notable changes to GOBL will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/). See also the [GOBL versions](https://docs.gobl.org/overview/versions) documentation site for more details.
 
-## [v0.73.0]] - 2024-04-22
+## [v0.xx.x] - xxxx-xx-xx
+
+### Added
+
+- Additional UUID validation rules: `IsV6`, `Isv7`, `HasTimestamp`, and `Timeless`.
+
+### Changed
+
+- Using Version 7 UUIDs as default in GOBL.
+
+### Fixed
+
+- Parsing empty UUIDs now returns an empty UUID instead of an error.
+
+## [v0.73.0] - 2024-04-22
 
 Refactoring UUID support.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Changed
 
-- Using Version 7 UUIDs as default in GOBL.
+- Using Version 7 UUIDs as default in GOBL. This version enables ordering by UUID and uses random extra data instead of a node ID.
 
 ### Fixed
 

--- a/envelope.go
+++ b/envelope.go
@@ -232,7 +232,7 @@ func (e *Envelope) calculate() error {
 		e.Head = head.NewHeader()
 	}
 	if e.Head.UUID.IsZero() {
-		e.Head.UUID = uuid.V1()
+		e.Head.UUID = uuid.V7()
 	}
 	var err error
 	e.Head.Digest, err = e.Digest()

--- a/head/header.go
+++ b/head/header.go
@@ -38,7 +38,7 @@ type Header struct {
 // NewHeader creates a new header and automatically assigns a UUIDv1.
 func NewHeader() *Header {
 	h := new(Header)
-	h.UUID = uuid.V1()
+	h.UUID = uuid.V7()
 	h.Meta = make(cbc.Meta)
 	h.Draft = true // default to draft
 	return h
@@ -52,7 +52,7 @@ func (h *Header) Validate() error {
 // ValidateWithContext checks that the header contains the basic information we need to function.
 func (h *Header) ValidateWithContext(ctx context.Context) error {
 	return validation.ValidateStructWithContext(ctx, h,
-		validation.Field(&h.UUID, validation.Required, uuid.IsV1),
+		validation.Field(&h.UUID, validation.Required, uuid.HasTimestamp),
 		validation.Field(&h.Digest, validation.Required),
 		validation.Field(&h.Stamps,
 			validation.When(h.Draft, validation.Empty),

--- a/head/header_test.go
+++ b/head/header_test.go
@@ -5,13 +5,14 @@ import (
 
 	"github.com/invopop/gobl/dsig"
 	"github.com/invopop/gobl/head"
+	"github.com/invopop/gobl/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestNewHeader(t *testing.T) {
 	h := head.NewHeader()
 	assert.False(t, h.UUID.IsZero())
-	assert.True(t, h.UUID.Version() == 1)
+	assert.Equal(t, uuid.Version(7), h.UUID.Version())
 	assert.NotPanics(t, func() {
 		h.Meta["foo"] = "bar"
 		h.Tags = append(h.Tags, "foo")

--- a/schema/object.go
+++ b/schema/object.go
@@ -76,7 +76,7 @@ func (d *Object) Calculate() error {
 	if ident, ok := d.payload.(Identifiable); ok {
 		id := ident.GetUUID()
 		if id.IsZero() {
-			ident.SetUUID(uuid.V1())
+			ident.SetUUID(uuid.V7())
 		}
 	}
 	pl, ok := d.payload.(Calculable)

--- a/uuid/identify.go
+++ b/uuid/identify.go
@@ -21,22 +21,32 @@ func IdentifyParse(s string) Identify {
 	return Identify{UUID: MustParse(s)}
 }
 
-// IdentifyV1 is a helper method to generate a V1 uuid ready to embed.
+// IdentifyV1 is a helper method to generate a version 1 uuid ready to embed.
 func IdentifyV1() Identify {
 	return Identify{UUID: V1()}
 }
 
-// IdentifyV3 is a helper method to generate a V3 uuid ready to embed.
+// IdentifyV3 is a helper method to generate a version 3 uuid ready to embed.
 func IdentifyV3(ns UUID, data []byte) Identify {
 	return Identify{UUID: V3(ns, data)}
 }
 
-// IdentifyV4 is a helper method to generate a V4 uuid ready to embed.
+// IdentifyV4 is a helper method to generate a version 4 uuid ready to embed.
 func IdentifyV4() Identify {
 	return Identify{UUID: V4()}
 }
 
-// IdentifyV5 is a helper method to generate a V5 uuid ready to embed.
+// IdentifyV5 is a helper method to generate a version 5 uuid ready to embed.
 func IdentifyV5(ns UUID, data []byte) Identify {
 	return Identify{UUID: V5(ns, data)}
+}
+
+// IdentifyV6 is a helper method to generate a version 6 uuid ready to embed.
+func IdentifyV6() Identify {
+	return Identify{UUID: V6()}
+}
+
+// IdentifyV7 is a helper method to generate a version 7 uuid ready to embed.
+func IdentifyV7() Identify {
+	return Identify{UUID: V7()}
 }

--- a/uuid/identify_test.go
+++ b/uuid/identify_test.go
@@ -39,6 +39,7 @@ func TestIdentifyV1(t *testing.T) {
 		Name:     "test",
 	}
 	assert.NotEmpty(t, doc.GetUUID())
+	assert.False(t, doc.UUID.Timestamp().IsZero())
 }
 
 func TestIdentifyV4(t *testing.T) {
@@ -78,4 +79,28 @@ func TestIdentifyV5(t *testing.T) {
 	}
 	assert.NotEmpty(t, doc.GetUUID())
 	assert.Equal(t, doc.GetUUID(), uuid.UUID("1f53a310-2a17-5acb-b76a-c39495e5356f"))
+}
+
+func TestIdentifyV6(t *testing.T) {
+	doc := struct {
+		uuid.Identify
+		Name string
+	}{
+		Identify: uuid.IdentifyV6(),
+		Name:     "test",
+	}
+	assert.NotEmpty(t, doc.GetUUID())
+	assert.False(t, doc.UUID.Timestamp().IsZero())
+}
+
+func TestIdentifyV7(t *testing.T) {
+	doc := struct {
+		uuid.Identify
+		Name string
+	}{
+		Identify: uuid.IdentifyV7(),
+		Name:     "test",
+	}
+	assert.NotEmpty(t, doc.GetUUID())
+	assert.False(t, doc.UUID.Timestamp().IsZero())
 }

--- a/uuid/uuid.go
+++ b/uuid/uuid.go
@@ -175,7 +175,7 @@ func (u UUID) String() string {
 
 // Validate checks to ensure the value is a UUID
 func (u UUID) Validate() error {
-	return validation.Validate(string(u), IsValid)
+	return validation.Validate(string(u), Valid)
 }
 
 // Parse decodes s into a UUID or provides an error.

--- a/uuid/uuid.go
+++ b/uuid/uuid.go
@@ -9,7 +9,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/invopop/jsonschema"
 	"github.com/invopop/validation"
-	"github.com/invopop/validation/is"
 )
 
 // UUID defines a string wrapper for dealing with UUIDs using the google uuid
@@ -176,7 +175,7 @@ func (u UUID) String() string {
 
 // Validate checks to ensure the value is a UUID
 func (u UUID) Validate() error {
-	return validation.Validate(string(u), is.UUID)
+	return validation.Validate(string(u), IsValid)
 }
 
 // Parse decodes s into a UUID or provides an error.

--- a/uuid/validation.go
+++ b/uuid/validation.go
@@ -9,6 +9,8 @@ import (
 )
 
 var (
+	// IsValid confirms the UUID is valid
+	IsValid = versionRule{}
 	// IsV1 confirms the UUID is version 1
 	IsV1 = versionRule{version: 1}
 	// IsV3 confirms the UUID is version 3

--- a/uuid/validation.go
+++ b/uuid/validation.go
@@ -9,8 +9,8 @@ import (
 )
 
 var (
-	// IsValid confirms the UUID is valid
-	IsValid = versionRule{}
+	// Valid confirms the UUID is valid
+	Valid = versionRule{}
 	// IsV1 confirms the UUID is version 1
 	IsV1 = versionRule{version: 1}
 	// IsV3 confirms the UUID is version 3

--- a/uuid/validation_test.go
+++ b/uuid/validation_test.go
@@ -150,6 +150,44 @@ func TestUUIDValidation(t *testing.T) {
 			uuid: "",
 			rule: uuid.IsNotZero,
 		},
+		{
+			name: "general good v1",
+			uuid: uuid.V1(),
+			rule: uuid.IsValid,
+		},
+		{
+			name: "general good v4",
+			uuid: uuid.V4(),
+			rule: uuid.IsValid,
+		},
+		{
+			name: "general good v7",
+			uuid: uuid.V7(),
+			rule: uuid.IsValid,
+		},
+		{
+			name: "general empty",
+			uuid: "",
+			rule: uuid.IsValid,
+		},
+		{
+			name: "general bad string",
+			uuid: "fooo",
+			rule: uuid.IsValid,
+			err:  "invalid UUID length: 4",
+		},
+		{
+			name: "general bad uuid",
+			uuid: uuid.UUID("fooo"),
+			rule: uuid.IsValid,
+			err:  "invalid UUID length: 4",
+		},
+		{
+			name: "other type",
+			uuid: 123,
+			rule: uuid.IsValid,
+			err:  "not a UUID",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/uuid/validation_test.go
+++ b/uuid/validation_test.go
@@ -153,39 +153,39 @@ func TestUUIDValidation(t *testing.T) {
 		{
 			name: "general good v1",
 			uuid: uuid.V1(),
-			rule: uuid.IsValid,
+			rule: uuid.Valid,
 		},
 		{
 			name: "general good v4",
 			uuid: uuid.V4(),
-			rule: uuid.IsValid,
+			rule: uuid.Valid,
 		},
 		{
 			name: "general good v7",
 			uuid: uuid.V7(),
-			rule: uuid.IsValid,
+			rule: uuid.Valid,
 		},
 		{
 			name: "general empty",
 			uuid: "",
-			rule: uuid.IsValid,
+			rule: uuid.Valid,
 		},
 		{
 			name: "general bad string",
 			uuid: "fooo",
-			rule: uuid.IsValid,
+			rule: uuid.Valid,
 			err:  "invalid UUID length: 4",
 		},
 		{
 			name: "general bad uuid",
 			uuid: uuid.UUID("fooo"),
-			rule: uuid.IsValid,
+			rule: uuid.Valid,
 			err:  "invalid UUID length: 4",
 		},
 		{
 			name: "other type",
 			uuid: 123,
-			rule: uuid.IsValid,
+			rule: uuid.Valid,
 			err:  "not a UUID",
 		},
 	}


### PR DESCRIPTION
* Fixed parsing issue for empty UUIDs
* Moving to using UUID v7 as default.