### PR TITLE
Add validation for export exemption codes in Verifactu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - `mx-cfdi-v4`: Support for "Global" B2C invoice reporting that group together B2C sales into a single document.
 - `mx-cfdi-v4`: Automatically set the `issue_time` if not already provided.
 - `tax`: `ExtensionsRequireAllOrNone` validation rule.
+- `es-verifactu-v1`: validation for export exemption codes.
+- `tax`: `ExtensionsExcludeCodes` validation rule.
 
 ### Removed
 

--- a/addons/es/verifactu/bill.go
+++ b/addons/es/verifactu/bill.go
@@ -77,13 +77,6 @@ func validateInvoice(inv *bill.Invoice) error {
 			validation.By(validateInvoiceTax(inv.Type)),
 			validation.Skip,
 		),
-		validation.Field(&inv.Lines,
-			validation.Each(
-				validation.By(validateInvoiceLine),
-				validation.Skip,
-			),
-			validation.Skip,
-		),
 		validation.Field(&inv.Notes,
 			org.ValidateNotesHasKey(org.NoteKeyGeneral),
 			validation.Skip,
@@ -168,49 +161,4 @@ func validateInvoicePreceding(val any) error {
 		// Tax data of previous invoices is required by Verifactu.
 		validation.Field(&p.Tax, validation.Required),
 	)
-}
-
-func validateInvoiceLine(value any) error {
-	obj, _ := value.(*bill.Line)
-	if obj == nil {
-		return nil
-	}
-	return validation.ValidateStruct(obj,
-		validation.Field(&obj.Taxes,
-			validation.Each(
-				validation.By(validateInvoiceLineTax),
-				validation.Skip,
-			),
-			validation.Skip,
-		),
-	)
-}
-
-func validateInvoiceLineTax(value any) error {
-	obj, ok := value.(*tax.Combo)
-	if obj == nil || !ok {
-		return nil
-	}
-	return validation.ValidateStruct(obj,
-		validation.Field(&obj.Ext,
-			validation.When(
-				(obj.Category == tax.CategoryVAT || obj.Category == es.TaxCategoryIGIC) && obj.Ext.Get(ExtKeyRegime) == "01",
-				validation.By(validateInvoiceLineTaxExtRegime01),
-				validation.Skip,
-			),
-			validation.Skip,
-		),
-	)
-}
-
-func validateInvoiceLineTaxExtRegime01(value any) error {
-	obj, ok := value.(tax.Extensions)
-	if !ok {
-		println("obj is not tax.Extensions type")
-		return nil
-	}
-	if obj.Get(ExtKeyExempt).In("E2", "E3") {
-		return validation.NewError("exempt_not_allowed", "When verifactu regime is 01, exempt code cannot be E2 or E3")
-	}
-	return nil
 }

--- a/addons/es/verifactu/bill_test.go
+++ b/addons/es/verifactu/bill_test.go
@@ -121,59 +121,6 @@ func TestInvoiceValidation(t *testing.T) {
 		assert.Empty(t, inv.Preceding[0].Ext)
 		assert.Equal(t, "21.00", inv.Preceding[0].Tax.Sum.String())
 	})
