### PR TITLE
Always update document when tags and rate keys present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Invoices in GOBL can now also finally produced for any country in the world, eve
 
 ### Changed
 
+- `bill.Invoice`: `simplified` tag will now always remove the customer.
 - `bill.Invoice`: using the `customer-rates` tag will now automatically copy the customer's country code, if available, to the individual tax combo lines.
 - `tax`: moved `NormalizeIdentity` method from the regimes common package so that it can be applied to all tax IDs, regardless of if they have a regime defined or not.
 - `pt`: VAT rate key is now optional if `pt-saft-tax-rate` is provided.
@@ -29,6 +30,9 @@ Invoices in GOBL can now also finally produced for any country in the world, eve
 - `mx`: scenarios will now copy the document and relation types to the tax extensions.
 - `cbc`: consolidated "keys" and "codes" lists from key definitions into a single values array.
 - `gr`: switched to use the new `round-then-sum` calculation method
+- `tax.Combo`: rates when defined will always update the combo.
+- `bill.Invoice`: tax tags will always cause scenarios to update the document.
+- `es`: support for `facturae` tag which will correct set local extensions instead of using scenario summary codes.
 
 ### Added
 

--- a/bill/invoice.go
+++ b/bill/invoice.go
@@ -158,10 +158,6 @@ func (inv *Invoice) ValidateWithContext(ctx context.Context) error {
 		),
 		validation.Field(&inv.Customer,
 			validation.By(validateInvoiceCustomer),
-			validation.When(
-				inv.hasTagSimplified(),
-				validation.Nil,
-			),
 		),
 		validation.Field(&inv.Lines,
 			validation.Required,
@@ -208,10 +204,6 @@ func validateInvoiceCustomer(value any) error {
 			),
 		),
 	)
