### PR TITLE
Inbox scheme with EN16931 updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 - `bill`: `Ordering` with `cost` code for accounting.
 - `it-sdi-v1`: Normalize address codes with 0 padding.
+- `eu-en16931-v2017`: Validating inboxes.
+- `org`: `Inbox` now with `scheme` field.
 
 ### Fixed
+
 - `dsig`: Upgraded signing packages.
 
 ## [v0.213.0] - 2025-03-25

--- a/addons/eu/en16931/en16931.go
+++ b/addons/eu/en16931/en16931.go
@@ -64,6 +64,8 @@ func normalize(doc any) {
 		normalizeOrgNote(obj)
 	case *org.Item:
 		normalizeOrgItem(obj)
+	case *org.Inbox:
+		normalizeOrgInbox(obj)
 	}
 }
 

--- a/addons/eu/en16931/en16931.go
+++ b/addons/eu/en16931/en16931.go
@@ -79,6 +79,10 @@ func validate(doc any) error {
 		return validateOrgItem(obj)
 	case *org.Attachment:
 		return validateOrgAttachment(obj)
+	case *org.Party:
+		return validateOrgParty(obj)
+	case *org.Inbox:
+		return validateOrgInbox(obj)
 	}
 	return nil
 }

--- a/addons/eu/en16931/org.go
+++ b/addons/eu/en16931/org.go
@@ -77,3 +77,29 @@ func validateOrgAttachment(a *org.Attachment) error {
 		),
 	)
 }
+
+func validateOrgParty(p *org.Party) error {
+	return validation.ValidateStruct(p,
+		validation.Field(&p.Inboxes,
+			validation.Length(0, 1).Error("cannot have more than one inbox (BT-34, BT-49)"),
+			validation.Skip,
+		),
+	)
+}
+
+func validateOrgInbox(i *org.Inbox) error {
+	return validation.ValidateStruct(i,
+		validation.Field(&i.Scheme,
+			validation.When(i.Code != cbc.CodeEmpty,
+				validation.Required.Error("cannot be blank with code (BR-62, BR-63)"),
+			),
+			validation.Skip,
+		),
+		validation.Field(&i.Code,
+			validation.When(i.Scheme != cbc.CodeEmpty,
+				validation.Required.Error("cannot be blank with scheme"),
+			),
+			validation.Skip,
+		),
+	)
+}

--- a/addons/eu/en16931/org.go
+++ b/addons/eu/en16931/org.go
@@ -1,6 +1,8 @@
 package en16931
 
 import (
+	"regexp"
+
 	"github.com/invopop/gobl/catalogues/untdid"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/org"
@@ -38,6 +40,10 @@ var orgNoteTextSubjectMap = map[cbc.Key]cbc.Code{
 	org.NoteKeyOther:          "ZZZ",
 }
 
+var (
+	orgInboxRegexpSchemeCode = regexp.MustCompile(`(\d{4}):.*`)
+)
+
 func normalizeOrgNote(n *org.Note) {
 	if n == nil {
 		return
@@ -58,6 +64,16 @@ func normalizeOrgItem(item *org.Item) {
 	}
 	if item.Unit == org.UnitEmpty {
 		item.Unit = org.UnitOne
+	}
+}
+
+func normalizeOrgInbox(i *org.Inbox) {
+	if i == nil || i.Code == cbc.CodeEmpty {
+		return
+	}
+	if orgInboxRegexpSchemeCode.MatchString(i.Code.String()) {
+		i.Scheme = cbc.Code(i.Code.String()[0:4])
+		i.Code = cbc.Code(i.Code.String()[5:])
 	}
 }
 

--- a/addons/eu/en16931/org_test.go
+++ b/addons/eu/en16931/org_test.go
@@ -62,6 +62,31 @@ func TestOrgItemNormalize(t *testing.T) {
 	})
 }
 
