### PR TITLE
Add support for Malaysian SST regime (MY) in GOBL

### DIFF
--- a/examples/my/invoice-my.yaml
+++ b/examples/my/invoice-my.yaml
@@ -1,0 +1,56 @@
+$schema: https://gobl.org/draft-0/bill/invoice
+$version: v0.214.1
+$regime: MY
+currency: MYR
+
+series: INV
+code: "2025-0001"
+issue_date: "2025-04-24"
+
+supplier:
+  tax_id:
+    country: "MY"
+    code: "201901234567"
+  name: "Tech Solutions Sdn Bhd"
+  alias: "TechSol"
+  emails:
+    - addr: "billing@techsol.my"
+  addresses:
+    - street: "123 Jalan Bukit Bintang"
+      locality: "Kuala Lumpur"
+      region: "Wilayah Persekutuan"
+      code: "55100"
+      country: "MY"
+
+customer:
+  name: "Innovatech Berhad"
+  tax_id:
+    country: "MY"
+    code: "202001234567"
+  emails:
+    - addr: "accounts@innovatech.my"
+  addresses:
+    - street: "456 Jalan Tun Razak"
+      locality: "Kuala Lumpur"
+      region: "Wilayah Persekutuan"
+      code: "50400"
+      country: "MY"
+
+lines:
+  - quantity: 1
+    item:
+      name: "Cloud Hosting Services - April 2025"
+      price: 50000
+      unit: "unit"
+    taxes:
+      - cat: service-tax
+        percent: "6.0%"
+
+  - quantity: 2
+    item:
+      name: "IT Support - Onsite Visit"
+      price: 15000
+      unit: "h"
+    taxes:
+      - cat: service-tax
+        percent: "6.0%"

--- a/examples/my/out/invoice.json
+++ b/examples/my/out/invoice.json
@@ -1,0 +1,111 @@
+{
+    "$schema": "https://gobl.org/draft-0/bill/invoice",
+    "$regime": "MY",
+    "type": "standard",
+    "series": "INV",
+    "code": "2025-0001",
+    "issue_date": "2025-04-24",
+    "currency": "MYR",
+    "supplier": {
+            "name": "Tech Solutions Sdn Bhd",
+            "alias": "TechSol",
+            "tax_id": {
+                    "country": "MY",
+                    "code": "201901234567"
+            },
+            "addresses": [
+                    {
+                            "street": "123 Jalan Bukit Bintang",
+                            "locality": "Kuala Lumpur",
+                            "region": "Wilayah Persekutuan",
+                            "code": "55100",
+                            "country": "MY"
+                    }
+            ],
+            "emails": [
+                    {
+                            "addr": "billing@techsol.my"
+                    }
+            ]
+    },
+    "customer": {
+            "name": "Innovatech Berhad",
+            "tax_id": {
+                    "country": "MY",
+                    "code": "202001234567"
+            },
+            "addresses": [
+                    {
+                            "street": "456 Jalan Tun Razak",
+                            "locality": "Kuala Lumpur",
+                            "region": "Wilayah Persekutuan",
+                            "code": "50400",
+                            "country": "MY"
+                    }
+            ],
+            "emails": [
+                    {
+                            "addr": "accounts@innovatech.my"
+                    }
+            ]
+    },
+    "lines": [
+            {
+                    "i": 1,
+                    "quantity": "1",
+                    "item": {
+                            "name": "Cloud Hosting Services - April 2025",
+                            "price": "50000.00",
+                            "unit": "unit"
+                    },
+                    "sum": "50000.00",
+                    "taxes": [
+                            {
+                                    "cat": "service-tax",
+                                    "percent": "6.0%"
+                            }
+                    ],
+                    "total": "50000.00"
+            },
+            {
+                    "i": 2,
+                    "quantity": "2",
+                    "item": {
+                            "name": "IT Support - Onsite Visit",
+                            "price": "15000.00",
+                            "unit": "h"
+                    },
+                    "sum": "30000.00",
+                    "taxes": [
+                            {
+                                    "cat": "service-tax",
+                                    "percent": "6.0%"
+                            }
+                    ],
+                    "total": "30000.00"
+            }
+    ],
+    "totals": {
+            "sum": "80000.00",
+            "total": "80000.00",
+            "taxes": {
+                    "categories": [
+                            {
+                                    "code": "service-tax",
+                                    "rates": [
+                                            {
+                                                    "base": "80000.00",
+                                                    "percent": "6.0%",
+                                                    "amount": "4800.00"
+                                            }
+                                    ],
+                                    "amount": "4800.00"
+                            }
+                    ],
+                    "sum": "4800.00"
+            },
+            "tax": "4800.00",
+            "total_with_tax": "84800.00",
+            "payable": "84800.00"
+    }
+}

