### PR TITLE
Export data accessors for handling via interfaces

### DIFF
--- a/bill/calculator.go
+++ b/bill/calculator.go
@@ -23,25 +23,25 @@ type billable interface {
 	HasTags(tags ...cbc.Key) bool
 	GetTags() []cbc.Key
 
-	getIssueDate() cal.Date
-	getIssueTime() *cal.Time
-	getValueDate() *cal.Date
-	getTax() *Tax
-	getPreceding() []*org.DocumentRef
-	getCustomer() *org.Party
-	getCurrency() currency.Code
-	getExchangeRates() []*currency.ExchangeRate
-	getLines() []*Line
-	getDiscounts() []*Discount
-	getCharges() []*Charge
-	getPaymentDetails() *PaymentDetails
-	getTotals() *Totals
-	getComplements() []*schema.Object
+	GetIssueDate() cal.Date
+	GetIssueTime() *cal.Time
+	GetValueDate() *cal.Date
+	GetTax() *Tax
+	GetPreceding() []*org.DocumentRef
+	GetCustomer() *org.Party
+	GetCurrency() currency.Code
+	GetExchangeRates() []*currency.ExchangeRate
+	GetLines() []*Line
+	GetDiscounts() []*Discount
+	GetCharges() []*Charge
+	GetPaymentDetails() *PaymentDetails
+	GetTotals() *Totals
+	GetComplements() []*schema.Object
 
-	setIssueDate(cal.Date)
-	setIssueTime(*cal.Time)
-	setCurrency(currency.Code)
-	setTotals(*Totals)
+	SetIssueDate(cal.Date)
+	SetIssueTime(*cal.Time)
+	SetCurrency(currency.Code)
+	SetTotals(*Totals)
 }
 
 func calculate(doc billable) error {
@@ -49,22 +49,22 @@ func calculate(doc billable) error {
 	calculateIssueDateAndTime(r, doc)
 
 	// Get the date used for tax calculations
-	date := doc.getValueDate()
+	date := doc.GetValueDate()
 	if date == nil {
-		id := doc.getIssueDate()
+		id := doc.GetIssueDate()
 		date = &id
 	}
 
 	// Convert empty or invalid currency to the regime's currency
-	if doc.getCurrency() == currency.CodeEmpty || doc.getCurrency().Def() == nil {
+	if doc.GetCurrency() == currency.CodeEmpty || doc.GetCurrency().Def() == nil {
 		if r == nil {
 			return validation.Errors{"currency": errors.New("missing")}
 		}
-		doc.setCurrency(r.Currency)
+		doc.SetCurrency(r.Currency)
 	}
-	cur := doc.getCurrency()
+	cur := doc.GetCurrency()
 
-	t := doc.getTotals()
+	t := doc.GetTotals()
 	// Prepare the totals we'll need with amounts based on currency
 	if t == nil {
 		t = new(Totals)
@@ -75,7 +75,7 @@ func calculate(doc billable) error {
 	// Figure out rounding rules and if prices include tax early
 	var pit cbc.Code
 	var rr cbc.Key
-	if tx := doc.getTax(); tx != nil {
+	if tx := doc.GetTax(); tx != nil {
 		if tx.PricesInclude != "" {
 			pit = tx.PricesInclude
 		}
@@ -93,59 +93,59 @@ func calculate(doc billable) error {
 	}
 
 	// Complements
-	if err := calculateComplements(doc.getComplements()); err != nil {
+	if err := calculateComplements(doc.GetComplements()); err != nil {
 		return validation.Errors{"complements": err}
 	}
 
 	// Preceding
-	calculateOrgDocumentRefs(doc.getPreceding(), cur, rr)
+	calculateOrgDocumentRefs(doc.GetPreceding(), cur, rr)
 
 	// Lines
-	if err := calculateLines(doc.getLines(), cur, doc.getExchangeRates(), rr); err != nil {
+	if err := calculateLines(doc.GetLines(), cur, doc.GetExchangeRates(), rr); err != nil {
 		return validation.Errors{"lines": err}
 	}
-	t.Sum = calculateLineSum(doc.getLines(), cur)
+	t.Sum = calculateLineSum(doc.GetLines(), cur)
 	t.Total = t.Sum
 
 	// Discount Lines
-	calculateDiscounts(doc.getDiscounts(), cur, t.Sum, rr)
-	if discounts := calculateDiscountSum(doc.getDiscounts(), cur); discounts != nil {
+	calculateDiscounts(doc.GetDiscounts(), cur, t.Sum, rr)
+	if discounts := calculateDiscountSum(doc.GetDiscounts(), cur); discounts != nil {
 		t.Discount = discounts
 		t.Total = t.Total.Subtract(*discounts)
 	}
 
 	// Charge Lines
-	calculateCharges(doc.getCharges(), cur, t.Sum, rr)
-	if charges := calculateChargeSum(doc.getCharges(), cur); charges != nil {
+	calculateCharges(doc.GetCharges(), cur, t.Sum, rr)
+	if charges := calculateChargeSum(doc.GetCharges(), cur); charges != nil {
 		t.Charge = charges
 		t.Total = t.Total.Add(*charges)
 	}
 
 	// Build list of taxable lines
 	tls := make([]tax.TaxableLine, 0)
-	for _, l := range doc.getLines() {
+	for _, l := range doc.GetLines() {
 		if l.Total != nil {
 			tls = append(tls, l)
 		}
 	}
-	for _, l := range doc.getDiscounts() {
+	for _, l := range doc.GetDiscounts() {
 		tls = append(tls, l)
 	}
-	for _, l := range doc.getCharges() {
+	for _, l := range doc.GetCharges() {
 		tls = append(tls, l)
 	}
 
 	if len(tls) == 0 {
 		// This applies for orders and deliveries that might not have
 		// any pricing details.
-		doc.setTotals(nil)
+		doc.SetTotals(nil)
 		return nil
 	}
 
 	// Now figure out the tax totals
 	t.Taxes = new(tax.Total)
 	tc := &tax.TotalCalculator{
-		Currency: doc.getCurrency(),
+		Currency: doc.GetCurrency(),
 		Rounding: rr,
 		Country:  r.GetCountry(),
 		Tags:     doc.GetTags(),
@@ -183,16 +183,16 @@ func calculate(doc billable) error {
 	// Before calculating the amount due and advances, we need to round
 	// everything. Payments reflect real monetary values and can never
 	// be fractions of the currency.
-	roundLines(doc.getLines())
-	roundDiscounts(doc.getDiscounts(), cur)
-	roundCharges(doc.getCharges(), cur)
+	roundLines(doc.GetLines())
+	roundDiscounts(doc.GetDiscounts(), cur)
+	roundCharges(doc.GetCharges(), cur)
 	t.round(zero)
 
 	if t.Rounding != nil {
 		// BT-144 in EN16931
 		t.Payable = t.Payable.Add(*t.Rounding)
 	}
-	if pd := doc.getPaymentDetails(); pd != nil {
+	if pd := doc.GetPaymentDetails(); pd != nil {
 		pd.calculateAdvances(zero, t.Payable)
 		// Deal with advances, if any. Note that in the current
 		// implementation multiple percentage advances are likely to
@@ -205,20 +205,20 @@ func calculate(doc billable) error {
 		// Calculate any due date amounts
 		pd.Terms.CalculateDues(zero, t.Payable)
 	}
-	doc.setTotals(t)
+	doc.SetTotals(t)
 
 	return nil
 }
 
 func calculateIssueDateAndTime(r *tax.RegimeDef, doc billable) {
 	tz := r.TimeLocation()
-	if doc.getIssueTime() != nil && doc.getIssueTime().IsZero() {
+	if doc.GetIssueTime() != nil && doc.GetIssueTime().IsZero() {
 		dn := cal.ThisSecondIn(tz)
 		tn := dn.Time()
-		doc.setIssueDate(dn.Date())
-		doc.setIssueTime(&tn)
-	} else if doc.getIssueDate().IsZero() {
-		doc.setIssueDate(cal.TodayIn(tz))
+		doc.SetIssueDate(dn.Date())
+		doc.SetIssueTime(&tn)
+	} else if doc.GetIssueDate().IsZero() {
+		doc.SetIssueDate(cal.TodayIn(tz))
 	}
 }
 
@@ -232,37 +232,37 @@ func calculateOrgDocumentRefs(drs []*org.DocumentRef, cur currency.Code, rr cbc.
 }
 
 func canRemoveIncludedTaxes(doc billable) bool {
-	return doc.getTax() != nil && !doc.getTax().PricesInclude.IsEmpty()
+	return doc.GetTax() != nil && !doc.GetTax().PricesInclude.IsEmpty()
 }
 
 func removeIncludedTaxes(doc billable) error {
 	if !canRemoveIncludedTaxes(doc) {
 		return nil
 	}
-	tpi := doc.getTax().PricesInclude
+	tpi := doc.GetTax().PricesInclude
 
-	totalWithTax := doc.getTotals().TotalWithTax
+	totalWithTax := doc.GetTotals().TotalWithTax
 
-	doc.setTotals(new(Totals))
-	lines := doc.getLines()
-	for i, l := range doc.getLines() {
+	doc.SetTotals(new(Totals))
+	lines := doc.GetLines()
+	for i, l := range doc.GetLines() {
 		lines[i] = removeLineIncludedTaxes(l, tpi)
 	}
 
-	discounts := doc.getDiscounts()
+	discounts := doc.GetDiscounts()
 	if len(discounts) > 0 {
 		for i, l := range discounts {
 			discounts[i] = l.removeIncludedTaxes(tpi)
 		}
 	}
-	charges := doc.getCharges()
+	charges := doc.GetCharges()
 	if len(charges) > 0 {
 		for i, l := range charges {
 			charges[i] = l.removeIncludedTaxes(tpi)
 		}
 	}
 
-	tx := doc.getTax()
+	tx := doc.GetTax()
 	tx.PricesInclude = ""
 
 	if err := calculate(doc); err != nil {
@@ -270,7 +270,7 @@ func removeIncludedTaxes(doc billable) error {
 	}
 
 	// Account for any rounding errors that we just can't handle
-	t := doc.getTotals()
+	t := doc.GetTotals()
 	if !totalWithTax.Equals(t.TotalWithTax) {
 		rnd := totalWithTax.Subtract(t.TotalWithTax)
 		t.Rounding = &rnd
@@ -283,17 +283,17 @@ func removeIncludedTaxes(doc billable) error {
 }
 
 func applyCustomerRates(doc billable) {
-	if doc.getCustomer() == nil || doc.getCustomer().TaxID == nil {
+	if doc.GetCustomer() == nil || doc.GetCustomer().TaxID == nil {
 		return
 	}
-	country := doc.getCustomer().TaxID.Country
-	for _, l := range doc.getLines() {
+	country := doc.GetCustomer().TaxID.Country
+	for _, l := range doc.GetLines() {
 		addCountryToTaxes(l.Taxes, country)
 	}
-	for _, d := range doc.getDiscounts() {
+	for _, d := range doc.GetDiscounts() {
 		addCountryToTaxes(d.Taxes, country)
 	}
-	for _, c := range doc.getCharges() {
+	for _, c := range doc.GetCharges() {
 		addCountryToTaxes(c.Taxes, country)
 	}
 }

--- a/bill/delivery.go
+++ b/bill/delivery.go
@@ -336,61 +336,73 @@ func (dlv *Delivery) ConvertInto(cur currency.Code) (*Delivery, error) {
 	return &d2, nil
 }
 
-/** Calculation Interface Methods **/
+/** Accessor methods for generic handling via interfaces. **/
 
-func (dlv *Delivery) getIssueDate() cal.Date {
+func (dlv *Delivery) GetSeries() cbc.Code {
+	return dlv.Series
+}
+func (dlv *Delivery) GetCode() cbc.Code {
+	return dlv.Code
+}
+func (dlv *Delivery) GetIssueDate() cal.Date {
 	return dlv.IssueDate
 }
-func (dlv *Delivery) getIssueTime() *cal.Time {
+func (dlv *Delivery) GetIssueTime() *cal.Time {
 	return dlv.IssueTime
 }
-func (dlv *Delivery) getValueDate() *cal.Date {
+func (dlv *Delivery) GetValueDate() *cal.Date {
 	return dlv.ValueDate
 }
-func (dlv *Delivery) getTax() *Tax {
+func (dlv *Delivery) GetTax() *Tax {
 	return dlv.Tax
 }
-func (dlv *Delivery) getPreceding() []*org.DocumentRef {
+func (dlv *Delivery) GetPreceding() []*org.DocumentRef {
 	return dlv.Preceding
 }
-func (dlv *Delivery) getCustomer() *org.Party {
+func (dlv *Delivery) GetSupplier() *org.Party {
+	return dlv.Supplier
+}
+func (dlv *Delivery) GetCustomer() *org.Party {
 	return dlv.Customer
 }
-func (dlv *Delivery) getCurrency() currency.Code {
+func (dlv *Delivery) GetCurrency() currency.Code {
 	return dlv.Currency
 }
-func (dlv *Delivery) getExchangeRates() []*currency.ExchangeRate {
+func (dlv *Delivery) GetExchangeRates() []*currency.ExchangeRate {
 	return dlv.ExchangeRates
 }
-func (dlv *Delivery) getLines() []*Line {
+func (dlv *Delivery) GetLines() []*Line {
 	return dlv.Lines
 }
-func (dlv *Delivery) getDiscounts() []*Discount {
+func (dlv *Delivery) GetDiscounts() []*Discount {
 	return dlv.Discounts
 }
-func (dlv *Delivery) getCharges() []*Charge {
+func (dlv *Delivery) GetCharges() []*Charge {
 	return dlv.Charges
 }
-func (dlv *Delivery) getPaymentDetails() *PaymentDetails {
+func (dlv *Delivery) GetPaymentDetails() *PaymentDetails {
 	return nil // no payment for deliveries
 }
-func (dlv *Delivery) getTotals() *Totals {
+func (dlv *Delivery) GetTotals() *Totals {
 	return dlv.Totals
 }
-func (dlv *Delivery) getComplements() []*schema.Object {
+func (dlv *Delivery) GetComplements() []*schema.Object {
 	return dlv.Complements
 }
 
-func (dlv *Delivery) setIssueDate(d cal.Date) {
+func (dlv *Delivery) SetCode(c cbc.Code) {
+	dlv.Code = c
+}
+func (dlv *Delivery) SetIssueDate(d cal.Date) {
 	dlv.IssueDate = d
 }
-func (dlv *Delivery) setIssueTime(t *cal.Time) {
+func (dlv *Delivery) SetIssueTime(t *cal.Time) {
 	dlv.IssueTime = t
 }
-func (dlv *Delivery) setCurrency(c currency.Code) {
+func (dlv *Delivery) SetCurrency(c currency.Code) {
 	dlv.Currency = c
 }
-func (dlv *Delivery) setTotals(t *Totals) {
+func (dlv *Delivery) SetTotals(t *Totals) {
 	dlv.Totals = t
 }
 

--- a/bill/invoice.go
+++ b/bill/invoice.go
@@ -344,61 +344,73 @@ func (inv *Invoice) RemoveIncludedTaxes() error {
 	return removeIncludedTaxes(inv)
 }
 
-/** Calculation Interface Methods **/
+/** Accessor methods for generic handling via interfaces. **/
 
-func (inv *Invoice) getIssueDate() cal.Date {
+func (inv *Invoice) GetSeries() cbc.Code {
+	return inv.Series
+}
+func (inv *Invoice) GetCode() cbc.Code {
+	return inv.Code
+}
+func (inv *Invoice) GetIssueDate() cal.Date {
 	return inv.IssueDate
 }
-func (inv *Invoice) getIssueTime() *cal.Time {
+func (inv *Invoice) GetIssueTime() *cal.Time {
 	return inv.IssueTime
 }
-func (inv *Invoice) getValueDate() *cal.Date {
+func (inv *Invoice) GetValueDate() *cal.Date {
 	return inv.ValueDate
 }
-func (inv *Invoice) getTax() *Tax {
+func (inv *Invoice) GetTax() *Tax {
 	return inv.Tax
 }
-func (inv *Invoice) getPreceding() []*org.DocumentRef {
+func (inv *Invoice) GetPreceding() []*org.DocumentRef {
 	return inv.Preceding
 }
-func (inv *Invoice) getCustomer() *org.Party {
+func (inv *Invoice) GetSupplier() *org.Party {
+	return inv.Supplier
+}
+func (inv *Invoice) GetCustomer() *org.Party {
 	return inv.Customer
 }
-func (inv *Invoice) getCurrency() currency.Code {
+func (inv *Invoice) GetCurrency() currency.Code {
 	return inv.Currency
 }
-func (inv *Invoice) getExchangeRates() []*currency.ExchangeRate {
+func (inv *Invoice) GetExchangeRates() []*currency.ExchangeRate {
 	return inv.ExchangeRates
 }
-func (inv *Invoice) getLines() []*Line {
+func (inv *Invoice) GetLines() []*Line {
 	return inv.Lines
 }
-func (inv *Invoice) getDiscounts() []*Discount {
+func (inv *Invoice) GetDiscounts() []*Discount {
 	return inv.Discounts
 }
-func (inv *Invoice) getCharges() []*Charge {
+func (inv *Invoice) GetCharges() []*Charge {
 	return inv.Charges
 }
-func (inv *Invoice) getPaymentDetails() *PaymentDetails {
+func (inv *Invoice) GetPaymentDetails() *PaymentDetails {
 	return inv.Payment
 }
-func (inv *Invoice) getTotals() *Totals {
+func (inv *Invoice) GetTotals() *Totals {
 	return inv.Totals
 }
-func (inv *Invoice) getComplements() []*schema.Object {
+func (inv *Invoice) GetComplements() []*schema.Object {
 	return inv.Complements
 }
 
-func (inv *Invoice) setIssueDate(d cal.Date) {
+func (inv *Invoice) SetCode(c cbc.Code) {
+	inv.Code = c
+}
+func (inv *Invoice) SetIssueDate(d cal.Date) {
 	inv.IssueDate = d
 }
-func (inv *Invoice) setIssueTime(t *cal.Time) {
+func (inv *Invoice) SetIssueTime(t *cal.Time) {
 	inv.IssueTime = t
 }
-func (inv *Invoice) setCurrency(c currency.Code) {
+func (inv *Invoice) SetCurrency(c currency.Code) {
 	inv.Currency = c
 }
-func (inv *Invoice) setTotals(t *Totals) {
+func (inv *Invoice) SetTotals(t *Totals) {
 	inv.Totals = t
 }
 

--- a/bill/order.go
+++ b/bill/order.go
@@ -306,61 +306,73 @@ func (ord *Order) ConvertInto(cur currency.Code) (*Order, error) {
 	return &o2, nil
 }
 
-/** Calculation Interface Methods **/
+/** Accessor methods for generic handling via interfaces. **/
 
-func (ord *Order) getIssueDate() cal.Date {
+func (ord *Order) GetSeries() cbc.Code {
+	return ord.Series
+}
+func (ord *Order) GetCode() cbc.Code {
+	return ord.Code
+}
+func (ord *Order) GetIssueDate() cal.Date {
 	return ord.IssueDate
 }
-func (ord *Order) getIssueTime() *cal.Time {
+func (ord *Order) GetIssueTime() *cal.Time {
 	return ord.IssueTime
 }
-func (ord *Order) getValueDate() *cal.Date {
+func (ord *Order) GetValueDate() *cal.Date {
 	return ord.ValueDate
 }
-func (ord *Order) getTax() *Tax {
+func (ord *Order) GetTax() *Tax {
 	return ord.Tax
 }
-func (ord *Order) getPreceding() []*org.DocumentRef {
+func (ord *Order) GetPreceding() []*org.DocumentRef {
 	return ord.Preceding
 }
-func (ord *Order) getCustomer() *org.Party {
+func (ord *Order) GetSupplier() *org.Party {
+	return ord.Supplier
+}
+func (ord *Order) GetCustomer() *org.Party {
 	return ord.Customer
 }
-func (ord *Order) getCurrency() currency.Code {
+func (ord *Order) GetCurrency() currency.Code {
 	return ord.Currency
 }
-func (ord *Order) getExchangeRates() []*currency.ExchangeRate {
+func (ord *Order) GetExchangeRates() []*currency.ExchangeRate {
 	return ord.ExchangeRates
 }
-func (ord *Order) getLines() []*Line {
+func (ord *Order) GetLines() []*Line {
 	return ord.Lines
 }
-func (ord *Order) getDiscounts() []*Discount {
+func (ord *Order) GetDiscounts() []*Discount {
 	return ord.Discounts
 }
-func (ord *Order) getCharges() []*Charge {
+func (ord *Order) GetCharges() []*Charge {
 	return ord.Charges
 }
-func (ord *Order) getPaymentDetails() *PaymentDetails {
+func (ord *Order) GetPaymentDetails() *PaymentDetails {
 	return ord.Payment
 }
-func (ord *Order) getTotals() *Totals {
+func (ord *Order) GetTotals() *Totals {
 	return ord.Totals
 }
-func (ord *Order) getComplements() []*schema.Object {
+func (ord *Order) GetComplements() []*schema.Object {
 	return ord.Complements
 }
 
-func (ord *Order) setIssueDate(d cal.Date) {
+func (ord *Order) SetCode(c cbc.Code) {
+	ord.Code = c
+}
+func (ord *Order) SetIssueDate(d cal.Date) {
 	ord.IssueDate = d
 }
-func (ord *Order) setIssueTime(t *cal.Time) {
+func (ord *Order) SetIssueTime(t *cal.Time) {
 	ord.IssueTime = t
 }
-func (ord *Order) setCurrency(c currency.Code) {
+func (ord *Order) SetCurrency(c currency.Code) {
 	ord.Currency = c
 }
-func (ord *Order) setTotals(t *Totals) {
+func (ord *Order) SetTotals(t *Totals) {
 	ord.Totals = t
 }
 

--- a/bill/payment.go
+++ b/bill/payment.go
@@ -319,6 +319,78 @@ func (pmt *Payment) calculate() error {
 	return nil
 }
 
+/** Accessor methods for generic handling via interfaces. **/
+
+func (pmt *Payment) GetSeries() cbc.Code {
+	return pmt.Series
+}
+func (pmt *Payment) GetCode() cbc.Code {
+	return pmt.Code
+}
+func (pmt *Payment) GetIssueDate() cal.Date {
+	return pmt.IssueDate
+}
+func (pmt *Payment) GetIssueTime() *cal.Time {
+	return pmt.IssueTime
+}
+func (pmt *Payment) GetValueDate() *cal.Date {
+	return pmt.ValueDate
+}
+func (pmt *Payment) GetTax() *Tax {
+	return nil // no tax for payments
+}
+func (pmt *Payment) GetPreceding() []*org.DocumentRef {
+	return pmt.Preceding
+}
+func (pmt *Payment) GetSupplier() *org.Party {
+	return pmt.Supplier
+}
+func (pmt *Payment) GetCustomer() *org.Party {
+	return pmt.Customer
+}
+func (pmt *Payment) GetCurrency() currency.Code {
+	return pmt.Currency
+}
+func (pmt *Payment) GetExchangeRates() []*currency.ExchangeRate {
+	return pmt.ExchangeRates
+}
+func (pmt *Payment) GetLines() []*Line {
+	return nil // no lines for payments
+}
+func (pmt *Payment) GetDiscounts() []*Discount {
+	return nil // no discounts for payments
+}
+func (pmt *Payment) GetCharges() []*Charge {
+	return nil // no charges for payments
+}
+func (pmt *Payment) GetPaymentDetails() *PaymentDetails {
+	return nil // no payment details for deliveries
+}
+func (pmt *Payment) GetTotals() *Totals {
+	return nil // no totals for payments
+}
+func (pmt *Payment) GetComplements() []*schema.Object {
+	return pmt.Complements
+}
+
+func (pmt *Payment) SetCode(c cbc.Code) {
+	pmt.Code = c
+}
+func (pmt *Payment) SetIssueDate(d cal.Date) {
+	pmt.IssueDate = d
+}
+func (pmt *Payment) SetIssueTime(t *cal.Time) {
+	pmt.IssueTime = t
+}
+func (pmt *Payment) SetCurrency(c currency.Code) {
+	pmt.Currency = c
+}
+func (pmt *Payment) SetTotals(t *Totals) {
+	// no totals for payments
+}
+
+/** ---- **/
+
 // JSONSchemaExtend extends the schema with additional property details
 func (pmt Payment) JSONSchemaExtend(js *jsonschema.Schema) {
 	props := js.Properties


### PR DESCRIPTION
- Export data accessors for overlapping fields in `bill.Invoice`, `bill.Delivery`, `bill.Order` and `bill.Payment` to enable generic handling via interfaces.

## Pre-Review Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added thorough tests with at **least** 90% code coverage.
- [ ] I've modified or created example GOBL documents to show my changes in use, if appropriate.
- [ ] When adding or modifying a tax regime or addon, I've added links to the source of the changes, either structured or in the comments.
- [ ] I've run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [ ] All linter warnings have been reviewed and fixed.
- [ ] I've been obsessive with pointer nil checks to avoid panics.
- [ ] The CHANGELOG.md has been updated with an overview of my changes.
- [ ] Requested a review from @samlown.

