### PR TITLE
Allow empty lines with discounts or charges, fix empty check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 - `org`: `Address` includes `LineOne()`, `LineTwo()`, `CompleteNumber()` methods to help with conversion to other formats with some regional formatting.
 
+### Changes
+
+- `bill`: `Invoice` can now have empty lines if discounts or charges present.
+
+### Fixes
+
+- `bill`: `Invoice` `GetExtensions` method now works correctly if missing totals [Issue #424](https://github.com/invopop/gobl/issues/424).
+
 ## [v0.205.0]
 
 ### Added

--- a/bill/invoice.go
+++ b/bill/invoice.go
@@ -151,7 +151,10 @@ func (inv *Invoice) ValidateWithContext(ctx context.Context) error {
 			validation.By(validateInvoiceCustomer),
 		),
 		validation.Field(&inv.Lines,
-			validation.Required,
+			validation.When(
+				len(inv.Discounts) == 0 && len(inv.Charges) == 0,
+				validation.Required.Error("cannot be empty without discounts or charges"),
+			),
 		),
 		validation.Field(&inv.Discounts),
 		validation.Field(&inv.Charges),

--- a/bill/invoice_scenarios.go
+++ b/bill/invoice_scenarios.go
@@ -19,9 +19,11 @@ func (inv *Invoice) GetExtensions() []tax.Extensions {
 			exts = append(exts, inv.Tax.Ext)
 		}
 	}
