### PR TITLE
Fix for json schema and cal date time which lacks timezone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - `org`: `Address` now includes a `state` code, for countries that require them.
 - `es-tbai-v1`: normalize address information to automatically add new `es-tbai-region` extension to invoices.
 - `org`: `Inbox` now supports `email` field, with auto-normalization of URLs and emails in the `code` field.
+- `currency`: Exchange rate "source" field.
 
 ### Changes
 
 - Moved regime examples into single `/examples` folder.
 - `org`: `Address`, `code` for the post code is now typed as a `cbc.Code`, like the new `state` field.
+
+### Fixes
+
+- `cal`: Fixing json schema issue with date times.
 
 ## [v0.204.1]
 

--- a/cal/date_time.go
+++ b/cal/date_time.go
@@ -96,12 +96,12 @@ func (dt DateTime) TimeZ() time.Time {
 // JSONSchema returns a custom json schema for the date time.
 func (DateTime) JSONSchema() *jsonschema.Schema {
 	return &jsonschema.Schema{
-		Type:   "string",
-		Format: "date-time",
-		Title:  "Date Time",
+		Type:    "string",
+		Title:   "Date Time",
+		Pattern: "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}$",
 		Description: here.Doc(`
 			Civil date time in simplified ISO format with no time zone
-			information, for example: 2021-05-26T13:45:00
+			nor location information, for example: 2021-05-26T13:45:00
 		`),
 	}
 }

--- a/cal/date_time_test.go
+++ b/cal/date_time_test.go
@@ -179,3 +179,11 @@ func TestDateTimeOf(t *testing.T) {
 	d := cal.DateTimeOf(x)
 	assert.Equal(t, "2023-07-28T12:12:01", d.String())
 }
+
+func TestJSONSchema(t *testing.T) {
+	data := []byte(`{"description":"Civil date time in simplified ISO format with no time zone\nnor location information, for example: 2021-05-26T13:45:00", "pattern":"^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}$", "title":"Date Time", "type":"string"}`)
+	schema := cal.DateTime{}.JSONSchema()
+	out, err := json.Marshal(schema)
+	require.NoError(t, err)
+	assert.JSONEq(t, string(data), string(out))
+}

--- a/currency/exchange_rate.go
+++ b/currency/exchange_rate.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/invopop/gobl/cal"
+	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/num"
 	"github.com/invopop/validation"
 )
@@ -36,9 +37,10 @@ type ExchangeRate struct {
 	// is determined by the source. The time may be zero if referring to a
 	// specific day only.
 	At *cal.DateTime `json:"at,omitempty" jsonschema:"title=At"`
-	// Source provides the name of the source where the exchange rate was
-	// obtained from.
-	Source string `json:"source,omitempty" jsonschema:"title=Source"`
+	// Source key provides a reference to the source the exchange rate was
+	// obtained from. Typically this will be determined by an application
+	// used to update exchange rates automatically.
+	Source cbc.Key `json:"source,omitempty" jsonschema:"title=Source"`
 	// How much is 1 of the "from" currency worth in the "to" currency.
 	Amount num.Amount `json:"amount" jsonschema:"title=Amount"`
 }
@@ -49,6 +51,7 @@ func (er *ExchangeRate) Validate() error {
 		validation.Field(&er.From, validation.Required),
 		validation.Field(&er.To, validation.Required),
 		validation.Field(&er.At, cal.DateTimeNotZero()),
+		validation.Field(&er.Source),
 		validation.Field(&er.Amount, num.Positive),
 	)
 }

