### PR TITLE
bill.Invoice: convert into a new currency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to GOBL will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/). See also the [GOBL versions](https://docs.gobl.org/overview/versions) documentation site for more details.
 
+## [vX.XX.X] - XXXX-XX-XX
+
+### Added
+
+- `bill.Invoice`: experimental `ConvertInto` method to convert the invoice's amounts from one currency into another.
+
 ## [v0.81.0] - 2024-07-17
 
 ### Added

--- a/bill/charges.go
+++ b/bill/charges.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/currency"
 	"github.com/invopop/gobl/num"
 	"github.com/invopop/gobl/tax"
 	"github.com/invopop/gobl/uuid"
@@ -97,6 +98,13 @@ func (m *Charge) removeIncludedTaxes(cat cbc.Code) *Charge {
 	}
 	m2 := *m
 	m2.Amount = m2.Amount.Upscale(accuracy).Remove(*rate.Percent)
+	return &m2
+}
+
+func (m *Charge) convertInto(ex *currency.ExchangeRate) *Charge {
+	accuracy := defaultCurrencyConversionAccuracy
+	m2 := *m
+	m2.Amount = m2.Amount.Upscale(accuracy).Multiply(ex.Amount)
 	return &m2
 }
 

--- a/bill/discounts.go
+++ b/bill/discounts.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/currency"
 	"github.com/invopop/gobl/num"
 	"github.com/invopop/gobl/tax"
 	"github.com/invopop/gobl/uuid"
@@ -98,6 +99,13 @@ func (m *Discount) removeIncludedTaxes(cat cbc.Code) *Discount {
 	}
 	m2 := *m
 	m2.Amount = m2.Amount.Upscale(accuracy).Remove(*rate.Percent)
+	return &m2
+}
+
+func (m *Discount) convertInto(ex *currency.ExchangeRate) *Discount {
+	accuracy := defaultCurrencyConversionAccuracy
+	m2 := *m
+	m2.Amount = m2.Amount.Upscale(accuracy).Multiply(ex.Amount)
 	return &m2
 }
 

