### PR TITLE
Additional Portugal SAF-T Validations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Added
+
+- `pt-saft-v1`: additional validations to prevent non-compliant invoices.
+
 ## [v0.215.0] - 2025-04-28
 
 ### Changed

--- a/addons/pt/saft/invoices_test.go
+++ b/addons/pt/saft/invoices_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/num"
 	"github.com/invopop/gobl/org"
+	"github.com/invopop/gobl/pay"
 	"github.com/invopop/gobl/tax"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -158,4 +159,78 @@ func TestInvoiceSeriesValidation(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestInvoicePaymentValidation(t *testing.T) {
+	addon := tax.AddonForKey(saft.V1)
+
+	t.Run("invoice with valid advance", func(t *testing.T) {
+		inv := validInvoice()
+		date := cal.MakeDate(2023, 1, 1) // Same as invoice date
+		inv.Payment = &bill.PaymentDetails{
+			Advances: []*pay.Advance{
+				{
+					Date:   &date,
+					Amount: num.MakeAmount(50, 0),
+				},
+			},
+		}
+		require.NoError(t, addon.Validator(inv))
+	})
+
+	t.Run("advance with different date than invoice", func(t *testing.T) {
+		inv := validInvoice()
+		date := cal.MakeDate(2023, 1, 2) // Different than invoice date
+		inv.Payment = &bill.PaymentDetails{
+			Advances: []*pay.Advance{
+				{
+					Date:   &date,
+					Amount: num.MakeAmount(50, 0),
+				},
+			},
+		}
+		assert.ErrorContains(t, addon.Validator(inv), "advances: (0: (date: must be the same as the invoice issue date")
+	})
+
+	t.Run("advance with nil date", func(t *testing.T) {
+		inv := validInvoice()
+		inv.Payment = &bill.PaymentDetails{
+			Advances: []*pay.Advance{
+				{
+					Date:   nil,
+					Amount: num.MakeAmount(50, 0),
+				},
+			},
+		}
+		assert.ErrorContains(t, addon.Validator(inv), "advances: (0: (date: cannot be blank")
+	})
+}
+
+func TestInvoiceNormalization(t *testing.T) {
+	addon := tax.AddonForKey(saft.V1)
+
+	t.Run("set default advance date", func(t *testing.T) {
+		inv := validInvoice()
+		inv.Payment = &bill.PaymentDetails{
+			Advances: []*pay.Advance{
+				{
+					Date:   nil,
+					Amount: num.MakeAmount(50, 0),
+				},
+			},
+		}
+
+		addon.Normalizer(inv)
+
+		assert.Equal(t, &inv.IssueDate, inv.Payment.Advances[0].Date)
+	})
+
+	t.Run("nil payment details", func(t *testing.T) {
+		inv := validInvoice()
+		inv.Payment = nil
+
+		addon.Normalizer(inv)
+
+		assert.Nil(t, inv.Payment)
+	})
 }

--- a/addons/pt/saft/invoices_test.go
+++ b/addons/pt/saft/invoices_test.go
@@ -110,6 +110,25 @@ func TestInvoiceValidation(t *testing.T) {
 		inv.Lines[0].Taxes = nil
 		assert.ErrorContains(t, addon.Validator(inv), "lines: (0: (taxes: missing category VAT")
 	})
+
+	t.Run("unpaid invoice-receipt", func(t *testing.T) {
+		inv := validInvoice()
+		inv.Series = "FR SERIES-A"
+		inv.Tax.Ext = tax.Extensions{
+			saft.ExtKeyInvoiceType: saft.InvoiceTypeInvoiceReceipt,
+		}
+		inv.Totals = &bill.Totals{
+			Due: num.NewAmount(10, 2), // Some payment due
+		}
+
+		assert.ErrorContains(t, addon.Validator(inv), "totals: (due: must be no greater than 0")
+
+		inv.Totals.Due = num.NewAmount(0, 2) // Zero payment due
+		require.NoError(t, addon.Validator(inv))
+
+		inv.Totals.Due = nil // No payment due
+		require.NoError(t, addon.Validator(inv))
+	})
 }
 
 func TestInvoiceSeriesValidation(t *testing.T) {

--- a/addons/pt/saft/invoices_test.go
+++ b/addons/pt/saft/invoices_test.go
@@ -283,6 +283,14 @@ func TestInvoicePaymentValidation(t *testing.T) {
 		}
 		assert.ErrorContains(t, addon.Validator(inv), "advances: (0: (date: cannot be blank")
 	})
+
+	t.Run("nil advance", func(t *testing.T) {
+		inv := validInvoice()
+		inv.Payment = &bill.PaymentDetails{
+			Advances: []*pay.Advance{nil},
+		}
+		require.NoError(t, addon.Validator(inv))
+	})
 }
 
 func TestInvoicePrecedingValidation(t *testing.T) {
@@ -326,6 +334,12 @@ func TestInvoicePrecedingValidation(t *testing.T) {
 			},
 		}
 		assert.ErrorContains(t, addon.Validator(inv), "preceding: (0: (issue_date: too late")
+	})
+
+	t.Run("nil preceding", func(t *testing.T) {
+		inv := validInvoice()
+		inv.Preceding = []*org.DocumentRef{nil}
+		require.NoError(t, addon.Validator(inv))
 	})
 }
 

--- a/addons/pt/saft/saft.go
+++ b/addons/pt/saft/saft.go
@@ -80,6 +80,8 @@ func normalize(doc any) {
 		normalizeOrder(obj)
 	case *bill.Delivery:
 		normalizeDelivery(obj)
+	case *bill.Invoice:
+		normalizeInvoice(obj)
 	}
 }
 


### PR DESCRIPTION
Adds validation and normalization logic to `pt-saft-v1` to prevent non-compliant invoices to be valid. Namely:

- Validates advances' date is present and matches the invoice issue date. 
  - Normalises advances to set the invoice issue date when nil
- Validates due total in invoice-receipts is zero (they must be fully paid)
- Validates preceding issue date is not after the invoice issue date
- Validates the total with taxes in simplified invoices doesn't exceed the legal maximum of 1000€

## Pre-Review Checklist

- [x] I have performed a self-review of my code.
- [x] I have added thorough tests with at **least** 90% code coverage.
- [x] I've modified or created example GOBL documents to show my changes in use, if appropriate.
- [x] When adding or modifying a tax regime or addon, I've added links to the source of the changes, either structured or in the comments.
- [x] I've run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [x] All linter warnings have been reviewed and fixed.
- [x] I've been obsessive with pointer nil checks to avoid panics.
- [x] The CHANGELOG.md has been updated with an overview of my changes.
- [x] Requested a review from @samlown.

