### PR TITLE
Support for replication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - `num.Percentage` has `Base()` method to access base amount.
 - MX: FuelAccountBalance complement now supports `percent` as an alternative to `rate`.
 - ES: added extra TicketBAI exemption reasons
+- Envelope `Replicate()` and supporting methods to be able to clone/replicate an envelope or document without any potentially conflicting data.
 
 ### Change
 

--- a/bill/invoice_replicate.go
+++ b/bill/invoice_replicate.go
@@ -1,0 +1,19 @@
+package bill
+
+import (
+	"github.com/invopop/gobl/cal"
+	"github.com/invopop/gobl/uuid"
+)
+
+// Replicate modifies the invoice's fields to ensure that it can be used as part
+// of a replication process. A replicated invoice is one that contains the same
+// base details like supplier, customer, lines, etc., but with updated identifiers
+// and dates.
+func (inv *Invoice) Replicate() error {
+	inv.UUID = uuid.Empty
+	inv.Code = ""
+	inv.IssueDate = cal.Today()
+	inv.ValueDate = nil
+	inv.OperationDate = nil
+	return nil
+}

--- a/bill/invoice_replicate_test.go
+++ b/bill/invoice_replicate_test.go
@@ -1,0 +1,40 @@
+package bill_test
+
+import (
+	"testing"
+
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/cal"
+	"github.com/invopop/gobl/num"
+	"github.com/invopop/gobl/org"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInvoiceReplicate(t *testing.T) {
+	lines := []*bill.Line{
+		{
+			Quantity: num.MakeAmount(2, 0),
+			Item: &org.Item{
+				Name:  "Test Item",
+				Price: num.MakeAmount(10, 0),
+			},
+		},
+	}
+	inv := baseInvoice(t, lines...)
+	inv.ValueDate = cal.NewDate(2022, 6, 1)
+	inv.OperationDate = cal.NewDate(2022, 6, 5)
+	require.NoError(t, inv.Calculate())
+	require.NoError(t, inv.Validate())
+
+	assert.Equal(t, "2022-06-13", inv.IssueDate.String())
+
+	require.NoError(t, inv.Replicate())
+
+	assert.Empty(t, inv.UUID)
+	assert.Empty(t, inv.Code)
+	td := cal.Today()
+	assert.Equal(t, inv.IssueDate.String(), td.String())
+	assert.Nil(t, inv.ValueDate)
+	assert.Nil(t, inv.OperationDate)
+}

--- a/bill/invoice_test.go
+++ b/bill/invoice_test.go
@@ -956,17 +956,20 @@ func TestValidation(t *testing.T) {
 func baseInvoice(t *testing.T, lines ...*bill.Line) *bill.Invoice {
 	t.Helper()
 	i := &bill.Invoice{
-		Code: "123TEST",
+		Series: "TEST",
+		Code:   "00123",
 		Tax: &bill.Tax{
 			PricesInclude: tax.CategoryVAT,
 		},
 		Supplier: &org.Party{
+			Name: "Test Supplier",
 			TaxID: &tax.Identity{
 				Country: l10n.ES,
 				Code:    "B98602642",
 			},
 		},
 		Customer: &org.Party{
+			Name: "Test Customer",
 			TaxID: &tax.Identity{
 				Country: l10n.ES,
 				Code:    "54387763P",

--- a/envelope.go
+++ b/envelope.go
@@ -284,6 +284,23 @@ func (e *Envelope) Correct(opts ...schema.Option) (*Envelope, error) {
 	return Envelop(nd)
 }
 
+// Replicate will create a new envelope with the same contents as the current,
+// but with schema specific options applied to remove information that must
+// change between documents, such as stamps, invoice code, date, UUID, etc.
+// The intention here is for users to be able to get a new copy of the original
+// document so that they can issue a new version with updated details, or
+// simply use the original as a template.
+func (e *Envelope) Replicate() (*Envelope, error) {
+	nd, err := e.Document.Clone()
+	if err != nil {
+		return nil, wrapError(err)
+	}
+	if err := nd.Replicate(); err != nil {
+		return nil, wrapError(err)
+	}
+	return Envelop(nd)
+}
+
 // CorrectionOptionsSchema will attempt to provide a corrective options JSON Schema
 // that can be used to generate a JSON object to send when correcting a document.
 // If none are available, the result will be nil.

--- a/envelope_test.go
+++ b/envelope_test.go
@@ -320,6 +320,29 @@ func TestEnvelopeCorrect(t *testing.T) {
 	})
 }
 
+func TestEnvelopeReplicate(t *testing.T) {
+	t.Run("replicate invoice", func(t *testing.T) {
+		env := gobl.NewEnvelope()
+
+		data, err := os.ReadFile("./regimes/es/examples/invoice-es-es.env.yaml")
+		require.NoError(t, err)
+		err = yaml.Unmarshal(data, env)
+		require.NoError(t, err)
+		require.NoError(t, env.Calculate())
+
+		_, err = env.Replicate()
+		require.NoError(t, err)
+
+		doc := env.Extract().(*bill.Invoice)
+		assert.Equal(t, "SAMPLE-001", doc.Code, "should not update in place")
+
+		e2, err := env.Replicate()
+		require.NoError(t, err)
+		doc = e2.Extract().(*bill.Invoice)
+		assert.Empty(t, doc.Code)
+	})
+}
+
 func TestDocument(t *testing.T) {
 	msg := testNoteExample()
 	env := gobl.NewEnvelope()

--- a/schema/object_test.go
+++ b/schema/object_test.go
@@ -59,20 +59,34 @@ func TestObjectCalculate(t *testing.T) {
 	assert.Equal(t, obj.UUID(), inv.UUID)
 }
 
+func TestObjectReplicate(t *testing.T) {
+	inv := exampleInvoice()
+	obj, err := schema.NewObject(inv)
+	require.NoError(t, err)
+	require.NoError(t, obj.Calculate())
+	ou := obj.UUID()
+	require.NoError(t, obj.Replicate())
+	assert.NotEqual(t, ou, obj.UUID())
+	assert.Empty(t, inv.Code, "should remove code")
+}
+
 // exampleInvoice defines a simple invoice example pre-calculations.
 func exampleInvoice() *bill.Invoice {
 	return &bill.Invoice{
-		Code: "123TEST",
+		Series: "TEST",
+		Code:   "000123",
 		Tax: &bill.Tax{
 			PricesInclude: tax.CategoryVAT,
 		},
 		Supplier: &org.Party{
+			Name: "Test Supplier",
 			TaxID: &tax.Identity{
 				Country: l10n.ES,
 				Code:    "B98602642",
 			},
 		},
 		Customer: &org.Party{
+			Name: "Test Customer",
 			TaxID: &tax.Identity{
 				Country: l10n.ES,
 				Code:    "54387763P",


### PR DESCRIPTION
* Adding new `Replicate()` method to envelopes and objects.
* `bill.Invoice` now has specific process for replication that removes specific fields.