### PR TITLE
PT: Updating reduced rate for PT-MA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to GOBL will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/). See also the [GOBL versions](https://docs.gobl.org/overview/versions) documentation site for more details.
 
+## [unreleased]
+
+### Updated
+- `pt`: reduced rate category for PT-MA was updated to reflect latest value of 4%
+
 ## [v0.200.1]
 
 ### Fixed

--- a/data/regimes/pt.json
+++ b/data/regimes/pt.json
@@ -197,6 +197,13 @@
               "ext": {
                 "pt-region": "PT-MA"
               },
+              "since": "2024-10-01",
+              "percent": "4.0%"
+            },
+            {
+              "ext": {
+                "pt-region": "PT-MA"
+              },
               "since": "2011-01-01",
               "percent": "5.0%"
             },

--- a/regimes/pt/examples/invoice-madeira-reduced.yaml
+++ b/regimes/pt/examples/invoice-madeira-reduced.yaml
@@ -1,0 +1,37 @@
+$schema: https://gobl.org/draft-0/bill/invoice
+$addons: ["pt-saft-v1"]
+uuid: "3aea7b56-59d8-4beb-90bd-f8f280d852a0"
+type: standard
+currency: EUR
+issue_date: "2024-10-02"
+supplier:
+  uuid: 9de7584f-ea5c-42a7-b159-5e4c6a280a5c
+  tax_id:
+    country: PT
+    code: "545259045"
+  name: Hotelzinho
+  addresses:
+    - street: Rua do Madeira
+      code: 1000-000
+      locality: Madeira
+customer:
+  name: Maria Santos Silva
+lines:
+  - quantity: 1
+    item:
+      name: Noite em quarto duplo
+      price: 100.00
+    taxes:
+      - cat: VAT
+        rate: reduced
+        ext:
+          pt-region: "PT-MA"
+  - quantity: 2
+    item:
+      name: Noite em quarto triplo
+      price: 120.00
+    taxes:
+      - cat: VAT
+        rate: reduced
+        ext:
+          pt-region: "PT-MA"

--- a/regimes/pt/examples/out/invoice-madeira-reduced.json
+++ b/regimes/pt/examples/out/invoice-madeira-reduced.json
@@ -1,0 +1,117 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
+		"dig": {
+			"alg": "sha256",
+			"val": "f725862208b860d8ff924cfb6ff523e189b7fffc26262a19d259d9cebbc69e22"
+		}
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"$regime": "PT",
+		"$addons": [
+			"pt-saft-v1"
+		],
+		"uuid": "3aea7b56-59d8-4beb-90bd-f8f280d852a0",
+		"type": "standard",
+		"code": "",
+		"issue_date": "2024-10-02",
+		"currency": "EUR",
+		"tax": {
+			"ext": {
+				"pt-saft-invoice-type": "FT"
+			}
+		},
+		"supplier": {
+			"uuid": "9de7584f-ea5c-42a7-b159-5e4c6a280a5c",
+			"name": "Hotelzinho",
+			"tax_id": {
+				"country": "PT",
+				"code": "545259045"
+			},
+			"addresses": [
+				{
+					"street": "Rua do Madeira",
+					"locality": "Madeira",
+					"code": "1000-000"
+				}
+			]
+		},
+		"customer": {
+			"name": "Maria Santos Silva"
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "1",
+				"item": {
+					"name": "Noite em quarto duplo",
+					"price": "100.00"
+				},
+				"sum": "100.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"rate": "reduced",
+						"percent": "4.0%",
+						"ext": {
+							"pt-region": "PT-MA",
+							"pt-saft-tax-rate": "RED"
+						}
+					}
+				],
+				"total": "100.00"
+			},
+			{
+				"i": 2,
+				"quantity": "2",
+				"item": {
+					"name": "Noite em quarto triplo",
+					"price": "120.00"
+				},
+				"sum": "240.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"rate": "reduced",
+						"percent": "4.0%",
+						"ext": {
+							"pt-region": "PT-MA",
+							"pt-saft-tax-rate": "RED"
+						}
+					}
+				],
+				"total": "240.00"
+			}
+		],
+		"totals": {
+			"sum": "340.00",
+			"total": "340.00",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "reduced",
+								"ext": {
+									"pt-region": "PT-MA",
+									"pt-saft-tax-rate": "RED"
+								},
+								"base": "340.00",
+								"percent": "4.0%",
+								"amount": "13.60"
+							}
+						],
+						"amount": "13.60"
+					}
+				],
+				"sum": "13.60"
+			},
+			"tax": "13.60",
+			"total_with_tax": "353.60",
+			"payable": "353.60"
+		}
+	}
+}

--- a/regimes/pt/tax_categories.go
+++ b/regimes/pt/tax_categories.go
@@ -93,6 +93,13 @@ var taxCategories = []*tax.CategoryDef{
 						Ext: tax.Extensions{
 							ExtKeyRegion: "PT-MA",
 						},
+						Since: cal.NewDate(2024, 10, 1),
+						Percent: num.MakePercentage(40, 3),
+					},
+					{
+						Ext: tax.Extensions{
+							ExtKeyRegion: "PT-MA",
+						},
 						Since:   cal.NewDate(2011, 1, 1),
 						Percent: num.MakePercentage(50, 3),
 					},


### PR DESCRIPTION
Updated reduced VAT rate for Madeira [from 5% to 4%](https://invoicexpress.com/nova-taxa-reduzida-iva-madeira/). 

Tax categories ordering is not validated for categories with extensions. From testing the example and checking the code my understanding is that the most current version of a tax rate should go first.