### PR TITLE
Fix: org party regime validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Fixed
+
+- `org`: Party validation now working with regimes when defined.
+
 ## [v0.206.0] - 2024-11-26
 
 ### Added

--- a/org/party.go
+++ b/org/party.go
@@ -92,7 +92,9 @@ func (p *Party) Validate() error {
 
 // ValidateWithContext is used to check the party's data meets minimum expectations.
 func (p *Party) ValidateWithContext(ctx context.Context) error {
+	ctx = p.ValidationContext(ctx)
 	return tax.ValidateStructWithContext(ctx, p,
+		validation.Field(&p.Regime),
 		validation.Field(&p.Name),
 		validation.Field(&p.TaxID),
 		validation.Field(&p.Identities),
@@ -107,6 +109,14 @@ func (p *Party) ValidateWithContext(ctx context.Context) error {
 		validation.Field(&p.Ext),
 		validation.Field(&p.Meta),
 	)
+}
+
+// ValidationContext returns a context with the regime's validation rules.
+func (p *Party) ValidationContext(ctx context.Context) context.Context {
+	if r := p.RegimeDef(); r != nil {
+		ctx = r.WithContext(ctx)
+	}
+	return ctx
 }
 
 // JSONSchemaExtend adds extra details to the schema.

--- a/org/party_test.go
+++ b/org/party_test.go
@@ -88,3 +88,36 @@ func TestPartyAddressNill(t *testing.T) {
 	party.Normalize(nil)
 	assert.NoError(t, party.Validate())
 }
+
+func TestPartyValidation(t *testing.T) {
+	t.Run("with regime", func(t *testing.T) {
+		party := org.Party{
+			Regime: tax.WithRegime("DE"),
+			Name:   "Invopop",
+			Identities: []*org.Identity{
+				{
+					Key:  "de-tax-number",
+					Code: "123 456 78901",
+				},
+			},
+		}
+		require.NoError(t, party.Calculate())
+		assert.NoError(t, party.Validate())
+		assert.Equal(t, "DE", party.GetRegime().String())
+	})
+	t.Run("with regime and bad code", func(t *testing.T) {
+		party := org.Party{
+			Regime: tax.WithRegime("DE"),
+			Name:   "Invopop",
+			Identities: []*org.Identity{
+				{
+					Key:  "de-tax-number",
+					Code: "1231312423432422",
+				},
+			},
+		}
+		require.NoError(t, party.Calculate())
+		err := party.Validate()
+		assert.ErrorContains(t, err, "identities: (0: (code: must be in a valid format.).).")
+	})
+}


### PR DESCRIPTION
## Describe your changes

Fixes an issue validating tax ID codes when the regime is provided inside an `org.Party`.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] I have added thorough tests with at **least** 90% code coverage.
- [ ] I've modified or created example GOBL documents the show my changes in use, if appropriate.
- [ ] When adding or modifying a tax regime or addon, I've added links to the source of the changes either structured or in the comments.
- [ ] I've run `go generate .` to ensure that Schemas and Regime data are up to date.
- [x] All linter warnings have been reviewed and fixed.
- [x] I've been obsessive with pointer nil checks to avoid panics.
- [x] The CHANGELOG.md has been updated with an overview of my changes.
- [ ] Requested a review from @samlown.

