### PR TITLE
Support for customising tax rounding for calculations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Each document class has a subset of types to cover multiple situations. Its been
 - `bill`: `Payment` - `request` type now supported.
 - `bill`: `Line` now includes a `breakdown` array of sub-lines that will be used to calculate the item's price, including individual discounts and charges. This effectively implements grouping, while maintaining compatibility with all other formats that do not support breakdowns.
 - `bill`: `Line` new `substituted` array of sub-lines for informational purposes when the originally requested line could not be fulfilled, especially relevant for orders.
+- `bill`: `Tax` includes `rounding` field to be able to override the tax regimes default rounding mechanism.
 
 ### Changed
 

--- a/bill/calculator.go
+++ b/bill/calculator.go
@@ -124,13 +124,22 @@ func calculate(doc billable) error {
 
 	// Now figure out the tax totals
 	var pit cbc.Code
-	if doc.getTax() != nil && doc.getTax().PricesInclude != "" {
-		pit = doc.getTax().PricesInclude
+	var rr cbc.Key
+	if tx := doc.getTax(); tx != nil {
+		if tx.PricesInclude != "" {
+			pit = tx.PricesInclude
+		}
+		if tx.Rounding != "" {
+			rr = tx.Rounding
+		}
+	}
+	if rr == "" {
+		rr = r.GetRoundingRule()
 	}
 	t.Taxes = new(tax.Total)
 	tc := &tax.TotalCalculator{
 		Currency: doc.getCurrency(),
-		Rounding: r.GetRoundingRule(),
+		Rounding: rr,
 		Country:  r.GetCountry(),
 		Tags:     doc.GetTags(),
 		Date:     *date,

--- a/bill/calculator_test.go
+++ b/bill/calculator_test.go
@@ -49,6 +49,17 @@ func TestCalculate(t *testing.T) {
 		require.NoError(t, inv.Calculate())
 		assert.Equal(t, "3.49", inv.Totals.Tax.String())
 	})
+	t.Run("with line errors", func(t *testing.T) {
+		inv := baseInvoice(t, &bill.Line{
+			Quantity: num.MakeAmount(1, 0),
+			Item: &org.Item{
+				Name:     "test item 1",
+				Currency: "USD",
+				Price:    num.NewAmount(942, 2),
+			},
+		})
+		require.ErrorContains(t, inv.Calculate(), "lines: (0: (item: no exchange rate found from 'USD' to 'EUR'.).)")
+	})
 }
 
 func TestRemoveIncludedTaxes(t *testing.T) {

--- a/bill/calculator_test.go
+++ b/bill/calculator_test.go
@@ -5,12 +5,51 @@ import (
 
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/num"
+	"github.com/invopop/gobl/org"
 	"github.com/invopop/gobl/tax"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 // Note: many calculation tests are distributed throughout this package.
+
+func TestCalculate(t *testing.T) {
+	t.Run("with round-then-sum rounding rule", func(t *testing.T) {
+		inv := baseInvoice(t, &bill.Line{
+			Quantity: num.MakeAmount(1, 0),
+			Item: &org.Item{
+				Name:  "test item 1",
+				Price: num.NewAmount(942, 2),
+			},
+			Taxes: tax.Set{
+				{
+					Category: tax.CategoryVAT,
+					Percent:  num.NewPercentage(24, 2),
+				},
+			},
+		}, &bill.Line{
+			Quantity: num.MakeAmount(1, 0),
+			Item: &org.Item{
+				Name:  "test item 2",
+				Price: num.NewAmount(942, 2),
+			},
+			Taxes: tax.Set{
+				{
+					Category: tax.CategoryVAT,
+					Percent:  num.NewPercentage(13, 2),
+				},
+			},
+		})
+		inv.Tax.PricesInclude = ""
+		inv.Tax.Rounding = tax.RoundingRuleRoundThenSum
+		require.NoError(t, inv.Calculate())
+		assert.Equal(t, "3.48", inv.Totals.Tax.String())
+
+		inv.Tax.Rounding = tax.RoundingRuleSumThenRound
+		require.NoError(t, inv.Calculate())
+		assert.Equal(t, "3.49", inv.Totals.Tax.String())
+	})
+}
 
 func TestRemoveIncludedTaxes(t *testing.T) {
 	t.Run("no included tax", func(t *testing.T) {

--- a/bill/invoice_test.go
+++ b/bill/invoice_test.go
@@ -902,7 +902,7 @@ func TestApplyCustomerRates(t *testing.T) {
 	})
 }
 
-func TestCalculate(t *testing.T) {
+func TestInvoiceCalculate(t *testing.T) {
 	i := &bill.Invoice{
 		Code: "123TEST",
 		Tax: &bill.Tax{

--- a/data/schemas/bill/delivery.json
+++ b/data/schemas/bill/delivery.json
@@ -1092,6 +1092,23 @@
           "title": "Prices Include",
           "description": "Category of the tax already included in the line item prices, especially\nuseful for B2C retailers with customers who prefer final prices inclusive of\ntax."
         },
+        "rounding": {
+          "$ref": "https://gobl.org/draft-0/cbc/key",
+          "oneOf": [
+            {
+              "const": "sum-then-round",
+              "title": "Sum Then Round",
+              "description": "The default method of calculating the totals in GOBL, and provides the best results\nfor most cases as the precision is maintained to the maximum amount possible. The\ntradeoff however is that sometimes the totals may not sum exactly based on what is visible."
+            },
+            {
+              "const": "round-then-sum",
+              "title": "Round Then Sum",
+              "description": "The alternative method of calculating the totals that will first round all the amounts\nto the currency's precision before making the sums. Totals using this approach can always\nbe recalculated using the amounts presented, but can lead to rounding errors in the case\nof pre-payments and when line item prices include tax."
+            }
+          ],
+          "title": "Rounding Model",
+          "description": "Rounding model used to perform tax calculations on the invoice. This\nwill be configured automatically based on the tax regime, or\n`sum-then-round` by default, but you can override here if needed.\nUse with caution, as some conversion tools may make assumptions about\nthe rounding model used."
+        },
         "ext": {
           "$ref": "https://gobl.org/draft-0/tax/extensions",
           "title": "Extensions",

--- a/data/schemas/bill/invoice.json
+++ b/data/schemas/bill/invoice.json
@@ -1153,6 +1153,23 @@
           "title": "Prices Include",
           "description": "Category of the tax already included in the line item prices, especially\nuseful for B2C retailers with customers who prefer final prices inclusive of\ntax."
         },
+        "rounding": {
+          "$ref": "https://gobl.org/draft-0/cbc/key",
+          "oneOf": [
+            {
+              "const": "sum-then-round",
+              "title": "Sum Then Round",
+              "description": "The default method of calculating the totals in GOBL, and provides the best results\nfor most cases as the precision is maintained to the maximum amount possible. The\ntradeoff however is that sometimes the totals may not sum exactly based on what is visible."
+            },
+            {
+              "const": "round-then-sum",
+              "title": "Round Then Sum",
+              "description": "The alternative method of calculating the totals that will first round all the amounts\nto the currency's precision before making the sums. Totals using this approach can always\nbe recalculated using the amounts presented, but can lead to rounding errors in the case\nof pre-payments and when line item prices include tax."
+            }
+          ],
+          "title": "Rounding Model",
+          "description": "Rounding model used to perform tax calculations on the invoice. This\nwill be configured automatically based on the tax regime, or\n`sum-then-round` by default, but you can override here if needed.\nUse with caution, as some conversion tools may make assumptions about\nthe rounding model used."
+        },
         "ext": {
           "$ref": "https://gobl.org/draft-0/tax/extensions",
           "title": "Extensions",

--- a/data/schemas/bill/order.json
+++ b/data/schemas/bill/order.json
@@ -1070,6 +1070,23 @@
           "title": "Prices Include",
           "description": "Category of the tax already included in the line item prices, especially\nuseful for B2C retailers with customers who prefer final prices inclusive of\ntax."
         },
+        "rounding": {
+          "$ref": "https://gobl.org/draft-0/cbc/key",
+          "oneOf": [
+            {
+              "const": "sum-then-round",
+              "title": "Sum Then Round",
+              "description": "The default method of calculating the totals in GOBL, and provides the best results\nfor most cases as the precision is maintained to the maximum amount possible. The\ntradeoff however is that sometimes the totals may not sum exactly based on what is visible."
+            },
+            {
+              "const": "round-then-sum",
+              "title": "Round Then Sum",
+              "description": "The alternative method of calculating the totals that will first round all the amounts\nto the currency's precision before making the sums. Totals using this approach can always\nbe recalculated using the amounts presented, but can lead to rounding errors in the case\nof pre-payments and when line item prices include tax."
+            }
+          ],
+          "title": "Rounding Model",
+          "description": "Rounding model used to perform tax calculations on the invoice. This\nwill be configured automatically based on the tax regime, or\n`sum-then-round` by default, but you can override here if needed.\nUse with caution, as some conversion tools may make assumptions about\nthe rounding model used."
+        },
         "ext": {
           "$ref": "https://gobl.org/draft-0/tax/extensions",
           "title": "Extensions",

--- a/data/schemas/tax/regime-def.json
+++ b/data/schemas/tax/regime-def.json
@@ -258,7 +258,7 @@
           "description": "Currency used by the country."
         },
         "calculator_rounding_rule": {
-          "type": "string",
+          "$ref": "https://gobl.org/draft-0/cbc/key",
           "title": "Calculator Rounding Rule",
           "description": "Rounding rule to use when calculating the tax totals, default is always\n`sum-then-round`."
         },

--- a/examples/es/invoice-es-rounding.yaml
+++ b/examples/es/invoice-es-rounding.yaml
@@ -1,0 +1,44 @@
+$schema: "https://gobl.org/draft-0/bill/invoice"
+uuid: "3aea7b56-59d8-4beb-90bd-f8f280d852a0"
+currency: "EUR"
+issue_date: "2025-02-01"
+series: "SAMPLE-R"
+code: "001"
+tax:
+  rounding: "round-then-sum"
+supplier:
+  tax_id:
+    country: "ES"
+    code: "B98602642" # random
+  name: "Provide One S.L."
+  emails:
+    - addr: "billing@example.com"
+  addresses:
+    - num: "42"
+      street: "Calle Pradillo"
+      locality: "Madrid"
+      region: "Madrid"
+      code: "28002"
+      country: "ES"
+
+customer:
+  tax_id:
+    country: "ES"
+    code: "54387763P"
+  name: "Sample Consumer"
+
+lines:
+  - quantity: 20
+    identifier:
+      label: "Subscription"
+      code: "SUB1234-ABC"
+    item:
+      name: "Development services"
+      price: "12.36"
+      unit: "h"
+    discounts:
+      - percent: "12.5%"
+        reason: "Special discount"
+    taxes:
+      - cat: VAT
+        rate: standard

--- a/examples/es/out/invoice-es-rounding.json
+++ b/examples/es/out/invoice-es-rounding.json
@@ -1,0 +1,107 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
+		"dig": {
+			"alg": "sha256",
+			"val": "8952bce519c44b1341449add39f95790c289259b2c1416baa1c5f470ac66e893"
+		}
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"$regime": "ES",
+		"uuid": "3aea7b56-59d8-4beb-90bd-f8f280d852a0",
+		"type": "standard",
+		"series": "SAMPLE-R",
+		"code": "001",
+		"issue_date": "2025-02-01",
+		"currency": "EUR",
+		"tax": {
+			"rounding": "round-then-sum"
+		},
+		"supplier": {
+			"name": "Provide One S.L.",
+			"tax_id": {
+				"country": "ES",
+				"code": "B98602642"
+			},
+			"addresses": [
+				{
+					"num": "42",
+					"street": "Calle Pradillo",
+					"locality": "Madrid",
+					"region": "Madrid",
+					"code": "28002",
+					"country": "ES"
+				}
+			],
+			"emails": [
+				{
+					"addr": "billing@example.com"
+				}
+			]
+		},
+		"customer": {
+			"name": "Sample Consumer",
+			"tax_id": {
+				"country": "ES",
+				"code": "54387763P"
+			}
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "20",
+				"identifier": {
+					"label": "Subscription",
+					"code": "SUB1234-ABC"
+				},
+				"item": {
+					"name": "Development services",
+					"price": "12.36",
+					"unit": "h"
+				},
+				"sum": "247.20",
+				"discounts": [
+					{
+						"reason": "Special discount",
+						"percent": "12.5%",
+						"amount": "30.90"
+					}
+				],
+				"taxes": [
+					{
+						"cat": "VAT",
+						"rate": "standard",
+						"percent": "21.0%"
+					}
+				],
+				"total": "216.30"
+			}
+		],
+		"totals": {
+			"sum": "216.30",
+			"total": "216.30",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"base": "216.30",
+								"percent": "21.0%",
+								"amount": "45.42"
+							}
+						],
+						"amount": "45.42"
+					}
+				],
+				"sum": "45.42"
+			},
+			"tax": "45.42",
+			"total_with_tax": "261.72",
+			"payable": "261.72"
+		}
+	}
+}

