### PR TITLE
Fix: invoice discount and change calculations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to GOBL will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/). See also the [GOBL versions](https://docs.gobl.org/overview/versions) documentation site for more details.
 
+## [XXXXXX] - XXXX-XX-XX
+
+### Changed
+
+- Invoice Discounts and Charges will no longer update the `base` property according to the document's sum.
+
+### Fixed
+
+- Precision handling of calculated invoice discounts and charges.
+
 ## [v0.76.0] - 2024-05-13
 
 Finally, invoice multi-currency support! It's been a very long time coming, but we've finalized the details on how to handle currency conversion in invoices and potentially other documents.

--- a/bill/charges.go
+++ b/bill/charges.go
@@ -100,10 +100,10 @@ func (m *Charge) removeIncludedTaxes(cat cbc.Code) *Charge {
 	return &m2
 }
 
-func calculateCharges(lines []*Charge, sum, zero num.Amount) error {
+func calculateCharges(lines []*Charge, sum, zero num.Amount) {
 	// COPIED FROM discount.go
 	if len(lines) == 0 {
-		return nil
+		return
 	}
 	for i, l := range lines {
 		l.Index = i + 1
@@ -122,7 +122,6 @@ func calculateCharges(lines []*Charge, sum, zero num.Amount) error {
 			l.amount = l.Amount
 		}
 	}
-	return nil
 }
 
 func calculateChargeSum(charges []*Charge, zero num.Amount) *num.Amount {

--- a/bill/charges.go
+++ b/bill/charges.go
@@ -42,11 +42,10 @@ type Charge struct {
 	Index int `json:"i" jsonschema:"title=Index" jsonschema_extras:"calculated=true"`
 	// Code to used to refer to the this charge
 	Ref string `json:"ref,omitempty" jsonschema:"title=Reference"`
-	// Base represents the value used as a base for percent calculations.
-	// If not already provided, we'll take the invoices sum before
-	// discounts.
+	// Base represents the value used as a base for percent calculations instead
+	// of the invoice's sum of lines.
 	Base *num.Amount `json:"base,omitempty" jsonschema:"title=Base"`
-	// Percentage to apply to the invoice's Sum
+	// Percentage to apply to the Base or Invoice Sum
 	Percent *num.Percentage `json:"percent,omitempty" jsonschema:"title=Percent"`
 	// Amount to apply (calculated if percent present)
 	Amount num.Amount `json:"amount" jsonschema:"title=Amount" jsonschema_extras:"calculated=true"`
@@ -58,6 +57,9 @@ type Charge struct {
 	Reason string `json:"reason,omitempty" jsonschema:"title=Reason"`
 	// Additional semi-structured information.
 	Meta cbc.Meta `json:"meta,omitempty" jsonschema:"title=Meta"`
+
+	//
+	amount num.Amount
 }
 
 // ValidateWithContext checks the charge's fields.
@@ -65,7 +67,12 @@ func (m *Charge) ValidateWithContext(ctx context.Context) error {
 	return validation.ValidateStructWithContext(ctx, m,
 		validation.Field(&m.UUID),
 		validation.Field(&m.Base),
-		validation.Field(&m.Percent),
+		validation.Field(&m.Percent,
+			validation.When(
+				m.Base != nil,
+				validation.Required,
+			),
+		),
 		validation.Field(&m.Amount, validation.Required),
 		validation.Field(&m.Taxes),
 		validation.Field(&m.Meta),
@@ -93,31 +100,39 @@ func (m *Charge) removeIncludedTaxes(cat cbc.Code) *Charge {
 	return &m2
 }
 
-func calculateCharges(zero, sum num.Amount, charges []*Charge) error { //nolint:unparam
-	if len(charges) == 0 {
+func calculateCharges(lines []*Charge, sum, zero num.Amount) error {
+	// COPIED FROM discount.go
+	if len(lines) == 0 {
 		return nil
 	}
-	for i, l := range charges {
+	for i, l := range lines {
 		l.Index = i + 1
 		if l.Percent != nil && !l.Percent.IsZero() {
-			if l.Base == nil {
-				l.Base = &sum
+			base := sum
+			exp := zero.Exp()
+			if l.Base != nil {
+				base = l.Base.RescaleUp(exp)
+				exp = base.Exp()
 			}
-			l.Amount = l.Percent.Of(*l.Base)
+			l.Amount = l.Percent.Of(base)
+			l.amount = l.Amount
+			l.Amount = l.Amount.Rescale(exp)
+		} else {
+			l.Amount = l.Amount.MatchPrecision(zero)
+			l.amount = l.Amount
 		}
-		l.Amount = l.Amount.MatchPrecision(zero)
 	}
 	return nil
 }
 
-func calculateChargeSum(zero num.Amount, charges []*Charge) *num.Amount {
+func calculateChargeSum(charges []*Charge, zero num.Amount) *num.Amount {
 	if len(charges) == 0 {
 		return nil
 	}
 	total := zero
 	for _, l := range charges {
-		total = total.MatchPrecision(l.Amount)
-		total = total.Add(l.Amount)
+		total = total.MatchPrecision(l.amount)
+		total = total.Add(l.amount)
 	}
 	return &total
 }

--- a/bill/charges_test.go
+++ b/bill/charges_test.go
@@ -21,9 +21,9 @@ func TestChargeTotals(t *testing.T) {
 	}
 	zero := num.MakeAmount(0, 2)
 	base := num.MakeAmount(30000, 2)
-	err := calculateCharges(zero, base, ls)
+	err := calculateCharges(ls, base, zero)
 	require.NoError(t, err)
-	sum := calculateChargeSum(zero, ls)
+	sum := calculateChargeSum(ls, zero)
 	require.NotNil(t, sum)
 	assert.Equal(t, 1, ls[0].Index)
 	assert.Equal(t, 2, ls[1].Index)
@@ -34,7 +34,7 @@ func TestChargeTotals(t *testing.T) {
 	assert.Equal(t, "60.00", ls[1].Amount.String())
 
 	ls = []*Charge{}
-	require.NoError(t, calculateCharges(zero, base, ls))
-	sum = calculateChargeSum(zero, ls)
+	require.NoError(t, calculateCharges(ls, base, zero))
+	sum = calculateChargeSum(ls, zero)
 	assert.Nil(t, sum)
 }

--- a/bill/charges_test.go
+++ b/bill/charges_test.go
@@ -27,8 +27,7 @@ func TestChargeTotals(t *testing.T) {
 		}
 		zero := num.MakeAmount(0, 2)
 		base := num.MakeAmount(30000, 2)
-		err := calculateCharges(ls, base, zero)
-		require.NoError(t, err)
+		calculateCharges(ls, base, zero)
 		sum := calculateChargeSum(ls, zero)
 		require.NotNil(t, sum)
 		assert.Equal(t, 1, ls[0].Index)
@@ -43,7 +42,7 @@ func TestChargeTotals(t *testing.T) {
 		assert.Equal(t, "40.00", ls[2].Amount.String())
 
 		ls = []*Charge{}
-		require.NoError(t, calculateCharges(ls, base, zero))
+		calculateCharges(ls, base, zero)
 		sum = calculateChargeSum(ls, zero)
 		assert.Nil(t, sum)
 	})
@@ -61,8 +60,7 @@ func TestChargeTotals(t *testing.T) {
 		}
 		zero := num.MakeAmount(0, 2)
 		base := num.MakeAmount(30844212, 6)
-		err := calculateCharges(ls, base, zero)
-		require.NoError(t, err)
+		calculateCharges(ls, base, zero)
 		sum := calculateChargeSum(ls, zero)
 		require.NotNil(t, sum)
 		assert.Equal(t, "6.17", ls[1].Amount.String())
@@ -79,8 +77,7 @@ func TestChargeTotals(t *testing.T) {
 		}
 		zero := num.MakeAmount(0, 2)
 		base := num.MakeAmount(30844212, 6)
-		err := calculateCharges(ls, base, zero)
-		require.NoError(t, err)
+		calculateCharges(ls, base, zero)
 		sum := calculateChargeSum(ls, zero)
 		require.NotNil(t, sum)
 		assert.Equal(t, "10.02", ls[0].Amount.String())
@@ -97,8 +94,7 @@ func TestChargeTotals(t *testing.T) {
 		}
 		zero := num.MakeAmount(0, 2)
 		base := num.MakeAmount(30844212, 6)
-		err := calculateCharges(ls, base, zero)
-		require.NoError(t, err)
+		calculateCharges(ls, base, zero)
 		sum := calculateChargeSum(ls, zero)
 		require.NotNil(t, sum)
 		assert.Equal(t, "10.0247", ls[0].Amount.String())

--- a/bill/charges_test.go
+++ b/bill/charges_test.go
@@ -9,32 +9,99 @@ import (
 )
 
 func TestChargeTotals(t *testing.T) {
-	ls := []*Charge{
-		{
-			Reason: "First Charge",
-			Amount: num.MakeAmount(100, 0),
-		},
-		{
-			Reason:  "Second Charge",
-			Percent: num.NewPercentage(20, 2),
-		},
-	}
-	zero := num.MakeAmount(0, 2)
-	base := num.MakeAmount(30000, 2)
-	err := calculateCharges(ls, base, zero)
-	require.NoError(t, err)
-	sum := calculateChargeSum(ls, zero)
-	require.NotNil(t, sum)
-	assert.Equal(t, 1, ls[0].Index)
-	assert.Equal(t, 2, ls[1].Index)
-	assert.Equal(t, "160.00", sum.String())
-	assert.Equal(t, "100.00", ls[0].Amount.String())
-	assert.Nil(t, ls[1].Base)
-	assert.Equal(t, "20%", ls[1].Percent.String())
-	assert.Equal(t, "60.00", ls[1].Amount.String())
+	t.Run("base line", func(t *testing.T) {
+		ls := []*Charge{
+			{
+				Reason: "First Charge",
+				Amount: num.MakeAmount(100, 0),
+			},
+			{
+				Reason:  "Second discount",
+				Percent: num.NewPercentage(20, 2),
+			},
+			{
+				Reason:  "Third discount",
+				Base:    num.NewAmount(20000, 2),
+				Percent: num.NewPercentage(20, 2),
+			},
+		}
+		zero := num.MakeAmount(0, 2)
+		base := num.MakeAmount(30000, 2)
+		err := calculateCharges(ls, base, zero)
+		require.NoError(t, err)
+		sum := calculateChargeSum(ls, zero)
+		require.NotNil(t, sum)
+		assert.Equal(t, 1, ls[0].Index)
+		assert.Nil(t, ls[0].Base)
+		assert.Equal(t, 2, ls[1].Index)
+		assert.Equal(t, "200.00", sum.String())
+		assert.Equal(t, "100.00", ls[0].Amount.String())
+		assert.Nil(t, ls[1].Base)
+		assert.Equal(t, "20%", ls[1].Percent.String())
+		assert.Equal(t, "60.00", ls[1].Amount.String())
+		assert.Equal(t, "200.00", ls[2].Base.String())
+		assert.Equal(t, "40.00", ls[2].Amount.String())
 
-	ls = []*Charge{}
-	require.NoError(t, calculateCharges(ls, base, zero))
-	sum = calculateChargeSum(ls, zero)
-	assert.Nil(t, sum)
+		ls = []*Charge{}
+		require.NoError(t, calculateCharges(ls, base, zero))
+		sum = calculateChargeSum(ls, zero)
+		assert.Nil(t, sum)
+	})
+
+	t.Run("with precision", func(t *testing.T) {
+		ls := []*Charge{
+			{
+				Reason: "First Charge",
+				Amount: num.MakeAmount(50, 0),
+			},
+			{
+				Reason:  "Second discount",
+				Percent: num.NewPercentage(20, 2),
+			},
+		}
+		zero := num.MakeAmount(0, 2)
+		base := num.MakeAmount(30844212, 6)
+		err := calculateCharges(ls, base, zero)
+		require.NoError(t, err)
+		sum := calculateChargeSum(ls, zero)
+		require.NotNil(t, sum)
+		assert.Equal(t, "6.17", ls[1].Amount.String())
+		assert.Equal(t, "56.168842", sum.String())
+	})
+
+	t.Run("with fixed base", func(t *testing.T) {
+		ls := []*Charge{
+			{
+				Reason:  "Charge",
+				Base:    num.NewAmount(5012, 2),
+				Percent: num.NewPercentage(20, 2),
+			},
+		}
+		zero := num.MakeAmount(0, 2)
+		base := num.MakeAmount(30844212, 6)
+		err := calculateCharges(ls, base, zero)
+		require.NoError(t, err)
+		sum := calculateChargeSum(ls, zero)
+		require.NotNil(t, sum)
+		assert.Equal(t, "10.02", ls[0].Amount.String())
+		assert.Equal(t, "10.02", sum.String())
+	})
+
+	t.Run("with fixed base high precision", func(t *testing.T) {
+		ls := []*Charge{
+			{
+				Reason:  "Charge",
+				Base:    num.NewAmount(501234, 4),
+				Percent: num.NewPercentage(20, 2),
+			},
+		}
+		zero := num.MakeAmount(0, 2)
+		base := num.MakeAmount(30844212, 6)
+		err := calculateCharges(ls, base, zero)
+		require.NoError(t, err)
+		sum := calculateChargeSum(ls, zero)
+		require.NotNil(t, sum)
+		assert.Equal(t, "10.0247", ls[0].Amount.String())
+		assert.Equal(t, "10.0247", sum.String())
+	})
 }

--- a/bill/charges_test.go
+++ b/bill/charges_test.go
@@ -29,7 +29,7 @@ func TestChargeTotals(t *testing.T) {
 	assert.Equal(t, 2, ls[1].Index)
 	assert.Equal(t, "160.00", sum.String())
 	assert.Equal(t, "100.00", ls[0].Amount.String())
-	assert.Equal(t, "300.00", ls[1].Base.String())
+	assert.Nil(t, ls[1].Base)
 	assert.Equal(t, "20%", ls[1].Percent.String())
 	assert.Equal(t, "60.00", ls[1].Amount.String())
 

--- a/bill/discounts.go
+++ b/bill/discounts.go
@@ -101,9 +101,9 @@ func (m *Discount) removeIncludedTaxes(cat cbc.Code) *Discount {
 	return &m2
 }
 
-func calculateDiscounts(lines []*Discount, sum, zero num.Amount) error {
+func calculateDiscounts(lines []*Discount, sum, zero num.Amount) {
 	if len(lines) == 0 {
-		return nil
+		return
 	}
 	for i, l := range lines {
 		l.Index = i + 1
@@ -122,7 +122,6 @@ func calculateDiscounts(lines []*Discount, sum, zero num.Amount) error {
 			l.amount = l.Amount
 		}
 	}
-	return nil
 }
 
 func calculateDiscountSum(discounts []*Discount, zero num.Amount) *num.Amount {

--- a/bill/discounts.go
+++ b/bill/discounts.go
@@ -42,10 +42,10 @@ type Discount struct {
 	Index int `json:"i" jsonschema:"title=Index" jsonschema_extras:"calculated=true"`
 	// Reference or ID for this Discount
 	Ref string `json:"ref,omitempty" jsonschema:"title=Reference"`
-	// Base represents the value used as a base for percent calculations.
-	// If not already provided, we'll take the invoices sum.
+	// Base represents the value used as a base for percent calculations instead
+	// of the invoice's sum of lines.
 	Base *num.Amount `json:"base,omitempty" jsonschema:"title=Base"`
-	// Percentage to apply to the invoice's Sum.
+	// Percentage to apply to the base or invoice's sum.
 	Percent *num.Percentage `json:"percent,omitempty" jsonschema:"title=Percent"`
 	// Amount to apply (calculated if percent present).
 	Amount num.Amount `json:"amount" jsonschema:"title=Amount" jsonschema_extras:"calculated=true"`
@@ -57,6 +57,9 @@ type Discount struct {
 	Reason string `json:"reason,omitempty" jsonschema:"title=Reason"`
 	// Additional semi-structured information.
 	Meta cbc.Meta `json:"meta,omitempty" jsonschema:"title=Meta"`
+
+	// internal amount for calculations
+	amount num.Amount
 }
 
 // ValidateWithContext checks the discount's fields.
@@ -64,7 +67,12 @@ func (m *Discount) ValidateWithContext(ctx context.Context) error {
 	return validation.ValidateStructWithContext(ctx, m,
 		validation.Field(&m.UUID),
 		validation.Field(&m.Base),
-		validation.Field(&m.Percent),
+		validation.Field(&m.Percent,
+			validation.When(
+				m.Base != nil,
+				validation.Required,
+			),
+		),
 		validation.Field(&m.Amount, validation.Required),
 		validation.Field(&m.Taxes),
 		validation.Field(&m.Meta),
@@ -93,31 +101,38 @@ func (m *Discount) removeIncludedTaxes(cat cbc.Code) *Discount {
 	return &m2
 }
 
-func calculateDiscounts(zero, sum num.Amount, discounts []*Discount) error { //nolint:unparam
-	if len(discounts) == 0 {
+func calculateDiscounts(lines []*Discount, sum, zero num.Amount) error {
+	if len(lines) == 0 {
 		return nil
 	}
-	for i, l := range discounts {
+	for i, l := range lines {
 		l.Index = i + 1
 		if l.Percent != nil && !l.Percent.IsZero() {
-			if l.Base == nil {
-				l.Base = &sum
+			base := sum
+			exp := zero.Exp()
+			if l.Base != nil {
+				base = l.Base.RescaleUp(exp)
+				exp = base.Exp()
 			}
-			l.Amount = l.Percent.Of(*l.Base)
+			l.Amount = l.Percent.Of(base)
+			l.amount = l.Amount
+			l.Amount = l.Amount.Rescale(exp)
+		} else {
+			l.Amount = l.Amount.MatchPrecision(zero)
+			l.amount = l.Amount
 		}
-		l.Amount = l.Amount.MatchPrecision(zero)
 	}
 	return nil
 }
 
-func calculateDiscountSum(zero num.Amount, discounts []*Discount) *num.Amount {
+func calculateDiscountSum(discounts []*Discount, zero num.Amount) *num.Amount {
 	if len(discounts) == 0 {
 		return nil
 	}
 	total := zero
 	for _, l := range discounts {
-		total = total.MatchPrecision(l.Amount)
-		total = total.Add(l.Amount)
+		total = total.MatchPrecision(l.amount)
+		total = total.Add(l.amount)
 	}
 	return &total
 }

--- a/bill/discounts_test.go
+++ b/bill/discounts_test.go
@@ -9,32 +9,99 @@ import (
 )
 
 func TestDiscountTotals(t *testing.T) {
-	ls := []*Discount{
-		{
-			Reason: "First Discount",
-			Amount: num.MakeAmount(100, 0),
-		},
-		{
-			Reason:  "Second discount",
-			Percent: num.NewPercentage(20, 2),
-		},
-	}
-	zero := num.MakeAmount(0, 2)
-	base := num.MakeAmount(30000, 2)
-	err := calculateDiscounts(zero, base, ls)
-	require.NoError(t, err)
-	sum := calculateDiscountSum(zero, ls)
-	require.NotNil(t, sum)
-	assert.Equal(t, 1, ls[0].Index)
-	assert.Equal(t, 2, ls[1].Index)
-	assert.Equal(t, "160.00", sum.String())
-	assert.Equal(t, "100.00", ls[0].Amount.String())
-	assert.Equal(t, "300.00", ls[1].Base.String())
-	assert.Equal(t, "20%", ls[1].Percent.String())
-	assert.Equal(t, "60.00", ls[1].Amount.String())
+	t.Run("base line", func(t *testing.T) {
+		ls := []*Discount{
+			{
+				Reason: "First Discount",
+				Amount: num.MakeAmount(100, 0),
+			},
+			{
+				Reason:  "Second discount",
+				Percent: num.NewPercentage(20, 2),
+			},
+			{
+				Reason:  "Third discount",
+				Base:    num.NewAmount(20000, 2),
+				Percent: num.NewPercentage(20, 2),
+			},
+		}
+		zero := num.MakeAmount(0, 2)
+		base := num.MakeAmount(30000, 2)
+		err := calculateDiscounts(ls, base, zero)
+		require.NoError(t, err)
+		sum := calculateDiscountSum(ls, zero)
+		require.NotNil(t, sum)
+		assert.Equal(t, 1, ls[0].Index)
+		assert.Nil(t, ls[0].Base)
+		assert.Equal(t, 2, ls[1].Index)
+		assert.Equal(t, "200.00", sum.String())
+		assert.Equal(t, "100.00", ls[0].Amount.String())
+		assert.Nil(t, ls[1].Base)
+		assert.Equal(t, "20%", ls[1].Percent.String())
+		assert.Equal(t, "60.00", ls[1].Amount.String())
+		assert.Equal(t, "200.00", ls[2].Base.String())
+		assert.Equal(t, "40.00", ls[2].Amount.String())
 
-	ls = []*Discount{}
-	require.NoError(t, calculateDiscounts(zero, base, ls))
-	sum = calculateDiscountSum(zero, ls)
-	assert.Nil(t, sum)
+		ls = []*Discount{}
+		require.NoError(t, calculateDiscounts(ls, base, zero))
+		sum = calculateDiscountSum(ls, zero)
+		assert.Nil(t, sum)
+	})
+
+	t.Run("with precision", func(t *testing.T) {
+		ls := []*Discount{
+			{
+				Reason: "First Discount",
+				Amount: num.MakeAmount(50, 0),
+			},
+			{
+				Reason:  "Second discount",
+				Percent: num.NewPercentage(20, 2),
+			},
+		}
+		zero := num.MakeAmount(0, 2)
+		base := num.MakeAmount(30844212, 6)
+		err := calculateDiscounts(ls, base, zero)
+		require.NoError(t, err)
+		sum := calculateDiscountSum(ls, zero)
+		require.NotNil(t, sum)
+		assert.Equal(t, "6.17", ls[1].Amount.String())
+		assert.Equal(t, "56.168842", sum.String())
+	})
+
+	t.Run("with fixed base", func(t *testing.T) {
+		ls := []*Discount{
+			{
+				Reason:  "Discount",
+				Base:    num.NewAmount(5012, 2),
+				Percent: num.NewPercentage(20, 2),
+			},
+		}
+		zero := num.MakeAmount(0, 2)
+		base := num.MakeAmount(30844212, 6)
+		err := calculateDiscounts(ls, base, zero)
+		require.NoError(t, err)
+		sum := calculateDiscountSum(ls, zero)
+		require.NotNil(t, sum)
+		assert.Equal(t, "10.02", ls[0].Amount.String())
+		assert.Equal(t, "10.02", sum.String())
+	})
+
+	t.Run("with fixed base high precision", func(t *testing.T) {
+		ls := []*Discount{
+			{
+				Reason:  "Discount",
+				Base:    num.NewAmount(501234, 4),
+				Percent: num.NewPercentage(20, 2),
+			},
+		}
+		zero := num.MakeAmount(0, 2)
+		base := num.MakeAmount(30844212, 6)
+		err := calculateDiscounts(ls, base, zero)
+		require.NoError(t, err)
+		sum := calculateDiscountSum(ls, zero)
+		require.NotNil(t, sum)
+		assert.Equal(t, "10.0247", ls[0].Amount.String())
+		assert.Equal(t, "10.0247", sum.String())
+	})
 }

--- a/bill/discounts_test.go
+++ b/bill/discounts_test.go
@@ -27,8 +27,7 @@ func TestDiscountTotals(t *testing.T) {
 		}
 		zero := num.MakeAmount(0, 2)
 		base := num.MakeAmount(30000, 2)
-		err := calculateDiscounts(ls, base, zero)
-		require.NoError(t, err)
+		calculateDiscounts(ls, base, zero)
 		sum := calculateDiscountSum(ls, zero)
 		require.NotNil(t, sum)
 		assert.Equal(t, 1, ls[0].Index)
@@ -43,7 +42,7 @@ func TestDiscountTotals(t *testing.T) {
 		assert.Equal(t, "40.00", ls[2].Amount.String())
 
 		ls = []*Discount{}
-		require.NoError(t, calculateDiscounts(ls, base, zero))
+		calculateDiscounts(ls, base, zero)
 		sum = calculateDiscountSum(ls, zero)
 		assert.Nil(t, sum)
 	})
@@ -61,8 +60,7 @@ func TestDiscountTotals(t *testing.T) {
 		}
 		zero := num.MakeAmount(0, 2)
 		base := num.MakeAmount(30844212, 6)
-		err := calculateDiscounts(ls, base, zero)
-		require.NoError(t, err)
+		calculateDiscounts(ls, base, zero)
 		sum := calculateDiscountSum(ls, zero)
 		require.NotNil(t, sum)
 		assert.Equal(t, "6.17", ls[1].Amount.String())
@@ -79,8 +77,7 @@ func TestDiscountTotals(t *testing.T) {
 		}
 		zero := num.MakeAmount(0, 2)
 		base := num.MakeAmount(30844212, 6)
-		err := calculateDiscounts(ls, base, zero)
-		require.NoError(t, err)
+		calculateDiscounts(ls, base, zero)
 		sum := calculateDiscountSum(ls, zero)
 		require.NotNil(t, sum)
 		assert.Equal(t, "10.02", ls[0].Amount.String())
@@ -97,8 +94,7 @@ func TestDiscountTotals(t *testing.T) {
 		}
 		zero := num.MakeAmount(0, 2)
 		base := num.MakeAmount(30844212, 6)
-		err := calculateDiscounts(ls, base, zero)
-		require.NoError(t, err)
+		calculateDiscounts(ls, base, zero)
 		sum := calculateDiscountSum(ls, zero)
 		require.NotNil(t, sum)
 		assert.Equal(t, "10.0247", ls[0].Amount.String())

--- a/bill/invoice.go
+++ b/bill/invoice.go
@@ -446,19 +446,19 @@ func (inv *Invoice) calculateWithRegime(r *tax.Regime) error {
 	t.Total = t.Sum
 
 	// Discount Lines
-	if err := calculateDiscounts(zero, t.Sum, inv.Discounts); err != nil {
+	if err := calculateDiscounts(inv.Discounts, t.Sum, zero); err != nil {
 		return validation.Errors{"discounts": err}
 	}
-	if discounts := calculateDiscountSum(zero, inv.Discounts); discounts != nil {
+	if discounts := calculateDiscountSum(inv.Discounts, zero); discounts != nil {
 		t.Discount = discounts
 		t.Total = t.Total.Subtract(*discounts)
 	}
 
 	// Charge Lines
-	if err := calculateCharges(zero, t.Sum, inv.Charges); err != nil {
+	if err := calculateCharges(inv.Charges, t.Sum, zero); err != nil {
 		return validation.Errors{"charges": err}
 	}
-	if charges := calculateChargeSum(zero, inv.Charges); charges != nil {
+	if charges := calculateChargeSum(inv.Charges, zero); charges != nil {
 		t.Charge = charges
 		t.Total = t.Total.Add(*charges)
 	}

--- a/bill/invoice.go
+++ b/bill/invoice.go
@@ -446,18 +446,14 @@ func (inv *Invoice) calculateWithRegime(r *tax.Regime) error {
 	t.Total = t.Sum
 
 	// Discount Lines
-	if err := calculateDiscounts(inv.Discounts, t.Sum, zero); err != nil {
-		return validation.Errors{"discounts": err}
-	}
+	calculateDiscounts(inv.Discounts, t.Sum, zero)
 	if discounts := calculateDiscountSum(inv.Discounts, zero); discounts != nil {
 		t.Discount = discounts
 		t.Total = t.Total.Subtract(*discounts)
 	}
 
 	// Charge Lines
-	if err := calculateCharges(inv.Charges, t.Sum, zero); err != nil {
-		return validation.Errors{"charges": err}
-	}
+	calculateCharges(inv.Charges, t.Sum, zero)
 	if charges := calculateChargeSum(inv.Charges, zero); charges != nil {
 		t.Charge = charges
 		t.Total = t.Total.Add(*charges)

--- a/uuid/validation_test.go
+++ b/uuid/validation_test.go
@@ -214,7 +214,7 @@ func TestUUIDValidation(t *testing.T) {
 
 	id = uuid.V6()
 	assert.NoError(t, validation.Validate(id, uuid.Within(1*time.Second)))
-	time.Sleep(12 * time.Millisecond)
+	time.Sleep(20 * time.Millisecond)
 	err = validation.Validate(id, uuid.Within(10*time.Millisecond))
 	assert.ErrorContains(t, err, "timestamp is outside acceptable range")
 


### PR DESCRIPTION
* Discount and charge lines with `percent` now use either `base` *or* the sum of lines.
* Precision in discount and charge lines maintained, but presented with currency accuracy.