### PR TITLE
Exempt rate optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Changed
 
 - Invoice Discounts and Charges will no longer update the `base` property according to the document's sum.
+- Exempt rate in `tax.Combo` no longer required when percent is empty.
 
 ### Fixed
 

--- a/regimes/it/categories.go
+++ b/regimes/it/categories.go
@@ -96,8 +96,8 @@ var categories = []*tax.Category{
 				Key:    tax.RateExempt,
 				Exempt: true,
 				Name: i18n.String{
-					i18n.EN: "None",
-					i18n.IT: "Natura",
+					i18n.EN: "Exempt",
+					i18n.IT: "Esente",
 				},
 				Extensions: []cbc.Key{
 					ExtKeySDINature,

--- a/regimes/pt/tax_categories.go
+++ b/regimes/pt/tax_categories.go
@@ -31,7 +31,9 @@ var taxCategories = []*tax.Category{
 		},
 		Retained:     false,
 		RateRequired: true,
-		Extensions:   []cbc.Key{ExtKeyRegion},
+		Extensions: []cbc.Key{
+			ExtKeyRegion,
+		},
 		Rates: []*tax.Rate{
 			{
 				Key: tax.RateStandard,
@@ -133,7 +135,9 @@ var taxCategories = []*tax.Category{
 				Map: cbc.CodeMap{
 					KeyATTaxCode: TaxCodeExempt,
 				},
-				Extensions: []cbc.Key{ExtKeyExemptionCode},
+				Extensions: []cbc.Key{
+					ExtKeyExemptionCode,
+				},
 			},
 		},
 	},

--- a/tax/set.go
+++ b/tax/set.go
@@ -45,7 +45,10 @@ func (c *Combo) ValidateWithContext(ctx context.Context) error {
 	cat := r.Category(c.Category)
 	rate := r.Rate(c.Category, c.Rate)
 	err := validation.ValidateStructWithContext(ctx, c,
-		validation.Field(&c.Category, validation.Required, r.InCategories()),
+		validation.Field(&c.Category,
+			validation.Required,
+			r.InCategories(),
+		),
 		validation.Field(&c.Rate,
 			validation.When(
 				(cat != nil && cat.RateRequired),
@@ -62,13 +65,12 @@ func (c *Combo) ValidateWithContext(ctx context.Context) error {
 				validation.Skip,
 			),
 		),
-		validation.Field(&c.Percent,
-			validation.When(rate == nil, validation.Required),
-			validation.When(rate != nil && rate.Exempt, validation.Nil),
-			validation.When(rate != nil && !rate.Exempt, validation.Required),
-		),
+		validation.Field(&c.Percent),
 		validation.Field(&c.Surcharge,
-			validation.When(c.Percent == nil, validation.Nil.Error("required with percent")),
+			validation.When(
+				c.Percent == nil,
+				validation.Nil.Error("required with percent"),
+			),
 		),
 	)
 	if err != nil {

--- a/tax/set_test.go
+++ b/tax/set_test.go
@@ -73,7 +73,7 @@ func TestSetValidation(t *testing.T) {
 					Category: "VAT",
 				},
 			},
-			err: "percent: cannot be blank",
+			err: nil, // no percent implies exempt
 		},
 		{
 			desc: "missing percentage with exempt rate",
@@ -114,7 +114,7 @@ func TestSetValidation(t *testing.T) {
 					Surcharge: num.NewPercentage(5, 3),
 				},
 			},
-			err: "percent: cannot be blank; surcharge: required with percent.",
+			err: "surcharge: required with percent.",
 		},
 		{
 			desc: "exempt rate with reason",
@@ -122,6 +122,18 @@ func TestSetValidation(t *testing.T) {
 				{
 					Category: "VAT",
 					Rate:     tax.RateExempt,
+					Ext: tax.Extensions{
+						es.ExtKeyTBAIExemption: "E1",
+					},
+				},
+			},
+			err: nil,
+		},
+		{
+			desc: "exempt, no rate, with extension",
+			set: tax.Set{
+				{
+					Category: "VAT",
 					Ext: tax.Extensions{
 						es.ExtKeyTBAIExemption: "E1",
 					},


### PR DESCRIPTION
* Exempt rate in `tax.Combo` is no longer required when no `percent` is included.