--- a/bill/invoice.go
+++ b/bill/invoice.go
@@ -25,7 +25,8 @@ const (
 )
 
 const (
-	defaultTaxRemovalAccuracy uint32 = 2
+	defaultTaxRemovalAccuracy         uint32 = 2
+	defaultCurrencyConversionAccuracy uint32 = 2
 )
 
 const (

--- a/bill/invoice_convert.go
+++ b/bill/invoice_convert.go
@@ -1,0 +1,121 @@
+package bill
+
+import (
+	"fmt"
+
+	"github.com/invopop/gobl/currency"
+	"github.com/invopop/gobl/pay"
+)
+
+// ConvertInto will use the defined exchange rates in the invoice to convert all the prices
+// into the given currency.
+//
+// The intent of this method is help convert the invoice amounts when the destination is
+// unable or unwilling to handle the current currency. This is typically the case
+// with tax related reports or declarations.
+//
+// The method will return a new invoice with all the amounts converted into the given
+// currency or an error if the conversion is not possible.
+//
+// Conversion is done by first exchanging the lowest common amounts to the destination
+// currency, then recalculating the totals.
+func (inv *Invoice) ConvertInto(cur currency.Code) (*Invoice, error) {
+	// Calculate ensures that all the totals and amounts have been prepared
+	// so we can make assumptions about the data that will be available,
+	// including the original currency!
+	if err := inv.Calculate(); err != nil {
+		return nil, err
+	}
+
+	if inv.Currency == cur {
+		return inv, nil
+	}
+	ex := currency.MatchExchangeRate(inv.ExchangeRates, inv.Currency, cur)
+	if ex == nil {
+		return nil, fmt.Errorf("no exchange rate defined for '%v' to '%v'", inv.Currency, cur)
+	}
+
+	i2 := *inv
+	i2.Totals = new(Totals)
+	i2.Lines = inv.converLines(ex)
+	i2.Discounts = inv.convertDiscounts(ex)
+	i2.Charges = inv.convertCharges(ex)
+	i2.Outlays = inv.convertOutlays(ex)
+	i2.Payment = inv.convertPayment(ex)
+	i2.Currency = cur
+
+	if err := i2.Calculate(); err != nil {
+		return nil, err
+	}
+
+	return &i2, nil
+}
+
+func (inv *Invoice) converLines(ex *currency.ExchangeRate) []*Line {
+	if len(inv.Lines) == 0 {
+		return nil
+	}
+	lines := make([]*Line, len(inv.Lines))
+	for i, l := range inv.Lines {
+		lines[i] = l.convertInto(ex)
+	}
+	return lines
+}
+
+func (inv *Invoice) convertDiscounts(ex *currency.ExchangeRate) []*Discount {
+	if len(inv.Discounts) == 0 {
+		return nil
+	}
+	discounts := make([]*Discount, len(inv.Discounts))
+	for i, d := range inv.Discounts {
+		discounts[i] = d.convertInto(ex)
+	}
+	return discounts
+}
+
+func (inv *Invoice) convertCharges(ex *currency.ExchangeRate) []*Charge {
+	if len(inv.Charges) == 0 {
+		return nil
+	}
+	charges := make([]*Charge, len(inv.Charges))
+	for i, c := range inv.Charges {
+		charges[i] = c.convertInto(ex)
+	}
+	return charges
+}
+
+func (inv *Invoice) convertOutlays(ex *currency.ExchangeRate) []*Outlay {
+	if len(inv.Outlays) == 0 {
+		return nil
+	}
+	outlays := make([]*Outlay, len(inv.Outlays))
+	for i, o := range inv.Outlays {
+		o2 := *o
+		o2.Amount = o2.Amount.
+			Upscale(defaultCurrencyConversionAccuracy).
+			Multiply(ex.Amount).
+			Downscale(defaultCurrencyConversionAccuracy)
+		outlays[i] = &o2
+	}
+	return outlays
+}
+
+func (inv *Invoice) convertPayment(ex *currency.ExchangeRate) *Payment {
+	if inv.Payment == nil {
+		return nil
+	}
+	p2 := *inv.Payment
+	if len(inv.Payment.Advances) == 0 {
+		return &p2
+	}
+	p2.Advances = make([]*pay.Advance, len(inv.Payment.Advances))
+	for i, a := range inv.Payment.Advances {
+		a2 := *a
+		a2.Amount = a2.Amount.
+			Upscale(defaultCurrencyConversionAccuracy).
+			Multiply(ex.Amount).
+			Downscale(defaultCurrencyConversionAccuracy)
+		p2.Advances[i] = &a2
+	}
+	return &p2
+}

--- a/bill/invoice_convert_test.go
+++ b/bill/invoice_convert_test.go
@@ -1,0 +1,127 @@
+package bill_test
+
+import (
+	"testing"
+
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/cal"
+	"github.com/invopop/gobl/currency"
+	"github.com/invopop/gobl/l10n"
+	"github.com/invopop/gobl/num"
+	"github.com/invopop/gobl/org"
+	"github.com/invopop/gobl/pay"
+	"github.com/invopop/gobl/tax"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInvoiceConvertInto(t *testing.T) {
+	t.Run("simple conversion", func(t *testing.T) {
+		lines := []*bill.Line{
+			{
+				Quantity: num.MakeAmount(1, 0),
+				Item: &org.Item{
+					Name:  "Test Item",
+					Price: num.MakeAmount(12050, 2),
+				},
+				Taxes: tax.Set{
+					{
+						Category: "VAT",
+						Rate:     tax.RateStandard,
+					},
+				},
+			},
+		}
+		inv := baseInvoice(t, lines...)
+		_, err := inv.ConvertInto(currency.USD)
+		assert.ErrorContains(t, err, "no exchange rate defined for 'EUR' to 'USD'")
+
+		inv.ExchangeRates = append(inv.ExchangeRates, &currency.ExchangeRate{
+			From:   currency.EUR,
+			To:     currency.USD,
+			Amount: num.MakeAmount(112, 2),
+		})
+
+		i2, err := inv.ConvertInto(currency.USD)
+		assert.NoError(t, err)
+		require.NotNil(t, i2)
+		assert.Equal(t, "134.96", i2.Totals.Payable.String())
+	})
+
+	t.Run("complex example", func(t *testing.T) {
+		i := &bill.Invoice{
+			Code: "123TEST",
+			ExchangeRates: []*currency.ExchangeRate{
+				{
+					From:   currency.EUR,
+					To:     currency.USD,
+					Amount: num.MakeAmount(112, 2),
+				},
+			},
+			Tax: &bill.Tax{
+				PricesInclude: tax.CategoryVAT,
+			},
+			Supplier: &org.Party{
+				TaxID: &tax.Identity{
+					Country: l10n.ES,
+					Code:    "B98602642",
+				},
+			},
+			Customer: &org.Party{
+				TaxID: &tax.Identity{
+					Country: l10n.ES,
+					Code:    "54387763P",
+				},
+			},
+			IssueDate: cal.MakeDate(2022, 6, 13),
+			Lines: []*bill.Line{
+				{
+					Quantity: num.MakeAmount(10, 0),
+					Item: &org.Item{
+						Name:  "Test Item",
+						Price: num.MakeAmount(10000, 2),
+					},
+					Taxes: tax.Set{
+						{
+							Category: "VAT",
+							Rate:     "standard",
+						},
+					},
+					Discounts: []*bill.LineDiscount{
+						{
+							Reason: "Testing",
+							Amount: num.MakeAmount(10000, 2),
+						},
+					},
+					Charges: []*bill.LineCharge{
+						{
+							Reason: "Testing Charge",
+							Amount: num.MakeAmount(5000, 2),
+						},
+					},
+				},
+			},
+			Outlays: []*bill.Outlay{
+				{
+					Description: "Something paid in advance",
+					Amount:      num.MakeAmount(1000, 2),
+				},
+			},
+			Payment: &bill.Payment{
+				Advances: []*pay.Advance{
+					{
+						Description: "Test Advance",
+						Amount:      num.MakeAmount(25000, 2),
+					},
+				},
+			},
+		}
+		i2, err := i.ConvertInto(currency.USD)
+		assert.NoError(t, err)
+		require.NotNil(t, i2)
+		assert.Equal(t, "11.20", i2.Outlays[0].Amount.String())
+		assert.Equal(t, "280.00", i2.Payment.Advances[0].Amount.String())
+		assert.Equal(t, i2.Totals.Sum.String(), "1064.00")
+		assert.Equal(t, i2.Totals.Due.String(), "795.20")
+	})
+}

--- a/bill/line.go
+++ b/bill/line.go
@@ -204,6 +204,58 @@ func (l *Line) removeIncludedTaxes(cat cbc.Code) *Line {
 	return &l2
 }
 
+func (l *Line) convertInto(ex *currency.ExchangeRate) *Line {
+	accuracy := defaultCurrencyConversionAccuracy
+
+	l2 := *l
+	l2i := *l.Item
+
+	// Add current price to the list of alternative prices
+	l2i.AltPrices = append(l2i.AltPrices, &currency.Amount{
+		Currency: l2i.Currency,
+		Value:    l2i.Price,
+	})
+
+	// Use alt price if available
+	altFound := false
+	for i, ap := range l2i.AltPrices {
+		if ap.Currency == ex.To {
+			l2i.Price = ap.Value
+			// remove this alt price from the list
+			l2i.AltPrices = append(l2i.AltPrices[:i], l2i.AltPrices[i+1:]...)
+			altFound = true
+			break
+		}
+	}
+	if !altFound {
+		// Perform exchange
+		l2i.Price = l2i.Price.Upscale(accuracy).Multiply(ex.Amount)
+	}
+
+	if len(l2.Discounts) > 0 {
+		rows := make([]*LineDiscount, len(l2.Discounts))
+		for i, v := range l.Discounts {
+			d := *v
+			d.Amount = d.Amount.Upscale(accuracy).Multiply(ex.Amount)
+			rows[i] = &d
+		}
+		l2.Discounts = rows
+	}
+
+	if len(l2.Charges) > 0 {
+		rows := make([]*LineCharge, len(l2.Charges))
+		for i, v := range l.Charges {
+			d := *v
+			d.Amount = d.Amount.Upscale(accuracy).Multiply(ex.Amount)
+			rows[i] = &d
+		}
+		l2.Charges = rows
+	}
+
+	l2.Item = &l2i
+	return &l2
+}
+
 func calculateLines(r *tax.Regime, lines []*Line, cur currency.Code, rates []*currency.ExchangeRate) error {
 	for i, l := range lines {
 		l.Index = i + 1


### PR DESCRIPTION
* Adding support for a new `bill.Invoice` `ConvertInto(cur)` method that will convert all of an invoices amounts into the defined currency.