### PR TITLE
Fix imprecise due total calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Fixed
+
+- `bill`: Fixed imprecise due total calculation
+
 ## [v0.215.0] - 2025-04-28
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Fixed
 
-- `bill`: Fixed imprecise due total calculation
+- `bill`: Rounding _before_ payment calculations.
+- `tax`: Rounding bug in totals calculations.
+
+### Added
+
+- `tax`: Totals now have public `Round` method.
 
 ## [v0.215.0] - 2025-04-28
 

--- a/bill/calculator.go
+++ b/bill/calculator.go
@@ -175,6 +175,8 @@ func calculate(doc billable) error {
 	if t.RetainedTax != nil {
 		t.Payable = t.Payable.Subtract(*t.RetainedTax)
 	}
+	// early rescale the payable amount so that the following calculations use the effective amount
+	t.Payable = t.Payable.Rescale(zero.Exp())
 	if t.Rounding != nil {
 		// BT-144 in EN16931
 		t.Payable = t.Payable.Add(*t.Rounding)

--- a/bill/calculator_test.go
+++ b/bill/calculator_test.go
@@ -125,6 +125,33 @@ func TestCalculate(t *testing.T) {
 		assert.Equal(t, "9.99", inv.Totals.Payable.String())
 	})
 
+	t.Run("with advances", func(t *testing.T) {
+		inv := baseInvoice(t, &bill.Line{
+			Quantity: num.MakeAmount(10, 0),
+			Item: &org.Item{
+				Name:  "test item 1",
+				Price: num.NewAmount(273585, 4),
+			},
+			Taxes: tax.Set{
+				{
+					Category: tax.CategoryVAT,
+					Percent:  num.NewPercentage(6, 2),
+				},
+			},
+		})
+		inv.Tax.PricesInclude = ""
+		inv.Payment = &bill.PaymentDetails{
+			Advances: []*pay.Advance{
+				{
+					Amount: num.MakeAmount(29001, 2),
+				},
+			},
+		}
+		require.NoError(t, inv.Calculate())
+		assert.Equal(t, "290.01", inv.Totals.Payable.String())
+		assert.Equal(t, "0.00", inv.Totals.Due.String())
+	})
+
 	t.Run("with retained taxes and advances", func(t *testing.T) {
 		inv := baseInvoice(t, &bill.Line{
 			Quantity: num.MakeAmount(1, 0),

--- a/bill/calculator_test.go
+++ b/bill/calculator_test.go
@@ -1,6 +1,7 @@
 package bill_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/invopop/gobl/bill"
@@ -125,30 +126,52 @@ func TestCalculate(t *testing.T) {
 		assert.Equal(t, "9.99", inv.Totals.Payable.String())
 	})
 
-	t.Run("with advances", func(t *testing.T) {
+	t.Run("with advances and rounding", func(t *testing.T) {
 		inv := baseInvoice(t, &bill.Line{
-			Quantity: num.MakeAmount(10, 0),
+			Quantity: num.MakeAmount(1, 0),
 			Item: &org.Item{
 				Name:  "test item 1",
-				Price: num.NewAmount(273585, 4),
-			},
-			Taxes: tax.Set{
-				{
-					Category: tax.CategoryVAT,
-					Percent:  num.NewPercentage(6, 2),
-				},
+				Price: num.NewAmount(90005, 3),
 			},
 		})
 		inv.Tax.PricesInclude = ""
 		inv.Payment = &bill.PaymentDetails{
 			Advances: []*pay.Advance{
 				{
-					Amount: num.MakeAmount(29001, 2),
+					Amount: num.MakeAmount(9001, 2),
 				},
 			},
 		}
 		require.NoError(t, inv.Calculate())
-		assert.Equal(t, "290.01", inv.Totals.Payable.String())
+		data, _ := json.MarshalIndent(inv.Totals, "", "  ")
+		t.Logf("TOTALS: %s", string(data))
+		assert.Equal(t, "90.01", inv.Totals.Payable.String())
+		assert.Equal(t, "0.00", inv.Totals.Due.String())
+	})
+
+	t.Run("with precision advances, calculated twice", func(t *testing.T) {
+		inv := baseInvoice(t, &bill.Line{
+			Quantity: num.MakeAmount(1, 0),
+			Item: &org.Item{
+				Name:  "test item 1",
+				Price: num.NewAmount(90005, 3),
+			},
+		})
+		inv.Tax.PricesInclude = ""
+		inv.Payment = &bill.PaymentDetails{
+			Advances: []*pay.Advance{
+				{
+					Amount: num.MakeAmount(900050, 4),
+				},
+			},
+		}
+		require.NoError(t, inv.Calculate())
+		data, _ := json.MarshalIndent(inv.Totals, "", "  ")
+		t.Logf("TOTALS: %s", string(data))
+		assert.Equal(t, "90.01", inv.Totals.Advances.String())
+		require.NoError(t, inv.Calculate())
+		assert.Equal(t, "90.01", inv.Totals.Advances.String())
+		assert.Equal(t, "90.01", inv.Totals.Payable.String())
 		assert.Equal(t, "0.00", inv.Totals.Due.String())
 	})
 

--- a/bill/invoice_test.go
+++ b/bill/invoice_test.go
@@ -537,6 +537,50 @@ func TestRemoveIncludedTax6WithDiscount(t *testing.T) {
 	assert.Equal(t, i.Totals.Payable.String(), i2.Totals.Payable.String())
 }
 
+func TestRemoveIncludedTax7(t *testing.T) {
+	lines := []*bill.Line{
+		{
+			Quantity: num.MakeAmount(10, 0),
+			Item: &org.Item{
+				Name:  "Test Item",
+				Price: num.NewAmount(2900, 2),
+			},
+			Taxes: tax.Set{
+				{
+					Category: "VAT",
+					Percent:  num.NewPercentage(6, 2),
+				},
+			},
+		},
+	}
+	i := baseInvoice(t, lines...)
+	i.Payment = &bill.PaymentDetails{
+		Advances: []*pay.Advance{
+			{
+				Amount: num.MakeAmount(29000, 2),
+			},
+		},
+	}
+	require.NoError(t, i.Calculate())
+
+	assert.Equal(t, "290.00", i.Totals.Sum.String())
+	assert.Equal(t, i.Totals.Sum.String(), i.Totals.Payable.String())
+
+	i2, err := kamino.Clone(i)
+	require.NoError(t, err)
+	require.NoError(t, i2.RemoveIncludedTaxes())
+
+	assert.Empty(t, i2.Tax.PricesInclude)
+	l0 := i2.Lines[0]
+	assert.Equal(t, "27.3585", l0.Item.Price.String())
+
+	assert.Equal(t, "273.59", i2.Totals.Sum.String())
+	assert.Equal(t, "273.59", i2.Totals.Total.String(), "slightly different from original")
+	assert.Equal(t, i.Totals.Tax.String(), i2.Totals.Tax.String())
+	assert.Equal(t, i.Totals.Payable.String(), i2.Totals.Payable.String())
+	assert.Equal(t, i.Totals.Due.String(), i2.Totals.Due.String())
+}
+
 func TestRemoveIncludedTaxQuantity(t *testing.T) {
 	i := &bill.Invoice{
 		Code: "123TEST",
@@ -685,9 +729,10 @@ func TestRemoveIncludedTaxDeep(t *testing.T) {
 		t.Logf("TOTALS: %v", string(data))
 	*/
 
+	assert.Equal(t, "1069.81", i.Totals.Tax.String())
 	assert.Equal(t, "17830.19", i.Totals.Total.String())
 	assert.Equal(t, "17830.20", i2.Totals.Total.String())
-	assert.Equal(t, "-0.01", i2.Totals.Rounding.String())
+	assert.Equal(t, "-0.02", i2.Totals.Rounding.String())
 	assert.Equal(t, i.Totals.Tax.String(), i2.Totals.Tax.String())
 	assert.Equal(t, i.Totals.Payable.String(), i2.Totals.Payable.String())
 }

--- a/bill/payment_details.go
+++ b/bill/payment_details.go
@@ -52,10 +52,11 @@ func (p *PaymentDetails) ResetAdvances() {
 	p.Advances = make([]*pay.Advance, 0)
 }
 
-func (p *PaymentDetails) calculateAdvances(zero num.Amount, totalWithTax num.Amount) {
+func (p *PaymentDetails) calculateAdvances(zero num.Amount, payable num.Amount) {
 	for _, a := range p.Advances {
-		a.CalculateFrom(totalWithTax)
-		a.Amount = a.Amount.MatchPrecision(zero)
+		a.CalculateFrom(payable)
+		// Payments must always have currency precision
+		a.Amount = a.Amount.Rescale(zero.Exp())
 	}
 }
 
@@ -63,11 +64,10 @@ func (p *PaymentDetails) totalAdvance(zero num.Amount) *num.Amount {
 	if p == nil || len(p.Advances) == 0 {
 		return nil
 	}
+	// Payments always maintain currency precision
 	sum := zero
 	for _, a := range p.Advances {
-		sum = sum.MatchPrecision(a.Amount)
 		sum = sum.Add(a.Amount)
-		a.Amount = a.Amount.Rescale(zero.Exp())
 	}
 	return &sum
 }

--- a/bill/payment_details_test.go
+++ b/bill/payment_details_test.go
@@ -104,7 +104,7 @@ func TestPaymentDetailsCalculations(t *testing.T) {
 		assert.Nil(t, p.totalAdvance(zero))
 	})
 
-	t.Run("maintains precision", func(t *testing.T) {
+	t.Run("uses currency precision", func(t *testing.T) {
 		zero := num.MakeAmount(0, 2)
 		total := num.MakeAmount(20845, 3)
 		p := &PaymentDetails{
@@ -117,8 +117,7 @@ func TestPaymentDetailsCalculations(t *testing.T) {
 		}
 		p.calculateAdvances(zero, total)
 		a := p.totalAdvance(zero)
-
 		assert.Equal(t, "20.85", p.Advances[0].Amount.String())
-		assert.Equal(t, "20.845", a.String())
+		assert.Equal(t, "20.85", a.String())
 	})
 }

--- a/bill/totals.go
+++ b/bill/totals.go
@@ -95,6 +95,9 @@ func (t *Totals) round(zero num.Amount) {
 		*t.TaxIncluded = t.TaxIncluded.Rescale(e)
 	}
 	t.Total = t.Total.Rescale(e)
+	if t.Taxes != nil {
+		t.Taxes.Round(zero)
+	}
 	t.Tax = t.Tax.Rescale(e)
 	t.TotalWithTax = t.TotalWithTax.Rescale(e)
 	if t.RetainedTax != nil {

--- a/data/schemas/pay/advance.json
+++ b/data/schemas/pay/advance.json
@@ -115,7 +115,7 @@
         "percent": {
           "$ref": "https://gobl.org/draft-0/num/percentage",
           "title": "Percent",
-          "description": "How much as a percentage of the total with tax was paid"
+          "description": "Percentage of the total amount payable that was paid. Note that\nmultiple advances with percentages may lead to rounding errors,\nespecially when the total advances sums to 100%. We recommend only\nincluding one advance with a percent value per document."
         },
         "amount": {
           "$ref": "https://gobl.org/draft-0/num/amount",

--- a/org/document_ref.go
+++ b/org/document_ref.go
@@ -71,6 +71,7 @@ func (dr *DocumentRef) Calculate(cur currency.Code, rr cbc.Key) {
 		return
 	}
 	dr.Tax.Calculate(cur, rr)
+	dr.Tax.Round(cur.Def().Zero())
 }
 
 // Validate ensures the Document looks correct.

--- a/pay/advance.go
+++ b/pay/advance.go
@@ -29,7 +29,10 @@ type Advance struct {
 	Grant bool `json:"grant,omitempty" jsonschema:"title=Grant"`
 	// Details about the advance.
 	Description string `json:"description" jsonschema:"title=Description"`
-	// How much as a percentage of the total with tax was paid
+	// Percentage of the total amount payable that was paid. Note that
+	// multiple advances with percentages may lead to rounding errors,
+	// especially when the total advances sums to 100%. We recommend only
+	// including one advance with a percent value per document.
 	Percent *num.Percentage `json:"percent,omitempty" jsonschema:"title=Percent"`
 	// How much was paid.
 	Amount num.Amount `json:"amount" jsonschema:"title=Amount"`

--- a/pay/advance.go
+++ b/pay/advance.go
@@ -66,11 +66,13 @@ func (a *Advance) Validate() error {
 // ValidateWithContext checks the advance looks okay inside the context.
 func (a *Advance) ValidateWithContext(ctx context.Context) error {
 	return tax.ValidateStructWithContext(ctx, a,
-		validation.Field(&a.Amount, validation.Required),
+		validation.Field(&a.Date),
 		validation.Field(&a.Key, HasValidMeansKey),
+		validation.Field(&a.Ref),
 		validation.Field(&a.Description, validation.Required),
 		validation.Field(&a.Percent),
 		validation.Field(&a.Amount),
+		validation.Field(&a.Currency),
 		validation.Field(&a.Card),
 		validation.Field(&a.CreditTransfer),
 		validation.Field(&a.Ext),
@@ -80,9 +82,9 @@ func (a *Advance) ValidateWithContext(ctx context.Context) error {
 
 // CalculateFrom will update the amount using the rate of the provided
 // total, if defined.
-func (a *Advance) CalculateFrom(totalWithTax num.Amount) {
+func (a *Advance) CalculateFrom(payable num.Amount) {
 	if a.Percent != nil {
-		a.Amount = a.Percent.Of(totalWithTax)
+		a.Amount = a.Percent.Of(payable)
 	}
 }
 

--- a/pay/advance_test.go
+++ b/pay/advance_test.go
@@ -4,10 +4,12 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/num"
 	"github.com/invopop/gobl/pay"
 	"github.com/invopop/gobl/tax"
 	"github.com/invopop/gobl/uuid"
+	"github.com/invopop/jsonschema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -37,4 +39,69 @@ func TestAdvanceUnmarshal(t *testing.T) {
 	err := json.Unmarshal([]byte(`{"desc":"foo"}`), a)
 	require.NoError(t, err)
 	assert.Equal(t, "foo", a.Description)
+}
+
+func TestAdvanceCalculateFrom(t *testing.T) {
+	t.Run("basic", func(t *testing.T) {
+		a := &pay.Advance{
+			Percent: num.NewPercentage(10, 2),
+		}
+		a.CalculateFrom(num.MakeAmount(1000, 2))
+		assert.Equal(t, num.NewAmount(100, 2).String(), a.Amount.String())
+	})
+	t.Run("nil", func(t *testing.T) {
+		a := &pay.Advance{
+			Percent: nil,
+		}
+		a.CalculateFrom(num.MakeAmount(1000, 2))
+		assert.True(t, a.Amount.IsZero())
+	})
+}
+
+func TestAdvanceValidate(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		a := &pay.Advance{
+			Identify:    uuid.Identify{UUID: uuid.Zero},
+			Description: "Test advance",
+			Percent:     num.NewPercentage(100, 2),
+		}
+		assert.NoError(t, a.Validate())
+	})
+	t.Run("invalid", func(t *testing.T) {
+		a := &pay.Advance{
+			Amount: num.MakeAmount(100, 2),
+		}
+		assert.ErrorContains(t, a.Validate(), "description: cannot be blank")
+	})
+	t.Run("valid means key", func(t *testing.T) {
+		a := &pay.Advance{
+			Description: "Test advance",
+			Percent:     num.NewPercentage(100, 2),
+			Key:         pay.MeansKeyCard,
+		}
+		assert.NoError(t, a.Validate())
+	})
+	t.Run("invalid means key", func(t *testing.T) {
+		a := &pay.Advance{
+			Description: "Test advance",
+			Percent:     num.NewPercentage(100, 2),
+			Key:         "invalid",
+		}
+		assert.ErrorContains(t, a.Validate(), "key: must be or start with a valid key.")
+	})
+}
+
+func TestAdvanceJSONSchemaExtend(t *testing.T) {
+	schema := &jsonschema.Schema{
+		Properties: jsonschema.NewProperties(),
+	}
+	schema.Properties.Set("key", &jsonschema.Schema{
+		Type: "string",
+	})
+	a := &pay.Advance{}
+	a.JSONSchemaExtend(schema)
+	prop, ok := schema.Properties.Get("key")
+	require.True(t, ok)
+	assert.Len(t, prop.AnyOf, 15)
+	assert.Equal(t, cbc.Key("any"), prop.AnyOf[0].Const)
 }

--- a/tax/totals.go
+++ b/tax/totals.go
@@ -331,7 +331,6 @@ func (t *Total) Calculate(cur currency.Code, rr cbc.Key) {
 	}
 	zero := cur.Def().Zero()
 	t.calculateFinalSum(zero, rr)
-	t.round(zero)
 }
 
 func (t *Total) calculateFinalSum(zero num.Amount, rr cbc.Key) {
@@ -396,10 +395,9 @@ func matchRoundingPrecision(rr cbc.Key, a, b num.Amount) num.Amount {
 	return a.MatchPrecision(b)
 }
 
-// round will go through all the values generated and round them to the currency's
-// preferred precision. The final precise sum will be available in the t.sum variable
-// still.
-func (t *Total) round(zero num.Amount) {
+// Round will go through all the values generated and round them to the currency's
+// preferred precision.
+func (t *Total) Round(zero num.Amount) {
 	for _, ct := range t.Categories {
 		for _, rt := range ct.Rates {
 			rt.Amount = rt.Amount.Rescale(zero.Exp())

--- a/tax/totals_calculator_test.go
+++ b/tax/totals_calculator_test.go
@@ -1278,6 +1278,7 @@ func TestTotalBySumCalculate(t *testing.T) {
 			if test.err != nil && assert.Error(t, err) {
 				assert.ErrorIs(t, err, test.err)
 			}
+			tot.Round(currency.EUR.Def().Zero())
 			if test.errContent != "" && assert.Error(t, err) {
 				assert.Contains(t, err.Error(), test.errContent)
 			}


### PR DESCRIPTION
- Performs all payable totals calculations after rounding.
- Fixes issue with pre-rounding of tax totals.
- Ensures that advances are always rounded to the precision of the currency before calculations.

## Pre-Review Checklist

- [x] I have performed a self-review of my code.
- [x] I have added thorough tests with at **least** 90% code coverage.
- _N/A_ I've modified or created example GOBL documents to show my changes in use, if appropriate.
- _N/A_ When adding or modifying a tax regime or addon, I've added links to the source of the changes, either structured or in the comments.
- _N/A_ I've run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [x] All linter warnings have been reviewed and fixed.
- [x] I've been obsessive with pointer nil checks to avoid panics.
- [x] The CHANGELOG.md has been updated with an overview of my changes.
- [x] Requested a review from @samlown.