-}
-
-func (inv *Invoice) hasTagSimplified() bool {
-	return inv.Tax != nil && tax.TagSimplified.In(inv.Tax.Tags...)
 }
 
 func partyHasTaxIDCode(party *org.Party) bool {
@@ -288,9 +280,6 @@ func (inv *Invoice) Calculate() error {
 	}
 	if err := inv.Supplier.Calculate(); err != nil {
 		return fmt.Errorf("supplier: %w", err)
-	}
-	if inv.hasTagSimplified() {
-		inv.Customer = nil
 	}
 	if inv.Customer != nil {
 		if err := inv.Customer.Calculate(); err != nil {

--- a/bill/invoice_scenarios.go
+++ b/bill/invoice_scenarios.go
@@ -97,8 +97,9 @@ func (inv *Invoice) prepareScenarios(r *tax.Regime) error {
 		if inv.Tax.Ext == nil {
 			inv.Tax.Ext = make(tax.Extensions)
 		}
-		if inv.Tax.Ext[k] == "" {
-			// only override if not set
+		// Always override if there are tags already present, *or* the extension
+		// is not already set.
+		if len(inv.Tax.Tags) > 0 || inv.Tax.Ext[k] == "" {
 			inv.Tax.Ext[k] = v
 		}
 	}

--- a/bill/invoice_scenarios_test.go
+++ b/bill/invoice_scenarios_test.go
@@ -77,4 +77,37 @@ func TestScenarios(t *testing.T) {
 		assert.Len(t, inv.Tax.Ext, 2)
 		assert.Equal(t, "TD01", inv.Tax.Ext[it.ExtKeySDIDocumentType].String())
 	})
+
+	t.Run("overwrite previous values with tag", func(t *testing.T) {
+		inv := baseInvoiceWithLines(t)
+		inv.Supplier.TaxID = &tax.Identity{
+			Country: "IT",
+			Code:    "12345678903",
+		}
+		inv.Tax = &bill.Tax{
+			Tags: []cbc.Key{"b2g"},
+			Ext: tax.Extensions{
+				it.ExtKeySDIFormat: "XXXX",
+			},
+		}
+		require.NoError(t, inv.Calculate())
+		assert.Len(t, inv.Tax.Ext, 2)
+		assert.Equal(t, "FPA12", inv.Tax.Ext[it.ExtKeySDIFormat].String())
+	})
+
+	t.Run("maintain previous values without tags", func(t *testing.T) {
+		inv := baseInvoiceWithLines(t)
+		inv.Supplier.TaxID = &tax.Identity{
+			Country: "IT",
+			Code:    "12345678903",
+		}
+		inv.Tax = &bill.Tax{
+			Ext: tax.Extensions{
+				it.ExtKeySDIFormat: "XXXX",
+			},
+		}
+		require.NoError(t, inv.Calculate())
+		assert.Len(t, inv.Tax.Ext, 2)
+		assert.Equal(t, "XXXX", inv.Tax.Ext[it.ExtKeySDIFormat].String())
+	})
 }

--- a/bill/invoice_test.go
+++ b/bill/invoice_test.go
@@ -1109,7 +1109,7 @@ func TestValidation(t *testing.T) {
 		}
 		require.NoError(t, inv.Calculate())
 		assert.NoError(t, inv.Validate())
-		assert.Nil(t, inv.Customer)
+		assert.NotNil(t, inv.Customer) // just ignore simplified tag
 	})
 
 	t.Run("customer name and tax ID code", func(t *testing.T) {

--- a/bill/invoice_test.go
+++ b/bill/invoice_test.go
@@ -1089,8 +1089,7 @@ func TestValidation(t *testing.T) {
 	t.Run("supplier name", func(t *testing.T) {
 		inv := baseInvoiceWithLines(t)
 		inv.Supplier.Name = ""
-		inv.Customer.TaxID.Code = "" // simplified
-		inv.Customer.Name = ""       // so this is okay
+		inv.Customer = nil // simplified
 		require.NoError(t, inv.Calculate())
 		err := inv.Validate()
 		assert.ErrorContains(t, err, "supplier: (name: cannot be blank.).")
@@ -1099,36 +1098,43 @@ func TestValidation(t *testing.T) {
 
 	t.Run("simplified", func(t *testing.T) {
 		inv := baseInvoiceWithLines(t)
-		inv.Customer = nil
 		require.NoError(t, inv.Calculate())
-		err := inv.Validate()
-		assert.ErrorContains(t, err, "customer: cannot be blank.")
+		require.NoError(t, inv.Validate())
+		assert.NotNil(t, inv.Customer)
 
 		inv.Tax = &bill.Tax{
 			Tags: []cbc.Key{
 				tax.TagSimplified,
 			},
 		}
+		require.NoError(t, inv.Calculate())
+		assert.NoError(t, inv.Validate())
+		assert.Nil(t, inv.Customer)
+	})
+
+	t.Run("customer name and tax ID code", func(t *testing.T) {
+		inv := baseInvoiceWithLines(t)
+		inv.Supplier.TaxID = &tax.Identity{
+			Country: "GB",
+			Code:    "000472631",
+		}
+		inv.Customer.Name = ""
+		require.NoError(t, inv.Calculate())
+		err := inv.Validate()
+		assert.ErrorContains(t, err, "customer: (name: cannot be blank.)")
+
+		inv.Customer.TaxID = nil
 		require.NoError(t, inv.Calculate())
 		err = inv.Validate()
 		assert.NoError(t, err)
 	})
 
-	t.Run("simplified without customer name", func(t *testing.T) {
-		inv := baseInvoiceWithLines(t)
-		inv.Tax = &bill.Tax{
-			Tags: []cbc.Key{
-				tax.TagSimplified,
-			},
-		}
-		inv.Customer.TaxID = nil
-		require.NoError(t, inv.Calculate())
-		err := inv.Validate()
-		assert.NoError(t, err)
-	})
-
 	t.Run("implied simplified without customer tax ID", func(t *testing.T) {
 		inv := baseInvoiceWithLines(t)
+		inv.Supplier.TaxID = &tax.Identity{
+			Country: "GB",
+			Code:    "000472631",
+		}
 		inv.Customer.TaxID = nil
 		inv.Customer.Name = ""
 		inv.Customer.Emails = append(inv.Customer.Emails, &org.Email{

--- a/bill/tax.go
+++ b/bill/tax.go
@@ -19,7 +19,9 @@ type Tax struct {
 	// tax.
 	PricesInclude cbc.Code `json:"prices_include,omitempty" jsonschema:"title=Prices Include"`
 
-	// Special tax tags that apply to this invoice according to local requirements.
+	// Tags are used to help identify specific tax scenarios or requirements that will
+	// apply changes to the contents of the invoice. Tags by design should always be optional,
+	// it should always be possible to build a valid invoice without any tags.
 	Tags []cbc.Key `json:"tags,omitempty" jsonschema:"title=Tags"`
 
 	// Additional extensions that are applied to the invoice as a whole as opposed to specific

--- a/cmd/gobl/testdata/Test_build_recalculate
+++ b/cmd/gobl/testdata/Test_build_recalculate
@@ -4,7 +4,7 @@
 		"uuid": "9d8eafd5-77be-11ec-b485-5405db9a3e49",
 		"dig": {
 			"alg": "sha256",
-			"val": "4083f1035c6ab38357f7758b2adac7a127b3b0227a486be7910bb2c91f9d40ee"
+			"val": "92e85433ebd91b6087e3fd2e16a82eb5fabc6e9577ade23e54d25e4d5741f7cd"
 		}
 	},
 	"doc": {
@@ -122,7 +122,7 @@
 					{
 						"cat": "VAT",
 						"rate": "zero",
-						"percent": "0%"
+						"percent": "0.0%"
 					}
 				],
 				"total": "172.50"
@@ -175,7 +175,7 @@
 							{
 								"key": "zero",
 								"base": "172.50",
-								"percent": "0%",
+								"percent": "0.0%",
 								"amount": "0.00"
 							}
 						],

--- a/cmd/gobl/testdata/Test_build_success
+++ b/cmd/gobl/testdata/Test_build_success
@@ -4,7 +4,7 @@
 		"uuid": "9d8eafd5-77be-11ec-b485-5405db9a3e49",
 		"dig": {
 			"alg": "sha256",
-			"val": "4083f1035c6ab38357f7758b2adac7a127b3b0227a486be7910bb2c91f9d40ee"
+			"val": "92e85433ebd91b6087e3fd2e16a82eb5fabc6e9577ade23e54d25e4d5741f7cd"
 		}
 	},
 	"doc": {
@@ -122,7 +122,7 @@
 					{
 						"cat": "VAT",
 						"rate": "zero",
-						"percent": "0%"
+						"percent": "0.0%"
 					}
 				],
 				"total": "172.50"
@@ -175,7 +175,7 @@
 							{
 								"key": "zero",
 								"base": "172.50",
-								"percent": "0%",
+								"percent": "0.0%",
 								"amount": "0.00"
 							}
 						],

--- a/cmd/gobl/testdata/Test_build_valid_file
+++ b/cmd/gobl/testdata/Test_build_valid_file
@@ -4,7 +4,7 @@
 		"uuid": "9d8eafd5-77be-11ec-b485-5405db9a3e49",
 		"dig": {
 			"alg": "sha256",
-			"val": "6574da6531cf058c7fcf89e36dff6061cf716553200d31dc468d50f88385f1f9"
+			"val": "72b55e21121adfb245c89d9aaa55b3c37d4bb4150c1f8592dced4b75b680a868"
 		}
 	},
 	"doc": {
@@ -122,7 +122,7 @@
 					{
 						"cat": "VAT",
 						"rate": "zero",
-						"percent": "0%"
+						"percent": "0.0%"
 					}
 				],
 				"total": "172.50"
@@ -175,7 +175,7 @@
 							{
 								"key": "zero",
 								"base": "172.50",
-								"percent": "0%",
+								"percent": "0.0%",
 								"amount": "0.00"
 							}
 						],

--- a/cmd/gobl/testdata/Test_sign_recalculate
+++ b/cmd/gobl/testdata/Test_sign_recalculate
@@ -4,7 +4,7 @@
 		"uuid": "9d8eafd5-77be-11ec-b485-5405db9a3e49",
 		"dig": {
 			"alg": "sha256",
-			"val": "4083f1035c6ab38357f7758b2adac7a127b3b0227a486be7910bb2c91f9d40ee"
+			"val": "92e85433ebd91b6087e3fd2e16a82eb5fabc6e9577ade23e54d25e4d5741f7cd"
 		}
 	},
 	"doc": {
@@ -122,7 +122,7 @@
 					{
 						"cat": "VAT",
 						"rate": "zero",
-						"percent": "0%"
+						"percent": "0.0%"
 					}
 				],
 				"total": "172.50"
@@ -175,7 +175,7 @@
 							{
 								"key": "zero",
 								"base": "172.50",
-								"percent": "0%",
+								"percent": "0.0%",
 								"amount": "0.00"
 							}
 						],

--- a/cmd/gobl/testdata/Test_sign_success
+++ b/cmd/gobl/testdata/Test_sign_success
@@ -4,7 +4,7 @@
 		"uuid": "9d8eafd5-77be-11ec-b485-5405db9a3e49",
 		"dig": {
 			"alg": "sha256",
-			"val": "4083f1035c6ab38357f7758b2adac7a127b3b0227a486be7910bb2c91f9d40ee"
+			"val": "92e85433ebd91b6087e3fd2e16a82eb5fabc6e9577ade23e54d25e4d5741f7cd"
 		}
 	},
 	"doc": {
@@ -122,7 +122,7 @@
 					{
 						"cat": "VAT",
 						"rate": "zero",
-						"percent": "0%"
+						"percent": "0.0%"
 					}
 				],
 				"total": "172.50"
@@ -175,7 +175,7 @@
 							{
 								"key": "zero",
 								"base": "172.50",
-								"percent": "0%",
+								"percent": "0.0%",
 								"amount": "0.00"
 							}
 						],

--- a/cmd/gobl/testdata/Test_sign_valid_file
+++ b/cmd/gobl/testdata/Test_sign_valid_file
@@ -4,7 +4,7 @@
 		"uuid": "9d8eafd5-77be-11ec-b485-5405db9a3e49",
 		"dig": {
 			"alg": "sha256",
-			"val": "6574da6531cf058c7fcf89e36dff6061cf716553200d31dc468d50f88385f1f9"
+			"val": "72b55e21121adfb245c89d9aaa55b3c37d4bb4150c1f8592dced4b75b680a868"
 		}
 	},
 	"doc": {
@@ -122,7 +122,7 @@
 					{
 						"cat": "VAT",
 						"rate": "zero",
-						"percent": "0%"
+						"percent": "0.0%"
 					}
 				],
 				"total": "172.50"
