### PR TITLE
Tax Regime and Identity support for "scheme"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Added
 
 - `pt-saft-v1`: support for stock movements (from `bill.Delivery`) and work documents (from `bill.Invoice` and `bill.Order`)
+- `tax`: Regime Definition now supports a primary `TaxScheme` property for usage in converting to other formats.
+- `tax`: `Identity` now supports an override `Scheme` field and `GetScheme` method that will fallback to the Regime's tax scheme default.
 
 ## Changed
 

--- a/data/regimes/ae.json
+++ b/data/regimes/ae.json
@@ -7,6 +7,7 @@
   "time_zone": "Asia/Dubai",
   "country": "AE",
   "currency": "AED",
+  "tax_scheme": "VAT",
   "tags": [
     {
       "schema": "bill/invoice",

--- a/data/regimes/at.json
+++ b/data/regimes/at.json
@@ -6,6 +6,7 @@
   "time_zone": "Europe/Vienna",
   "country": "AT",
   "currency": "EUR",
+  "tax_scheme": "VAT",
   "tags": [
     {
       "schema": "bill/invoice",

--- a/data/regimes/be.json
+++ b/data/regimes/be.json
@@ -6,6 +6,7 @@
   "time_zone": "Europe/Brussels",
   "country": "BE",
   "currency": "EUR",
+  "tax_scheme": "VAT",
   "tags": [
     {
       "schema": "bill/invoice",

--- a/data/regimes/ca.json
+++ b/data/regimes/ca.json
@@ -6,6 +6,7 @@
   "time_zone": "America/Toronto",
   "country": "CA",
   "currency": "CAD",
+  "tax_scheme": "GST",
   "corrections": [
     {
       "schema": "bill/invoice",

--- a/data/regimes/ch.json
+++ b/data/regimes/ch.json
@@ -6,6 +6,7 @@
   "time_zone": "Europe/Zurich",
   "country": "CH",
   "currency": "CHF",
+  "tax_scheme": "VAT",
   "tags": [
     {
       "schema": "bill/invoice",

--- a/data/regimes/de.json
+++ b/data/regimes/de.json
@@ -7,6 +7,7 @@
   "time_zone": "Europe/Berlin",
   "country": "DE",
   "currency": "EUR",
+  "tax_scheme": "VAT",
   "tags": [
     {
       "schema": "bill/invoice",

--- a/data/regimes/el.json
+++ b/data/regimes/el.json
@@ -10,6 +10,7 @@
     "GR"
   ],
   "currency": "EUR",
+  "tax_scheme": "VAT",
   "calculator_rounding_rule": "currency",
   "tags": [
     {

--- a/data/regimes/es.json
+++ b/data/regimes/es.json
@@ -7,6 +7,7 @@
   "time_zone": "Europe/Madrid",
   "country": "ES",
   "currency": "EUR",
+  "tax_scheme": "VAT",
   "tags": [
     {
       "schema": "bill/invoice",

--- a/data/regimes/fr.json
+++ b/data/regimes/fr.json
@@ -10,6 +10,7 @@
   "time_zone": "Europe/Paris",
   "country": "FR",
   "currency": "EUR",
+  "tax_scheme": "VAT",
   "tags": [
     {
       "schema": "bill/invoice",

--- a/data/regimes/gb.json
+++ b/data/regimes/gb.json
@@ -10,6 +10,7 @@
     "XU"
   ],
   "currency": "GBP",
+  "tax_scheme": "VAT",
   "tags": [
     {
       "schema": "bill/invoice",

--- a/data/regimes/in.json
+++ b/data/regimes/in.json
@@ -6,6 +6,7 @@
   "time_zone": "Asia/Kolkata",
   "country": "IN",
   "currency": "INR",
+  "tax_scheme": "GST",
   "scenarios": [
     {
       "schema": "bill/invoice",

--- a/data/regimes/it.json
+++ b/data/regimes/it.json
@@ -7,6 +7,7 @@
   "time_zone": "Europe/Rome",
   "country": "IT",
   "currency": "EUR",
+  "tax_scheme": "VAT",
   "tags": [
     {
       "schema": "bill/invoice",

--- a/data/regimes/mx.json
+++ b/data/regimes/mx.json
@@ -7,6 +7,7 @@
   "time_zone": "America/Mexico_City",
   "country": "MX",
   "currency": "MXN",
+  "tax_scheme": "VAT",
   "tags": [
     {
       "schema": "bill/invoice",

--- a/data/regimes/nl.json
+++ b/data/regimes/nl.json
@@ -7,6 +7,7 @@
   "time_zone": "Europe/Amsterdam",
   "country": "NL",
   "currency": "EUR",
+  "tax_scheme": "VAT",
   "tags": [
     {
       "schema": "bill/invoice",

--- a/data/regimes/pl.json
+++ b/data/regimes/pl.json
@@ -7,6 +7,7 @@
   "time_zone": "Europe/Warsaw",
   "country": "PL",
   "currency": "PLN",
+  "tax_scheme": "VAT",
   "tags": [
     {
       "schema": "bill/invoice",

--- a/data/regimes/pt.json
+++ b/data/regimes/pt.json
@@ -7,6 +7,7 @@
   "time_zone": "Europe/Lisbon",
   "country": "PT",
   "currency": "EUR",
+  "tax_scheme": "VAT",
   "tags": [
     {
       "schema": "bill/invoice",

--- a/data/schemas/tax/identity.json
+++ b/data/schemas/tax/identity.json
@@ -21,6 +21,11 @@
           "title": "Type",
           "description": "Type is set according to the requirements of each regime, some have a single\ntax document type code, others require a choice to be made.\n\nDeprecated: Tax Identities should only be used for VAT or similar codes\nfor companies. Use the identities array for other types of identification."
         },
+        "scheme": {
+          "$ref": "https://gobl.org/draft-0/cbc/code",
+          "title": "Scheme",
+          "description": "Scheme is an optional field that may be used to override the tax regime's\ndefault scheme. Many electronic formats such as UBL or CII define an\nequivalent field which may be added."
+        },
         "zone": {
           "$ref": "https://gobl.org/draft-0/l10n/code",
           "title": "Zone",

--- a/data/schemas/tax/regime-def.json
+++ b/data/schemas/tax/regime-def.json
@@ -262,6 +262,11 @@
           "title": "Currency",
           "description": "Currency used by the country."
         },
+        "tax_scheme": {
+          "$ref": "https://gobl.org/draft-0/cbc/code",
+          "title": "Tax Scheme",
+          "description": "TaxScheme defines the principal scheme of consumption tax that should be\napplied to the regime and associated with Tax IDs in some export formats\nsuch as UBL or CII. Some regimes may not have a Tax Scheme and as a\nconsequence will not use tax identities, like the US."
+        },
         "calculator_rounding_rule": {
           "$ref": "https://gobl.org/draft-0/cbc/key",
           "title": "Calculator Rounding Rule",

--- a/examples/es/invoice-es-igic.yaml
+++ b/examples/es/invoice-es-igic.yaml
@@ -1,0 +1,52 @@
+$schema: "https://gobl.org/draft-0/bill/invoice"
+$addons: ["es-facturae-v3"]
+uuid: "3aea7b56-59d8-4beb-90bd-f8f280d852a0"
+currency: "EUR"
+issue_date: "2022-02-01"
+code: "SAMPLE-001"
+
+supplier:
+    tax_id:
+        country: "ES"
+        code: "B98602642" # random
+        scheme: "IGIC"
+    name: "Provide One S.L."
+    emails:
+        - addr: "billing@example.com"
+    addresses:
+        - num: "42"
+          street: "Calle Pradillo"
+          locality: "Madrid"
+          region: "Madrid"
+          code: "28002"
+          country: "ES"
+
+customer:
+    tax_id:
+        country: "ES"
+        code: "54387763P"
+    name: "Sample Consumer"
+
+lines:
+    - quantity: 20
+      identifier:
+          label: "Subscription"
+          code: "SUB1234-ABC"
+      item:
+          name: "Development services"
+          price: "90.00"
+          unit: "h"
+      discounts:
+          - percent: "10%"
+            reason: "Special discount"
+          - amount: "0.00"
+      taxes:
+          - cat: IGIC
+            rate: standard
+    - quantity: 1
+      item:
+          name: "Financial service"
+          price: "10.00"
+      taxes:
+          - cat: VAT
+            rate: zero

--- a/examples/es/out/invoice-es-igic.json
+++ b/examples/es/out/invoice-es-igic.json
@@ -1,0 +1,142 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
+		"dig": {
+			"alg": "sha256",
+			"val": "f9df0f7241ab76d50dd6c6c9bec6c882e9d4e5a1bba490c0de7f941e80a13c49"
+		}
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"$regime": "ES",
+		"$addons": [
+			"es-facturae-v3"
+		],
+		"uuid": "3aea7b56-59d8-4beb-90bd-f8f280d852a0",
+		"type": "standard",
+		"code": "SAMPLE-001",
+		"issue_date": "2022-02-01",
+		"currency": "EUR",
+		"tax": {
+			"ext": {
+				"es-facturae-doc-type": "FC",
+				"es-facturae-invoice-class": "OO"
+			}
+		},
+		"supplier": {
+			"name": "Provide One S.L.",
+			"tax_id": {
+				"country": "ES",
+				"code": "B98602642",
+				"scheme": "IGIC"
+			},
+			"addresses": [
+				{
+					"num": "42",
+					"street": "Calle Pradillo",
+					"locality": "Madrid",
+					"region": "Madrid",
+					"code": "28002",
+					"country": "ES"
+				}
+			],
+			"emails": [
+				{
+					"addr": "billing@example.com"
+				}
+			]
+		},
+		"customer": {
+			"name": "Sample Consumer",
+			"tax_id": {
+				"country": "ES",
+				"code": "54387763P"
+			}
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "20",
+				"identifier": {
+					"label": "Subscription",
+					"code": "SUB1234-ABC"
+				},
+				"item": {
+					"name": "Development services",
+					"price": "90.00",
+					"unit": "h"
+				},
+				"sum": "1800.00",
+				"discounts": [
+					{
+						"reason": "Special discount",
+						"percent": "10%",
+						"amount": "180.00"
+					}
+				],
+				"taxes": [
+					{
+						"cat": "IGIC",
+						"rate": "standard",
+						"percent": "7.0%"
+					}
+				],
+				"total": "1620.00"
+			},
+			{
+				"i": 2,
+				"quantity": "1",
+				"item": {
+					"name": "Financial service",
+					"price": "10.00"
+				},
+				"sum": "10.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"rate": "zero",
+						"percent": "0.0%"
+					}
+				],
+				"total": "10.00"
+			}
+		],
+		"totals": {
+			"sum": "1630.00",
+			"total": "1630.00",
+			"taxes": {
+				"categories": [
+					{
+						"code": "IGIC",
+						"rates": [
+							{
+								"key": "standard",
+								"base": "1620.00",
+								"percent": "7.0%",
+								"amount": "113.40"
+							}
+						],
+						"amount": "113.40"
+					},
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "zero",
+								"base": "10.00",
+								"percent": "0.0%",
+								"amount": "0.00"
+							}
+						],
+						"amount": "0.00"
+					}
+				],
+				"sum": "113.40"
+			},
+			"tax": "113.40",
+			"total_with_tax": "1743.40",
+			"payable": "1743.40"
+		}
+	}
+}

--- a/regimes/ae/ae.go
+++ b/regimes/ae/ae.go
@@ -17,8 +17,9 @@ func init() {
 // New provides the tax region definition for AE.
 func New() *tax.RegimeDef {
 	return &tax.RegimeDef{
-		Country:  "AE",
-		Currency: currency.AED,
+		Country:   "AE",
+		Currency:  currency.AED,
+		TaxScheme: tax.CategoryVAT,
 		Name: i18n.String{
 			i18n.EN: "United Arab Emirates",
 			i18n.AR: "الإمارات العربية المتحدة",

--- a/regimes/at/at.go
+++ b/regimes/at/at.go
@@ -17,8 +17,9 @@ func init() {
 // New provides the tax region definition
 func New() *tax.RegimeDef {
 	return &tax.RegimeDef{
-		Country:  "AT",
-		Currency: currency.EUR,
+		Country:   "AT",
+		Currency:  currency.EUR,
+		TaxScheme: tax.CategoryVAT,
 		Name: i18n.String{
 			i18n.EN: "Austria",
 		},

--- a/regimes/be/be.go
+++ b/regimes/be/be.go
@@ -17,8 +17,9 @@ func init() {
 // New provides the tax region definition
 func New() *tax.RegimeDef {
 	return &tax.RegimeDef{
-		Country:  "BE",
-		Currency: currency.EUR,
+		Country:   "BE",
+		Currency:  currency.EUR,
+		TaxScheme: tax.CategoryVAT,
 		Name: i18n.String{
 			i18n.EN: "Belgium",
 		},

--- a/regimes/ca/ca.go
+++ b/regimes/ca/ca.go
@@ -24,8 +24,9 @@ const (
 // New provides the tax region definition
 func New() *tax.RegimeDef {
 	return &tax.RegimeDef{
-		Country:  "CA",
-		Currency: currency.CAD,
+		Country:   "CA",
+		Currency:  currency.CAD,
+		TaxScheme: tax.CategoryGST,
 		Name: i18n.String{
 			i18n.EN: "Canada",
 		},

--- a/regimes/ch/ch.go
+++ b/regimes/ch/ch.go
@@ -17,8 +17,9 @@ func init() {
 // New provides the tax region definition
 func New() *tax.RegimeDef {
 	return &tax.RegimeDef{
-		Country:  "CH",
-		Currency: currency.CHF,
+		Country:   "CH",
+		Currency:  currency.CHF,
+		TaxScheme: tax.CategoryVAT,
 		Name: i18n.String{
 			i18n.EN: "Switzerland",
 		},

--- a/regimes/de/de.go
+++ b/regimes/de/de.go
@@ -18,8 +18,9 @@ func init() {
 // New provides the tax region definition
 func New() *tax.RegimeDef {
 	return &tax.RegimeDef{
-		Country:  "DE",
-		Currency: currency.EUR,
+		Country:   "DE",
+		Currency:  currency.EUR,
+		TaxScheme: tax.CategoryVAT,
 		Name: i18n.String{
 			i18n.EN: "Germany",
 			i18n.DE: "Deutschland",

--- a/regimes/es/es.go
+++ b/regimes/es/es.go
@@ -51,8 +51,9 @@ const (
 // New provides the Spanish tax regime definition
 func New() *tax.RegimeDef {
 	return &tax.RegimeDef{
-		Country:  "ES",
-		Currency: currency.EUR,
+		Country:   "ES",
+		Currency:  currency.EUR,
+		TaxScheme: tax.CategoryVAT,
 		Name: i18n.String{
 			i18n.EN: "Spain",
 			i18n.ES: "España",

--- a/regimes/fr/fr.go
+++ b/regimes/fr/fr.go
@@ -28,8 +28,9 @@ func init() {
 // New provides the tax region definition
 func New() *tax.RegimeDef {
 	return &tax.RegimeDef{
-		Country:  "FR",
-		Currency: currency.EUR,
+		Country:   "FR",
+		Currency:  currency.EUR,
+		TaxScheme: tax.CategoryVAT,
 		Name: i18n.String{
 			i18n.EN: "France",
 			i18n.FR: "La France",

--- a/regimes/gb/gb.go
+++ b/regimes/gb/gb.go
@@ -33,6 +33,7 @@ func New() *tax.RegimeDef {
 		Country:         "GB",
 		AltCountryCodes: altCountryCodes,
 		Currency:        currency.GBP,
+		TaxScheme:       tax.CategoryVAT,
 		Name: i18n.String{
 			i18n.EN: "United Kingdom",
 		},

--- a/regimes/gr/gr.go
+++ b/regimes/gr/gr.go
@@ -30,7 +30,8 @@ func New() *tax.RegimeDef {
 		AltCountryCodes: []l10n.Code{
 			"GR", // regular ISO code
 		},
-		Currency: currency.EUR,
+		Currency:  currency.EUR,
+		TaxScheme: tax.CategoryVAT,
 		Name: i18n.String{
 			i18n.EN: "Greece",
 			i18n.EL: "Ελλάδα",

--- a/regimes/in/in.go
+++ b/regimes/in/in.go
@@ -17,8 +17,9 @@ func init() {
 // New provides the tax region definition for India.
 func New() *tax.RegimeDef {
 	return &tax.RegimeDef{
-		Country:  "IN",
-		Currency: currency.INR,
+		Country:   "IN",
+		Currency:  currency.INR,
+		TaxScheme: tax.CategoryGST,
 		Name: i18n.String{
 			i18n.EN: "India",
 		},

--- a/regimes/it/it.go
+++ b/regimes/it/it.go
@@ -18,8 +18,9 @@ func init() {
 // New instantiates a new Italian regime.
 func New() *tax.RegimeDef {
 	return &tax.RegimeDef{
-		Country:  "IT",
-		Currency: currency.EUR,
+		Country:   "IT",
+		Currency:  currency.EUR,
+		TaxScheme: tax.CategoryVAT,
 		Name: i18n.String{
 			i18n.EN: "Italy",
 			i18n.IT: "Italia",

--- a/regimes/mx/mx.go
+++ b/regimes/mx/mx.go
@@ -35,8 +35,9 @@ const (
 // New provides the tax region definition
 func New() *tax.RegimeDef {
 	return &tax.RegimeDef{
-		Country:  "MX",
-		Currency: currency.MXN,
+		Country:   "MX",
+		Currency:  currency.MXN,
+		TaxScheme: tax.CategoryVAT,
 		Name: i18n.String{
 			i18n.EN: "Mexico",
 			i18n.ES: "México",

--- a/regimes/nl/nl.go
+++ b/regimes/nl/nl.go
@@ -18,8 +18,9 @@ func init() {
 // New provides the Dutch region definition
 func New() *tax.RegimeDef {
 	return &tax.RegimeDef{
-		Country:  "NL",
-		Currency: currency.EUR,
+		Country:   "NL",
+		Currency:  currency.EUR,
+		TaxScheme: tax.CategoryVAT,
 		Name: i18n.String{
 			i18n.EN: "The Netherlands",
 			i18n.NL: "Nederland",

--- a/regimes/pl/pl.go
+++ b/regimes/pl/pl.go
@@ -30,8 +30,9 @@ const (
 // New instantiates a new Polish regime.
 func New() *tax.RegimeDef {
 	return &tax.RegimeDef{
-		Country:  "PL",
-		Currency: currency.PLN,
+		Country:   "PL",
+		Currency:  currency.PLN,
+		TaxScheme: tax.CategoryVAT,
 		Name: i18n.String{
 			i18n.EN: "Poland",
 			i18n.PL: "Polska",

--- a/regimes/pt/pt.go
+++ b/regimes/pt/pt.go
@@ -35,8 +35,9 @@ const (
 // New instantiates a new Portugal regime for the given zone.
 func New() *tax.RegimeDef {
 	return &tax.RegimeDef{
-		Country:  "PT",
-		Currency: currency.EUR,
+		Country:   "PT",
+		Currency:  currency.EUR,
+		TaxScheme: tax.CategoryVAT,
 		Name: i18n.String{
 			i18n.EN: "Portugal",
 			i18n.PT: "Portugal",

--- a/tax/identity_test.go
+++ b/tax/identity_test.go
@@ -118,13 +118,21 @@ func TestIdentityGetScheme(t *testing.T) {
 		}
 		assert.Equal(t, tax.CategoryVAT, tID.GetScheme())
 	})
-	t.Run("use empty", func(t *testing.T) {
+	t.Run("use empty for regime without default", func(t *testing.T) {
 		tID := &tax.Identity{
 			Country: "US",
 			Code:    "1234567",
 		}
 		assert.Equal(t, cbc.CodeEmpty, tID.GetScheme())
 	})
+	t.Run("use empty for no regime", func(t *testing.T) {
+		tID := &tax.Identity{
+			Country: "ZW", // Will need fixing when ZW supported :-)
+			Code:    "1234567",
+		}
+		assert.Equal(t, cbc.CodeEmpty, tID.GetScheme())
+	})
+
 }
 
 func TestValidationRules(t *testing.T) {

--- a/tax/regime_def.go
+++ b/tax/regime_def.go
@@ -48,6 +48,12 @@ type RegimeDef struct {
 	// Currency used by the country.
 	Currency currency.Code `json:"currency" jsonschema:"title=Currency"`
 
+	// TaxScheme defines the principal scheme of consumption tax that should be
+	// applied to the regime and associated with Tax IDs in some export formats
+	// such as UBL or CII. Some regimes may not have a Tax Scheme and as a
+	// consequence will not use tax identities, like the US.
+	TaxScheme cbc.Code `json:"tax_scheme,omitempty" jsonschema:"title=Tax Scheme"`
+
 	// Rounding rule to use when calculating the tax totals, default is always
 	// `sum-then-round`.
 	CalculatorRoundingRule cbc.Key `json:"calculator_rounding_rule,omitempty" jsonschema:"title=Calculator Rounding Rule"`
@@ -291,6 +297,7 @@ func (r *RegimeDef) ValidateWithContext(ctx context.Context) error {
 		validation.Field(&r.Country),
 		validation.Field(&r.Zone),
 		validation.Field(&r.Currency),
+		validation.Field(&r.TaxScheme),
 		validation.Field(&r.Tags),
 		validation.Field(&r.Identities),
 		validation.Field(&r.Extensions),


### PR DESCRIPTION
- Adds a new "scheme" field to tax regimes and identities for usage when converting to other electronic formats that have a specific requirement for the field.

## Pre-Review Checklist

- [x] I have performed a self-review of my code.
- [x] I have added thorough tests with at **least** 90% code coverage.
- [x] I've modified or created example GOBL documents to show my changes in use, if appropriate.
- [ ] When adding or modifying a tax regime or addon, I've added links to the source of the changes, either structured or in the comments.
- [x] I've run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [x] All linter warnings have been reviewed and fixed.
- [x] I've been obsessive with pointer nil checks to avoid panics.
- [x] The CHANGELOG.md has been updated with an overview of my changes.
- [ ] Requested a review from @samlown.