-
-	t.Run("invalid exempt code E2 with regime 01", func(t *testing.T) {
-		inv := testInvoiceStandard(t)
-		inv.Lines[0].Taxes[0].Category = tax.CategoryVAT
-		inv.Lines[0].Taxes[0].Ext = tax.Extensions{
-			verifactu.ExtKeyRegime: "01",
-			verifactu.ExtKeyExempt: "E2",
-		}
-		assertValidationError(t, inv, "lines: (0: (taxes: (0: (ext: When verifactu regime is 01, exempt code cannot be E2 or E3.).).).).")
-	})
-
-	t.Run("invalid exempt code E3 with regime 01", func(t *testing.T) {
-		inv := testInvoiceStandard(t)
-		inv.Lines[0].Taxes[0].Category = tax.CategoryVAT
-		inv.Lines[0].Taxes[0].Ext = tax.Extensions{
-			verifactu.ExtKeyRegime: "01",
-			verifactu.ExtKeyExempt: "E3",
-		}
-		assertValidationError(t, inv, "lines: (0: (taxes: (0: (ext: When verifactu regime is 01, exempt code cannot be E2 or E3.).).).).")
-	})
-
-	t.Run("valid exempt code E1 with regime 01", func(t *testing.T) {
-		inv := testInvoiceStandard(t)
-		inv.Lines[0].Taxes[0].Category = tax.CategoryVAT
-		inv.Lines[0].Taxes[0].Ext = tax.Extensions{
-			verifactu.ExtKeyRegime: "01",
-			verifactu.ExtKeyExempt: "E1",
-		}
-		require.NoError(t, inv.Calculate())
-		require.NoError(t, inv.Validate())
-	})
-
-	t.Run("valid exempt code E2 with regime 02", func(t *testing.T) {
-		inv := testInvoiceStandard(t)
-		inv.Lines[0].Taxes[0].Category = tax.CategoryVAT
-		inv.Lines[0].Taxes[0].Ext = tax.Extensions{
-			verifactu.ExtKeyRegime: "02",
-			verifactu.ExtKeyExempt: "E2",
-		}
-		require.NoError(t, inv.Calculate())
-		require.NoError(t, inv.Validate())
-	})
-
-	t.Run("IGIC tax with regime 01 and invalid exempt code", func(t *testing.T) {
-		inv := testInvoiceStandard(t)
-		inv.Lines[0].Taxes[0].Category = "IGIC"
-		inv.Lines[0].Taxes[0].Ext = tax.Extensions{
-			verifactu.ExtKeyRegime: "01",
-			verifactu.ExtKeyExempt: "E3",
-		}
-		assertValidationError(t, inv, "lines: (0: (taxes: (0: (ext: When verifactu regime is 01, exempt code cannot be E2 or E3.).).).).")
-	})
-
 }
 
 func assertValidationError(t *testing.T, inv *bill.Invoice, expected string) {

--- a/addons/es/verifactu/tax.go
+++ b/addons/es/verifactu/tax.go
@@ -58,7 +58,7 @@ func validateTaxCombo(tc *tax.Combo) error {
 			tax.ExtensionsRequire(ExtKeyRegime),
 			// https://www.agenciatributaria.es/static_files/AEAT_Desarrolladores/EEDD/IVA/VERI-FACTU/Validaciones_Errores_Veri-Factu.pdf (Page 10, section 15.5)
 			validation.When(
-				(tc.Category.In(tax.CategoryVAT, es.TaxCategoryIGIC) && tc.Ext.Get(ExtKeyRegime) == "01",
+				tc.Category.In(tax.CategoryVAT, es.TaxCategoryIGIC) && tc.Ext.Get(ExtKeyRegime) == "01",
 				tax.ExtensionsExcludeCodes(ExtKeyExempt, "E2", "E3"),
 			),
 			validation.Skip,

--- a/addons/es/verifactu/tax.go
+++ b/addons/es/verifactu/tax.go
@@ -56,6 +56,10 @@ func validateTaxCombo(tc *tax.Combo) error {
 				tax.ExtensionsRequire(ExtKeyExempt),
 			),
 			tax.ExtensionsRequire(ExtKeyRegime),
+			validation.When(
+				(tc.Category == tax.CategoryVAT || tc.Category == es.TaxCategoryIGIC) && tc.Ext.Get(ExtKeyRegime) == "01",
+				tax.ExtensionsExcludeCodes(ExtKeyExempt, "E2", "E3"),
+			),
 			validation.Skip,
 		),
 	)

--- a/addons/es/verifactu/tax.go
+++ b/addons/es/verifactu/tax.go
@@ -58,7 +58,7 @@ func validateTaxCombo(tc *tax.Combo) error {
 			tax.ExtensionsRequire(ExtKeyRegime),
 			// https://www.agenciatributaria.es/static_files/AEAT_Desarrolladores/EEDD/IVA/VERI-FACTU/Validaciones_Errores_Veri-Factu.pdf (Page 10, section 15.5)
 			validation.When(
-				(tc.Category == tax.CategoryVAT || tc.Category == es.TaxCategoryIGIC) && tc.Ext.Get(ExtKeyRegime) == "01",
+				(tc.Category.In(tax.CategoryVAT, es.TaxCategoryIGIC) && tc.Ext.Get(ExtKeyRegime) == "01",
 				tax.ExtensionsExcludeCodes(ExtKeyExempt, "E2", "E3"),
 			),
 			validation.Skip,

--- a/addons/es/verifactu/tax.go
+++ b/addons/es/verifactu/tax.go
@@ -56,6 +56,7 @@ func validateTaxCombo(tc *tax.Combo) error {
 				tax.ExtensionsRequire(ExtKeyExempt),
 			),
 			tax.ExtensionsRequire(ExtKeyRegime),
+			// https://www.agenciatributaria.es/static_files/AEAT_Desarrolladores/EEDD/IVA/VERI-FACTU/Validaciones_Errores_Veri-Factu.pdf (Page 10, section 15.5)
 			validation.When(
 				(tc.Category == tax.CategoryVAT || tc.Category == es.TaxCategoryIGIC) && tc.Ext.Get(ExtKeyRegime) == "01",
 				tax.ExtensionsExcludeCodes(ExtKeyExempt, "E2", "E3"),

--- a/addons/es/verifactu/tax_test.go
+++ b/addons/es/verifactu/tax_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/invopop/gobl/l10n"
+	"github.com/invopop/gobl/regimes/es"
 	"github.com/invopop/gobl/tax"
 	"github.com/stretchr/testify/assert"
 )
@@ -85,4 +86,66 @@ func TestValidateTaxCombo(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	t.Run("exempt with valid reason", func(t *testing.T) {
+		tc := &tax.Combo{
+			Category: tax.CategoryVAT,
+			Ext: tax.Extensions{
+				ExtKeyRegime: "01",
+				ExtKeyExempt: "E1",
+			},
+		}
+		err := validateTaxCombo(tc)
+		assert.NoError(t, err)
+	})
+
+	t.Run("excludes E2 exemption code with regime 01", func(t *testing.T) {
+		tc := &tax.Combo{
+			Category: tax.CategoryVAT,
+			Ext: tax.Extensions{
+				ExtKeyRegime: "01",
+				ExtKeyExempt: "E2",
+			},
+		}
+		err := validateTaxCombo(tc)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "E2")
+	})
+
+	t.Run("excludes E3 exemption code with regime 01", func(t *testing.T) {
+		tc := &tax.Combo{
+			Category: tax.CategoryVAT,
+			Ext: tax.Extensions{
+				ExtKeyRegime: "01",
+				ExtKeyExempt: "E3",
+			},
+		}
+		err := validateTaxCombo(tc)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "E3")
+	})
+
+	t.Run("allows E2 exemption code with non-01 regime", func(t *testing.T) {
+		tc := &tax.Combo{
+			Category: tax.CategoryVAT,
+			Ext: tax.Extensions{
+				ExtKeyRegime: "02",
+				ExtKeyExempt: "E2",
+			},
+		}
+		err := validateTaxCombo(tc)
+		assert.NoError(t, err)
+	})
+
+	t.Run("excludes E2 exemption code with regime 01 and IGIC category", func(t *testing.T) {
+		tc := &tax.Combo{
+			Category: es.TaxCategoryIGIC,
+			Ext: tax.Extensions{
+				ExtKeyRegime: "01",
+				ExtKeyExempt: "E2",
+			},
+		}
+		err := validateTaxCombo(tc)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "E2")
+	})
 }