--- a/currency/exchange_rate.go
+++ b/currency/exchange_rate.go
@@ -32,11 +32,15 @@ type ExchangeRate struct {
 	From Code `json:"from" jsonschema:"title=From"`
 	// Currency code this exchange rate will convert into.
 	To Code `json:"to" jsonschema:"title=To"`
+	// At represents the effective date and time at which the exchange rate
+	// is determined by the source. The time may be zero if referring to a
+	// specific day only.
+	At *cal.DateTime `json:"at,omitempty" jsonschema:"title=At"`
+	// Source provides the name of the source where the exchange rate was
+	// obtained from.
+	Source string `json:"source,omitempty" jsonschema:"title=Source"`
 	// How much is 1 of the "from" currency worth in the "to" currency.
 	Amount num.Amount `json:"amount" jsonschema:"title=Amount"`
-	// At represents the date and time (which may be 00:00:00) when the
-	// currency rate amount was determined.
-	At *cal.DateTime `json:"at,omitempty" jsonschema:"title=At"`
 }
 
 // Validate ensures the content of the exchange rate looks good.
@@ -44,8 +48,8 @@ func (er *ExchangeRate) Validate() error {
 	return validation.ValidateStruct(er,
 		validation.Field(&er.From, validation.Required),
 		validation.Field(&er.To, validation.Required),
+		validation.Field(&er.At, cal.DateTimeNotZero()),
 		validation.Field(&er.Amount, num.Positive),
-		validation.Field(&er.At),
 	)
 }
 

--- a/data/schemas/cal/date-time.json
+++ b/data/schemas/cal/date-time.json
@@ -5,9 +5,9 @@
   "$defs": {
     "DateTime": {
       "type": "string",
-      "format": "date-time",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}$",
       "title": "Date Time",
-      "description": "Civil date time in simplified ISO format with no time zone\ninformation, for example: 2021-05-26T13:45:00"
+      "description": "Civil date time in simplified ISO format with no time zone\nnor location information, for example: 2021-05-26T13:45:00"
     }
   }
 }

--- a/data/schemas/currency/exchange-rate.json
+++ b/data/schemas/currency/exchange-rate.json
@@ -15,15 +15,20 @@
           "title": "To",
           "description": "Currency code this exchange rate will convert into."
         },
+        "at": {
+          "$ref": "https://gobl.org/draft-0/cal/date-time",
+          "title": "At",
+          "description": "At represents the effective date and time at which the exchange rate\nis determined by the source. The time may be zero if referring to a\nspecific day only."
+        },
+        "source": {
+          "type": "string",
+          "title": "Source",
+          "description": "Source provides the name of the source where the exchange rate was\nobtained from."
+        },
         "amount": {
           "$ref": "https://gobl.org/draft-0/num/amount",
           "title": "Amount",
           "description": "How much is 1 of the \"from\" currency worth in the \"to\" currency."
-        },
-        "at": {
-          "$ref": "https://gobl.org/draft-0/cal/date-time",
-          "title": "At",
-          "description": "At represents the date and time (which may be 00:00:00) when the\ncurrency rate amount was determined."
         }
       },
       "type": "object",

--- a/data/schemas/currency/exchange-rate.json
+++ b/data/schemas/currency/exchange-rate.json
@@ -21,9 +21,9 @@
           "description": "At represents the effective date and time at which the exchange rate\nis determined by the source. The time may be zero if referring to a\nspecific day only."
         },
         "source": {
-          "type": "string",
+          "$ref": "https://gobl.org/draft-0/cbc/key",
           "title": "Source",
-          "description": "Source provides the name of the source where the exchange rate was\nobtained from."
+          "description": "Source key provides a reference to the source the exchange rate was\nobtained from. Typically this will be determined by an application\nused to update exchange rates automatically."
         },
         "amount": {
           "$ref": "https://gobl.org/draft-0/num/amount",


### PR DESCRIPTION
## Describe your changes

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] I have added thorough tests with at **least** 90% code coverage.
- [x] I've modified or created example GOBL documents the show my changes in use, if appropriate.
- [ ] When adding or modifying a tax regime or addon, I've added links to the source of the changes either structured or in the comments.
- [x] I've run `go generate .` to ensure that Schemas and Regime data are up to date.
- [ ] All linter warnings have been reviewed and fixed.
- [x] I've been obsessive with pointer nil checks to avoid panics.
- [x] The CHANGELOG.md has been updated with an overview of my changes.
- [ ] Requested a review from @samlown.

