### PR TITLE
New invoice line codes for EN16931 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Added
 
-- `bill`: `Line` now incudes three new fields intended for greater EN16931 compatibility: `identifier`, `order`, and `cost`.
+- `bill`: `Line` now incudes three new fields intended for greater EN16931 compatibility: `identifier`, `period`, `order`, and `cost`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Added
+
+- `bill`: `Line` now incudes three new fields intended for greater EN16931 compatibility: `identifier`, `order`, and `cost`.
+
 ### Fixed
 
 - `eu-en16931-v2017`: removing validation of advanced payment means extension.

--- a/addons/br/nfse/invoices_test.go
+++ b/addons/br/nfse/invoices_test.go
@@ -151,7 +151,7 @@ func TestSuppliersValidation(t *testing.T) {
 		}
 		err := addon.Validator(inv)
 		if assert.Error(t, err) {
-			assert.Contains(t, err.Error(), "identities: missing key br-nfse-municipal-reg;")
+			assert.Contains(t, err.Error(), "identities: missing key 'br-nfse-municipal-reg';")
 		}
 
 		sup.Identities = append(sup.Identities, &org.Identity{
@@ -160,7 +160,7 @@ func TestSuppliersValidation(t *testing.T) {
 		})
 		err = addon.Validator(inv)
 		if assert.Error(t, err) {
-			assert.NotContains(t, err.Error(), "identities: missing key br-nfse-municipal-reg;")
+			assert.NotContains(t, err.Error(), "identities: missing key 'br-nfse-municipal-reg';")
 		}
 	})
 

--- a/addons/de/xrechnung/invoices_test.go
+++ b/addons/de/xrechnung/invoices_test.go
@@ -132,7 +132,7 @@ func TestInvoiceValidation(t *testing.T) {
 		inv.Supplier.TaxID = nil
 		require.NoError(t, inv.Calculate())
 		err := inv.Validate()
-		assert.ErrorContains(t, err, "supplier: (identities: missing key de-tax-number; tax_id: cannot be blank.).")
+		assert.ErrorContains(t, err, "supplier: (identities: missing key 'de-tax-number'; tax_id: cannot be blank.).")
 	})
 	t.Run("missing supplier tax ID but has tax number", func(t *testing.T) {
 		// this is validation is performed in the DE regime, but we're

--- a/addons/gr/mydata/extensions.go
+++ b/addons/gr/mydata/extensions.go
@@ -877,12 +877,12 @@ var extensions = []*cbc.Definition{
 						"i": 1,
 						"quantity": "20",
 						"item": {
-						"name": "Υπηρεσίες Ανάπτυξης",
-						"price": "90.00",
-						"ext": {
-							"gr-mydata-income-cat": "category1_1",
-							"gr-mydata-income-type": "E3_561_001",
-						}
+							"name": "Υπηρεσίες Ανάπτυξης",
+							"price": "90.00",
+							"ext": {
+								"gr-mydata-income-cat": "category1_1",
+								"gr-mydata-income-type": "E3_561_001",
+							}
 						}
 					}
 				]

--- a/addons/it/sdi/invoices_test.go
+++ b/addons/it/sdi/invoices_test.go
@@ -135,7 +135,7 @@ func TestCustomerValidation(t *testing.T) {
 		require.NoError(t, inv.Calculate())
 		err := inv.Validate()
 		// ensure contains bother errors
-		assert.ErrorContains(t, err, "identities: missing key it-fiscal-code")
+		assert.ErrorContains(t, err, "identities: missing key 'it-fiscal-code'")
 		assert.ErrorContains(t, err, "tax_id: (code: cannot be blank.")
 	})
 

