### PR TITLE
More flexible cbc.Code, better normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Finally, the `draft` flag has been removed from the header, and much more emphas
 - `bill.Preceding`: replaced with `org.DocumentRef`.
 - `bill.Invoice`: Ordering now using arrays of `org.DocumentRef`.
 - `bill.Invoice`: `series` and `code` now use `cbc.Code` and normalization instead of the independent invoice code.
+- `cbc`: `Code` now allows spaces, and has normalization method to avoid validation issues.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ Finally, the `draft` flag has been removed from the header, and much more emphas
 - `bill.Preceding`: replaced with `org.DocumentRef`.
 - `bill.Invoice`: Ordering now using arrays of `org.DocumentRef`.
 - `bill.Invoice`: `series` and `code` now use `cbc.Code` and normalization instead of the independent invoice code.
-- `cbc`: `Code` now allows spaces, and has normalization method to avoid validation issues.
+- `cbc`: `Code` now allows spaces, dashes, and lower-case letters. Normalization will remove duplicate symbols.
 
 ### Added
 

--- a/bill/invoice.go
+++ b/bill/invoice.go
@@ -589,12 +589,6 @@ func (inv *Invoice) UnmarshalJSON(data []byte) error {
 // JSONSchemaExtend extends the schema with additional property details
 func (Invoice) JSONSchemaExtend(js *jsonschema.Schema) {
 	props := js.Properties
-	if prop, ok := props.Get("series"); ok {
-		prop.Pattern = cbc.CodePattern
-	}
-	if prop, ok := props.Get("code"); ok {
-		prop.Pattern = cbc.CodePattern
-	}
 	// Extend type list
 	if its, ok := props.Get("type"); ok {
 		its.OneOf = make([]*jsonschema.Schema, len(InvoiceTypes))

--- a/bill/invoice_test.go
+++ b/bill/invoice_test.go
@@ -1052,8 +1052,8 @@ func TestNormalization(t *testing.T) {
 	inv.Series = " bar 2024 "
 	inv.Code = " 123_Test "
 	require.NoError(t, inv.Calculate())
-	assert.Equal(t, cbc.Code("BAR 2024"), inv.Series)
-	assert.Equal(t, cbc.Code("123-TEST"), inv.Code)
+	assert.Equal(t, cbc.Code("bar 2024"), inv.Series)
+	assert.Equal(t, cbc.Code("123_Test"), inv.Code)
 }
 
 func TestValidation(t *testing.T) {

--- a/bill/invoice_test.go
+++ b/bill/invoice_test.go
@@ -1050,9 +1050,9 @@ func TestInvoiceForUnknownRegime(t *testing.T) {
 func TestNormalization(t *testing.T) {
 	inv := baseInvoiceWithLines(t)
 	inv.Series = " bar 2024 "
-	inv.Code = " 123 Test "
+	inv.Code = " 123_Test "
 	require.NoError(t, inv.Calculate())
-	assert.Equal(t, cbc.Code("BAR-2024"), inv.Series)
+	assert.Equal(t, cbc.Code("BAR 2024"), inv.Series)
 	assert.Equal(t, cbc.Code("123-TEST"), inv.Code)
 }
 

--- a/bill/ordering_test.go
+++ b/bill/ordering_test.go
@@ -22,8 +22,8 @@ func TestOrderingNormalize(t *testing.T) {
 		},
 	}
 	o.Normalize(nil)
-	assert.Equal(t, "FOO", o.Code.String())
-	assert.Equal(t, "BAR", o.Projects[0].Code.String())
+	assert.Equal(t, "Foo", o.Code.String())
+	assert.Equal(t, "Bar", o.Projects[0].Code.String())
 	assert.Empty(t, o.Projects[0].Ext)
 }
 

--- a/cbc/code.go
+++ b/cbc/code.go
@@ -13,8 +13,13 @@ import (
 // at. We use "code" instead of "id", to reenforce the fact that codes should
 // be more easily set and used by humans within definitions than IDs or UUIDs.
 // Codes are standardised so that when validated they must contain between
-// 1 and 32 inclusive upper-case letters or numbers with optional periods (`.`),
-// dashes (`-`), forward slashes (`/`), or spaces (` `) to separate blocks.
+// 1 and 32 inclusive english alphabet letters or numbers with optional
+// periods (`.`), dashes (`-`), underscores (`_`), forward slashes (`/`), or
+// spaces (` `) to separate blocks. Each block must only be separated by a
+// single symbol.
+//
+// The objective is to have a code that is easy to read and understand, while
+// still being unique and easy to validate.
 type Code string
 
 // CodeMap is a map of keys to specific codes, useful to determine regime specific
@@ -23,16 +28,15 @@ type CodeMap map[Key]Code
 
 // Basic code constants.
 var (
-	CodePattern              = `^[A-Z0-9]+([\.\-\/ ]?[A-Z0-9]+)*$`
+	CodePattern              = `^[A-Za-z0-9]+([\.\-\/ _]?[A-Za-z0-9]+)*$`
 	CodePatternRegexp        = regexp.MustCompile(CodePattern)
 	CodeMinLength     uint64 = 1
 	CodeMaxLength     uint64 = 32
 )
 
 var (
-	codeSeparatorRegexp    = regexp.MustCompile(`([\.\-\/ ])[^A-Z0-9]+`)
-	codeDashSwapRegexp     = regexp.MustCompile(`_`)
-	codeInvalidCharsRegexp = regexp.MustCompile(`[^A-Z0-9\.\-\/ ]`)
+	codeSeparatorRegexp    = regexp.MustCompile(`([\.\-\/ _])[^A-Za-z0-9]+`)
+	codeInvalidCharsRegexp = regexp.MustCompile(`[^A-Za-z0-9\.\-\/ _]`)
 )
 
 // CodeEmpty is used when no code is defined.
@@ -41,9 +45,8 @@ const CodeEmpty Code = ""
 // NormalizeCode attempts to clean and normalize the provided code so that
 // it matches what we'd expect instead of raising validation errors.
 func NormalizeCode(c Code) Code {
-	code := strings.ToUpper(c.String())
+	code := c.String()
 	code = strings.TrimSpace(code)
-	code = codeDashSwapRegexp.ReplaceAllString(code, "-")
 	code = codeSeparatorRegexp.ReplaceAllString(code, "$1")
 	code = codeInvalidCharsRegexp.ReplaceAllString(code, "")
 	return Code(code)

--- a/cbc/code.go
+++ b/cbc/code.go
@@ -14,7 +14,7 @@ import (
 // be more easily set and used by humans within definitions than IDs or UUIDs.
 // Codes are standardised so that when validated they must contain between
 // 1 and 32 inclusive upper-case letters or numbers with optional periods (`.`),
-// dashes (`-`), or forward slashes (`/`) to separate blocks.
+// dashes (`-`), forward slashes (`/`), or spaces (` `) to separate blocks.
 type Code string
 
 // CodeMap is a map of keys to specific codes, useful to determine regime specific
@@ -23,15 +23,16 @@ type CodeMap map[Key]Code
 
 // Basic code constants.
 var (
-	CodePattern              = `^[A-Z0-9]+([\.\-\/]?[A-Z0-9]+)*$`
+	CodePattern              = `^[A-Z0-9]+([\.\-\/ ]?[A-Z0-9]+)*$`
 	CodePatternRegexp        = regexp.MustCompile(CodePattern)
 	CodeMinLength     uint64 = 1
 	CodeMaxLength     uint64 = 32
 )
 
 var (
-	codeUnderscoreOrSpaceRegexp = regexp.MustCompile(`[_ ]`)
-	codeInvalidCharsRegexp      = regexp.MustCompile(`[^A-Z0-9\.\-\/]`)
+	codeSeparatorRegexp    = regexp.MustCompile(`([\.\-\/ ])[^A-Z0-9]+`)
+	codeDashSwapRegexp     = regexp.MustCompile(`_`)
+	codeInvalidCharsRegexp = regexp.MustCompile(`[^A-Z0-9\.\-\/ ]`)
 )
 
 // CodeEmpty is used when no code is defined.
@@ -42,7 +43,8 @@ const CodeEmpty Code = ""
 func NormalizeCode(c Code) Code {
 	code := strings.ToUpper(c.String())
 	code = strings.TrimSpace(code)
-	code = codeUnderscoreOrSpaceRegexp.ReplaceAllString(code, "-")
+	code = codeDashSwapRegexp.ReplaceAllString(code, "-")
+	code = codeSeparatorRegexp.ReplaceAllString(code, "$1")
 	code = codeInvalidCharsRegexp.ReplaceAllString(code, "")
 	return Code(code)
 }

--- a/cbc/code_test.go
+++ b/cbc/code_test.go
@@ -28,12 +28,12 @@ func TestNormalizeCode(t *testing.T) {
 		{
 			name: "lowercase",
 			code: cbc.Code("foo"),
-			want: cbc.Code("FOO"),
+			want: cbc.Code("foo"),
 		},
 		{
 			name: "mixed case",
 			code: cbc.Code("Foo"),
-			want: cbc.Code("FOO"),
+			want: cbc.Code("Foo"),
 		},
 		{
 			name: "with spaces",
@@ -48,31 +48,31 @@ func TestNormalizeCode(t *testing.T) {
 		{
 			name: "underscore",
 			code: cbc.Code("FOO_BAR"),
-			want: cbc.Code("FOO-BAR"),
+			want: cbc.Code("FOO_BAR"),
 		},
 		{
 			name: "whitespace",
 			code: cbc.Code(" foo-bar1  "),
-			want: cbc.Code("FOO-BAR1"),
+			want: cbc.Code("foo-bar1"),
 		},
 		{
 			name: "invalid chars",
 			code: cbc.Code("f$oo-bar1!"),
-			want: cbc.Code("FOO-BAR1"),
+			want: cbc.Code("foo-bar1"),
 		},
 		{
 			name: "multiple spaces",
 			code: cbc.Code("foo bar dome"),
-			want: cbc.Code("FOO BAR DOME"),
+			want: cbc.Code("foo bar dome"),
 		},
 		{
 			name: "multiple symbols 1",
 			code: cbc.Code("foo- bar-$dome"),
-			want: cbc.Code("FOO-BAR-DOME"),
+			want: cbc.Code("foo-bar-dome"),
 		},
 		{
 			name: "multiple symbols 2",
-			code: cbc.Code("foo  bar--dome"),
+			code: cbc.Code("FOO  BAR--DOME"),
 			want: cbc.Code("FOO BAR-DOME"),
 		},
 	}
@@ -97,6 +97,10 @@ func TestCode_Validate(t *testing.T) {
 		{
 			name: "valid 2",
 			code: cbc.Code("12345678901234567890ABCD"),
+		},
+		{
+			name: "valid with lower",
+			code: cbc.Code("ABC abc/123"),
 		},
 		{
 			name: "valid with dot",
@@ -148,11 +152,6 @@ func TestCode_Validate(t *testing.T) {
 		{
 			name:    "dash at end",
 			code:    cbc.Code("B123-"),
-			wantErr: "valid format",
-		},
-		{
-			name:    "lower case",
-			code:    cbc.Code("ab"),
 			wantErr: "valid format",
 		},
 		{

--- a/cbc/code_test.go
+++ b/cbc/code_test.go
@@ -38,7 +38,7 @@ func TestNormalizeCode(t *testing.T) {
 		{
 			name: "with spaces",
 			code: cbc.Code("FOO BAR"),
-			want: cbc.Code("FOO-BAR"),
+			want: cbc.Code("FOO BAR"),
 		},
 		{
 			name: "empty",
@@ -63,7 +63,17 @@ func TestNormalizeCode(t *testing.T) {
 		{
 			name: "multiple spaces",
 			code: cbc.Code("foo bar dome"),
+			want: cbc.Code("FOO BAR DOME"),
+		},
+		{
+			name: "multiple symbols 1",
+			code: cbc.Code("foo- bar-$dome"),
 			want: cbc.Code("FOO-BAR-DOME"),
+		},
+		{
+			name: "multiple symbols 2",
+			code: cbc.Code("foo  bar--dome"),
+			want: cbc.Code("FOO BAR-DOME"),
 		},
 	}
 	for _, tt := range tests {
@@ -107,6 +117,10 @@ func TestCode_Validate(t *testing.T) {
 		{
 			name: "valid with slash",
 			code: cbc.Code("B3/12"),
+		},
+		{
+			name: "valid with space",
+			code: cbc.Code("FR 12/BX"),
 		},
 		{
 			name: "empty",

--- a/data/addons/gr-mydata-v1.json
+++ b/data/addons/gr-mydata-v1.json
@@ -1058,6 +1058,14 @@
           "type": [
             "standard"
           ],
+          "ext": {
+            "gr-mydata-invoice-type": "2.1"
+          }
+        },
+        {
+          "type": [
+            "standard"
+          ],
           "tags": [
             "goods"
           ],

--- a/data/schemas/bill/invoice.json
+++ b/data/schemas/bill/invoice.json
@@ -236,13 +236,13 @@
         },
         "series": {
           "$ref": "https://gobl.org/draft-0/cbc/code",
-          "pattern": "^[A-Z0-9]+([\\.\\-\\/]?[A-Z0-9]+)*$",
+          "pattern": "^[A-Z0-9]+([\\.\\-\\/ ]?[A-Z0-9]+)*$",
           "title": "Series",
           "description": "Used as a prefix to group codes."
         },
         "code": {
           "$ref": "https://gobl.org/draft-0/cbc/code",
-          "pattern": "^[A-Z0-9]+([\\.\\-\\/]?[A-Z0-9]+)*$",
+          "pattern": "^[A-Z0-9]+([\\.\\-\\/ ]?[A-Z0-9]+)*$",
           "title": "Code",
           "description": "Sequential code used to identify this invoice in tax declarations."
         },

--- a/data/schemas/bill/invoice.json
+++ b/data/schemas/bill/invoice.json
@@ -236,13 +236,11 @@
         },
         "series": {
           "$ref": "https://gobl.org/draft-0/cbc/code",
-          "pattern": "^[A-Z0-9]+([\\.\\-\\/ ]?[A-Z0-9]+)*$",
           "title": "Series",
           "description": "Used as a prefix to group codes."
         },
         "code": {
           "$ref": "https://gobl.org/draft-0/cbc/code",
-          "pattern": "^[A-Z0-9]+([\\.\\-\\/ ]?[A-Z0-9]+)*$",
           "title": "Code",
           "description": "Sequential code used to identify this invoice in tax declarations."
         },

--- a/data/schemas/cbc/code.json
+++ b/data/schemas/cbc/code.json
@@ -7,7 +7,7 @@
       "type": "string",
       "maxLength": 32,
       "minLength": 1,
-      "pattern": "^[A-Z0-9]+([\\.\\-\\/ ]?[A-Z0-9]+)*$",
+      "pattern": "^[A-Za-z0-9]+([\\.\\-\\/ _]?[A-Za-z0-9]+)*$",
       "title": "Code",
       "description": "Alphanumerical text identifier with upper-case letters, no whitespace, nor symbols."
     }

--- a/data/schemas/cbc/code.json
+++ b/data/schemas/cbc/code.json
@@ -7,7 +7,7 @@
       "type": "string",
       "maxLength": 32,
       "minLength": 1,
-      "pattern": "^[A-Z0-9]+([\\.\\-\\/]?[A-Z0-9]+)*$",
+      "pattern": "^[A-Z0-9]+([\\.\\-\\/ ]?[A-Z0-9]+)*$",
       "title": "Code",
       "description": "Alphanumerical text identifier with upper-case letters, no whitespace, nor symbols."
     }

--- a/data/schemas/org/document-ref.json
+++ b/data/schemas/org/document-ref.json
@@ -23,13 +23,11 @@
         },
         "series": {
           "$ref": "https://gobl.org/draft-0/cbc/code",
-          "pattern": "^[A-Z0-9]+([\\.\\-\\/]?[A-Z0-9]+)*$",
           "title": "Series",
           "description": "Series the referenced document belongs to."
         },
         "code": {
           "$ref": "https://gobl.org/draft-0/cbc/code",
-          "pattern": "^[A-Z0-9]+([\\.\\-\\/]?[A-Z0-9]+)*$",
           "title": "Code",
           "description": "Source document's code or other identifier."
         },

--- a/data/schemas/tax/identity.json
+++ b/data/schemas/tax/identity.json
@@ -12,6 +12,7 @@
         },
         "code": {
           "$ref": "https://gobl.org/draft-0/cbc/code",
+          "pattern": "^[A-Z0-9]+$",
           "title": "Code",
           "description": "Normalized code shown on the original identity document."
         },

--- a/org/document_ref.go
+++ b/org/document_ref.go
@@ -8,7 +8,6 @@ import (
 	"github.com/invopop/gobl/head"
 	"github.com/invopop/gobl/tax"
 	"github.com/invopop/gobl/uuid"
-	"github.com/invopop/jsonschema"
 	"github.com/invopop/validation"
 	"github.com/invopop/validation/is"
 )
@@ -78,15 +77,4 @@ func (dr *DocumentRef) ValidateWithContext(ctx context.Context) error {
 		validation.Field(&dr.Ext),
 		validation.Field(&dr.Meta),
 	)
-}
-
-// JSONSchemaExtend extends the schema with additional property details
-func (DocumentRef) JSONSchemaExtend(schema *jsonschema.Schema) {
-	props := schema.Properties
-	if prop, ok := props.Get("series"); ok {
-		prop.Pattern = cbc.CodePattern
-	}
-	if prop, ok := props.Get("code"); ok {
-		prop.Pattern = cbc.CodePattern
-	}
 }

--- a/org/document_ref_test.go
+++ b/org/document_ref_test.go
@@ -26,6 +26,6 @@ func TestDocumentNormalize(t *testing.T) {
 		},
 	}
 	dr.Normalize(nil)
-	assert.Equal(t, "FOO", dr.Code.String())
+	assert.Equal(t, "Foo", dr.Code.String())
 	assert.Empty(t, dr.Ext)
 }

--- a/org/identity.go
+++ b/org/identity.go
@@ -6,9 +6,19 @@ import (
 	"strings"
 
 	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/l10n"
 	"github.com/invopop/gobl/tax"
 	"github.com/invopop/gobl/uuid"
 	"github.com/invopop/validation"
+)
+
+// Default or common identity keys that may be used to identify a person or company.
+const (
+	IdentityKeyPassport cbc.Key = "passport"
+	IdentifyKeyNational cbc.Key = "national"
+	IdentityKeyForeign  cbc.Key = "foreign"
+	IdentityKeyResident cbc.Key = "resident"
+	IdentityKeyOther    cbc.Key = "other"
 )
 
 // Identity is used to define a code for a specific context.
@@ -16,6 +26,8 @@ type Identity struct {
 	uuid.Identify
 	// Optional label useful for non-standard identities to give a bit more context.
 	Label string `json:"label,omitempty" jsonschema:"title=Label"`
+	// Country from which the identity was issued.
+	Country l10n.ISOCountryCode `json:"country,omitempty" jsonschema:"title=Country"`
 	// Uniquely classify this identity using a key instead of a code.
 	Key cbc.Key `json:"key,omitempty" jsonschema:"title=Key"`
 	// The type of Code being represented and usually specific for
@@ -37,6 +49,7 @@ func (i *Identity) Validate() error {
 func (i *Identity) ValidateWithContext(ctx context.Context) error {
 	return tax.ValidateStructWithContext(ctx, i,
 		validation.Field(&i.Label),
+		validation.Field(&i.Country),
 		validation.Field(&i.Key),
 		validation.Field(&i.Type,
 			validation.When(i.Key != "",

--- a/regimes/es/identities.go
+++ b/regimes/es/identities.go
@@ -3,41 +3,33 @@ package es
 import (
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/i18n"
-)
-
-// Spain recognises a certain set of identity types specifically that may be mapped
-// to local keys.
-const (
-	IdentityKeyPassport  cbc.Key = "es-passport"
-	IdentityKeyForeignID cbc.Key = "es-foreign-id"
-	IdentityKeyResident  cbc.Key = "es-resident"
-	IdentityKeyOther     cbc.Key = "es-other"
+	"github.com/invopop/gobl/org"
 )
 
 var identityKeyDefinitions = []*cbc.KeyDefinition{
 	{
-		Key: IdentityKeyPassport,
+		Key: org.IdentityKeyPassport,
 		Name: i18n.String{
 			i18n.EN: "Passport",
 			i18n.ES: "Pasaporte",
 		},
 	},
 	{
-		Key: IdentityKeyForeignID,
+		Key: org.IdentityKeyForeign,
 		Name: i18n.String{
 			i18n.EN: "National ID Card or similar from a foreign country",
 			i18n.ES: "Documento oficial de identificación expedido por el país o territorio de residencia",
 		},
 	},
 	{
-		Key: IdentityKeyResident,
+		Key: org.IdentityKeyResident,
 		Name: i18n.String{
 			i18n.EN: "Residential permit",
 			i18n.ES: "Certificado de residencia",
 		},
 	},
 	{
-		Key: IdentityKeyOther,
+		Key: org.IdentityKeyOther,
 		Name: i18n.String{
 			i18n.EN: "An other type of source not listed",
 			i18n.ES: "Otro documento probatorio",

--- a/tax/extensions_test.go
+++ b/tax/extensions_test.go
@@ -42,12 +42,12 @@ func TestExtValue(t *testing.T) {
 	ev = tax.ExtValue("testing")
 	assert.Equal(t, "testing", ev.String())
 	assert.Equal(t, cbc.Key("testing"), ev.Key())
-	assert.Equal(t, cbc.CodeEmpty, ev.Code())
+	assert.Equal(t, cbc.Code("testing"), ev.Code())
 
-	ev = tax.ExtValue("A string")
+	ev = tax.ExtValue("A $tring")
 	assert.Equal(t, cbc.CodeEmpty, ev.Code())
 	assert.Equal(t, cbc.KeyEmpty, ev.Key())
-	assert.Equal(t, "A string", ev.String())
+	assert.Equal(t, "A $tring", ev.String())
 }
 
 func TestExtValidation(t *testing.T) {

--- a/tax/identity.go
+++ b/tax/identity.go
@@ -44,6 +44,12 @@ type Identity struct {
 }
 
 var (
+	// IdentityCodePattern is the regular expression pattern used to validate tax identity codes.
+	IdentityCodePattern = `^[A-Z0-9]+$`
+
+	// IdentityCodePatternRegexp is the regular expression used to validate tax identity codes.
+	IdentityCodePatternRegexp = regexp.MustCompile(IdentityCodePattern)
+
 	// ErrIdentityCodeInvalid is returned when the tax identity code is not valid.
 	ErrIdentityCodeInvalid = errors.New("invalid tax identity code")
 
@@ -111,7 +117,7 @@ func (id *Identity) Normalize() {
 func (id *Identity) Validate() error {
 	err := validation.ValidateStruct(id,
 		validation.Field(&id.Country, validation.Required),
-		validation.Field(&id.Code),
+		validation.Field(&id.Code, validation.Match(IdentityCodePatternRegexp)),
 		validation.Field(&id.Zone, validation.Empty),
 		validation.Field(&id.Type),
 	)
@@ -140,6 +146,9 @@ func (v validateTaxID) Validate(value interface{}) error {
 
 // JSONSchemaExtend adds extra details to the schema.
 func (Identity) JSONSchemaExtend(js *jsonschema.Schema) {
+	if cp, ok := js.Properties.Get("code"); ok {
+		cp.Pattern = IdentityCodePattern
+	}
 	js.Extras = map[string]any{
 		schema.Recommended: []string{
 			"code",


### PR DESCRIPTION
* Finally allowing spaces, underscores, and lower-case letters inside `cbc.Code` given the usage with invoice series and code.
* Normalization will now clean multiple separator symbols to use the first symbol found, which is the "essence" of Codes.