--- a/examples/my/test-wrong-invoice-my.yaml
+++ b/examples/my/test-wrong-invoice-my.yaml
@@ -1,0 +1,37 @@
+$schema: https://gobl.org/draft-0/bill/invoice
+$version: v0.214.1
+$regime: MY
+currency: MYR
+
+series: INV
+code: "2025-0002"
+issue_date: "2025-04-24"
+
+supplier:
+  name: "Tech Solutions Sdn Bhd"
+  alias: "TechSol"
+  emails:
+    - addr: "billing@techsol.my"
+  addresses:
+    - street: "123 Jalan Bukit Bintang"
+      locality: "Kuala Lumpur"
+      region: "Wilayah Persekutuan"
+      code: "55100"
+      country: "MY"
+
+customer:
+  name: "Innovatech Berhad"
+  tax_id:
+    country: "MY"
+    code: "INVALID"
+  emails:
+    - addr: "accounts@innovatech.my"
+  addresses:
+    - street: "456 Jalan Tun Razak"
+      locality: "Kuala Lumpur"
+      region: "Wilayah Persekutuan"
+      code: "50400"
+      country: "MY"
+
+# Only 0 lines → should trigger validation error
+lines: []

--- a/regimes/my/README.md
+++ b/regimes/my/README.md
@@ -1,0 +1,67 @@
+# 🇲🇾 GOBL Malaysia Tax Regime
+
+Find example MY GOBL files in the [`examples`](../../examples/my) (uncalculated documents) and [`examples/out`](../../examples/my/out) (calculated envelopes) subdirectories.
+
+## Malaysia-specific Requirements
+
+### Tax IDs
+
+In Malaysia, companies and taxable entities are primarily identified using:
+
+- **Business Registration Number**: A 12-digit number issued upon company registration. Example: `201901234567`
+- **Service Tax / Sales Tax Registration Numbers**: For companies registered under SST (Sales and Service Tax), tax IDs may appear in alphanumeric formats such as:
+  - `SST1234567890`
+  - `W10-12345678-123`
+  - These identifiers may include letters and hyphens.
+
+During the normalization process of Tax Identities, GOBL will automatically **uppercase** Malaysian tax IDs for consistency.
+
+A Malaysian company's `org.Party` definition inside an invoice may look like:
+
+```json
+{
+  "tax_id": {
+    "country": "MY",
+    "code": "201901234567"
+  },
+  "name": "Tech Solutions Sdn Bhd",
+  "addresses": [
+    {
+      "street": "123 Jalan Bukit Bintang",
+      "locality": "Kuala Lumpur",
+      "region": "Wilayah Persekutuan",
+      "code": "55100",
+      "country": "MY"
+    }
+  ],
+  "emails": [
+    {
+      "addr": "billing@techsol.my"
+    }
+  ],
+  "identities": [
+    {
+      "type": "SST",
+      "code": "SST1234567890"
+    }
+  ]
+}
+```
+
+**Notes:**
+- The primary `tax_id` field must always be filled.
+- Additional tax identifiers like SST numbers can be included in the `identities` array for clarity or regulatory needs.
+- Both numeric-only and alphanumeric tax IDs are accepted, following Malaysian Customs regulations.
+- The logic to validate or normalize values in the identities array (e.g., SST numbers) has not been implemented yet.
+
+## Disclaimer
+
+> This implementation of the Malaysian tax regime (`MY`) for GOBL has been developed as part of a technical exercise and is intended for **demonstration and testing purposes only**. While every effort has been made to align with publicly available SST regulations and business practices in Malaysia, this module is **not certified for production use** and may not cover all legal, fiscal, or e-invoicing requirements.
+>
+> Users are advised to consult with a certified tax advisor or local regulatory authority before using this module in any commercial or legal context.
+
+
+Sources:
+- [Royal Malaysian Customs Department - Sales and Service Tax](https://mysst.customs.gov.my/)
+
+

--- a/regimes/my/invoice_test.go
+++ b/regimes/my/invoice_test.go
@@ -1,0 +1,73 @@
+package my_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/cal"
+	"github.com/invopop/gobl/num"
+	"github.com/invopop/gobl/org"
+	"github.com/invopop/gobl/tax"
+)
+
+func TestInvoiceValidation(t *testing.T) {
+	t.Run("standard invoice", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		require.NoError(t, inv.Calculate())
+		require.NoError(t, inv.Validate())
+	})
+
+	t.Run("missing supplier tax ID", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.SetRegime("MY")
+		inv.Supplier.TaxID = nil
+		require.NoError(t, inv.Calculate())
+		err := inv.Validate()
+		assert.ErrorContains(t, err, "supplier: (tax_id: cannot be blank.)")
+	})
+}
+
+// testInvoiceStandard provides a valid minimal Malaysian invoice
+func testInvoiceStandard(t *testing.T) *bill.Invoice {
+	t.Helper()
+
+	return &bill.Invoice{
+		Regime:    tax.WithRegime("MY"),
+		Currency:  "MYR",
+		Code:      "INV-0001",
+		IssueDate: cal.MakeDate(2025, 4, 24),
+		Supplier: &org.Party{
+			Name: "Tech Solutions Sdn Bhd",
+			TaxID: &tax.Identity{
+				Country: "MY",
+				Code:    "201901234567",
+			},
+		},
+		Customer: &org.Party{
+			Name: "Innovatech Berhad",
+			TaxID: &tax.Identity{
+				Country: "MY",
+				Code:    "202001234567",
+			},
+		},
+		Lines: []*bill.Line{
+			{
+				Quantity: num.MakeAmount(1, 0),
+				Item: &org.Item{
+					Name:  "Cloud Hosting Services",
+					Price: num.NewAmount(10000, 2), // 100.00 MYR
+					Unit:  org.UnitHour,
+				},
+				Taxes: tax.Set{
+					{
+						Category: "service-tax",
+						Percent:  num.NewPercentage(6, 1),
+					},
+				},
+			},
+		},
+	}
+}

