### PR TITLE
DE: freelance tax number support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Added
 
 - `bill.Invoice`: experimental `ConvertInto` method to convert the invoice's amounts from one currency into another.
+- DE: support for "de-tax-number" identity which can be used instead of regular tax ID code inside Germany.
+- DE: "simplified" tax tag removes requirement for supplier tax identification.
 
 ## [v0.81.0] - 2024-07-17
 

--- a/cbc/code.go
+++ b/cbc/code.go
@@ -12,8 +12,8 @@ import (
 // at. We use "code" instead of "id", to reenforce the fact that codes should
 // be more easily set and used by humans within definitions than IDs or UUIDs.
 // Codes are standardised so that when validated they must contain between
-// 1 and 24 inclusive upper-case letters or numbers with optional periods (`.`)
-// or dashes (`-`) to separate blocks.
+// 1 and 24 inclusive upper-case letters or numbers with optional periods (`.`),
+// dashes (`-`), or forward slashes (`/`) to separate blocks.
 type Code string
 
 // CodeMap is a map of keys to specific codes, useful to determine regime specific
@@ -22,7 +22,7 @@ type CodeMap map[Key]Code
 
 // Basic code constants.
 var (
-	CodePattern          = `^[A-Z0-9]+([\.\-]?[A-Z0-9]+)*$`
+	CodePattern          = `^[A-Z0-9]+([\.\-\/]?[A-Z0-9]+)*$`
 	CodeMinLength uint64 = 1
 	CodeMaxLength uint64 = 24
 )

--- a/cbc/code_test.go
+++ b/cbc/code_test.go
@@ -45,6 +45,10 @@ func TestCode_Validate(t *testing.T) {
 			code: cbc.Code("B3-1-2"),
 		},
 		{
+			name: "valid with slash",
+			code: cbc.Code("B3/12"),
+		},
+		{
 			name: "empty",
 			code: cbc.Code(""),
 		},

--- a/cbc/code_test.go
+++ b/cbc/code_test.go
@@ -78,6 +78,11 @@ func TestCode_Validate(t *testing.T) {
 			wantErr: "valid format",
 		},
 		{
+			name:    "multiple symbols",
+			code:    cbc.Code("AB/.CD"),
+			wantErr: "valid format",
+		},
+		{
 			name:    "too long",
 			code:    cbc.Code("12345678901234567890ABCDE"),
 			wantErr: "length must be between",

--- a/regimes/de/de.go
+++ b/regimes/de/de.go
@@ -7,6 +7,7 @@ import (
 	"github.com/invopop/gobl/currency"
 	"github.com/invopop/gobl/i18n"
 	"github.com/invopop/gobl/l10n"
+	"github.com/invopop/gobl/org"
 	"github.com/invopop/gobl/regimes/common"
 	"github.com/invopop/gobl/tax"
 )
@@ -29,6 +30,7 @@ func New() *tax.Regime {
 		Scenarios: []*tax.ScenarioSet{
 			invoiceScenarios,
 		},
+		IdentityKeys: identityKeyDefinitions, // identities.go
 		Corrections: []*tax.CorrectionDefinition{
 			{
 				Schema: bill.ShortSchemaInvoice,
@@ -58,6 +60,8 @@ func Validate(doc interface{}) error {
 // Calculate will attempt to clean the object passed to it.
 func Calculate(doc interface{}) error {
 	switch obj := doc.(type) {
+	case *org.Identity:
+		return normalizeIdentity(obj)
 	case *tax.Identity:
 		return common.NormalizeTaxIdentity(obj)
 	}

--- a/regimes/de/examples/invoice-de-de-stnr.yaml
+++ b/regimes/de/examples/invoice-de-de-stnr.yaml
@@ -1,0 +1,49 @@
+$schema: "https://gobl.org/draft-0/bill/invoice"
+uuid: "3aea7b56-59d8-4beb-90bd-f8f280d852a0"
+currency: "EUR"
+issue_date: "2022-02-01"
+series: "SAMPLE"
+code: "001"
+
+supplier:
+  tax_id:
+    country: "DE"
+  identities:
+    - key: "de-tax-number"
+      code: "92/345/67894"
+  name: "Provide One GmbH"
+  emails:
+    - addr: "billing@example.com"
+  addresses:
+    - num: "16"
+      street: "Dietmar-Hopp-Allee"
+      locality: "Walldorf"
+      code: "69190"
+      country: "DE"
+
+customer:
+  tax_id:
+    country: "DE"
+    code: "282741168"
+  name: "Sample Consumer"
+  emails:
+    - addr: "email@sample.com"
+  addresses:
+    - num: "25"
+      street: "Werner-Heisenberg-Allee"
+      locality: "München"
+      code: "80939"
+      country": "DE"
+
+lines:
+  - quantity: 20
+    item:
+      name: "Development services"
+      price: "90.00"
+      unit: "h"
+    discounts:
+      - percent: "10%"
+        reason: "Special discount"
+    taxes:
+      - cat: VAT
+        rate: standard

--- a/regimes/de/examples/invoice-de-simplified.yaml
+++ b/regimes/de/examples/invoice-de-simplified.yaml
@@ -1,0 +1,34 @@
+$schema: "https://gobl.org/draft-0/bill/invoice"
+uuid: "3aea7b56-59d8-4beb-90bd-f8f280d852a0"
+currency: "EUR"
+issue_date: "2022-02-01"
+series: "SAMPLE"
+code: "001"
+tax:
+  tags:
+    - "simplified"
+supplier:
+  tax_id:
+    country: "DE"
+  name: "Provide One GmbH"
+  emails:
+    - addr: "billing@example.com"
+  addresses:
+    - num: "16"
+      street: "Dietmar-Hopp-Allee"
+      locality: "Walldorf"
+      code: "69190"
+      country: "DE"
+
+lines:
+  - quantity: 20
+    item:
+      name: "Development services"
+      price: "90.00"
+      unit: "h"
+    discounts:
+      - percent: "10%"
+        reason: "Special discount"
+    taxes:
+      - cat: VAT
+        rate: standard

--- a/regimes/de/examples/out/invoice-de-de-stnr.json
+++ b/regimes/de/examples/out/invoice-de-de-stnr.json
@@ -1,0 +1,117 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
+		"dig": {
+			"alg": "sha256",
+			"val": "5debf22de57b209288fd8bed0a41ed1afadc27d9bca798340adb860797c607d8"
+		},
+		"draft": true
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"uuid": "3aea7b56-59d8-4beb-90bd-f8f280d852a0",
+		"type": "standard",
+		"series": "SAMPLE",
+		"code": "001",
+		"issue_date": "2022-02-01",
+		"currency": "EUR",
+		"supplier": {
+			"name": "Provide One GmbH",
+			"tax_id": {
+				"country": "DE"
+			},
+			"identities": [
+				{
+					"key": "de-tax-number",
+					"code": "9234567894"
+				}
+			],
+			"addresses": [
+				{
+					"num": "16",
+					"street": "Dietmar-Hopp-Allee",
+					"locality": "Walldorf",
+					"code": "69190",
+					"country": "DE"
+				}
+			],
+			"emails": [
+				{
+					"addr": "billing@example.com"
+				}
+			]
+		},
+		"customer": {
+			"name": "Sample Consumer",
+			"tax_id": {
+				"country": "DE",
+				"code": "282741168"
+			},
+			"addresses": [
+				{
+					"num": "25",
+					"street": "Werner-Heisenberg-Allee",
+					"locality": "München",
+					"code": "80939"
+				}
+			],
+			"emails": [
+				{
+					"addr": "email@sample.com"
+				}
+			]
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "20",
+				"item": {
+					"name": "Development services",
+					"price": "90.00",
+					"unit": "h"
+				},
+				"sum": "1800.00",
+				"discounts": [
+					{
+						"percent": "10%",
+						"amount": "180.00",
+						"reason": "Special discount"
+					}
+				],
+				"taxes": [
+					{
+						"cat": "VAT",
+						"rate": "standard",
+						"percent": "19%"
+					}
+				],
+				"total": "1620.00"
+			}
+		],
+		"totals": {
+			"sum": "1620.00",
+			"total": "1620.00",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"base": "1620.00",
+								"percent": "19%",
+								"amount": "307.80"
+							}
+						],
+						"amount": "307.80"
+					}
+				],
+				"sum": "307.80"
+			},
+			"tax": "307.80",
+			"total_with_tax": "1927.80",
+			"payable": "1927.80"
+		}
+	}
+}