+func TestOrgInboxNormalize(t *testing.T) {
+	ad := tax.AddonForKey(en16931.V2017)
+
+	t.Run("accepts nil", func(t *testing.T) {
+		var i *org.Inbox
+		assert.NotPanics(t, func() {
+			ad.Normalizer(i)
+		})
+	})
+	t.Run("accepts empty", func(t *testing.T) {
+		i := &org.Inbox{}
+		assert.NotPanics(t, func() {
+			ad.Normalizer(i)
+		})
+	})
+	t.Run("normalizes scheme and code", func(t *testing.T) {
+		i := &org.Inbox{
+			Code: "0004:BAR",
+		}
+		ad.Normalizer(i)
+		assert.Equal(t, "0004", i.Scheme.String())
+		assert.Equal(t, "BAR", i.Code.String())
+	})
+}
+
 func TestOrgItemValidate(t *testing.T) {
 	ad := tax.AddonForKey(en16931.V2017)
 	t.Run("missing unit", func(t *testing.T) {

--- a/data/schemas/org/inbox.json
+++ b/data/schemas/org/inbox.json
@@ -19,12 +19,12 @@
         "key": {
           "$ref": "https://gobl.org/draft-0/cbc/key",
           "title": "Key",
-          "description": "Type of inbox being defined."
+          "description": "Type of inbox being defined if required for clarification between multiple\ninboxes."
         },
-        "role": {
-          "$ref": "https://gobl.org/draft-0/cbc/key",
-          "title": "Role",
-          "description": "Role assigned to this inbox that may be relevant for the consumer."
+        "scheme": {
+          "$ref": "https://gobl.org/draft-0/cbc/code",
+          "title": "Scheme",
+          "description": "Scheme ID of the code used to identify the inbox. This is context specific\nand usually an ISO 6523 code or CEF (Connecting Europe Facility) code."
         },
         "code": {
           "$ref": "https://gobl.org/draft-0/cbc/code",
@@ -40,15 +40,10 @@
           "type": "string",
           "title": "Email",
           "description": "Email address for the inbox. Mutually exclusive with Code and URL."
-        },
-        "ext": {
-          "$ref": "https://gobl.org/draft-0/tax/extensions",
-          "title": "Extensions",
-          "description": "Extension code map for any additional regime or addon specific codes that may be required."
         }
       },
       "type": "object",
-      "description": "Inbox is used to store data about a connection with a service that is responsible for potentially receiving copies of GOBL envelopes or other document formats defined locally."
+      "description": "Inbox is used to store data about a connection with a service that is responsible for automatically receiving copies of GOBL envelopes or other document formats."
     }
   }
 }

--- a/examples/es/invoice-es-es-peppol-1.yaml
+++ b/examples/es/invoice-es-es-peppol-1.yaml
@@ -1,0 +1,52 @@
+$schema: "https://gobl.org/draft-0/bill/invoice"
+$addons: ["eu-en16931-v2017"]
+uuid: "3aea7b56-59d8-4beb-90bd-f8f280d852a0"
+currency: "EUR"
+issue_date: "2024-12-04"
+series: "SAMPLE"
+code: "004"
+
+supplier:
+  tax_id:
+    country: "ES"
+    code: "B98602642" # random
+  name: "Provide One S.L."
+  inboxes:
+    - scheme: "9920"
+      code: "B98602642"
+  emails:
+    - addr: "billing@example.com"
+  addresses:
+    - num: "42"
+      street: "Calle Pradillo"
+      locality: "Madrid"
+      region: "Madrid"
+      code: "28002"
+      country: "ES"
+
+customer:
+  tax_id:
+    country: "ES"
+    code: "54387763P"
+  name: "Sample Consumer"
+  inboxes:
+    - scheme: "9920"
+      code: "54387763P"
+
+lines:
+  - quantity: 20
+    item:
+      name: "Development services"
+      price: "90.00"
+      unit: "h"
+    discounts:
+      - percent: "10%"
+        reason: "Special discount"
+      - amount: "0.00"
+    taxes:
+      - cat: VAT
+        rate: standard
+
+notes:
+  - key: "general"
+    text: "Random invoice"