--- a/regimes/my/invoices.go
+++ b/regimes/my/invoices.go
@@ -1,0 +1,53 @@
+package my
+
+import (
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/org"
+	"github.com/invopop/gobl/tax"
+	"github.com/invopop/validation"
+)
+
+func validateInvoice(inv *bill.Invoice) error {
+	return validation.ValidateStruct(inv,
+		validation.Field(&inv.Supplier,
+			validation.By(validateSupplier),
+			validation.Skip,
+		),
+		validation.Field(&inv.Customer,
+			validation.By(validateCustomer),
+			validation.Skip,
+		),
+		validation.Field(&inv.Lines,
+			validation.Required,
+			validation.Length(1, 0),
+		),
+	)
+}
+
+func validateSupplier(val any) error {
+	obj, _ := val.(*org.Party)
+	if obj == nil {
+		return nil
+	}
+	return validation.ValidateStruct(obj,
+		validation.Field(&obj.TaxID,
+			validation.Required,
+			tax.RequireIdentityCode,
+			validation.Skip,
+		),
+	)
+}
+
+func validateCustomer(val any) error {
+	obj, _ := val.(*org.Party)
+	if obj == nil {
+		return nil
+	}
+	return validation.ValidateStruct(obj,
+		validation.Field(&obj.TaxID,
+			validation.Required,
+			tax.RequireIdentityCode,
+			validation.Skip,
+		),
+	)
+}

