### PR TITLE
Fixing validation of advance key check in EN16931 addon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Fixed
+
+- `eu-en16931-v2017`: removing validation of advanced payment means extension.
+
 ## [v0.209.0] - 2025-02-04
 
 This significant release adds support for the new `bill.Receipt` schema, to be used to represent payments (sent from suppliers) and remittance advice (sent from customers). This is still in testing phases, so may still require significant changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Fixed
 
 - `eu-en16931-v2017`: removing validation of advanced payment means extension.
+- `pay`: `Card` fields now optional.
 
 ## [v0.209.0] - 2025-02-04
 

--- a/addons/eu/en16931/en16931.go
+++ b/addons/eu/en16931/en16931.go
@@ -48,8 +48,6 @@ func normalize(doc any) {
 	switch obj := doc.(type) {
 	case *bill.Invoice:
 		normalizeBillInvoice(obj)
-	case *pay.Advance:
-		normalizePayAdvance(obj)
 	case *pay.Instructions:
 		normalizePayInstructions(obj)
 	case *tax.Combo:
@@ -71,8 +69,6 @@ func normalize(doc any) {
 
 func validate(doc any) error {
 	switch obj := doc.(type) {
-	case *pay.Advance:
-		return validatePayAdvance(obj)
 	case *pay.Instructions:
 		return validatePayInstructions(obj)
 	case *bill.Invoice:

--- a/addons/eu/en16931/pay.go
+++ b/addons/eu/en16931/pay.go
@@ -23,26 +23,6 @@ var paymentMeansMap = tax.Extensions{
 	pay.MeansKeyDirectDebit.With(pay.MeansKeySEPA):    "59",
 }
 
-func normalizePayAdvance(adv *pay.Advance) {
-	if adv == nil {
-		return
-	}
-	if val, ok := paymentMeansMap[adv.Key]; ok {
-		adv.Ext = adv.Ext.Merge(
-			tax.Extensions{untdid.ExtKeyPaymentMeans: val},
-		)
-	}
-}
-
-func validatePayAdvance(adv *pay.Advance) error {
-	return validation.ValidateStruct(adv,
-		validation.Field(&adv.Ext,
-			tax.ExtensionsRequire(untdid.ExtKeyPaymentMeans),
-			validation.Skip,
-		),
-	)
-}
-
 func normalizePayInstructions(instr *pay.Instructions) {
 	if instr == nil {
 		return
@@ -57,6 +37,7 @@ func normalizePayInstructions(instr *pay.Instructions) {
 func validatePayInstructions(instr *pay.Instructions) error {
 	return validation.ValidateStruct(instr,
 		validation.Field(&instr.Ext,
+			// BR-49
 			tax.ExtensionsRequire(untdid.ExtKeyPaymentMeans),
 			validation.Skip,
 		),

--- a/addons/eu/en16931/pay_test.go
+++ b/addons/eu/en16931/pay_test.go
@@ -6,48 +6,11 @@ import (
 	"github.com/invopop/gobl/addons/eu/en16931"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/catalogues/untdid"
-	"github.com/invopop/gobl/num"
 	"github.com/invopop/gobl/pay"
 	"github.com/invopop/gobl/tax"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func TestPayAdvances(t *testing.T) {
-	ad := tax.AddonForKey(en16931.V2017)
-
-	t.Run("valid advance", func(t *testing.T) {
-		adv := &pay.Advance{
-			Key: pay.MeansKeyCreditTransfer,
-		}
-		ad.Normalizer(adv)
-		assert.Equal(t, "30", adv.Ext[untdid.ExtKeyPaymentMeans].String())
-	})
-
-	t.Run("nil advance", func(t *testing.T) {
-		var adv *pay.Advance
-		assert.NotPanics(t, func() {
-			ad.Normalizer(adv)
-		})
-	})
-
-	t.Run("validation", func(t *testing.T) {
-		inv := testInvoiceStandard(t)
-		inv.Payment = &bill.Payment{
-			Advances: []*pay.Advance{
-				{
-					Key:         pay.MeansKeyCreditTransfer,
-					Description: "Advance payment",
-					Percent:     num.NewPercentage(100, 2),
-				},
-			},
-		}
-		require.NoError(t, inv.Calculate())
-		assert.Equal(t, "30", inv.Payment.Advances[0].Ext[untdid.ExtKeyPaymentMeans].String())
-		err := inv.Validate()
-		assert.NoError(t, err)
-	})
-}
 
 func TestPayInstructions(t *testing.T) {
 	ad := tax.AddonForKey(en16931.V2017)

--- a/data/schemas/pay/advance.json
+++ b/data/schemas/pay/advance.json
@@ -174,11 +174,6 @@
         }
       },
       "type": "object",
-      "required": [
-        "first6",
-        "last4",
-        "holder"
-      ],
       "description": "Card contains simplified card holder data as a reference for the customer."
     },
     "CreditTransfer": {

--- a/data/schemas/pay/instructions.json
+++ b/data/schemas/pay/instructions.json
@@ -22,11 +22,6 @@
         }
       },
       "type": "object",
-      "required": [
-        "first6",
-        "last4",
-        "holder"
-      ],
       "description": "Card contains simplified card holder data as a reference for the customer."
     },
     "CreditTransfer": {

--- a/pay/instructions.go
+++ b/pay/instructions.go
@@ -43,11 +43,11 @@ type Instructions struct {
 // to be stored openly.
 type Card struct {
 	// First 6 digits of the card's Primary Account Number (PAN).
-	First6 string `json:"first6" jsonschema:"title=First 6"`
+	First6 string `json:"first6,omitempty" jsonschema:"title=First 6"`
 	// Last 4 digits of the card's Primary Account Number (PAN).
-	Last4 string `json:"last4" jsonschema:"title=Last 4"`
+	Last4 string `json:"last4,omitempty" jsonschema:"title=Last 4"`
 	// Name of the person whom the card belongs to.
-	Holder string `json:"holder" jsonschema:"title=Holder Name"`
+	Holder string `json:"holder,omitempty" jsonschema:"title=Holder Name"`
 }
 
 // DirectDebit defines the data that will be used to make the direct debit.


### PR DESCRIPTION
- Fixes issue when validating presence of a payment advance key, which is not a strict requirement of EN16931
- Also including fix to reduce requirements on payment card fields

## Pre-Review Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added thorough tests with at **least** 90% code coverage.
- [ ] I've modified or created example GOBL documents to show my changes in use, if appropriate.
- [ ] When adding or modifying a tax regime or addon, I've added links to the source of the changes, either structured or in the comments.
- [ ] I've run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [ ] All linter warnings have been reviewed and fixed.
- [ ] I've been obsessive with pointer nil checks to avoid panics.
- [ ] The CHANGELOG.md has been updated with an overview of my changes.
- [ ] Requested a review from @samlown.

