### PR TITLE
Set proper regime when alternative code is given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 - `bill.Invoice` - remove empty taxes instances.
 - `tax.Identity` - support Calculate method to normalize IDs.
+- `tax.Regime` - properly set regime when alternative codes is given.
 
 ## [v0.202.0]
 

--- a/tax/regime.go
+++ b/tax/regime.go
@@ -26,11 +26,12 @@ func (r Regime) GetRegime() l10n.TaxCountryCode {
 // that the regime is actually defined. Missing regimes will silently replace
 // the current regime with an empty value.
 func (r *Regime) SetRegime(country l10n.TaxCountryCode) {
-	if Regimes().For(country.Code()) == nil {
+	rd := Regimes().For(country.Code())
+	if rd == nil {
 		r.Country = ""
 		return
 	}
-	r.Country = country
+	r.Country = rd.Country
 }
 
 // RegimeDef provides the associated regime definition.

--- a/tax/regimes_test.go
+++ b/tax/regimes_test.go
@@ -3,6 +3,7 @@ package tax_test
 import (
 	"testing"
 
+	"github.com/invopop/gobl/l10n"
 	"github.com/invopop/gobl/tax"
 	"github.com/stretchr/testify/assert"
 )
@@ -18,4 +19,23 @@ func TestAllRegimes(t *testing.T) {
 func TestRegimesAltCountryCodes(t *testing.T) {
 	r := tax.RegimeDefFor("GR")
 	assert.Equal(t, "EL", r.Country.String())
+}
+
+func TestSetRegime(t *testing.T) {
+	tests := []struct {
+		reg string
+		exp string
+	}{
+		{"ES", "ES"},
+		{"GR", "EL"},
+		{"YY", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.reg, func(t *testing.T) {
+			r := new(tax.Regime)
+			r.SetRegime(l10n.TaxCountryCode(tt.reg))
+			assert.Equal(t, tt.exp, r.GetRegime().String())
+		})
+	}
 }


### PR DESCRIPTION
## Describe your changes

Sets the proper tax regime code (_e.g._ `EL`) when the alternative code is given (_e.g._ `GR`)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] I have added thorough tests with at **least** 90% code coverage.
- [x] I've modified or created example GOBL documents the show my changes in use, if appropriate.
- [x] When adding or modifying a tax regime or addon, I've added links to the source of the changes either structured or in the comments.
- [x] I've run `go generate .` to ensure that Schemas and Regime data are up to date.
- [x] All linter warnings have been reviewed and fixed.
- [x] I've been obsessive with pointer nil checks to avoid panics.
- [x] Requested a review from @samlown.