--- a/regimes/my/my.go
+++ b/regimes/my/my.go
@@ -1,0 +1,53 @@
+// Package it provides the Malaysian tax regime.
+package my
+
+import (
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/currency"
+	"github.com/invopop/gobl/i18n"
+	"github.com/invopop/gobl/regimes/common"
+	"github.com/invopop/gobl/tax"
+)
+
+func init() {
+	tax.RegisterRegimeDef(New())
+}
+
+// New instantiates a new Malaysian regime.
+func New() *tax.RegimeDef {
+	return &tax.RegimeDef{
+		Country:   "MY",
+		Currency:  currency.MYR,
+		TaxScheme: tax.CategoryST, // tax/constants.go. Malaysia uses SST — a form of ST in GOBL terms.
+		Name: i18n.String{
+			i18n.EN: "Malaysia",
+			i18n.MS: "Malaysia", // Write Malay in Malay
+		},
+		TimeZone: "Asia/Kuala_Lumpur",
+		Tags: []*tax.TagSet{
+			common.InvoiceTags(), // CHECK which tags I used use
+		},
+		Validator:  Validate,
+		Normalizer: Normalize,
+		Categories: taxCategories, // tax_categories.go
+	}
+}
+
+// Validate checks the document type and determines if it can be validated.
+func Validate(doc interface{}) error {
+	switch obj := doc.(type) {
+	case *bill.Invoice:
+		return validateInvoice(obj)
+	case *tax.Identity:
+		return validateTaxIdentity(obj)
+	}
+	return nil
+}
+
+// Normalize will attempt to clean the object passed to it.
+func Normalize(doc any) {
+	switch obj := doc.(type) {
+	case *tax.Identity:
+		normalizeTaxIdentity(obj)
+	}
+}