--- a/addons/es/verifactu/tax_test.go
+++ b/addons/es/verifactu/tax_test.go
@@ -107,8 +107,7 @@ func TestValidateTaxCombo(t *testing.T) {
 			},
 		}
 		err := validateTaxCombo(tc)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "E2")
+		assert.ErrorContains(t, err, "E2")
 	})
 
 	t.Run("excludes E3 exemption code with regime 01", func(t *testing.T) {

--- a/tax/extensions.go
+++ b/tax/extensions.go
@@ -338,6 +338,42 @@ func (v validateExtCodeValues) Validate(value interface{}) error {
 	return nil
 }
 
+// ExtensionsExcludeCodes returns a validation rule that ensures the extension map's
+// key does not have any of the provided **codes**.
+func ExtensionsExcludeCodes(key cbc.Key, codes ...cbc.Code) validation.Rule {
+	return validateExtCodeExcludeValues{
+		key:    key,
+		values: codes,
+	}
+}
+
+type validateExtCodeExcludeValues struct {
+	key    cbc.Key
+	values []cbc.Code
+}
+
+func (v validateExtCodeExcludeValues) Validate(value interface{}) error {
+	em, ok := value.(Extensions)
+	if !ok {
+		return nil
+	}
+	err := make(validation.Errors)
+
+	if ev, ok := em[v.key]; ok {
+		for _, val := range v.values {
+			if ev == val {
+				err[v.key.String()] = fmt.Errorf("value '%s' not allowed", ev)
+				break
+			}
+		}
+	}
+
+	if len(err) > 0 {
+		return err
+	}
+	return nil
+}
+
 // JSONSchemaExtend provides extra details about the extension map which are
 // not automatically determined. In this case we add validation for the map's
 // keys.

--- a/tax/extensions.go
+++ b/tax/extensions.go
@@ -301,7 +301,7 @@ func (v validateExtCodeMap) Validate(value interface{}) error {
 // ExtensionsHasCodes returns a validation rule that ensures the extension map's
 // key has one of the provided **codes**.
 func ExtensionsHasCodes(key cbc.Key, codes ...cbc.Code) validation.Rule {
-	return validateExtCode{
+	return validateExtCodes{
 		key:       key,
 		values:    codes,
 		inclusion: true,
@@ -311,20 +311,20 @@ func ExtensionsHasCodes(key cbc.Key, codes ...cbc.Code) validation.Rule {
 // ExtensionsExcludeCodes returns a validation rule that ensures the extension map's
 // key does not have any of the provided **codes**.
 func ExtensionsExcludeCodes(key cbc.Key, codes ...cbc.Code) validation.Rule {
-	return validateExtCode{
+	return validateExtCodes{
 		key:       key,
 		values:    codes,
 		inclusion: false,
 	}
 }
 
-type validateExtCode struct {
+type validateExtCodes struct {
 	key       cbc.Key
 	values    []cbc.Code
 	inclusion bool
 }
 
-func (v validateExtCode) Validate(value interface{}) error {
+func (v validateExtCodes) Validate(value interface{}) error {
 	em, ok := value.(Extensions)
 	if !ok {
 		return nil

--- a/tax/extensions_test.go
+++ b/tax/extensions_test.go
@@ -307,6 +307,58 @@ func TestExtensionsHasValues(t *testing.T) {
 	})
 }
 
+func TestExtensionsExcludeCodes(t *testing.T) {
+	t.Run("nil", func(t *testing.T) {
+		err := validation.Validate(nil,
+			tax.ExtensionsExcludeCodes(untdid.ExtKeyDocumentType, "380", "381"),
+		)
+		assert.NoError(t, err)
+	})
+	t.Run("empty", func(t *testing.T) {
+		em := tax.Extensions{}
+		err := validation.Validate(em,
+			tax.ExtensionsExcludeCodes(untdid.ExtKeyDocumentType, "380", "381"),
+		)
+		assert.NoError(t, err)
+	})
+	t.Run("different extensions", func(t *testing.T) {
+		em := tax.Extensions{
+			iso.ExtKeySchemeID: "1234",
+		}
+		err := validation.Validate(em,
+			tax.ExtensionsExcludeCodes(untdid.ExtKeyDocumentType, "380", "381"),
+		)
+		assert.NoError(t, err)
+	})
+	t.Run("allowed code", func(t *testing.T) {
+		em := tax.Extensions{
+			untdid.ExtKeyDocumentType: "326",
+		}
+		err := validation.Validate(em,
+			tax.ExtensionsExcludeCodes(untdid.ExtKeyDocumentType, "380", "381"),
+		)
+		assert.NoError(t, err)
+	})
+	t.Run("excluded code", func(t *testing.T) {
+		em := tax.Extensions{
+			untdid.ExtKeyDocumentType: "380",
+		}
+		err := validation.Validate(em,
+			tax.ExtensionsExcludeCodes(untdid.ExtKeyDocumentType, "380", "381"),
+		)
+		assert.ErrorContains(t, err, "untdid-document-type: value '380' not allowed")
+	})
+	t.Run("another excluded code", func(t *testing.T) {
+		em := tax.Extensions{
+			untdid.ExtKeyDocumentType: "381",
+		}
+		err := validation.Validate(em,
+			tax.ExtensionsExcludeCodes(untdid.ExtKeyDocumentType, "380", "381"),
+		)
+		assert.ErrorContains(t, err, "untdid-document-type: value '381' not allowed")
+	})
+}
+
 func TestExtensionsHas(t *testing.T) {
 	em := tax.Extensions{
 		"key": "value",


### PR DESCRIPTION
- Added this validation: `Si Impuesto = “01” (IVA), “03” (IGIC) o no se cumplimenta (considerándose “01” - IVA), y
ClaveRegimen es igual a “01”, no pueden marcarse los valores de OperacionExenta “E2”
y “E3”`. 

It can be found in the error and validation doc from Verifactu: https://www.agenciatributaria.es/static_files/AEAT_Desarrolladores/EEDD/IVA/VERI-FACTU/Validaciones_Errores_Veri-Factu.pdf (Page 10, section 15.5)

## Pre-Review Checklist

- [x] I have performed a self-review of my code.
- [x] I have added thorough tests with at **least** 90% code coverage.
- [ ] I've modified or created example GOBL documents to show my changes in use, if appropriate.
- [x] When adding or modifying a tax regime or addon, I've added links to the source of the changes, either structured or in the comments.
- [x] I've run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [x] All linter warnings have been reviewed and fixed.
- [x] I've been obsessive with pointer nil checks to avoid panics.
- [x] The CHANGELOG.md has been updated with an overview of my changes.
- [x] Requested a review from @samlown.

