### PR TITLE
Fixing grammer error in tax extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - `bill`: `Tax.MergeExtensions` convenience method for adding extensions to tax objects and avoid nil panics.
 - `cbc`: `Key.Pop` method for splitting keys with sub-keys, e.g. `cbc.Key("a+b").Pop() == cbc.Key("a")`.
 
+### Changed
+
+- `tax`: renamed `ExtensionsRequires` to `ExtensionsRequire`, to bring in line with `ExtensionsExclude`.
+
 ### Fixed
 
 - `bill`: corrected issues around correction definitions and merging types.

--- a/addons/br/nfse/invoices.go
+++ b/addons/br/nfse/invoices.go
@@ -68,7 +68,7 @@ func validateSupplier(value interface{}) error {
 			validation.Skip,
 		),
 		validation.Field(&obj.Ext,
-			tax.ExtensionsRequires(
+			tax.ExtensionsRequire(
 				ExtKeySimples,
 				ExtKeyMunicipality,
 				ExtKeyFiscalIncentive,

--- a/addons/br/nfse/item.go
+++ b/addons/br/nfse/item.go
@@ -13,7 +13,7 @@ func validateItem(item *org.Item) error {
 
 	return validation.ValidateStruct(item,
 		validation.Field(&item.Ext,
-			tax.ExtensionsRequires(ExtKeyService),
+			tax.ExtensionsRequire(ExtKeyService),
 			validation.Skip,
 		),
 	)

--- a/addons/br/nfse/tax_combo.go
+++ b/addons/br/nfse/tax_combo.go
@@ -15,7 +15,7 @@ func validateTaxCombo(tc *tax.Combo) error {
 	return validation.ValidateStruct(tc,
 		validation.Field(&tc.Ext,
 			validation.When(tc.Category == br.TaxCategoryISS,
-				tax.ExtensionsRequires(ExtKeyISSLiability),
+				tax.ExtensionsRequire(ExtKeyISSLiability),
 			),
 		),
 	)

--- a/addons/co/dian/invoices.go
+++ b/addons/co/dian/invoices.go
@@ -80,7 +80,7 @@ func validateInvoiceSupplier(value interface{}) error {
 			validation.When(
 				municipalityCodeRequired(obj.TaxID),
 				validation.Required,
-				tax.ExtensionsRequires(ExtKeyMunicipality),
+				tax.ExtensionsRequire(ExtKeyMunicipality),
 			),
 			validation.Skip,
 		),
@@ -120,7 +120,7 @@ func validateInvoiceCustomer(tags []cbc.Key) func(value any) error {
 				validation.When(
 					municipalityCodeRequired(obj.TaxID),
 					validation.Required,
-					tax.ExtensionsRequires(ExtKeyMunicipality),
+					tax.ExtensionsRequire(ExtKeyMunicipality),
 				),
 				validation.Skip,
 			),
@@ -154,11 +154,11 @@ func validateInvoicePreceding(typ cbc.Key) validation.RuleFunc {
 			validation.Field(&obj.Ext,
 				validation.When(
 					typ == bill.InvoiceTypeCreditNote,
-					tax.ExtensionsRequires(ExtKeyCreditCode),
+					tax.ExtensionsRequire(ExtKeyCreditCode),
 				),
 				validation.When(
 					typ == bill.InvoiceTypeDebitNote,
-					tax.ExtensionsRequires(ExtKeyDebitCode),
+					tax.ExtensionsRequire(ExtKeyDebitCode),
 				),
 			),
 			validation.Field(&obj.Reason, validation.Required),

--- a/addons/es/facturae/invoice.go
+++ b/addons/es/facturae/invoice.go
@@ -72,7 +72,7 @@ func validateInvoiceTax(val any) error {
 	}
 	return validation.ValidateStruct(t,
 		validation.Field(&t.Ext,
-			tax.ExtensionsRequires(
+			tax.ExtensionsRequire(
 				ExtKeyDocType,
 				ExtKeyInvoiceClass,
 			),
@@ -89,7 +89,7 @@ func validateInvoicePreceding(val any) error {
 	return validation.ValidateStruct(p,
 		validation.Field(&p.IssueDate, validation.Required),
 		validation.Field(&p.Ext,
-			tax.ExtensionsRequires(ExtKeyCorrection),
+			tax.ExtensionsRequire(ExtKeyCorrection),
 			validation.Skip,
 		),
 	)

--- a/addons/es/tbai/invoice.go
+++ b/addons/es/tbai/invoice.go
@@ -102,7 +102,7 @@ func validateInvoiceTax(val any) error {
 	}
 	return validation.ValidateStruct(obj,
 		validation.Field(&obj.Ext,
-			tax.ExtensionsRequires(ExtKeyRegion),
+			tax.ExtensionsRequire(ExtKeyRegion),
 			validation.Skip,
 		),
 	)
@@ -137,7 +137,7 @@ func validateInvoicePreceding(val any) error {
 		validation.Field(&p.IssueDate, validation.Required),
 		validation.Field(&p.Series, validation.Required),
 		validation.Field(&p.Ext,
-			tax.ExtensionsRequires(ExtKeyCorrection),
+			tax.ExtensionsRequire(ExtKeyCorrection),
 			validation.Skip,
 		),
 	)
@@ -168,7 +168,7 @@ func validateInvoiceLineTax(value any) error {
 		validation.Field(&obj.Ext,
 			validation.When(
 				obj.Rate == tax.RateExempt,
-				tax.ExtensionsRequires(ExtKeyExemption),
+				tax.ExtensionsRequire(ExtKeyExemption),
 			),
 			validation.Skip,
 		),

--- a/addons/es/verifactu/bill.go
+++ b/addons/es/verifactu/bill.go
@@ -98,7 +98,7 @@ func validateInvoiceTax(it cbc.Key) validation.RuleFunc {
 		obj := val.(*bill.Tax)
 		return validation.ValidateStruct(obj,
 			validation.Field(&obj.Ext,
-				tax.ExtensionsRequires(ExtKeyDocType),
+				tax.ExtensionsRequire(ExtKeyDocType),
 				validation.When(
 					it.In(bill.InvoiceTypeStandard),
 					tax.ExtensionsHasValues(
@@ -122,7 +122,7 @@ func validateInvoiceTax(it cbc.Key) validation.RuleFunc {
 				),
 				validation.When(
 					obj.Ext.Get(ExtKeyDocType).In(docTypesCreditDebit...),
-					tax.ExtensionsRequires(ExtKeyCorrectionType),
+					tax.ExtensionsRequire(ExtKeyCorrectionType),
 				),
 				validation.Skip,
 			),

--- a/addons/es/verifactu/tax.go
+++ b/addons/es/verifactu/tax.go
@@ -49,11 +49,11 @@ func validateTaxCombo(tc *tax.Combo) error {
 		validation.Field(&tc.Ext,
 			validation.When(
 				tc.Percent != nil, // Taxed
-				tax.ExtensionsRequires(ExtKeyOpClass),
+				tax.ExtensionsRequire(ExtKeyOpClass),
 			),
 			validation.When(
 				tc.Percent == nil && !tc.Ext.Has(ExtKeyOpClass),
-				tax.ExtensionsRequires(ExtKeyExempt),
+				tax.ExtensionsRequire(ExtKeyExempt),
 			),
 			tax.ExtensionsRequires(ExtKeyRegime),
 			validation.Skip,

--- a/addons/es/verifactu/tax.go
+++ b/addons/es/verifactu/tax.go
@@ -55,7 +55,7 @@ func validateTaxCombo(tc *tax.Combo) error {
 				tc.Percent == nil && !tc.Ext.Has(ExtKeyOpClass),
 				tax.ExtensionsRequire(ExtKeyExempt),
 			),
-			tax.ExtensionsRequires(ExtKeyRegime),
+			tax.ExtensionsRequire(ExtKeyRegime),
 			validation.Skip,
 		),
 	)

--- a/addons/eu/en16931/bill.go
+++ b/addons/eu/en16931/bill.go
@@ -89,7 +89,7 @@ func validateBillInvoiceTax(value any) error {
 	}
 	return validation.ValidateStruct(tx,
 		validation.Field(&tx.Ext,
-			tax.ExtensionsRequires(untdid.ExtKeyDocumentType),
+			tax.ExtensionsRequire(untdid.ExtKeyDocumentType),
 			validation.Skip,
 		),
 	)

--- a/addons/eu/en16931/pay.go
+++ b/addons/eu/en16931/pay.go
@@ -37,7 +37,7 @@ func normalizePayAdvance(adv *pay.Advance) {
 func validatePayAdvance(adv *pay.Advance) error {
 	return validation.ValidateStruct(adv,
 		validation.Field(&adv.Ext,
-			tax.ExtensionsRequires(untdid.ExtKeyPaymentMeans),
+			tax.ExtensionsRequire(untdid.ExtKeyPaymentMeans),
 			validation.Skip,
 		),
 	)
@@ -57,7 +57,7 @@ func normalizePayInstructions(instr *pay.Instructions) {
 func validatePayInstructions(instr *pay.Instructions) error {
 	return validation.ValidateStruct(instr,
 		validation.Field(&instr.Ext,
-			tax.ExtensionsRequires(untdid.ExtKeyPaymentMeans),
+			tax.ExtensionsRequire(untdid.ExtKeyPaymentMeans),
 			validation.Skip,
 		),
 	)

--- a/addons/eu/en16931/tax_combo.go
+++ b/addons/eu/en16931/tax_combo.go
@@ -52,7 +52,7 @@ func validateTaxCombo(tc *tax.Combo) error {
 	}
 	return validation.ValidateStruct(tc,
 		validation.Field(&tc.Ext,
-			tax.ExtensionsRequires(untdid.ExtKeyTaxCategory),
+			tax.ExtensionsRequire(untdid.ExtKeyTaxCategory),
 			tax.ExtensionsHasValues(untdid.ExtKeyTaxCategory, acceptedTaxCategories...),
 			validation.Skip,
 		),

--- a/addons/gr/mydata/invoices.go
+++ b/addons/gr/mydata/invoices.go
@@ -71,7 +71,7 @@ func validateInvoiceTax(value any) error {
 	}
 	return validation.ValidateStruct(t,
 		validation.Field(&t.Ext,
-			tax.ExtensionsRequires(ExtKeyInvoiceType),
+			tax.ExtensionsRequire(ExtKeyInvoiceType),
 			validation.Skip,
 		),
 	)
@@ -146,7 +146,7 @@ func validateInvoiceItem(value any) error {
 		validation.Field(&i.Ext,
 			validation.When(
 				i.Ext.Has(ExtKeyIncomeCat) || i.Ext.Has(ExtKeyIncomeType),
-				tax.ExtensionsRequires(ExtKeyIncomeCat, ExtKeyIncomeType),
+				tax.ExtensionsRequire(ExtKeyIncomeCat, ExtKeyIncomeType),
 			),
 			validation.Skip,
 		),

--- a/addons/gr/mydata/pay.go
+++ b/addons/gr/mydata/pay.go
@@ -65,7 +65,7 @@ func validatePayInstructions(value any) error {
 			validation.Skip,
 		),
 		validation.Field(&i.Ext,
-			tax.ExtensionsRequires(ExtKeyPaymentMeans),
+			tax.ExtensionsRequire(ExtKeyPaymentMeans),
 			validation.Skip,
 		),
 	)
@@ -82,7 +82,7 @@ func validatePayAdvance(value any) error {
 			validation.Skip,
 		),
 		validation.Field(&a.Ext,
-			tax.ExtensionsRequires(ExtKeyPaymentMeans),
+			tax.ExtensionsRequire(ExtKeyPaymentMeans),
 			validation.Skip,
 		),
 	)

--- a/addons/gr/mydata/tax_combo.go
+++ b/addons/gr/mydata/tax_combo.go
@@ -38,17 +38,17 @@ func validateTaxCombo(tc *tax.Combo) error {
 	case tax.CategoryVAT:
 		return validation.ValidateStruct(tc,
 			validation.Field(&tc.Ext,
-				tax.ExtensionsRequires(ExtKeyVATRate),
+				tax.ExtensionsRequire(ExtKeyVATRate),
 				validation.When(
 					tc.Percent == nil,
-					tax.ExtensionsRequires(ExtKeyExemption),
+					tax.ExtensionsRequire(ExtKeyExemption),
 				),
 				validation.When(
 					// MyDATA uses income category and type for accounting purposes
 					// and for them to be grouped with taxes. We ensure they're present
 					// here so that the
 					tc.Ext.Has(ExtKeyIncomeCat) || tc.Ext.Has(ExtKeyIncomeType),
-					tax.ExtensionsRequires(ExtKeyIncomeCat, ExtKeyIncomeType),
+					tax.ExtensionsRequire(ExtKeyIncomeCat, ExtKeyIncomeType),
 				),
 				validation.Skip,
 			),

--- a/addons/it/sdi/invoices.go
+++ b/addons/it/sdi/invoices.go
@@ -92,7 +92,7 @@ func validateSupplier(value interface{}) error {
 			validation.Skip,
 		),
 		validation.Field(&supplier.Ext,
-			tax.ExtensionsRequires(ExtKeyFiscalRegime),
+			tax.ExtensionsRequire(ExtKeyFiscalRegime),
 			validation.Skip,
 		),
 	)

--- a/addons/it/sdi/pay.go
+++ b/addons/it/sdi/pay.go
@@ -85,7 +85,7 @@ func normalizePayAdvance(adv *pay.Advance) {
 func validatePayAdvance(a *pay.Advance) error {
 	return validation.ValidateStruct(a,
 		validation.Field(&a.Ext,
-			tax.ExtensionsRequires(ExtKeyPaymentMeans),
+			tax.ExtensionsRequire(ExtKeyPaymentMeans),
 			validation.Skip,
 		),
 	)
@@ -94,7 +94,7 @@ func validatePayAdvance(a *pay.Advance) error {
 func validatePayInstructions(i *pay.Instructions) error {
 	return validation.ValidateStruct(i,
 		validation.Field(&i.Ext,
-			tax.ExtensionsRequires(ExtKeyPaymentMeans),
+			tax.ExtensionsRequire(ExtKeyPaymentMeans),
 			validation.Skip,
 		),
 	)

--- a/addons/it/sdi/tax.go
+++ b/addons/it/sdi/tax.go
@@ -17,7 +17,7 @@ func validateTaxCombo(val any) error {
 			validation.Field(&c.Ext,
 				validation.When(
 					c.Percent == nil,
-					tax.ExtensionsRequires(ExtKeyExempt),
+					tax.ExtensionsRequire(ExtKeyExempt),
 				),
 				validation.Skip,
 			),
@@ -26,7 +26,7 @@ func validateTaxCombo(val any) error {
 	case it.TaxCategoryIRPEF, it.TaxCategoryIRES, it.TaxCategoryINPS, it.TaxCategoryENPAM, it.TaxCategoryENASARCO:
 		return validation.ValidateStruct(c,
 			validation.Field(&c.Ext,
-				tax.ExtensionsRequires(ExtKeyRetained),
+				tax.ExtensionsRequire(ExtKeyRetained),
 				validation.Skip,
 			),
 		)

--- a/addons/mx/cfdi/invoice.go
+++ b/addons/mx/cfdi/invoice.go
@@ -63,13 +63,13 @@ func validateInvoiceTax(preceding []*org.DocumentRef) validation.RuleFunc {
 		}
 		return validation.ValidateStruct(obj,
 			validation.Field(&obj.Ext,
-				tax.ExtensionsRequires(
+				tax.ExtensionsRequire(
 					ExtKeyDocType,
 					ExtKeyIssuePlace,
 				),
 				validation.When(
 					len(preceding) > 0,
-					tax.ExtensionsRequires(
+					tax.ExtensionsRequire(
 						ExtKeyRelType,
 					),
 				),
@@ -93,7 +93,7 @@ func validateInvoiceCustomer(value any) error {
 		validation.Field(&obj.Ext,
 			validation.When(
 				isMexican(obj),
-				tax.ExtensionsRequires(
+				tax.ExtensionsRequire(
 					ExtKeyFiscalRegime,
 					ExtKeyUse,
 				),
@@ -135,7 +135,7 @@ func validateInvoiceSupplier(value any) error {
 			validation.Skip,
 		),
 		validation.Field(&obj.Ext,
-			tax.ExtensionsRequires(
+			tax.ExtensionsRequire(
 				ExtKeyFiscalRegime,
 			),
 		),

--- a/addons/mx/cfdi/item.go
+++ b/addons/mx/cfdi/item.go
@@ -22,7 +22,7 @@ func validateItem(value any) error {
 	}
 	return validation.ValidateStruct(item,
 		validation.Field(&item.Ext,
-			tax.ExtensionsRequires(ExtKeyProdServ),
+			tax.ExtensionsRequire(ExtKeyProdServ),
 			validation.By(validItemExtensions),
 			validation.Skip,
 		),

--- a/addons/mx/cfdi/pay.go
+++ b/addons/mx/cfdi/pay.go
@@ -85,7 +85,7 @@ func normalizePayAdvance(adv *pay.Advance) {
 func validatePayAdvance(a *pay.Advance) error {
 	return validation.ValidateStruct(a,
 		validation.Field(&a.Ext,
-			tax.ExtensionsRequires(ExtKeyPaymentMeans),
+			tax.ExtensionsRequire(ExtKeyPaymentMeans),
 			validation.Skip,
 		),
 	)
@@ -94,7 +94,7 @@ func validatePayAdvance(a *pay.Advance) error {
 func validatePayInstructions(i *pay.Instructions) error {
 	return validation.ValidateStruct(i,
 		validation.Field(&i.Ext,
-			tax.ExtensionsRequires(ExtKeyPaymentMeans),
+			tax.ExtensionsRequire(ExtKeyPaymentMeans),
 			validation.Skip,
 		),
 	)

--- a/addons/pt/saft/tax_combo.go
+++ b/addons/pt/saft/tax_combo.go
@@ -56,11 +56,11 @@ func validateTaxCombo(val any) error {
 				// country tax rate.
 				validation.When(
 					c.Country == "",
-					tax.ExtensionsRequires(ExtKeyTaxRate),
+					tax.ExtensionsRequire(ExtKeyTaxRate),
 				),
 				validation.When(
 					c.Percent == nil,
-					tax.ExtensionsRequires(ExtKeyExemption),
+					tax.ExtensionsRequire(ExtKeyExemption),
 				),
 				validation.Skip,
 			),

--- a/regimes/pl/invoices.go
+++ b/regimes/pl/invoices.go
@@ -89,7 +89,7 @@ func (v *invoiceValidator) preceding(value interface{}) error {
 	}
 	return validation.ValidateStruct(obj,
 		validation.Field(&obj.Ext,
-			tax.ExtensionsRequires(ExtKeyKSeFEffectiveDate),
+			tax.ExtensionsRequire(ExtKeyKSeFEffectiveDate),
 		),
 		validation.Field(&obj.Reason, validation.Required),
 	)

--- a/tax/extensions.go
+++ b/tax/extensions.go
@@ -225,9 +225,9 @@ func ExtensionsHas(keys ...cbc.Key) validation.Rule {
 	}
 }
 
-// ExtensionsRequires returns a validation rule that ensures all the
+// ExtensionsRequire returns a validation rule that ensures all the
 // extension map's keys match those provided in the list.
-func ExtensionsRequires(keys ...cbc.Key) validation.Rule {
+func ExtensionsRequire(keys ...cbc.Key) validation.Rule {
 	return validateExtCodeMap{
 		required: true,
 		keys:     keys,

--- a/tax/extensions_test.go
+++ b/tax/extensions_test.go
@@ -188,14 +188,14 @@ func TestExtensionsHasValidation(t *testing.T) {
 func TestExtensionsRequiresValidation(t *testing.T) {
 	t.Run("nil", func(t *testing.T) {
 		err := validation.Validate(nil,
-			tax.ExtensionsRequires(untdid.ExtKeyDocumentType),
+			tax.ExtensionsRequire(untdid.ExtKeyDocumentType),
 		)
 		assert.NoError(t, err)
 	})
 	t.Run("empty", func(t *testing.T) {
 		em := tax.Extensions{}
 		err := validation.Validate(em,
-			tax.ExtensionsRequires(untdid.ExtKeyDocumentType),
+			tax.ExtensionsRequire(untdid.ExtKeyDocumentType),
 		)
 		assert.ErrorContains(t, err, "untdid-document-type: required")
 	})
@@ -204,7 +204,7 @@ func TestExtensionsRequiresValidation(t *testing.T) {
 			untdid.ExtKeyDocumentType: "326",
 		}
 		err := validation.Validate(em,
-			tax.ExtensionsRequires(untdid.ExtKeyDocumentType),
+			tax.ExtensionsRequire(untdid.ExtKeyDocumentType),
 		)
 		assert.NoError(t, err)
 	})
@@ -214,7 +214,7 @@ func TestExtensionsRequiresValidation(t *testing.T) {
 			iso.ExtKeySchemeID:        "1234",
 		}
 		err := validation.Validate(em,
-			tax.ExtensionsRequires(untdid.ExtKeyDocumentType),
+			tax.ExtensionsRequire(untdid.ExtKeyDocumentType),
 		)
 		assert.NoError(t, err)
 	})
@@ -223,7 +223,7 @@ func TestExtensionsRequiresValidation(t *testing.T) {
 			iso.ExtKeySchemeID: "1234",
 		}
 		err := validation.Validate(em,
-			tax.ExtensionsRequires(untdid.ExtKeyDocumentType),
+			tax.ExtensionsRequire(untdid.ExtKeyDocumentType),
 		)
 		assert.ErrorContains(t, err, "untdid-document-type: required")
 	})


### PR DESCRIPTION
Small typo change to improve grammar: `ExtensionsRequires` to `ExtensionsRequire`.