--- a/regimes/de/examples/out/invoice-de-simplified.json
+++ b/regimes/de/examples/out/invoice-de-simplified.json
@@ -1,0 +1,96 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
+		"dig": {
+			"alg": "sha256",
+			"val": "6b64b5c3a706249f78119114d94f68e151a27b2a8504485352d4ecc547943d5c"
+		},
+		"draft": true
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"uuid": "3aea7b56-59d8-4beb-90bd-f8f280d852a0",
+		"type": "standard",
+		"series": "SAMPLE",
+		"code": "001",
+		"issue_date": "2022-02-01",
+		"currency": "EUR",
+		"tax": {
+			"tags": [
+				"simplified"
+			]
+		},
+		"supplier": {
+			"name": "Provide One GmbH",
+			"tax_id": {
+				"country": "DE"
+			},
+			"addresses": [
+				{
+					"num": "16",
+					"street": "Dietmar-Hopp-Allee",
+					"locality": "Walldorf",
+					"code": "69190",
+					"country": "DE"
+				}
+			],
+			"emails": [
+				{
+					"addr": "billing@example.com"
+				}
+			]
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "20",
+				"item": {
+					"name": "Development services",
+					"price": "90.00",
+					"unit": "h"
+				},
+				"sum": "1800.00",
+				"discounts": [
+					{
+						"percent": "10%",
+						"amount": "180.00",
+						"reason": "Special discount"
+					}
+				],
+				"taxes": [
+					{
+						"cat": "VAT",
+						"rate": "standard",
+						"percent": "19%"
+					}
+				],
+				"total": "1620.00"
+			}
+		],
+		"totals": {
+			"sum": "1620.00",
+			"total": "1620.00",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"base": "1620.00",
+								"percent": "19%",
+								"amount": "307.80"
+							}
+						],
+						"amount": "307.80"
+					}
+				],
+				"sum": "307.80"
+			},
+			"tax": "307.80",
+			"total_with_tax": "1927.80",
+			"payable": "1927.80"
+		}
+	}
+}