--- a/tax/regime_def.go
+++ b/tax/regime_def.go
@@ -50,7 +50,7 @@ type RegimeDef struct {
 
 	// Rounding rule to use when calculating the tax totals, default is always
 	// `sum-then-round`.
-	CalculatorRoundingRule RoundingRule `json:"calculator_rounding_rule,omitempty" jsonschema:"title=Calculator Rounding Rule"`
+	CalculatorRoundingRule cbc.Key `json:"calculator_rounding_rule,omitempty" jsonschema:"title=Calculator Rounding Rule"`
 
 	// Tags that can be applied at the document level to identify additional
 	// considerations.
@@ -226,7 +226,7 @@ func (r *RegimeDef) GetCountry() l10n.TaxCountryCode {
 }
 
 // GetRoundingRule provides the regime's rounding rule, or the default.
-func (r *RegimeDef) GetRoundingRule() RoundingRule {
+func (r *RegimeDef) GetRoundingRule() cbc.Key {
 	if r != nil && r.CalculatorRoundingRule != "" {
 		return r.CalculatorRoundingRule
 	}

--- a/tax/rounding_rules.go
+++ b/tax/rounding_rules.go
@@ -1,0 +1,53 @@
+package tax
+
+import (
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/i18n"
+	"github.com/invopop/gobl/pkg/here"
+)
+
+const (
+	// RoundingRuleSumThenRound is the default method of calculating the totals
+	// in GOBL, and provides the best results for most cases as the precision
+	// is maintained to the maximum amount possible. The tradeoff however is
+	// that sometimes the totals may not sum exactly based on what is visible.
+	RoundingRuleSumThenRound cbc.Key = "sum-then-round"
+
+	// RoundingRuleRoundThenSum is the alternative method of calculating the totals
+	// that will first round all the amounts to the currency's precision before
+	// making the sums. Totals using this approach can always be recalculated using
+	// the amounts presented, but can lead to rounding errors in the case of
+	// pre-payments and when line item prices include tax.
+	RoundingRuleRoundThenSum cbc.Key = "round-then-sum"
+)
+
+// RoundingRules defines the list of supported rounding rules.
+var RoundingRules = []*cbc.Definition{
+	{
+		Key: RoundingRuleSumThenRound,
+		Name: i18n.String{
+			i18n.EN: "Sum Then Round",
+		},
+		Desc: i18n.String{
+			i18n.EN: here.Doc(`
+				The default method of calculating the totals in GOBL, and provides the best results
+				for most cases as the precision is maintained to the maximum amount possible. The
+				tradeoff however is that sometimes the totals may not sum exactly based on what is visible.
+			`),
+		},
+	},
+	{
+		Key: RoundingRuleRoundThenSum,
+		Name: i18n.String{
+			i18n.EN: "Round Then Sum",
+		},
+		Desc: i18n.String{
+			i18n.EN: here.Doc(`
+				The alternative method of calculating the totals that will first round all the amounts
+				to the currency's precision before making the sums. Totals using this approach can always
+				be recalculated using the amounts presented, but can lead to rounding errors in the case
+				of pre-payments and when line item prices include tax.
+			`),
+		},
+	},
+}

--- a/tax/totals_calculator.go
+++ b/tax/totals_calculator.go
@@ -12,7 +12,7 @@ import (
 // data for calculating tax totals from TaxableLines.
 type TotalCalculator struct {
 	Country  l10n.TaxCountryCode
-	Rounding RoundingRule
+	Rounding cbc.Key
 	Currency currency.Code
 	Tags     []cbc.Key
 	Date     cal.Date
@@ -94,7 +94,7 @@ func (tc *TotalCalculator) calculateBaseRateTotals(taxLines []*taxLine, t *Total
 	for _, tl := range taxLines {
 		for _, c := range tl.taxes {
 			rt := t.rateTotalFor(c, tc.zero)
-			rt.Base = tc.Rounding.matchPrecision(rt.Base, tl.total)
+			rt.Base = matchRoundingPrecision(tc.Rounding, rt.Base, tl.total)
 			rt.Base = rt.Base.Add(tl.total)
 		}
 	}

--- a/tax/totals_calculator_test.go
+++ b/tax/totals_calculator_test.go
@@ -26,7 +26,7 @@ func TestTotalBySumCalculate(t *testing.T) {
 	var tests = []struct {
 		desc        string
 		country     l10n.TaxCountryCode // default "ES"
-		rounding    tax.RoundingRule
+		rounding    cbc.Key
 		tags        []cbc.Key      // default empty
 		ext         tax.Extensions // default empty
 		lines       []tax.TaxableLine


### PR DESCRIPTION
- Exposes the tax rounding calculator method so that it can be overriden on a per-document basis.

## Pre-Review Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added thorough tests with at **least** 90% code coverage.
- [ ] I've modified or created example GOBL documents to show my changes in use, if appropriate.
- [ ] When adding or modifying a tax regime or addon, I've added links to the source of the changes, either structured or in the comments.
- [ ] I've run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [ ] All linter warnings have been reviewed and fixed.
- [ ] I've been obsessive with pointer nil checks to avoid panics.
- [ ] The CHANGELOG.md has been updated with an overview of my changes.
- [ ] Requested a review from @samlown.