-	for _, cat := range inv.Totals.Taxes.Categories {
-		for _, rate := range cat.Rates {
-			exts = append(exts, rate.Ext)
+	if inv.Totals != nil && inv.Totals.Taxes != nil {
+		for _, cat := range inv.Totals.Taxes.Categories {
+			for _, rate := range cat.Rates {
+				exts = append(exts, rate.Ext)
+			}
 		}
 	}
 	return exts

--- a/bill/invoice_scenarios_test.go
+++ b/bill/invoice_scenarios_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/invopop/gobl/addons/it/sdi"
+	"github.com/invopop/gobl/addons/pt/saft"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/tax"
@@ -105,14 +106,23 @@ func TestScenarios(t *testing.T) {
 }
 
 func TestInvoiceGetExtensions(t *testing.T) {
-	inv := baseInvoiceWithLines(t)
-	inv.Addons = tax.WithAddons(sdi.V1)
-	inv.Supplier.TaxID = &tax.Identity{
-		Country: "IT",
-		Code:    "12345678903",
-	}
-	require.NoError(t, inv.Calculate())
-	ext := inv.GetExtensions()
-	assert.Len(t, ext, 2)
-	assert.Equal(t, "FPR12", ext[0][sdi.ExtKeyFormat].String())
+	t.Run("with lines", func(t *testing.T) {
+		inv := baseInvoiceWithLines(t)
+		inv.Addons = tax.WithAddons(sdi.V1)
+		inv.Supplier.TaxID = &tax.Identity{
+			Country: "IT",
+			Code:    "12345678903",
+		}
+		require.NoError(t, inv.Calculate())
+		ext := inv.GetExtensions()
+		assert.Len(t, ext, 2)
+		assert.Equal(t, "FPR12", ext[0][sdi.ExtKeyFormat].String())
+	})
+	t.Run("missing lines", func(t *testing.T) {
+		inv := baseInvoice(t)
+		inv.Addons = tax.WithAddons(saft.V1)
+		require.NoError(t, inv.Calculate())
+		ext := inv.GetExtensions()
+		assert.Len(t, ext, 1)
+	})
 }

--- a/bill/invoice_test.go
+++ b/bill/invoice_test.go
@@ -1135,6 +1135,26 @@ func TestValidation(t *testing.T) {
 		err := inv.Validate()
 		assert.ErrorContains(t, err, "customer: (name: cannot be blank.).")
 	})
+
+	t.Run("missing lines", func(t *testing.T) {
+		inv := baseInvoice(t)
+		require.NoError(t, inv.Calculate())
+		err := inv.Validate()
+		assert.ErrorContains(t, err, "lines: cannot be empty without discounts or charges.")
+	})
+
+	t.Run("missing lines with charge", func(t *testing.T) {
+		inv := baseInvoice(t)
+		inv.Charges = []*bill.Charge{
+			{
+				Reason: "Testing",
+				Amount: num.MakeAmount(1000, 2),
+			},
+		}
+		require.NoError(t, inv.Calculate())
+		err := inv.Validate()
+		assert.NoError(t, err)
+	})
 }
 
 func TestInvoiceTagsValidation(t *testing.T) {

--- a/examples/es/invoice-es-es-only-charges.yaml
+++ b/examples/es/invoice-es-es-only-charges.yaml
@@ -1,0 +1,35 @@
+$schema: "https://gobl.org/draft-0/bill/invoice"
+$addons: ["es-facturae-v3"]
+uuid: "3aea7b56-59d8-4beb-90bd-f8f280d852a0"
+currency: "EUR"
+issue_date: "2024-11-15"
+series: "SAMPLE"
+code: "001"
+
+supplier:
+  tax_id:
+    country: "ES"
+    code: "B98602642" # random
+  name: "Provide One S.L."
+  emails:
+    - addr: "billing@example.com"
+  addresses:
+    - num: "42"
+      street: "Calle Pradillo"
+      locality: "Madrid"
+      region: "Madrid"
+      code: "28002"
+      country: "ES"
+
+customer:
+  tax_id:
+    country: "ES"
+    code: "54387763P"
+  name: "Sample Consumer"
+
+charges:
+  - reason: "A charge not related to a product"
+    amount: "50.00"
+    taxes:
+      - cat: VAT
+        rate: standard

--- a/examples/es/out/invoice-es-es-only-charges.json
+++ b/examples/es/out/invoice-es-es-only-charges.json
@@ -1,0 +1,97 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
+		"dig": {
+			"alg": "sha256",
+			"val": "3e611352aff72a27ab67167092eb70ef6dd7a291d9928744567c070368fe0551"
+		}
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"$regime": "ES",
+		"$addons": [
+			"es-facturae-v3"
+		],
+		"uuid": "3aea7b56-59d8-4beb-90bd-f8f280d852a0",
+		"type": "standard",
+		"series": "SAMPLE",
+		"code": "001",
+		"issue_date": "2024-11-15",
+		"currency": "EUR",
+		"tax": {
+			"ext": {
+				"es-facturae-doc-type": "FC",
+				"es-facturae-invoice-class": "OO"
+			}
+		},
+		"supplier": {
+			"name": "Provide One S.L.",
+			"tax_id": {
+				"country": "ES",
+				"code": "B98602642"
+			},
+			"addresses": [
+				{
+					"num": "42",
+					"street": "Calle Pradillo",
+					"locality": "Madrid",
+					"region": "Madrid",
+					"code": "28002",
+					"country": "ES"
+				}
+			],
+			"emails": [
+				{
+					"addr": "billing@example.com"
+				}
+			]
+		},
+		"customer": {
+			"name": "Sample Consumer",
+			"tax_id": {
+				"country": "ES",
+				"code": "54387763P"
+			}
+		},
+		"charges": [
+			{
+				"i": 1,
+				"reason": "A charge not related to a product",
+				"amount": "50.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"rate": "standard",
+						"percent": "21.0%"
+					}
+				]
+			}
+		],
+		"totals": {
+			"sum": "0.00",
+			"charge": "50.00",
+			"total": "50.00",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"base": "50.00",
+								"percent": "21.0%",
+								"amount": "10.50"
+							}
+						],
+						"amount": "10.50"
+					}
+				],
+				"sum": "10.50"
+			},
+			"tax": "10.50",
+			"total_with_tax": "60.50",
+			"payable": "60.50"
+		}
+	}
+}


### PR DESCRIPTION
## Describe your changes

Fixes #424. Invoices can now be built without lines if discounts or charges are present.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] I have added thorough tests with at **least** 90% code coverage.
- [x] I've modified or created example GOBL documents the show my changes in use, if appropriate.
- [ ] When adding or modifying a tax regime or addon, I've added links to the source of the changes either structured or in the comments.
- [x] I've run `go generate .` to ensure that Schemas and Regime data are up to date.
- [x] All linter warnings have been reviewed and fixed.
- [x] I've been obsessive with pointer nil checks to avoid panics.
- [x] The CHANGELOG.md has been updated with an overview of my changes.
- [ ] Requested a review from @samlown.