--- a/data/addons/gr-mydata-v1.json
+++ b/data/addons/gr-mydata-v1.json
@@ -716,7 +716,7 @@
         "en": "Income Classification Category"
       },
       "desc": {
-        "en": "Invoices reported to the Greek tax authority via myDATA can optionally include information\nabout the income classification of each invoice item.\n\nIn a GOBL invoice, the `gr-mydata-income-cat` and `gr-mydata-income-type` extensions can be\nset at the item level to any of the values expected by the IAPR. For example:\n\n```json\n\"lines\": [\n\t{\n\t\t\"i\": 1,\n\t\t\"quantity\": \"20\",\n\t\t\"item\": {\n\t\t\"name\": \"Υπηρεσίες Ανάπτυξης\",\n\t\t\"price\": \"90.00\",\n\t\t\"ext\": {\n\t\t\t\"gr-mydata-income-cat\": \"category1_1\",\n\t\t\t\"gr-mydata-income-type\": \"E3_561_001\",\n\t\t}\n\t\t}\n\t}\n]\n```"
+        "en": "Invoices reported to the Greek tax authority via myDATA can optionally include information\nabout the income classification of each invoice item.\n\nIn a GOBL invoice, the `gr-mydata-income-cat` and `gr-mydata-income-type` extensions can be\nset at the item level to any of the values expected by the IAPR. For example:\n\n```json\n\"lines\": [\n\t{\n\t\t\"i\": 1,\n\t\t\"quantity\": \"20\",\n\t\t\"item\": {\n\t\t\t\"name\": \"Υπηρεσίες Ανάπτυξης\",\n\t\t\t\"price\": \"90.00\",\n\t\t\t\"ext\": {\n\t\t\t\t\"gr-mydata-income-cat\": \"category1_1\",\n\t\t\t\t\"gr-mydata-income-type\": \"E3_561_001\",\n\t\t\t}\n\t\t}\n\t}\n]\n```"
       },
       "values": [
         {

--- a/data/schemas/bill/invoice.json
+++ b/data/schemas/bill/invoice.json
@@ -647,10 +647,30 @@
           "title": "Quantity",
           "description": "Number of items"
         },
+        "identifier": {
+          "$ref": "https://gobl.org/draft-0/org/identity",
+          "title": "Identifier",
+          "description": "Single identifier provided by the supplier for an object on which the\nline item is based and is not considered a universal identity. Examples\ninclude a subscription number, telephone number, meter point, etc.\nUtilize the label property to provide a description of the identifier."
+        },
+        "period": {
+          "$ref": "https://gobl.org/draft-0/cal/period",
+          "title": "Period",
+          "description": "A period of time relevant to when the service or item is delivered."
+        },
+        "order": {
+          "$ref": "https://gobl.org/draft-0/cbc/code",
+          "title": "Order Reference",
+          "description": "Order reference for a specific line within a purchase order provided by the buyer."
+        },
+        "cost": {
+          "$ref": "https://gobl.org/draft-0/cbc/code",
+          "title": "Cost Reference",
+          "description": "Buyer accounting reference cost code to associate with the line."
+        },
         "item": {
           "$ref": "https://gobl.org/draft-0/org/item",
           "title": "Item",
-          "description": "Details about what is being sold"
+          "description": "Details about the item, service or good, that is being sold"
         },
         "sum": {
           "$ref": "https://gobl.org/draft-0/num/amount",

--- a/data/schemas/org/item.json
+++ b/data/schemas/org/item.json
@@ -12,7 +12,7 @@
           "description": "Universally Unique Identifier."
         },
         "ref": {
-          "type": "string",
+          "$ref": "https://gobl.org/draft-0/cbc/code",
           "title": "Ref",
           "description": "Primary reference code that identifies this item.\nAdditional codes can be provided in the 'identities' property."
         },

--- a/examples/es/invoice-es-es.yaml
+++ b/examples/es/invoice-es-es.yaml
@@ -29,6 +29,9 @@ customer:
 
 lines:
   - quantity: 20
+    identifier:
+      label: "Subscription"
+      code: "SUB1234-ABC"
     item:
       name: "Development services"
       price: "90.00"

--- a/examples/es/out/invoice-es-es.json
+++ b/examples/es/out/invoice-es-es.json
@@ -4,7 +4,7 @@
 		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
 		"dig": {
 			"alg": "sha256",
-			"val": "88c970d2e4aa21a7fd711856c45fcf847a4af61bce0d4c2dafb2c1550f9701fc"
+			"val": "01ca58456fb5549d7786c607e1970defce128c794de702a5d0af95ca798c91a4"
 		}
 	},
 	"doc": {
@@ -57,6 +57,10 @@
 			{
 				"i": 1,
 				"quantity": "20",
+				"identifier": {
+					"label": "Subscription",
+					"code": "SUB1234-ABC"
+				},
 				"item": {
 					"name": "Development services",
 					"price": "90.00",

--- a/org/identity.go
+++ b/org/identity.go
@@ -130,10 +130,10 @@ func (v validateIdentitySet) matches(row *Identity) bool {
 func (v validateIdentitySet) String() string {
 	var parts []string
 	if v.typ != cbc.CodeEmpty {
-		parts = append(parts, fmt.Sprintf("type %s", v.typ))
+		parts = append(parts, fmt.Sprintf("type '%s'", v.typ))
 	}
 	if len(v.keys) != 0 {
-		parts = append(parts, fmt.Sprintf("key %s", strings.Join(cbc.KeyStrings(v.keys), ", ")))
+		parts = append(parts, fmt.Sprintf("key '%s'", strings.Join(cbc.KeyStrings(v.keys), ", ")))
 	}
 	return strings.Join(parts, ", ")
 }
@@ -165,7 +165,7 @@ func AddIdentity(in []*Identity, i *Identity) []*Identity {
 		return []*Identity{i}
 	}
 	for _, v := range in {
-		if v.Type == i.Type || v.Key == i.Key {
+		if v.Type == i.Type && v.Key == i.Key {
 			*v = *i // copy in place
 			return in
 		}

--- a/org/identity_test.go
+++ b/org/identity_test.go
@@ -7,27 +7,78 @@ import (
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/org"
 	"github.com/invopop/gobl/tax"
+	"github.com/invopop/validation"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestAddIdentity(t *testing.T) {
-	foo := cbc.Code("FOO")
-	st := struct {
-		Identities []*org.Identity
-	}{
-		Identities: []*org.Identity{
-			{
-				Type: foo,
-				Code: "BAR",
+	t.Run("basic", func(t *testing.T) {
+		foo := cbc.Code("FOO")
+		st := struct {
+			Identities []*org.Identity
+		}{
+			Identities: []*org.Identity{
+				{
+					Type: foo,
+					Code: "BAR",
+				},
 			},
-		},
-	}
-	st.Identities = org.AddIdentity(st.Identities, &org.Identity{
-		Type: foo,
-		Code: "BARDOM",
+		}
+		st.Identities = org.AddIdentity(st.Identities, &org.Identity{
+			Type: foo,
+			Code: "BARDOM",
+		})
+		assert.Len(t, st.Identities, 1)
+		assert.Equal(t, "BARDOM", st.Identities[0].Code.String())
 	})
-	assert.Len(t, st.Identities, 1)
-	assert.Equal(t, "BARDOM", st.Identities[0].Code.String())
+	t.Run("nil array", func(t *testing.T) {
+		var st struct {
+			Identities []*org.Identity
+		}
+		st.Identities = org.AddIdentity(st.Identities, &org.Identity{
+			Type: "FOO",
+			Code: "BAR",
+		})
+		assert.Len(t, st.Identities, 1)
+		assert.Equal(t, "BAR", st.Identities[0].Code.String())
+	})
+	t.Run("append type", func(t *testing.T) {
+		foo := cbc.Code("FOO")
+		st := struct {
+			Identities []*org.Identity
+		}{
+			Identities: []*org.Identity{
+				{
+					Type: foo,
+					Code: "BAR",
+				},
+			},
+		}
+		st.Identities = org.AddIdentity(st.Identities, &org.Identity{
+			Type: "FOO2",
+			Code: "BARDOM",
+		})
+		assert.Len(t, st.Identities, 2)
+		assert.Equal(t, "BARDOM", st.Identities[1].Code.String())
+	})
+	t.Run("append key", func(t *testing.T) {
+		st := struct {
+			Identities []*org.Identity
+		}{
+			Identities: []*org.Identity{
+				{
+					Key:  "foo",
+					Code: "BAR",
+				},
+			},
+		}
+		st.Identities = org.AddIdentity(st.Identities, &org.Identity{
+			Key:  "foo-second",
+			Code: "BARDOM",
+		})
+		assert.Len(t, st.Identities, 2)
+		assert.Equal(t, "BARDOM", st.Identities[1].Code.String())
+	})
 }
 
 func TestIdentityNormalize(t *testing.T) {
@@ -79,5 +130,80 @@ func TestIdentityValidate(t *testing.T) {
 		}
 		err := id.Validate()
 		assert.ErrorContains(t, err, "type: must be empty when key is set")
+	})
+}
+
+func TestIdentitySetValidators(t *testing.T) {
+	t.Run("ignore other types", func(t *testing.T) {
+		var idents *org.Identity
+		err := validation.Validate(idents, org.RequireIdentityType("FOO"))
+		assert.NoError(t, err)
+	})
+	t.Run("require identity type", func(t *testing.T) {
+		idents := []*org.Identity{
+			{
+				Type: "BAR",
+				Code: "FOO",
+			},
+		}
+		err := validation.Validate(idents, org.RequireIdentityType("BAR"))
+		assert.NoError(t, err)
+
+		err = validation.Validate(idents, org.RequireIdentityType("FOO"))
+		assert.ErrorContains(t, err, "missing type 'FOO'")
+	})
+
+	t.Run("require identity key", func(t *testing.T) {
+		idents := []*org.Identity{
+			{
+				Type: "BAR",
+				Code: "FOO",
+			},
+			{
+				Key:  "fiscal-code",
+				Code: "12345",
+			},
+		}
+		err := validation.Validate(idents, org.RequireIdentityKey("fiscal-code"))
+		assert.NoError(t, err)
+
+		err = validation.Validate(idents, org.RequireIdentityKey("code"))
+		assert.ErrorContains(t, err, "missing key 'code'")
+	})
+}
+
+func TestIdentityForType(t *testing.T) {
+	t.Run("basic", func(t *testing.T) {
+		idents := []*org.Identity{
+			{
+				Type: "BAR",
+				Code: "FOO",
+			},
+			{
+				Type: "FOO",
+				Code: "BAR",
+			},
+		}
+		id := org.IdentityForType(idents, "FOO")
+		assert.Equal(t, "BAR", id.Code.String())
+		assert.Nil(t, org.IdentityForType(idents, "BAZ"))
+	})
+}
+
+func TestIdentityForKey(t *testing.T) {
+	t.Run("basic", func(t *testing.T) {
+		idents := []*org.Identity{
+			{
+				Key:  "bar",
+				Code: "FOO",
+			},
+			{
+				Key:  "foo",
+				Code: "BAR",
+			},
+		}
+		id := org.IdentityForKey(idents, "foo")
+		assert.Equal(t, "BAR", id.Code.String())
+		assert.Nil(t, org.IdentityForKey(idents, "baz"))
 	})
 }

--- a/org/item.go
+++ b/org/item.go
@@ -25,7 +25,7 @@ type Item struct {
 	uuid.Identify
 	// Primary reference code that identifies this item.
 	// Additional codes can be provided in the 'identities' property.
-	Ref string `json:"ref,omitempty" jsonschema:"title=Ref"`
+	Ref cbc.Code `json:"ref,omitempty" jsonschema:"title=Ref"`
 	// Special key used to classify the item sometimes required by some regimes.
 	Key cbc.Key `json:"key,omitempty" jsonschema:"title=Key"`
 	// Brief name of the item
@@ -70,6 +70,7 @@ func (i *Item) Normalize(normalizers tax.Normalizers) {
 func (i *Item) ValidateWithContext(ctx context.Context) error {
 	return tax.ValidateStructWithContext(ctx, i,
 		validation.Field(&i.UUID),
+		validation.Field(&i.Ref),
 		validation.Field(&i.Key),
 		validation.Field(&i.Name, validation.Required),
 		validation.Field(&i.Identities),

--- a/org/item_test.go
+++ b/org/item_test.go
@@ -1,0 +1,43 @@
+package org_test
+
+import (
+	"testing"
+
+	"github.com/invopop/gobl/num"
+	"github.com/invopop/gobl/org"
+	"github.com/invopop/gobl/tax"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestItemNormalization(t *testing.T) {
+	t.Run("nil", func(t *testing.T) {
+		var i *org.Item
+		assert.NotPanics(t, func() {
+			i.Normalize(nil)
+		})
+	})
+	t.Run("extensions", func(t *testing.T) {
+		i := &org.Item{
+			Name:  "test item",
+			Price: num.MakeAmount(100, 2),
+			Ext: tax.Extensions{
+				"test": "",
+			},
+		}
+		i.Normalize(nil)
+		assert.Equal(t, "test item", i.Name)
+		assert.Equal(t, num.MakeAmount(100, 2), i.Price)
+		assert.Nil(t, i.Ext)
+	})
+}
+
+func TestItemValidation(t *testing.T) {
+	// Check that the item is valid
+	t.Run("basics", func(t *testing.T) {
+		i := &org.Item{
+			Name:  "test item",
+			Price: num.MakeAmount(100, 2),
+		}
+		assert.NoError(t, i.Validate())
+	})
+}

--- a/regimes/de/invoices_test.go
+++ b/regimes/de/invoices_test.go
@@ -58,7 +58,7 @@ func TestInvoiceValidation(t *testing.T) {
 		inv = validInvoice()
 		inv.Supplier.TaxID = nil
 		require.NoError(t, inv.Calculate())
-		assert.ErrorContains(t, inv.Validate(), "supplier: (identities: missing key de-tax-number; tax_id: cannot be blank.).")
+		assert.ErrorContains(t, inv.Validate(), "supplier: (identities: missing key 'de-tax-number'; tax_id: cannot be blank.).")
 	})
 
 	t.Run("simplified invoice - no tax details", func(t *testing.T) {

--- a/regimes/in/org_item_test.go
+++ b/regimes/in/org_item_test.go
@@ -34,6 +34,6 @@ func TestOrgItemValidation(t *testing.T) {
 			},
 		}
 		err := tr.ValidateObject(i)
-		assert.ErrorContains(t, err, "identities: missing type HSN.")
+		assert.ErrorContains(t, err, "identities: missing type 'HSN'.")
 	})
 }


### PR DESCRIPTION
- `bill.Line` has new properties: `identifier`, `period`, `order`, and `code`, in order to comply with EN16931 requirements.

## Pre-Review Checklist

- [x] I have performed a self-review of my code.
- [x] I have added thorough tests with at **least** 90% code coverage.
- [x] I've modified or created example GOBL documents to show my changes in use, if appropriate.
- [ ] When adding or modifying a tax regime or addon, I've added links to the source of the changes, either structured or in the comments.
- [x] I've run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [x] All linter warnings have been reviewed and fixed.
- [x] I've been obsessive with pointer nil checks to avoid panics.
- [x] The CHANGELOG.md has been updated with an overview of my changes.
- [ ] Requested a review from @samlown.