--- a/regimes/my/tax_categories.go
+++ b/regimes/my/tax_categories.go
@@ -1,0 +1,111 @@
+package my
+
+import (
+	"github.com/invopop/gobl/cal"
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/i18n"
+	"github.com/invopop/gobl/num"
+	"github.com/invopop/gobl/tax"
+)
+
+var taxCategories = []*tax.CategoryDef{
+	//
+	// Sales Tax (part of SST)
+	//
+	{
+		Code: "sales-tax", // Custom subcategory under SST
+		Name: i18n.String{
+			i18n.EN: "Sales Tax",
+		},
+		Title: i18n.String{
+			i18n.EN: "Sales and Service Tax (Sales Portion)",
+		},
+		Sources: []*cbc.Source{
+			{
+				Title: i18n.String{
+					i18n.EN: "Royal Malaysian Customs Department - Sales and Service Tax",
+				},
+				URL: "https://mysst.customs.gov.my/",
+			},
+		},
+		Rates: []*tax.RateDef{
+			{
+				Key: "standard-5",
+				Name: i18n.String{
+					i18n.EN: "Standard Rate 5%",
+				},
+				Values: []*tax.RateValueDef{
+					{
+						Since:   cal.NewDate(2018, 9, 1),
+						Percent: num.MakePercentage(5, 2),
+					},
+				},
+			},
+			{
+				Key: "standard-10",
+				Name: i18n.String{
+					i18n.EN: "Standard Rate 10%",
+				},
+				Values: []*tax.RateValueDef{
+					{
+						Since:   cal.NewDate(2018, 9, 1),
+						Percent: num.MakePercentage(10, 2),
+					},
+				},
+			},
+		},
+	},
+
+	//
+	// Service Tax (part of SST)
+	//
+	{
+		Code: "service-tax", // Custom subcategory under SST
+		Name: i18n.String{
+			i18n.EN: "Service Tax",
+		},
+		Title: i18n.String{
+			i18n.EN: "Sales and Service Tax (Service Portion)",
+		},
+		Sources: []*cbc.Source{
+			{
+				Title: i18n.String{
+					i18n.EN: "Royal Malaysian Customs Department - Service Tax Guide",
+				},
+				URL: "https://mysst.customs.gov.my/",
+			},
+		},
+		Rates: []*tax.RateDef{
+			{
+				Key: "standard-6",
+				Name: i18n.String{
+					i18n.EN: "Specific Services Rate 6%",
+				},
+				Description: i18n.String{
+					i18n.EN: "Applies to food and beverage, telecommunications, parking, logistics services only.",
+				},
+				Values: []*tax.RateValueDef{
+					{
+						Since:   cal.NewDate(2018, 9, 1),
+						Percent: num.MakePercentage(6, 2),
+					},
+				},
+			},
+			{
+				Key: "standard-8",
+				Name: i18n.String{
+					i18n.EN: "General Services Rate 8%",
+				},
+				Description: i18n.String{
+					i18n.EN: "Applies to general services as of March 1, 2024.",
+				},
+				Values: []*tax.RateValueDef{
+					{
+						Since:   cal.NewDate(2024, 3, 1),
+						Percent: num.MakePercentage(8, 2),
+					},
+				},
+			},
+		},
+	},
+}

--- a/regimes/my/tax_identity.go
+++ b/regimes/my/tax_identity.go
@@ -1,0 +1,51 @@
+package my
+
+import (
+	"errors"
+	"regexp"
+	"strings"
+
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/tax"
+	"github.com/invopop/validation"
+)
+
+var (
+	// Malaysian Business Registration Numbers are typically 12-digit numbers
+	taxCodeMYNumeric = regexp.MustCompile(`^\d{12}$`)
+
+	// Alphanumeric SST/Service Tax IDs — e.g., SST1234567890 or W10-12345678-123
+	taxCodeSST    = regexp.MustCompile(`^SST\d{10,12}$`)
+	taxCodeWStyle = regexp.MustCompile(`^[A-Z0-9]{1,4}-\d{8}-\d{3}$`)
+)
+
+// normalizeTaxIdentity performs basic uppercasing and trims whitespace for consistency.
+func normalizeTaxIdentity(tID *tax.Identity) {
+	if tID == nil {
+		return
+	}
+	code := strings.TrimSpace(tID.Code.String()) // trim spaces
+	code = strings.ReplaceAll(code, " ", "")     // remove internal spaces too
+	tID.Code = cbc.Code(strings.ToUpper(code))   // uppercase
+}
+
+// validateTaxIdentity validates Malaysian tax IDs.
+func validateTaxIdentity(tID *tax.Identity) error {
+	return validation.ValidateStruct(tID,
+		validation.Field(&tID.Code, validation.By(validateMYTaxCode)),
+	)
+}
+
+func validateMYTaxCode(value interface{}) error {
+	code, ok := value.(cbc.Code)
+	if !ok || code == "" {
+		return nil
+	}
+	str := strings.ToUpper(strings.TrimSpace(code.String()))
+
+	if taxCodeMYNumeric.MatchString(str) || taxCodeSST.MatchString(str) || taxCodeWStyle.MatchString(str) {
+		return nil
+	}
+
+	return errors.New("invalid MY tax ID format")
+}