--- a/examples/es/out/invoice-es-es-peppol-1.json
+++ b/examples/es/out/invoice-es-es-peppol-1.json
@@ -1,0 +1,132 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
+		"dig": {
+			"alg": "sha256",
+			"val": "9abedc90f2cfc65d55da078bc88dc5ed78d8260f3e858af4194d79ee0bc5aeec"
+		}
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"$regime": "ES",
+		"$addons": [
+			"eu-en16931-v2017"
+		],
+		"uuid": "3aea7b56-59d8-4beb-90bd-f8f280d852a0",
+		"type": "standard",
+		"series": "SAMPLE",
+		"code": "004",
+		"issue_date": "2024-12-04",
+		"currency": "EUR",
+		"tax": {
+			"ext": {
+				"untdid-document-type": "380"
+			}
+		},
+		"supplier": {
+			"name": "Provide One S.L.",
+			"tax_id": {
+				"country": "ES",
+				"code": "B98602642"
+			},
+			"inboxes": [
+				{
+					"scheme": "9920",
+					"code": "B98602642"
+				}
+			],
+			"addresses": [
+				{
+					"num": "42",
+					"street": "Calle Pradillo",
+					"locality": "Madrid",
+					"region": "Madrid",
+					"code": "28002",
+					"country": "ES"
+				}
+			],
+			"emails": [
+				{
+					"addr": "billing@example.com"
+				}
+			]
+		},
+		"customer": {
+			"name": "Sample Consumer",
+			"tax_id": {
+				"country": "ES",
+				"code": "54387763P"
+			},
+			"inboxes": [
+				{
+					"scheme": "9920",
+					"code": "54387763P"
+				}
+			]
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "20",
+				"item": {
+					"name": "Development services",
+					"price": "90.00",
+					"unit": "h"
+				},
+				"sum": "1800.00",
+				"discounts": [
+					{
+						"reason": "Special discount",
+						"percent": "10%",
+						"amount": "180.00"
+					}
+				],
+				"taxes": [
+					{
+						"cat": "VAT",
+						"rate": "standard",
+						"percent": "21.0%",
+						"ext": {
+							"untdid-tax-category": "S"
+						}
+					}
+				],
+				"total": "1620.00"
+			}
+		],
+		"totals": {
+			"sum": "1620.00",
+			"total": "1620.00",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"ext": {
+									"untdid-tax-category": "S"
+								},
+								"base": "1620.00",
+								"percent": "21.0%",
+								"amount": "340.20"
+							}
+						],
+						"amount": "340.20"
+					}
+				],
+				"sum": "340.20"
+			},
+			"tax": "340.20",
+			"total_with_tax": "1960.20",
+			"payable": "1960.20"
+		},
+		"notes": [
+			{
+				"key": "general",
+				"text": "Random invoice"
+			}
+		]
+	}
+}

--- a/org/inbox_test.go
+++ b/org/inbox_test.go
@@ -3,10 +3,8 @@ package org_test
 import (
 	"testing"
 
-	"github.com/invopop/gobl/catalogues/iso"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/org"
-	"github.com/invopop/gobl/tax"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -71,26 +69,14 @@ func TestInboxNormalize(t *testing.T) {
 			id.Normalize(nil)
 		})
 	})
-	t.Run("missing extensions", func(t *testing.T) {
+	t.Run("with scheme", func(t *testing.T) {
 		id := &org.Inbox{
-			Key:  cbc.Key("inbox"),
-			Code: "BAR",
-			Ext:  tax.Extensions{},
-		}
-		id.Normalize(nil)
-		assert.Equal(t, "inbox", id.Key.String())
-		assert.Nil(t, id.Ext)
-	})
-	t.Run("with extension", func(t *testing.T) {
-		id := &org.Inbox{
-			Code: "BAR",
-			Ext: tax.Extensions{
-				iso.ExtKeySchemeID: "0004",
-			},
+			Scheme: " 0004 ",
+			Code:   " BAR ",
 		}
 		id.Normalize(nil)
 		assert.Equal(t, "BAR", id.Code.String())
-		assert.Equal(t, "0004", id.Ext[iso.ExtKeySchemeID].String())
+		assert.Equal(t, "0004", id.Scheme.String())
 	})
 	t.Run("with email in code", func(t *testing.T) {
 		id := &org.Inbox{
@@ -115,10 +101,8 @@ func TestInboxNormalize(t *testing.T) {
 func TestInboxValidate(t *testing.T) {
 	t.Run("with basics", func(t *testing.T) {
 		id := &org.Inbox{
-			Code: "BAR",
-			Ext: tax.Extensions{
-				iso.ExtKeySchemeID: "0004",
-			},
+			Scheme: "0004",
+			Code:   "BAR",
 		}
 		err := id.Validate()
 		assert.NoError(t, err)


### PR DESCRIPTION
- Inbox now includes a `scheme` field to be able to copy EndpointID data from other formats.
- EN16931 addon will now restrict to just one inbox

## Pre-Review Checklist

- [x] I have performed a self-review of my code.
- [x] I have added thorough tests with at **least** 90% code coverage.
- [x] I've modified or created example GOBL documents to show my changes in use, if appropriate.
- [ ] When adding or modifying a tax regime or addon, I've added links to the source of the changes, either structured or in the comments.
- [x] I've run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [x] All linter warnings have been reviewed and fixed.
- [x] I've been obsessive with pointer nil checks to avoid panics.
- [x] The CHANGELOG.md has been updated with an overview of my changes.
- [ ] Requested a review from @samlown.