--- a/regimes/de/identities.go
+++ b/regimes/de/identities.go
@@ -1,0 +1,38 @@
+package de
+
+import (
+	"strings"
+
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/i18n"
+	"github.com/invopop/gobl/org"
+	"github.com/invopop/gobl/regimes/common"
+)
+
+const (
+	// IdentityKeyTaxNumber represents the German tax number (Steuernummer) issued to
+	// people that can be included on invoices inside Germany. For international
+	// sales, the registered VAT number (Umsatzsteueridentifikationsnummer) should
+	// be used instead.
+	IdentityKeyTaxNumber cbc.Key = "de-tax-number"
+)
+
+var identityKeyDefinitions = []*cbc.KeyDefinition{
+	{
+		Key: IdentityKeyTaxNumber,
+		Name: i18n.String{
+			i18n.EN: "Tax Number",
+			i18n.DE: "Steuernummer",
+		},
+	},
+}
+
+func normalizeIdentity(id *org.Identity) error {
+	if id == nil || id.Key != IdentityKeyTaxNumber {
+		return nil
+	}
+	code := strings.ToUpper(id.Code.String())
+	code = common.TaxCodeBadCharsRegexp.ReplaceAllString(code, "")
+	id.Code = cbc.Code(code)
+	return nil
+}


### PR DESCRIPTION
* Invoices can now be issued with either a Tax ID Code, *or* the German "Tax Number" identity.
* Simplified Invoices in Germany remove the requirement for the presence of any supplier tax code.