### PR TITLE
Billing codes now recommended by schema, improved field description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 - `pt-saft-v1`: support for stock movements (from `bill.Delivery`) and work documents (from `bill.Invoice` and `bill.Order`)
 
+## Changed
+
+- `bill`: `code` field now "recommended" in Order, Delivery, Invoice, & Payment schemas, but should not raise error until signing.
+
 ## [v0.212.1] - 2025-03-11
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## Changed
 
-- `bill`: `code` field now "recommended" in Order, Delivery, Invoice, & Payment schemas, but should not raise error until signing.
+- `bill`: `code` field now "recommended" in Order, Delivery, Invoice, & Payment schemas, but should not raise JSON Schema warnings. Validation will continue to fail when signing.
 
 ## [v0.212.1] - 2025-03-11
 

--- a/bill/delivery.go
+++ b/bill/delivery.go
@@ -89,10 +89,14 @@ type Delivery struct {
 
 	// Type of delivery document.
 	Type cbc.Key `json:"type" jsonschema:"title=Type" jsonschema_extras:"enum=advice,note,waybill,receipt"`
-	// Used as a prefix to group codes.
+	// Series is used to identify groups of deliveries by date, business area, project,
+	// type, customer, a combination of any, or other company specific data.
+	// If the output format does not support the series as a separate field, it will be
+	// prepended to the code for presentation with a dash (`-`) for separation.
 	Series cbc.Code `json:"series,omitempty" jsonschema:"title=Series"`
-	// Sequential code used to identify this delivery in tax declarations.
-	Code cbc.Code `json:"code" jsonschema:"title=Code"`
+	// Code is a sequential identifier that uniquely identifies the delivery. The code can
+	// be left empty initially, but is **required** to **sign** the document.
+	Code cbc.Code `json:"code,omitempty" jsonschema:"title=Code"`
 	// When the delivery document is to be issued.
 	IssueDate cal.Date `json:"issue_date" jsonschema:"title=Issue Date" jsonschema_extras:"calculated=true"`
 	// When the taxes of this delivery become accountable, if none set, the issue date is used.
@@ -401,6 +405,9 @@ func (dlv Delivery) JSONSchemaExtend(js *jsonschema.Schema) {
 	js.Extras = map[string]any{
 		schema.Recommended: []string{
 			"$regime",
+			"series",
+			"code",
+			"lines",
 		},
 	}
 }

--- a/bill/invoice.go
+++ b/bill/invoice.go
@@ -32,33 +32,39 @@ type Invoice struct {
 	tax.Tags
 	uuid.Identify
 
-	// Type of invoice document subject to the requirements of the local tax regime.
+	// Type of invoice document. May be restricted by local tax regime requirements.
 	Type cbc.Key `json:"type" jsonschema:"title=Type" jsonschema_extras:"calculated=true"`
-	// Used as a prefix to group codes.
+	// Series is used to identify groups of invoices by date, business area, project,
+	// type of document, customer type, a combination of any or other company specific data.
+	// If the output format does not support the series as a separate field, it will be
+	// prepended to the code for presentation with a dash (`-`) for separation.
 	Series cbc.Code `json:"series,omitempty" jsonschema:"title=Series"`
-	// Sequential code used to identify this invoice in tax declarations.
-	Code cbc.Code `json:"code" jsonschema:"title=Code"`
-	// When the invoice was created.
+	// Code is a sequential identifier that uniquely identifies the invoice. The code can
+	// be left empty initially, but is **required** to **sign** the invoice.
+	Code cbc.Code `json:"code,omitempty" jsonschema:"title=Code"`
+	// Issue date for when the invoice was created and issued. Todays date is used if
+	// none is set. There are often legal restrictions on how far back an invoice
+	// can be issued.
 	IssueDate cal.Date `json:"issue_date" jsonschema:"title=Issue Date" jsonschema_extras:"calculated=true"`
 	// Date when the operation defined by the invoice became effective.
 	OperationDate *cal.Date `json:"op_date,omitempty" jsonschema:"title=Operation Date"`
 	// When the taxes of this invoice become accountable, if none set, the issue date is used.
 	ValueDate *cal.Date `json:"value_date,omitempty" jsonschema:"title=Value Date"`
-	// Currency for all invoice totals.
+	// Currency for all invoice amounts and totals, unless explicitly stated otherwise.
 	Currency currency.Code `json:"currency" jsonschema:"title=Currency" jsonschema_extras:"calculated=true"`
 	// Exchange rates to be used when converting the invoices monetary values into other currencies.
 	ExchangeRates []*currency.ExchangeRate `json:"exchange_rates,omitempty" jsonschema:"title=Exchange Rates"`
 
-	// Key information regarding previous invoices and potentially details as to why they
-	// were corrected.
+	// Document references for previous invoices that this document replaces or extends.
 	Preceding []*org.DocumentRef `json:"preceding,omitempty" jsonschema:"title=Preceding Details"`
 
-	// Special tax configuration for billing.
+	// Special billing tax configuration options.
 	Tax *Tax `json:"tax,omitempty" jsonschema:"title=Tax"`
 
 	// The entity supplying the goods or services and usually responsible for paying taxes.
 	Supplier *org.Party `json:"supplier" jsonschema:"title=Supplier"`
-	// Legal entity receiving the goods or services, may be nil in certain circumstances such as simplified invoices.
+	// Legal entity receiving the goods or services, may be nil in certain circumstances
+	// such as simplified invoices.
 	Customer *org.Party `json:"customer,omitempty" jsonschema:"title=Customer"`
 
 	// List of invoice lines representing each of the items sold to the customer.
@@ -426,6 +432,8 @@ func (inv Invoice) JSONSchemaExtend(js *jsonschema.Schema) {
 	js.Extras = map[string]any{
 		schema.Recommended: []string{
 			"$regime",
+			"series",
+			"code",
 			"lines",
 		},
 	}

--- a/bill/invoice_type.go
+++ b/bill/invoice_type.go
@@ -4,7 +4,6 @@ import (
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/i18n"
 	"github.com/invopop/gobl/pkg/here"
-	"github.com/invopop/validation"
 )
 
 // Predefined list of the invoice type codes officially supported.
@@ -105,15 +104,7 @@ var InvoiceTypes = []*cbc.Definition{
 	},
 }
 
-var isValidInvoiceType = validation.In(validInvoiceTypes()...)
-
-func validInvoiceTypes() []interface{} {
-	list := make([]interface{}, len(InvoiceTypes))
-	for i, d := range InvoiceTypes {
-		list[i] = d.Key
-	}
-	return list
-}
+var isValidInvoiceType = cbc.InKeyDefs(InvoiceTypes)
 
 // UNTDID1001 provides the official code number assigned with the Invoice type.
 func (i *Invoice) UNTDID1001() cbc.Code {

--- a/bill/order.go
+++ b/bill/order.go
@@ -74,10 +74,14 @@ type Order struct {
 
 	// Type of the order.
 	Type cbc.Key `json:"type,omitempty" jsonschema:"title=Type"`
-	// Used as a prefix to group codes.
+	// Series is used to identify groups of orders by date, business area, project,
+	// type, customer, a combination of any, or other company specific data.
+	// If the output format does not support the series as a separate field, it will be
+	// prepended to the code for presentation with a dash (`-`) for separation.
 	Series cbc.Code `json:"series,omitempty" jsonschema:"title=Series"`
-	// Sequential code used to identify this invoice in tax declarations.
-	Code cbc.Code `json:"code" jsonschema:"title=Code"`
+	// Code is a sequential identifier that uniquely identifies the order. The code can
+	// be left empty initially, but is **required** to **sign** the document.
+	Code cbc.Code `json:"code,omitempty" jsonschema:"title=Code"`
 	// When the invoice was created.
 	IssueDate cal.Date `json:"issue_date" jsonschema:"title=Issue Date" jsonschema_extras:"calculated=true"`
 	// Date when the operation defined by the invoice became effective.
@@ -371,6 +375,9 @@ func (ord Order) JSONSchemaExtend(js *jsonschema.Schema) {
 	js.Extras = map[string]any{
 		schema.Recommended: []string{
 			"$regime",
+			"series",
+			"code",
+			"lines",
 		},
 	}
 }

--- a/bill/payment_test.go
+++ b/bill/payment_test.go
@@ -322,7 +322,7 @@ func TestPaymentJSONSchemaExtend(t *testing.T) {
 		assert.Equal(t, it.Key.String(), prop.OneOf[0].Const)
 	})
 	t.Run("recommended", func(t *testing.T) {
-		assert.Len(t, js.Extras[schema.Recommended], 1)
+		assert.Len(t, js.Extras[schema.Recommended], 4)
 	})
 
 }

--- a/data/schemas/bill/delivery.json
+++ b/data/schemas/bill/delivery.json
@@ -316,12 +316,12 @@
         "series": {
           "$ref": "https://gobl.org/draft-0/cbc/code",
           "title": "Series",
-          "description": "Used as a prefix to group codes."
+          "description": "Series is used to identify groups of deliveries by date, business area, project,\ntype, customer, a combination of any, or other company specific data.\nIf the output format does not support the series as a separate field, it will be\nprepended to the code for presentation with a dash (`-`) for separation."
         },
         "code": {
           "$ref": "https://gobl.org/draft-0/cbc/code",
           "title": "Code",
-          "description": "Sequential code used to identify this delivery in tax declarations."
+          "description": "Code is a sequential identifier that uniquely identifies the delivery. The code can\nbe left empty initially, but is **required** to **sign** the document."
         },
         "issue_date": {
           "$ref": "https://gobl.org/draft-0/cal/date",
@@ -469,13 +469,15 @@
       "type": "object",
       "required": [
         "type",
-        "code",
         "issue_date",
         "supplier"
       ],
       "description": "Delivery document used to describe the delivery of goods or potentially also services.",
       "recommended": [
-        "$regime"
+        "$regime",
+        "series",
+        "code",
+        "lines"
       ]
     },
     "Discount": {

--- a/data/schemas/bill/invoice.json
+++ b/data/schemas/bill/invoice.json
@@ -484,23 +484,23 @@
             }
           ],
           "title": "Type",
-          "description": "Type of invoice document subject to the requirements of the local tax regime.",
+          "description": "Type of invoice document. May be restricted by local tax regime requirements.",
           "calculated": true
         },
         "series": {
           "$ref": "https://gobl.org/draft-0/cbc/code",
           "title": "Series",
-          "description": "Used as a prefix to group codes."
+          "description": "Series is used to identify groups of invoices by date, business area, project,\ntype of document, customer type, a combination of any or other company specific data.\nIf the output format does not support the series as a separate field, it will be\nprepended to the code for presentation with a dash (`-`) for separation."
         },
         "code": {
           "$ref": "https://gobl.org/draft-0/cbc/code",
           "title": "Code",
-          "description": "Sequential code used to identify this invoice in tax declarations."
+          "description": "Code is a sequential identifier that uniquely identifies the invoice. The code can\nbe left empty initially, but is **required** to **sign** the invoice."
         },
         "issue_date": {
           "$ref": "https://gobl.org/draft-0/cal/date",
           "title": "Issue Date",
-          "description": "When the invoice was created.",
+          "description": "Issue date for when the invoice was created and issued. Todays date is used if\nnone is set. There are often legal restrictions on how far back an invoice\ncan be issued.",
           "calculated": true
         },
         "op_date": {
@@ -516,7 +516,7 @@
         "currency": {
           "$ref": "https://gobl.org/draft-0/currency/code",
           "title": "Currency",
-          "description": "Currency for all invoice totals.",
+          "description": "Currency for all invoice amounts and totals, unless explicitly stated otherwise.",
           "calculated": true
         },
         "exchange_rates": {
@@ -533,12 +533,12 @@
           },
           "type": "array",
           "title": "Preceding Details",
-          "description": "Key information regarding previous invoices and potentially details as to why they\nwere corrected."
+          "description": "Document references for previous invoices that this document replaces or extends."
         },
         "tax": {
           "$ref": "#/$defs/Tax",
           "title": "Tax",
-          "description": "Special tax configuration for billing."
+          "description": "Special billing tax configuration options."
         },
         "supplier": {
           "$ref": "https://gobl.org/draft-0/org/party",
@@ -548,7 +548,7 @@
         "customer": {
           "$ref": "https://gobl.org/draft-0/org/party",
           "title": "Customer",
-          "description": "Legal entity receiving the goods or services, may be nil in certain circumstances such as simplified invoices."
+          "description": "Legal entity receiving the goods or services, may be nil in certain circumstances\nsuch as simplified invoices."
         },
         "lines": {
           "items": {
@@ -628,7 +628,6 @@
       "type": "object",
       "required": [
         "type",
-        "code",
         "issue_date",
         "currency",
         "supplier",
@@ -637,6 +636,8 @@
       "description": "Invoice represents a payment claim for goods or services supplied under conditions agreed between the supplier and the customer.",
       "recommended": [
         "$regime",
+        "series",
+        "code",
         "lines"
       ]
     },

--- a/data/schemas/bill/order.json
+++ b/data/schemas/bill/order.json
@@ -474,12 +474,12 @@
         "series": {
           "$ref": "https://gobl.org/draft-0/cbc/code",
           "title": "Series",
-          "description": "Used as a prefix to group codes."
+          "description": "Series is used to identify groups of orders by date, business area, project,\ntype, customer, a combination of any, or other company specific data.\nIf the output format does not support the series as a separate field, it will be\nprepended to the code for presentation with a dash (`-`) for separation."
         },
         "code": {
           "$ref": "https://gobl.org/draft-0/cbc/code",
           "title": "Code",
-          "description": "Sequential code used to identify this invoice in tax declarations."
+          "description": "Code is a sequential identifier that uniquely identifies the order. The code can\nbe left empty initially, but is **required** to **sign** the document."
         },
         "issue_date": {
           "$ref": "https://gobl.org/draft-0/cal/date",
@@ -637,14 +637,16 @@
       },
       "type": "object",
       "required": [
-        "code",
         "issue_date",
         "currency",
         "supplier"
       ],
       "description": "Order documents are used for the initial part of a order-to-invoice process where the buyer requests goods or services from the seller.",
       "recommended": [
-        "$regime"
+        "$regime",
+        "series",
+        "code",
+        "lines"
       ]
     },
     "PaymentDetails": {

--- a/data/schemas/bill/payment.json
+++ b/data/schemas/bill/payment.json
@@ -288,12 +288,12 @@
         "series": {
           "$ref": "https://gobl.org/draft-0/cbc/code",
           "title": "Series",
-          "description": "Used as a prefix to group codes."
+          "description": "Series is used to identify groups of payments by date, business area, project,\ntype, customer, a combination of any, or other company specific data.\nIf the output format does not support the series as a separate field, it will be\nprepended to the code for presentation with a dash (`-`) for separation."
         },
         "code": {
           "$ref": "https://gobl.org/draft-0/cbc/code",
           "title": "Code",
-          "description": "Sequential code used to identify this payment in tax declarations."
+          "description": "Code is a sequential identifier that uniquely identifies the payment. The code can\nbe left empty initially, but is **required** to **sign** the document."
         },
         "issue_date": {
           "$ref": "https://gobl.org/draft-0/cal/date",
@@ -396,7 +396,6 @@
       "type": "object",
       "required": [
         "type",
-        "code",
         "issue_date",
         "currency",
         "supplier",
@@ -405,7 +404,10 @@
       ],
       "description": "A Payment is used to link an invoice or invoices with a payment transaction.",
       "recommended": [
-        "$regime"
+        "$regime",
+        "series",
+        "code",
+        "lines"
       ]
     },
     "PaymentLine": {

--- a/examples/pt/out/credit-note.json
+++ b/examples/pt/out/credit-note.json
@@ -4,7 +4,7 @@
 		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
 		"dig": {
 			"alg": "sha256",
-			"val": "db749c4e502af8fa352426db5d6137b070b40e0f7bdc0dc60f2b90546db0bb43"
+			"val": "1d7284735c9e0c95ec790de9f3e7a7ce239134999b39ead2d9f0d15459fd23db"
 		}
 	},
 	"doc": {
@@ -15,7 +15,6 @@
 		],
 		"uuid": "3aea7b56-59d8-4beb-90bd-f8f280d852a0",
 		"type": "credit-note",
-		"code": "",
 		"issue_date": "2023-01-30",
 		"currency": "EUR",
 		"preceding": [

--- a/examples/pt/out/invoice-azores-migrate.json
+++ b/examples/pt/out/invoice-azores-migrate.json
@@ -4,7 +4,7 @@
 		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
 		"dig": {
 			"alg": "sha256",
-			"val": "8ad1ad6d393e137ba17da0992046f72d38bfe8ff087567cbf0ebd88c5b039cc4"
+			"val": "72a954790c3e875ebcd1d429a45a50789bae0b5ef37e708aaf119f89cb76c613"
 		}
 	},
 	"doc": {
@@ -15,7 +15,6 @@
 		],
 		"uuid": "3aea7b56-59d8-4beb-90bd-f8f280d852a0",
 		"type": "standard",
-		"code": "",
 		"issue_date": "2023-01-30",
 		"currency": "EUR",
 		"tax": {

--- a/examples/pt/out/invoice-azores.json
+++ b/examples/pt/out/invoice-azores.json
@@ -4,7 +4,7 @@
 		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
 		"dig": {
 			"alg": "sha256",
-			"val": "8ad1ad6d393e137ba17da0992046f72d38bfe8ff087567cbf0ebd88c5b039cc4"
+			"val": "72a954790c3e875ebcd1d429a45a50789bae0b5ef37e708aaf119f89cb76c613"
 		}
 	},
 	"doc": {
@@ -15,7 +15,6 @@
 		],
 		"uuid": "3aea7b56-59d8-4beb-90bd-f8f280d852a0",
 		"type": "standard",
-		"code": "",
 		"issue_date": "2023-01-30",
 		"currency": "EUR",
 		"tax": {

--- a/examples/pt/out/invoice-b2c-es.json
+++ b/examples/pt/out/invoice-b2c-es.json
@@ -4,7 +4,7 @@
 		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
 		"dig": {
 			"alg": "sha256",
-			"val": "2f931d947ec5ae081abb21617faf30f62dc47ef9041c3abf9a273b5db0d02d2f"
+			"val": "ff5dda136dd374c760a71962572a7a4e6064787782daf9e47321a6f30620903a"
 		}
 	},
 	"doc": {
@@ -15,7 +15,6 @@
 		],
 		"uuid": "3aea7b56-59d8-4beb-90bd-f8f280d852a0",
 		"type": "standard",
-		"code": "",
 		"issue_date": "2023-01-30",
 		"currency": "EUR",
 		"tax": {

--- a/examples/pt/out/invoice-custom.json
+++ b/examples/pt/out/invoice-custom.json
@@ -4,7 +4,7 @@
 		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
 		"dig": {
 			"alg": "sha256",
-			"val": "dd680a51dff5404c7e7273e45c176ba8f33790a9298ac79b8167f7a6ce5f7d7a"
+			"val": "521ff61b991cf7cc73324e1e72d72c486d4f3c9e5295cd4520d05d9d62a50416"
 		}
 	},
 	"doc": {
@@ -15,7 +15,6 @@
 		],
 		"uuid": "3aea7b56-59d8-4beb-90bd-f8f280d852a0",
 		"type": "standard",
-		"code": "",
 		"issue_date": "2023-01-30",
 		"currency": "EUR",
 		"tax": {

--- a/examples/pt/out/invoice-exempt.json
+++ b/examples/pt/out/invoice-exempt.json
@@ -4,7 +4,7 @@
 		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
 		"dig": {
 			"alg": "sha256",
-			"val": "ddde5a861581b82d0d7a6f455492e21fa07ea152938b28cc677cceb46d86a5de"
+			"val": "3a53d519b27568260ef3c83bc1e3c554afc1447e2ff01ea2a6ddd644b16f3511"
 		}
 	},
 	"doc": {
@@ -15,7 +15,6 @@
 		],
 		"uuid": "3aea7b56-59d8-4beb-90bd-f8f280d852a0",
 		"type": "standard",
-		"code": "",
 		"issue_date": "2023-01-30",
 		"currency": "EUR",
 		"tax": {

--- a/examples/pt/out/invoice-madeira-reduced.json
+++ b/examples/pt/out/invoice-madeira-reduced.json
@@ -4,7 +4,7 @@
 		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
 		"dig": {
 			"alg": "sha256",
-			"val": "8a4ae8548fe4ae85d94314bdffddf1896051df6a915592b33c1b19529090055e"
+			"val": "506a18400ed6bda4911f98eb7f8dd94d9328c3d3420257e7fee9beed40c042a1"
 		}
 	},
 	"doc": {
@@ -15,7 +15,6 @@
 		],
 		"uuid": "3aea7b56-59d8-4beb-90bd-f8f280d852a0",
 		"type": "standard",
-		"code": "",
 		"issue_date": "2024-10-02",
 		"currency": "EUR",
 		"tax": {

--- a/examples/pt/out/invoice.json
+++ b/examples/pt/out/invoice.json
@@ -4,7 +4,7 @@
 		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
 		"dig": {
 			"alg": "sha256",
-			"val": "cb699176e14b5b52bdb176c35c6ccd94e3df75cc04a0758e8eb88cf9a9b8a3a4"
+			"val": "f6920d43cca50f1360d8ad0b151ac374ed69d04b18b4f7fbedf0e6003a299141"
 		}
 	},
 	"doc": {
@@ -15,7 +15,6 @@
 		],
 		"uuid": "3aea7b56-59d8-4beb-90bd-f8f280d852a0",
 		"type": "standard",
-		"code": "",
 		"issue_date": "2023-01-30",
 		"currency": "EUR",
 		"tax": {

--- a/internal/cli/testdata/TestCorrect_success
+++ b/internal/cli/testdata/TestCorrect_success
@@ -3,7 +3,6 @@
     "doc": {
         "$regime": "ES",
         "$schema": "https://gobl.org/draft-0/bill/invoice",
-        "code": "",
         "currency": "EUR",
         "customer": {
             "name": "Sample Consumer",
@@ -137,13 +136,13 @@
             "total_with_tax": "1717.20"
         },
         "type": "credit-note",
-        "uuid": "01956a9d-10a1-7562-89e6-bc040f79546a"
+        "uuid": "01959046-b5ee-7b9e-97d1-f3f908800101"
     },
     "head": {
         "dig": {
             "alg": "sha256",
-            "val": "2ed1a613f7fcea31e8f09b1b921a516cbd4f84191dece37a3651bd0322696b3f"
+            "val": "2d4a2237b2f55d4a3af4693a2d4bdb6aeac84d2c3c910ff59e17033d052fa998"
         },
-        "uuid": "01956a9d-10a1-7557-8e0f-0f4173650c2e"
+        "uuid": "01959046-b5ee-7b97-93b6-86b79b28492b"
     }
 }

--- a/internal/cli/testdata/TestCorrect_success_just_invoice
+++ b/internal/cli/testdata/TestCorrect_success_just_invoice
@@ -1,7 +1,6 @@
 {
     "$regime": "ES",
     "$schema": "https://gobl.org/draft-0/bill/invoice",
-    "code": "",
     "currency": "EUR",
     "customer": {
         "name": "Sample Consumer",

--- a/internal/cli/testdata/TestReplicate_success
+++ b/internal/cli/testdata/TestReplicate_success
@@ -3,7 +3,6 @@
     "doc": {
         "$regime": "ES",
         "$schema": "https://gobl.org/draft-0/bill/invoice",
-        "code": "",
         "currency": "EUR",
         "customer": {
             "name": "Sample Consumer",
@@ -12,7 +11,7 @@
                 "country": "ES"
             }
         },
-        "issue_date": "2025-03-06",
+        "issue_date": "2025-03-13",
         "lines": [
             {
                 "discounts": [
@@ -126,13 +125,13 @@
             "total_with_tax": "1717.20"
         },
         "type": "standard",
-        "uuid": "01956a9d-10a5-7026-8461-f45c0a9a833f"
+        "uuid": "01959046-b5f4-7064-a79c-da272c10967b"
     },
     "head": {
         "dig": {
             "alg": "sha256",
-            "val": "57e1126e3682139fbe74a26f5af2c824743faf1fcb3775627417a9326870eb64"
+            "val": "3afd59842622cf2702a44db94b7b45d83512142c3a76ac06abd7d144351d4fdf"
         },
-        "uuid": "01956a9d-10a5-702b-9b9e-d4198f5cee20"
+        "uuid": "01959046-b5f4-706a-be32-b0cc62ccc60c"
     }
 }

--- a/internal/cli/testdata/TestReplicate_success_just_invoice
+++ b/internal/cli/testdata/TestReplicate_success_just_invoice
@@ -1,7 +1,6 @@
 {
     "$regime": "ES",
     "$schema": "https://gobl.org/draft-0/bill/invoice",
-    "code": "",
     "currency": "EUR",
     "customer": {
         "name": "Sample Consumer",
@@ -10,7 +9,7 @@
             "country": "ES"
         }
     },
-    "issue_date": "2024-09-16",
+    "issue_date": "2025-03-13",
     "lines": [
         {
             "discounts": [
@@ -124,5 +123,5 @@
         "total_with_tax": "1717.20"
     },
     "type": "standard",
-    "uuid": "0191fb27-f9da-74e3-8c2a-8c39b05c2987"
+    "uuid": "01959046-b5f3-776b-91f7-30de3498d5f0"
 }

--- a/org/identity.go
+++ b/org/identity.go
@@ -33,7 +33,6 @@ const (
 	IdentityKeyEAN       cbc.Key = "ean"       // European Article Number
 	IdentityKeyUPC       cbc.Key = "upc"       // UPC (Universal Product Code)
 	IdentityKeyIMEI      cbc.Key = "imei"      // International Mobile Equipment Identity
-	IdentityKeyPeppol    cbc.Key = "peppol"    // Peppol Participant Identifier
 	IdentityKeyDUNS      cbc.Key = "duns"      // Dun & Bradstreet D-U-N-S Number
 	IdentityKeyOther     cbc.Key = "other"
 )

--- a/org/identity.go
+++ b/org/identity.go
@@ -33,6 +33,8 @@ const (
 	IdentityKeyEAN       cbc.Key = "ean"       // European Article Number
 	IdentityKeyUPC       cbc.Key = "upc"       // UPC (Universal Product Code)
 	IdentityKeyIMEI      cbc.Key = "imei"      // International Mobile Equipment Identity
+	IdentityKeyPeppol    cbc.Key = "peppol"    // Peppol Participant Identifier
+	IdentityKeyDUNS      cbc.Key = "duns"      // Dun & Bradstreet D-U-N-S Number
 	IdentityKeyOther     cbc.Key = "other"
 )
 


### PR DESCRIPTION
- Improved series and code descriptions in billing documents.
- `code` is now optional in base schema, and only recommended. Thus removing the warning that is usually presented in the builder.

## Pre-Review Checklist

- [x] I have performed a self-review of my code.
- [x] I have added thorough tests with at **least** 90% code coverage.
- [x] I've modified or created example GOBL documents to show my changes in use, if appropriate.
- [ ] When adding or modifying a tax regime or addon, I've added links to the source of the changes, either structured or in the comments.
- [x] I've run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [x] All linter warnings have been reviewed and fixed.
- [x] I've been obsessive with pointer nil checks to avoid panics.
- [x] The CHANGELOG.md has been updated with an overview of my changes.
- [ ] Requested a review from @samlown.