@@ -175,7 +175,7 @@
 							{
 								"key": "zero",
 								"base": "172.50",
-								"percent": "0%",
+								"percent": "0.0%",
 								"amount": "0.00"
 							}
 						],

--- a/regimes/co/examples/out/simplified-id.json
+++ b/regimes/co/examples/out/simplified-id.json
@@ -4,7 +4,7 @@
 		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
 		"dig": {
 			"alg": "sha256",
-			"val": "20992f6285d38abe96eebf992d8910cb623df19a6e64ed468a9ccd0c340a0f61"
+			"val": "51e3501eeaabd57c06aade3b7b13c05e18c2de278c3ee25822c6ba681b73e77f"
 		},
 		"draft": true
 	},
@@ -30,15 +30,6 @@
 			"ext": {
 				"co-dian-municipality": "11001"
 			}
-		},
-		"customer": {
-			"name": "Test end user",
-			"identities": [
-				{
-					"key": "co-id-card",
-					"code": "1234567890"
-				}
-			]
 		},
 		"lines": [
 			{

--- a/regimes/co/examples/out/simplified-id.json
+++ b/regimes/co/examples/out/simplified-id.json
@@ -4,7 +4,7 @@
 		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
 		"dig": {
 			"alg": "sha256",
-			"val": "51e3501eeaabd57c06aade3b7b13c05e18c2de278c3ee25822c6ba681b73e77f"
+			"val": "20992f6285d38abe96eebf992d8910cb623df19a6e64ed468a9ccd0c340a0f61"
 		},
 		"draft": true
 	},
@@ -30,6 +30,15 @@
 			"ext": {
 				"co-dian-municipality": "11001"
 			}
+		},
+		"customer": {
+			"name": "Test end user",
+			"identities": [
+				{
+					"key": "co-id-card",
+					"code": "1234567890"
+				}
+			]
 		},
 		"lines": [
 			{

--- a/regimes/es/es.go
+++ b/regimes/es/es.go
@@ -55,13 +55,11 @@ const (
 
 // Custom keys used typically in meta information.
 const (
-	KeyAddressCode                 cbc.Key = "post"
-	KeyFacturaE                    cbc.Key = "facturae"
-	KeyFacturaETaxTypeCode         cbc.Key = "facturae-tax-type-code"
-	KeyFacturaEInvoiceDocumentType cbc.Key = "facturae-invoice-document-type"
-	KeyFacturaEInvoiceClass        cbc.Key = "facturae-invoice-class"
-	KeyTicketBAICausaExencion      cbc.Key = "ticketbai-causa-exencion"
-	KeyTicketBAIIDType             cbc.Key = "ticketbai-id-type"
+	KeyAddressCode            cbc.Key = "post"
+	KeyFacturaE               cbc.Key = "facturae"
+	KeyFacturaETaxTypeCode    cbc.Key = "facturae-tax-type-code"
+	KeyTicketBAICausaExencion cbc.Key = "ticketbai-causa-exencion"
+	KeyTicketBAIIDType        cbc.Key = "ticketbai-id-type"
 )
 
 // New provides the Spanish tax regime definition

--- a/regimes/es/examples/invoice-es-es.yaml
+++ b/regimes/es/examples/invoice-es-es.yaml
@@ -4,6 +4,10 @@ currency: "EUR"
 issue_date: "2022-02-01"
 code: "SAMPLE-001"
 
+tax:
+  tags:
+    - "facturae"
+
 supplier:
   tax_id:
     country: "ES"

--- a/regimes/es/examples/out/invoice-es-es.json
+++ b/regimes/es/examples/out/invoice-es-es.json
@@ -4,7 +4,7 @@
 		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
 		"dig": {
 			"alg": "sha256",
-			"val": "23cd4a6e2d2d49558d11106ca64cd6de7446fa779362e26e4e7789b1128b0b5b"
+			"val": "e7456b345749a48978afef1eaaa39c2effa7bb4e265c371478a21503f008a600"
 		},
 		"draft": true
 	},
@@ -15,6 +15,15 @@
 		"code": "SAMPLE-001",
 		"issue_date": "2022-02-01",
 		"currency": "EUR",
+		"tax": {
+			"tags": [
+				"facturae"
+			],
+			"ext": {
+				"es-facturae-doc-type": "FC",
+				"es-facturae-invoice-class": "OO"
+			}
+		},
 		"supplier": {
 			"name": "Provide One S.L.",
 			"tax_id": {

--- a/regimes/es/extensions.go
+++ b/regimes/es/extensions.go
@@ -8,13 +8,96 @@ import (
 
 // Spanish regime extension codes for local electronic formats.
 const (
-	ExtKeyTBAIExemption      = "es-tbai-exemption"
-	ExtKeyTBAIProduct        = "es-tbai-product"
-	ExtKeyTBAICorrection     = "es-tbai-correction"
-	ExtKeyFacturaECorrection = "es-facturae-correction"
+	ExtKeyTBAIExemption        = "es-tbai-exemption"
+	ExtKeyTBAIProduct          = "es-tbai-product"
+	ExtKeyTBAICorrection       = "es-tbai-correction"
+	ExtKeyFacturaECorrection   = "es-facturae-correction"
+	ExtKeyFacturaEDocType      = "es-facturae-doc-type"
+	ExtKeyFacturaEInvoiceClass = "es-facturae-invoice-class"
 )
 
 var extensionKeys = []*cbc.KeyDefinition{
+	{
+		Key: ExtKeyFacturaEDocType,
+		Name: i18n.String{
+			i18n.EN: "FacturaE: Document Type",
+			i18n.ES: "FacturaE: Tipo de Documento",
+		},
+		Values: []*cbc.ValueDefinition{
+			{
+				Value: "FC",
+				Name: i18n.String{
+					i18n.EN: "Commercial Invoice",
+					i18n.ES: "Factura Comercial",
+				},
+			},
+			{
+				Value: "FA",
+				Name: i18n.String{
+					i18n.EN: "Simplified Invoice",
+					i18n.ES: "Factura Simplificada",
+				},
+			},
+			{
+				Value: "AF",
+				Name: i18n.String{
+					i18n.EN: "Self-billed Invoice",
+					i18n.ES: "Auto-Factura",
+				},
+			},
+		},
+	},
+	{
+		Key: ExtKeyFacturaEInvoiceClass,
+		Name: i18n.String{
+			i18n.EN: "FacturaE: Invoice Class",
+			i18n.ES: "FacturaE: Clase de Factura",
+		},
+		Values: []*cbc.ValueDefinition{
+			{
+				Value: "OO",
+				Name: i18n.String{
+					i18n.EN: "Original",
+					i18n.ES: "Original",
+				},
+			},
+			{
+				Value: "OR",
+				Name: i18n.String{
+					i18n.EN: "Corrective Original",
+					i18n.ES: "Original Rectificativa",
+				},
+			},
+			{
+				Value: "OC",
+				Name: i18n.String{
+					i18n.EN: "Summary Original",
+					i18n.ES: "Original Recapitulativa",
+				},
+			},
+			{
+				Value: "CO",
+				Name: i18n.String{
+					i18n.EN: "Copy of the Original",
+					i18n.ES: "Duplicado Original",
+				},
+			},
+			{
+				Value: "CR",
+				Name: i18n.String{
+					i18n.EN: "Copy of the Corrective",
+					i18n.ES: "Duplicado Rectificativa",
+				},
+			},
+			{
+				Value: "CC",
+				Name: i18n.String{
+					i18n.EN: "Copy of the Summary",
+					i18n.ES: "Duplicado Recapitulativa",
+				},
+			},
+		},
+	},
 	{
 		Key: ExtKeyFacturaECorrection,
 		Name: i18n.String{

--- a/regimes/es/scenarios.go
+++ b/regimes/es/scenarios.go
@@ -124,20 +124,27 @@ var invoiceScenarios = &tax.ScenarioSet{
 				bill.InvoiceTypeCreditNote,
 				bill.InvoiceTypeDebitNote,
 			},
-			Codes: cbc.CodeMap{
-				KeyFacturaEInvoiceDocumentType: "FC", // default
+			Tags: []cbc.Key{TagFacturaE},
+			Ext: tax.Extensions{
+				ExtKeyFacturaEDocType: "FC", // default
 			},
 		},
 		{
-			Tags: []cbc.Key{tax.TagSimplified},
-			Codes: cbc.CodeMap{
-				KeyFacturaEInvoiceDocumentType: "FA",
+			Tags: []cbc.Key{
+				TagFacturaE,
+				tax.TagSimplified,
+			},
+			Ext: tax.Extensions{
+				ExtKeyFacturaEDocType: "FA",
 			},
 		},
 		{
-			Tags: []cbc.Key{tax.TagSelfBilled},
-			Codes: cbc.CodeMap{
-				KeyFacturaEInvoiceDocumentType: "AF",
+			Tags: []cbc.Key{
+				TagFacturaE,
+				tax.TagSelfBilled,
+			},
+			Ext: tax.Extensions{
+				ExtKeyFacturaEDocType: "AF",
 			},
 		},
 		// ** Invoice Class **
@@ -145,8 +152,9 @@ var invoiceScenarios = &tax.ScenarioSet{
 			Types: []cbc.Key{
 				bill.InvoiceTypeStandard,
 			},
-			Codes: cbc.CodeMap{
-				KeyFacturaEInvoiceClass: "OO", // Original Invoice
+			Tags: []cbc.Key{TagFacturaE},
+			Ext: tax.Extensions{
+				ExtKeyFacturaEInvoiceClass: "OO", // Original Invoice
 			},
 		},
 		{
@@ -155,35 +163,36 @@ var invoiceScenarios = &tax.ScenarioSet{
 				bill.InvoiceTypeCreditNote,
 				bill.InvoiceTypeDebitNote,
 			},
-			Codes: cbc.CodeMap{
-				KeyFacturaEInvoiceClass: "OR", // Corrective
+			Tags: []cbc.Key{TagFacturaE},
+			Ext: tax.Extensions{
+				ExtKeyFacturaEInvoiceClass: "OR", // Corrective
 			},
 		},
 		{
-			Tags: []cbc.Key{TagSummary},
-			Codes: cbc.CodeMap{
-				KeyFacturaEInvoiceClass: "OC", // Summary
+			Tags: []cbc.Key{TagFacturaE, TagSummary},
+			Ext: tax.Extensions{
+				ExtKeyFacturaEInvoiceClass: "OC", // Summary
 			},
 		},
 		{
-			Tags:  []cbc.Key{TagCopy},
 			Types: []cbc.Key{bill.InvoiceTypeStandard},
-			Codes: cbc.CodeMap{
-				KeyFacturaEInvoiceClass: "CO", // Copy of the original
+			Tags:  []cbc.Key{TagFacturaE, TagCopy},
+			Ext: tax.Extensions{
+				ExtKeyFacturaEInvoiceClass: "CO", // Copy of the original
 			},
 		},
 		{
-			Tags:  []cbc.Key{TagCopy},
 			Types: []cbc.Key{bill.InvoiceTypeCorrective},
-			Codes: cbc.CodeMap{
-				KeyFacturaEInvoiceClass: "CR", // Copy of the corrective
+			Tags:  []cbc.Key{TagFacturaE, TagCopy},
+			Ext: tax.Extensions{
+				ExtKeyFacturaEInvoiceClass: "CR", // Copy of the corrective
 			},
 		},
 		{
-			Tags:  []cbc.Key{TagCopy, TagSummary},
 			Types: []cbc.Key{bill.InvoiceTypeStandard},
-			Codes: cbc.CodeMap{
-				KeyFacturaEInvoiceClass: "CC", // Copy of the summary
+			Tags:  []cbc.Key{TagFacturaE, TagCopy, TagSummary},
+			Ext: tax.Extensions{
+				ExtKeyFacturaEInvoiceClass: "CC", // Copy of the summary
 			},
 		},
 		// ** Special Messages **

--- a/regimes/es/scenarios_test.go
+++ b/regimes/es/scenarios_test.go
@@ -107,13 +107,13 @@ func testInvoiceSimplified(t *testing.T) *bill.Invoice {
 func TestInvoiceDocumentScenarios(t *testing.T) {
 	i := testInvoiceStandard(t)
 	require.NoError(t, i.Calculate())
-	assert.Len(t, i.Notes, 0)
+	assert.Empty(t, i.Tax.Ext[es.ExtKeyFacturaEDocType])
 
-	// TODO: refactor this to have the scenarios add extensions,
-	// or perform these checks in the conversion module.
-	ss := i.ScenarioSummary() //nolint:staticcheck
-	assert.Contains(t, ss.Codes, es.KeyFacturaEInvoiceDocumentType)
-	assert.Equal(t, ss.Codes[es.KeyFacturaEInvoiceDocumentType], cbc.Code("FC"))
+	i = testInvoiceStandard(t)
+	i.Tax.Tags = []cbc.Key{"facturae"}
+	require.NoError(t, i.Calculate())
+	assert.Len(t, i.Notes, 0)
+	assert.Equal(t, i.Tax.Ext[es.ExtKeyFacturaEDocType].String(), "FC")
 
 	i = testInvoiceStandard(t)
 	i.Tax.Tags = []cbc.Key{es.TagTravelAgency}

--- a/regimes/mx/invoice_test.go
+++ b/regimes/mx/invoice_test.go
@@ -110,7 +110,8 @@ func TestCustomerValidation(t *testing.T) {
 	assertValidationError(t, inv, "customer: (tax_id: cannot be blank.)")
 
 	inv.Customer = nil
-	assertValidationError(t, inv, "customer: cannot be blank")
+	require.NoError(t, inv.Calculate())
+	assert.NoError(t, inv.Validate())
 }
 
 func TestLineValidation(t *testing.T) {

--- a/tax/combo.go
+++ b/tax/combo.go
@@ -165,11 +165,6 @@ func (c *Combo) prepareRate(category *Category, tags []cbc.Key, date cal.Date) e
 		return nil
 	}
 
-	if c.Percent != nil {
-		// If the percent was already set, don't attempt to replace it.
-		return nil
-	}
-
 	// if there are no rate values, don't attempt to prepare anything else.
 	if len(rate.Values) == 0 {
 		return nil

--- a/tax/totals_calculator_test.go
+++ b/tax/totals_calculator_test.go
@@ -415,9 +415,8 @@ func TestTotalBySumCalculate(t *testing.T) {
 				Sum: num.MakeAmount(2100, 2),
 			},
 		},
-
 		{
-			desc: "with VAT percents defined, maintain rate",
+			desc: "with VAT percents defined, replace for rate",
 			lines: []tax.TaxableLine{
 				&taxableLine{
 					taxes: tax.Set{
@@ -440,14 +439,14 @@ func TestTotalBySumCalculate(t *testing.T) {
 							{
 								Key:     tax.RateStandard,
 								Base:    num.MakeAmount(10000, 2),
-								Percent: num.NewPercentage(20, 2),
-								Amount:  num.MakeAmount(2000, 2),
+								Percent: num.NewPercentage(210, 3),
+								Amount:  num.MakeAmount(2100, 2),
 							},
 						},
-						Amount: num.MakeAmount(2000, 2),
+						Amount: num.MakeAmount(2100, 2),
 					},
 				},
-				Sum: num.MakeAmount(2000, 2),
+				Sum: num.MakeAmount(2100, 2),
 			},
 		},
 		{


### PR DESCRIPTION
* If a scenario can be determined from the tags, always update the document.
* No tags, do not modify.
* If a tax combo has a rate key, always update.
* ES: FacturaE moved from Codes to Extensions and using the `facturae` tag.
* Simplified tag no longer required, and is implied from the lack of a customer.