### PR TITLE
Add `at-hash` stamp to store the AT's hash of an invoice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [vX.XX.X] - 2024-XX-XX
 
+### Added
+
+- PT: `at-hash` stamp to store the AT's hash of an invoice
+
 ## [v0.79.0] - 2024-06-05
 
 ### Added

--- a/regimes/pt/pt.go
+++ b/regimes/pt/pt.go
@@ -26,6 +26,7 @@ const (
 const (
 	StampProviderATATCUD cbc.Key = "at-atcud"
 	StampProviderATQR    cbc.Key = "at-qr"
+	StampProviderATHash  cbc.Key = "at-hash"
 )
 
 // New instantiates a new Portugal regime for the given zone.


### PR DESCRIPTION
* Supersedes #302 