--- a/regimes/my/tax_identity_test.go
+++ b/regimes/my/tax_identity_test.go
@@ -1,0 +1,71 @@
+package my_test
+
+import (
+	"testing"
+
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/regimes/my"
+	"github.com/invopop/gobl/tax"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizeTaxIdentity(t *testing.T) {
+	r := my.New()
+
+	tests := []struct {
+		Code     cbc.Code
+		Expected cbc.Code
+	}{
+		{
+			Code:     "sSt1234567890",
+			Expected: "SST1234567890",
+		},
+		{
+			Code:     " w10-12345678-123 ",
+			Expected: "W10-12345678-123",
+		},
+		{
+			Code:     "201901234567",
+			Expected: "201901234567",
+		},
+	}
+	for _, ts := range tests {
+		tID := &tax.Identity{Country: "MY", Code: ts.Code}
+		r.NormalizeObject(tID)
+		assert.Equal(t, ts.Expected, tID.Code)
+	}
+}
+
+func TestValidateTaxIdentity(t *testing.T) {
+	r := my.New()
+
+	tests := []struct {
+		Code  cbc.Code
+		Valid bool
+	}{
+		// Valid 12-digit business numbers
+		{Code: "201901234567", Valid: true},
+		{Code: "123456789012", Valid: true},
+
+		// Valid SST numbers
+		{Code: "SST1234567890", Valid: true},
+		{Code: "W10-12345678-123", Valid: true},
+
+		// Invalid ones
+		{Code: "2019-123456", Valid: false},        // Wrong format
+		{Code: "XYZ", Valid: false},                // Too short
+		{Code: "SST-INVALID-NUMBER", Valid: false}, // Wrong pattern
+	}
+
+	for _, ts := range tests {
+		t.Run(string(ts.Code), func(t *testing.T) {
+			tID := &tax.Identity{Country: "MY", Code: ts.Code}
+			err := r.ValidateObject(tID)
+			if ts.Valid {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+			}
+		})
+	}
+}

--- a/regimes/regimes.go
+++ b/regimes/regimes.go
@@ -20,6 +20,7 @@ import (
 	_ "github.com/invopop/gobl/regimes/in"
 	_ "github.com/invopop/gobl/regimes/it"
 	_ "github.com/invopop/gobl/regimes/mx"
+	_ "github.com/invopop/gobl/regimes/my"
 	_ "github.com/invopop/gobl/regimes/nl"
 	_ "github.com/invopop/gobl/regimes/pl"
 	_ "github.com/invopop/gobl/regimes/pt"


### PR DESCRIPTION
This PR introduces initial support for Malaysia (`MY`) into the GOBL system, implementing the Sales and Service Tax (SST) structure. The contribution includes a new regime definition, validation logic, tax category definitions, and tests.

**Implemented Features:**

1. **New Malaysian Regime**
   - Registered `MY` regime using `TaxScheme: "st"` (Sales Tax system)
   - Configured metadata (currency, timezone, tags, etc.)
   
2. **Tax Categories for SST**
   - Defined two custom categories:
     - `sales-tax` with 5% and 10% rates
     - `service-tax` with 6% and 8% rates (including March 2024 update)
   - Included metadata such as official source URLs and date of applicability

3. **Invoice Validation (`invoice.go`)**
   - Ensures `supplier` and `customer` have a valid `tax_id`
   - Enforces a minimum of one invoice line

4. **Tax Identity Validation (`tax_identity.go`)**
   - Supports 12-digit registration numbers and SST-style alphanumeric formats
   - Normalizes values (e.g., removes spaces, uppercases SST IDs)
   - Includes unit tests for normalization and validation logic

5. **Testing**
   - `invoice_test.go` validates:
     - A correct Malaysian invoice
     - Missing or invalid tax IDs
   - `tax_identity_test.go` verifies:
     - Normalization of SST and registration numbers
     - Acceptance and rejection of known-valid/invalid formats

**Notes:**

- `identities[]` field (e.g., for SST numbers) is supported structurally but not yet validated.
- Includes a disclaimer in the README clarifying that this is a technical exercise for demonstration purposes only and not production-certified.