### PR TITLE
Extend and export the billable interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Changed
+
+- `bill`: Extend and export the methods in the `billable` interface to allow for generic handling of bill documents (Invoice, Payment, Delivery and Order) outside of the package.
+
 ## [v0.216.0] - 2025-05-12
 
 ### Added
@@ -14,14 +18,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - `it-ticket-v1`: Stamp key for document number added and void document number.
 - `it-ticket-v1`: Extension for customer lottery code.
 - `it-ticket-v1`: Add line extension for line ID that will be issued by the AdE.
-- `it-ticket-v1`: Add corrections to addon with document number stamp. 
+- `it-ticket-v1`: Add corrections to addon with document number stamp.
 - `tax`: Totals now have public `Round` method.
 
 ### Fixed
 
 - `bill`: Rounding _before_ payment calculations.
 - `tax`: Rounding bug in totals calculations.
-- `it-sdi-v1` : Removed `isItalian` check on customer address 
+- `it-sdi-v1` : Removed `isItalian` check on customer address
 
 ## [v0.215.0] - 2025-04-28
 

--- a/bill/bill.go
+++ b/bill/bill.go
@@ -2,7 +2,12 @@
 package bill
 
 import (
+	"github.com/invopop/gobl/cal"
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/currency"
+	"github.com/invopop/gobl/org"
 	"github.com/invopop/gobl/schema"
+	"github.com/invopop/gobl/tax"
 )
 
 func init() {
@@ -32,3 +37,42 @@ const (
 	ShortSchemaInvoice  = "bill/invoice"
 	ShortSchemaPayment  = "bill/payment"
 )
+
+// billable defines a contract for document types within the bill package that
+// share common structure and behavior (e.g. invoice, payment, delivery or
+// order). It defines the set of methods these types must implement to enable
+// generic handling.
+//
+// The methods are exported to allow for generic handling from outside the
+// package. However, the interface itself is kept private to promote the use of
+// small, purpose-built interfaces for each use case.
+type billable interface {
+	// From tax.Regime
+	RegimeDef() *tax.RegimeDef
+
+	// From tax.Tags
+	HasTags(tags ...cbc.Key) bool
+	GetTags() []cbc.Key
+
+	GetIssueDate() cal.Date
+	GetIssueTime() *cal.Time
+	GetValueDate() *cal.Date
+	GetTax() *Tax
+	GetPreceding() []*org.DocumentRef
+	GetSupplier() *org.Party
+	GetCustomer() *org.Party
+	GetCurrency() currency.Code
+	GetExchangeRates() []*currency.ExchangeRate
+	GetLines() []*Line
+	GetDiscounts() []*Discount
+	GetCharges() []*Charge
+	GetPaymentDetails() *PaymentDetails
+	GetTotals() *Totals
+	GetComplements() []*schema.Object
+
+	SetCode(cbc.Code)
+	SetIssueDate(cal.Date)
+	SetIssueTime(*cal.Time)
+	SetCurrency(currency.Code)
+	SetTotals(*Totals)
+}

--- a/bill/calculator.go
+++ b/bill/calculator.go
@@ -13,58 +13,27 @@ import (
 	"github.com/invopop/validation"
 )
 
-// billable defines the methods required to be able to perform calculations and
-// other operations on a bill document with a common basic structure.
-type billable interface {
-	// From tax.Regime
-	RegimeDef() *tax.RegimeDef
-
-	// From tax.Tags
-	HasTags(tags ...cbc.Key) bool
-	GetTags() []cbc.Key
-
-	getIssueDate() cal.Date
-	getIssueTime() *cal.Time
-	getValueDate() *cal.Date
-	getTax() *Tax
-	getPreceding() []*org.DocumentRef
-	getCustomer() *org.Party
-	getCurrency() currency.Code
-	getExchangeRates() []*currency.ExchangeRate
-	getLines() []*Line
-	getDiscounts() []*Discount
-	getCharges() []*Charge
-	getPaymentDetails() *PaymentDetails
-	getTotals() *Totals
-	getComplements() []*schema.Object
-
-	setIssueDate(cal.Date)
-	setIssueTime(*cal.Time)
-	setCurrency(currency.Code)
-	setTotals(*Totals)
-}
-
 func calculate(doc billable) error {
 	r := doc.RegimeDef() // may be nil!
 	calculateIssueDateAndTime(r, doc)
 
 	// Get the date used for tax calculations
-	date := doc.getValueDate()
+	date := doc.GetValueDate()
 	if date == nil {
-		id := doc.getIssueDate()
+		id := doc.GetIssueDate()
 		date = &id
 	}
 
 	// Convert empty or invalid currency to the regime's currency
-	if doc.getCurrency() == currency.CodeEmpty || doc.getCurrency().Def() == nil {
+	if doc.GetCurrency() == currency.CodeEmpty || doc.GetCurrency().Def() == nil {
 		if r == nil {
 			return validation.Errors{"currency": errors.New("missing")}
 		}
-		doc.setCurrency(r.Currency)
+		doc.SetCurrency(r.Currency)
 	}
-	cur := doc.getCurrency()
+	cur := doc.GetCurrency()
 
-	t := doc.getTotals()
+	t := doc.GetTotals()
 	// Prepare the totals we'll need with amounts based on currency
 	if t == nil {
 		t = new(Totals)
@@ -75,7 +44,7 @@ func calculate(doc billable) error {
 	// Figure out rounding rules and if prices include tax early
 	var pit cbc.Code
 	var rr cbc.Key
-	if tx := doc.getTax(); tx != nil {
+	if tx := doc.GetTax(); tx != nil {
 		if tx.PricesInclude != "" {
 			pit = tx.PricesInclude
 		}
@@ -93,59 +62,59 @@ func calculate(doc billable) error {
 	}
 
 	// Complements
-	if err := calculateComplements(doc.getComplements()); err != nil {
+	if err := calculateComplements(doc.GetComplements()); err != nil {
 		return validation.Errors{"complements": err}
 	}
 
 	// Preceding
-	calculateOrgDocumentRefs(doc.getPreceding(), cur, rr)
+	calculateOrgDocumentRefs(doc.GetPreceding(), cur, rr)
 
 	// Lines
-	if err := calculateLines(doc.getLines(), cur, doc.getExchangeRates(), rr); err != nil {
+	if err := calculateLines(doc.GetLines(), cur, doc.GetExchangeRates(), rr); err != nil {
 		return validation.Errors{"lines": err}
 	}
-	t.Sum = calculateLineSum(doc.getLines(), cur)
+	t.Sum = calculateLineSum(doc.GetLines(), cur)
 	t.Total = t.Sum
 
 	// Discount Lines
-	calculateDiscounts(doc.getDiscounts(), cur, t.Sum, rr)
-	if discounts := calculateDiscountSum(doc.getDiscounts(), cur); discounts != nil {
+	calculateDiscounts(doc.GetDiscounts(), cur, t.Sum, rr)
+	if discounts := calculateDiscountSum(doc.GetDiscounts(), cur); discounts != nil {
 		t.Discount = discounts
 		t.Total = t.Total.Subtract(*discounts)
 	}
 
 	// Charge Lines
-	calculateCharges(doc.getCharges(), cur, t.Sum, rr)
-	if charges := calculateChargeSum(doc.getCharges(), cur); charges != nil {
+	calculateCharges(doc.GetCharges(), cur, t.Sum, rr)
+	if charges := calculateChargeSum(doc.GetCharges(), cur); charges != nil {
 		t.Charge = charges
 		t.Total = t.Total.Add(*charges)
 	}
 
 	// Build list of taxable lines
 	tls := make([]tax.TaxableLine, 0)
-	for _, l := range doc.getLines() {
+	for _, l := range doc.GetLines() {
 		if l.Total != nil {
 			tls = append(tls, l)
 		}
 	}
-	for _, l := range doc.getDiscounts() {
+	for _, l := range doc.GetDiscounts() {
 		tls = append(tls, l)
 	}
-	for _, l := range doc.getCharges() {
+	for _, l := range doc.GetCharges() {
 		tls = append(tls, l)
 	}
 
 	if len(tls) == 0 {
 		// This applies for orders and deliveries that might not have
 		// any pricing details.
-		doc.setTotals(nil)
+		doc.SetTotals(nil)
 		return nil
 	}
 
 	// Now figure out the tax totals
 	t.Taxes = new(tax.Total)
 	tc := &tax.TotalCalculator{
-		Currency: doc.getCurrency(),
+		Currency: doc.GetCurrency(),
 		Rounding: rr,
 		Country:  r.GetCountry(),
 		Tags:     doc.GetTags(),
@@ -183,16 +152,16 @@ func calculate(doc billable) error {
 	// Before calculating the amount due and advances, we need to round
 	// everything. Payments reflect real monetary values and can never
 	// be fractions of the currency.
-	roundLines(doc.getLines())
-	roundDiscounts(doc.getDiscounts(), cur)
-	roundCharges(doc.getCharges(), cur)
+	roundLines(doc.GetLines())
+	roundDiscounts(doc.GetDiscounts(), cur)
+	roundCharges(doc.GetCharges(), cur)
 	t.round(zero)
 
 	if t.Rounding != nil {
 		// BT-144 in EN16931
 		t.Payable = t.Payable.Add(*t.Rounding)
 	}
-	if pd := doc.getPaymentDetails(); pd != nil {
+	if pd := doc.GetPaymentDetails(); pd != nil {
 		pd.calculateAdvances(zero, t.Payable)
 		// Deal with advances, if any. Note that in the current
 		// implementation multiple percentage advances are likely to
@@ -205,20 +174,20 @@ func calculate(doc billable) error {
 		// Calculate any due date amounts
 		pd.Terms.CalculateDues(zero, t.Payable)
 	}
-	doc.setTotals(t)
+	doc.SetTotals(t)
 
 	return nil
 }
 
 func calculateIssueDateAndTime(r *tax.RegimeDef, doc billable) {
 	tz := r.TimeLocation()
-	if doc.getIssueTime() != nil && doc.getIssueTime().IsZero() {
+	if doc.GetIssueTime() != nil && doc.GetIssueTime().IsZero() {
 		dn := cal.ThisSecondIn(tz)
 		tn := dn.Time()
-		doc.setIssueDate(dn.Date())
-		doc.setIssueTime(&tn)
-	} else if doc.getIssueDate().IsZero() {
-		doc.setIssueDate(cal.TodayIn(tz))
+		doc.SetIssueDate(dn.Date())
+		doc.SetIssueTime(&tn)
+	} else if doc.GetIssueDate().IsZero() {
+		doc.SetIssueDate(cal.TodayIn(tz))
 	}
 }
 
@@ -232,37 +201,37 @@ func calculateOrgDocumentRefs(drs []*org.DocumentRef, cur currency.Code, rr cbc.
 }
 
 func canRemoveIncludedTaxes(doc billable) bool {
-	return doc.getTax() != nil && !doc.getTax().PricesInclude.IsEmpty()
+	return doc.GetTax() != nil && !doc.GetTax().PricesInclude.IsEmpty()
 }
 
 func removeIncludedTaxes(doc billable) error {
 	if !canRemoveIncludedTaxes(doc) {
 		return nil
 	}
-	tpi := doc.getTax().PricesInclude
+	tpi := doc.GetTax().PricesInclude
 
-	totalWithTax := doc.getTotals().TotalWithTax
+	totalWithTax := doc.GetTotals().TotalWithTax
 
-	doc.setTotals(new(Totals))
-	lines := doc.getLines()
-	for i, l := range doc.getLines() {
+	doc.SetTotals(new(Totals))
+	lines := doc.GetLines()
+	for i, l := range doc.GetLines() {
 		lines[i] = removeLineIncludedTaxes(l, tpi)
 	}
 
-	discounts := doc.getDiscounts()
+	discounts := doc.GetDiscounts()
 	if len(discounts) > 0 {
 		for i, l := range discounts {
 			discounts[i] = l.removeIncludedTaxes(tpi)
 		}
 	}
-	charges := doc.getCharges()
+	charges := doc.GetCharges()
 	if len(charges) > 0 {
 		for i, l := range charges {
 			charges[i] = l.removeIncludedTaxes(tpi)
 		}
 	}
 
-	tx := doc.getTax()
+	tx := doc.GetTax()
 	tx.PricesInclude = ""
 
 	if err := calculate(doc); err != nil {
@@ -270,7 +239,7 @@ func removeIncludedTaxes(doc billable) error {
 	}
 
 	// Account for any rounding errors that we just can't handle
-	t := doc.getTotals()
+	t := doc.GetTotals()
 	if !totalWithTax.Equals(t.TotalWithTax) {
 		rnd := totalWithTax.Subtract(t.TotalWithTax)
 		t.Rounding = &rnd
@@ -283,17 +252,17 @@ func removeIncludedTaxes(doc billable) error {
 }
 
 func applyCustomerRates(doc billable) {
-	if doc.getCustomer() == nil || doc.getCustomer().TaxID == nil {
+	if doc.GetCustomer() == nil || doc.GetCustomer().TaxID == nil {
 		return
 	}
-	country := doc.getCustomer().TaxID.Country
-	for _, l := range doc.getLines() {
+	country := doc.GetCustomer().TaxID.Country
+	for _, l := range doc.GetLines() {
 		addCountryToTaxes(l.Taxes, country)
 	}
-	for _, d := range doc.getDiscounts() {
+	for _, d := range doc.GetDiscounts() {
 		addCountryToTaxes(d.Taxes, country)
 	}
-	for _, c := range doc.getCharges() {
+	for _, c := range doc.GetCharges() {
 		addCountryToTaxes(c.Taxes, country)
 	}
 }

--- a/bill/delivery.go
+++ b/bill/delivery.go
@@ -336,63 +336,120 @@ func (dlv *Delivery) ConvertInto(cur currency.Code) (*Delivery, error) {
 	return &d2, nil
 }
 
-/** Calculation Interface Methods **/
+/** Billable interface implementation **/
 
-func (dlv *Delivery) getIssueDate() cal.Date {
+// GetSeries returns the series of the delivery.
+func (dlv *Delivery) GetSeries() cbc.Code {
+	return dlv.Series
+}
+
+// GetCode returns the code of the delivery.
+func (dlv *Delivery) GetCode() cbc.Code {
+	return dlv.Code
+}
+
+// GetIssueDate returns the issue date of the delivery.
+func (dlv *Delivery) GetIssueDate() cal.Date {
 	return dlv.IssueDate
 }
-func (dlv *Delivery) getIssueTime() *cal.Time {
+
+// GetIssueTime returns the issue time of the delivery.
+func (dlv *Delivery) GetIssueTime() *cal.Time {
 	return dlv.IssueTime
 }
-func (dlv *Delivery) getValueDate() *cal.Date {
+
+// GetValueDate returns the value date of the delivery.
+func (dlv *Delivery) GetValueDate() *cal.Date {
 	return dlv.ValueDate
 }
-func (dlv *Delivery) getTax() *Tax {
+
+// GetTax returns the tax configuration of the delivery.
+func (dlv *Delivery) GetTax() *Tax {
 	return dlv.Tax
 }
-func (dlv *Delivery) getPreceding() []*org.DocumentRef {
+
+// GetPreceding returns the preceding document references of the delivery.
+func (dlv *Delivery) GetPreceding() []*org.DocumentRef {
 	return dlv.Preceding
 }
-func (dlv *Delivery) getCustomer() *org.Party {
+
+// GetSupplier returns the supplier of the delivery.
+func (dlv *Delivery) GetSupplier() *org.Party {
+	return dlv.Supplier
+}
+
+// GetCustomer returns the customer of the delivery.
+func (dlv *Delivery) GetCustomer() *org.Party {
 	return dlv.Customer
 }
-func (dlv *Delivery) getCurrency() currency.Code {
+
+// GetCurrency returns the currency of the delivery.
+func (dlv *Delivery) GetCurrency() currency.Code {
 	return dlv.Currency
 }
-func (dlv *Delivery) getExchangeRates() []*currency.ExchangeRate {
+
+// GetExchangeRates returns the exchange rates of the delivery.
+func (dlv *Delivery) GetExchangeRates() []*currency.ExchangeRate {
 	return dlv.ExchangeRates
 }
-func (dlv *Delivery) getLines() []*Line {
+
+// GetLines returns the lines of the delivery.
+func (dlv *Delivery) GetLines() []*Line {
 	return dlv.Lines
 }
-func (dlv *Delivery) getDiscounts() []*Discount {
+
+// GetDiscounts returns the discounts of the delivery.
+func (dlv *Delivery) GetDiscounts() []*Discount {
 	return dlv.Discounts
 }
-func (dlv *Delivery) getCharges() []*Charge {
+
+// GetCharges returns the charges of the delivery.
+func (dlv *Delivery) GetCharges() []*Charge {
 	return dlv.Charges
 }
-func (dlv *Delivery) getPaymentDetails() *PaymentDetails {
-	return nil // no payment for deliveries
+
+// GetPaymentDetails returns the payment details of the delivery.
+func (dlv *Delivery) GetPaymentDetails() *PaymentDetails {
+	return nil // no payment details for deliveries
 }
-func (dlv *Delivery) getTotals() *Totals {
+
+// GetTotals returns the totals of the delivery.
+func (dlv *Delivery) GetTotals() *Totals {
 	return dlv.Totals
 }
-func (dlv *Delivery) getComplements() []*schema.Object {
+
+// GetComplements returns the complements of the delivery.
+func (dlv *Delivery) GetComplements() []*schema.Object {
 	return dlv.Complements
 }
 
-func (dlv *Delivery) setIssueDate(d cal.Date) {
+// SetCode sets the code of the delivery.
+func (dlv *Delivery) SetCode(c cbc.Code) {
+	dlv.Code = c
+}
+
+// SetIssueDate sets the issue date of the delivery.
+func (dlv *Delivery) SetIssueDate(d cal.Date) {
 	dlv.IssueDate = d
 }
-func (dlv *Delivery) setIssueTime(t *cal.Time) {
+
+// SetIssueTime sets the issue time of the delivery.
+func (dlv *Delivery) SetIssueTime(t *cal.Time) {
 	dlv.IssueTime = t
 }
-func (dlv *Delivery) setCurrency(c currency.Code) {
+
+// SetCurrency sets the currency of the delivery.
+func (dlv *Delivery) SetCurrency(c currency.Code) {
 	dlv.Currency = c
 }
-func (dlv *Delivery) setTotals(t *Totals) {
+
+// SetTotals sets the totals of the delivery.
+func (dlv *Delivery) SetTotals(t *Totals) {
 	dlv.Totals = t
 }
+
+// ensure the billable interface is fully implemented
+var _ billable = &Delivery{}
 
 /** ---- **/
 

--- a/bill/delivery_test.go
+++ b/bill/delivery_test.go
@@ -6,9 +6,11 @@ import (
 
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cal"
+	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/currency"
 	"github.com/invopop/gobl/num"
 	"github.com/invopop/gobl/org"
+	"github.com/invopop/gobl/schema"
 	"github.com/invopop/gobl/tax"
 	"github.com/invopop/jsonschema"
 	"github.com/stretchr/testify/assert"
@@ -197,4 +199,47 @@ func TestDeliveryJSONSchemaExtend(t *testing.T) {
 		assert.Equal(t, it.Key.String(), prop.OneOf[0].Const)
 	})
 
+}
+
+func TestDeliveryBillable(t *testing.T) {
+	dlv := baseDeliveryWithLines(t)
+	dlv.IssueTime = cal.NewTime(10, 30, 0)
+	dlv.ValueDate = cal.NewDate(2023, 1, 15)
+	dlv.Currency = currency.EUR
+	dlv.ExchangeRates = []*currency.ExchangeRate{{}}
+	dlv.Complements = []*schema.Object{{}}
+
+	assert.Equal(t, dlv.Series, dlv.GetSeries())
+	assert.Equal(t, dlv.Code, dlv.GetCode())
+	assert.Equal(t, dlv.IssueDate, dlv.GetIssueDate())
+	assert.Equal(t, dlv.IssueTime, dlv.GetIssueTime())
+	assert.Equal(t, dlv.ValueDate, dlv.GetValueDate())
+	assert.Equal(t, dlv.Tax, dlv.GetTax())
+	assert.Equal(t, dlv.Preceding, dlv.GetPreceding())
+	assert.Equal(t, dlv.Currency, dlv.GetCurrency())
+	assert.Equal(t, dlv.ExchangeRates, dlv.GetExchangeRates())
+	assert.Equal(t, dlv.Supplier, dlv.GetSupplier())
+	assert.Equal(t, dlv.Customer, dlv.GetCustomer())
+	assert.Equal(t, dlv.Lines, dlv.GetLines())
+	assert.Equal(t, dlv.Discounts, dlv.GetDiscounts())
+	assert.Equal(t, dlv.Charges, dlv.GetCharges())
+	assert.Equal(t, dlv.Totals, dlv.GetTotals())
+	assert.Equal(t, dlv.Complements, dlv.GetComplements())
+	assert.Nil(t, dlv.GetPaymentDetails())
+
+	dlv.SetCode(cbc.Code("002"))
+	assert.Equal(t, cbc.Code("002"), dlv.Code)
+
+	dlv.SetIssueDate(cal.MakeDate(2023, 2, 1))
+	assert.Equal(t, cal.MakeDate(2023, 2, 1), dlv.IssueDate)
+
+	dlv.SetIssueTime(cal.NewTime(11, 30, 0))
+	assert.Equal(t, cal.NewTime(11, 30, 0), dlv.IssueTime)
+
+	dlv.SetCurrency(currency.USD)
+	assert.Equal(t, currency.USD, dlv.Currency)
+
+	newTotals := &bill.Totals{}
+	dlv.SetTotals(newTotals)
+	assert.Equal(t, newTotals, dlv.GetTotals())
 }

--- a/bill/invoice.go
+++ b/bill/invoice.go
@@ -344,63 +344,120 @@ func (inv *Invoice) RemoveIncludedTaxes() error {
 	return removeIncludedTaxes(inv)
 }
 
-/** Calculation Interface Methods **/
+/** Billable interface implementation **/
 
-func (inv *Invoice) getIssueDate() cal.Date {
+// GetSeries returns the series of the invoice.
+func (inv *Invoice) GetSeries() cbc.Code {
+	return inv.Series
+}
+
+// GetCode returns the code of the invoice.
+func (inv *Invoice) GetCode() cbc.Code {
+	return inv.Code
+}
+
+// GetIssueDate returns the issue date of the invoice.
+func (inv *Invoice) GetIssueDate() cal.Date {
 	return inv.IssueDate
 }
-func (inv *Invoice) getIssueTime() *cal.Time {
+
+// GetIssueTime returns the issue time of the invoice.
+func (inv *Invoice) GetIssueTime() *cal.Time {
 	return inv.IssueTime
 }
-func (inv *Invoice) getValueDate() *cal.Date {
+
+// GetValueDate returns the value date of the invoice.
+func (inv *Invoice) GetValueDate() *cal.Date {
 	return inv.ValueDate
 }
-func (inv *Invoice) getTax() *Tax {
+
+// GetTax returns the tax configuration of the invoice.
+func (inv *Invoice) GetTax() *Tax {
 	return inv.Tax
 }
-func (inv *Invoice) getPreceding() []*org.DocumentRef {
+
+// GetPreceding returns the preceding document references of the invoice.
+func (inv *Invoice) GetPreceding() []*org.DocumentRef {
 	return inv.Preceding
 }
-func (inv *Invoice) getCustomer() *org.Party {
+
+// GetSupplier returns the supplier of the invoice.
+func (inv *Invoice) GetSupplier() *org.Party {
+	return inv.Supplier
+}
+
+// GetCustomer returns the customer of the invoice.
+func (inv *Invoice) GetCustomer() *org.Party {
 	return inv.Customer
 }
-func (inv *Invoice) getCurrency() currency.Code {
+
+// GetCurrency returns the currency of the invoice.
+func (inv *Invoice) GetCurrency() currency.Code {
 	return inv.Currency
 }
-func (inv *Invoice) getExchangeRates() []*currency.ExchangeRate {
+
+// GetExchangeRates returns the exchange rates of the invoice.
+func (inv *Invoice) GetExchangeRates() []*currency.ExchangeRate {
 	return inv.ExchangeRates
 }
-func (inv *Invoice) getLines() []*Line {
+
+// GetLines returns the lines of the invoice.
+func (inv *Invoice) GetLines() []*Line {
 	return inv.Lines
 }
-func (inv *Invoice) getDiscounts() []*Discount {
+
+// GetDiscounts returns the discounts of the invoice.
+func (inv *Invoice) GetDiscounts() []*Discount {
 	return inv.Discounts
 }
-func (inv *Invoice) getCharges() []*Charge {
+
+// GetCharges returns the charges of the invoice.
+func (inv *Invoice) GetCharges() []*Charge {
 	return inv.Charges
 }
-func (inv *Invoice) getPaymentDetails() *PaymentDetails {
+
+// GetPaymentDetails returns the payment details of the invoice.
+func (inv *Invoice) GetPaymentDetails() *PaymentDetails {
 	return inv.Payment
 }
-func (inv *Invoice) getTotals() *Totals {
+
+// GetTotals returns the totals of the invoice.
+func (inv *Invoice) GetTotals() *Totals {
 	return inv.Totals
 }
-func (inv *Invoice) getComplements() []*schema.Object {
+
+// GetComplements returns the complements of the invoice.
+func (inv *Invoice) GetComplements() []*schema.Object {
 	return inv.Complements
 }
 
-func (inv *Invoice) setIssueDate(d cal.Date) {
+// SetCode sets the code of the invoice.
+func (inv *Invoice) SetCode(c cbc.Code) {
+	inv.Code = c
+}
+
+// SetIssueDate sets the issue date of the invoice.
+func (inv *Invoice) SetIssueDate(d cal.Date) {
 	inv.IssueDate = d
 }
-func (inv *Invoice) setIssueTime(t *cal.Time) {
+
+// SetIssueTime sets the issue time of the invoice.
+func (inv *Invoice) SetIssueTime(t *cal.Time) {
 	inv.IssueTime = t
 }
-func (inv *Invoice) setCurrency(c currency.Code) {
+
+// SetCurrency sets the currency of the invoice.
+func (inv *Invoice) SetCurrency(c currency.Code) {
 	inv.Currency = c
 }
-func (inv *Invoice) setTotals(t *Totals) {
+
+// SetTotals sets the totals of the invoice.
+func (inv *Invoice) SetTotals(t *Totals) {
 	inv.Totals = t
 }
+
+// ensure the billable interface is fully implemented
+var _ billable = &Invoice{}
 
 /** ---- **/
 

--- a/bill/invoice_test.go
+++ b/bill/invoice_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/invopop/gobl/num"
 	"github.com/invopop/gobl/org"
 	"github.com/invopop/gobl/pay"
+	"github.com/invopop/gobl/schema"
 	"github.com/invopop/gobl/tax"
 	"github.com/invopop/jsonschema"
 	"github.com/stretchr/testify/assert"
@@ -1342,4 +1343,47 @@ func TestInvoiceJSONSchemaExtend(t *testing.T) {
 		assert.Equal(t, it.Key.String(), prop.OneOf[0].Const)
 	})
 
+}
+
+func TestInvoiceBillable(t *testing.T) {
+	inv := baseInvoiceWithLines(t)
+	inv.IssueTime = cal.NewTime(10, 30, 0)
+	inv.ValueDate = cal.NewDate(2023, 1, 15)
+	inv.Currency = currency.EUR
+	inv.ExchangeRates = []*currency.ExchangeRate{{}}
+	inv.Complements = []*schema.Object{{}}
+
+	assert.Equal(t, inv.Series, inv.GetSeries())
+	assert.Equal(t, inv.Code, inv.GetCode())
+	assert.Equal(t, inv.IssueDate, inv.GetIssueDate())
+	assert.Equal(t, inv.IssueTime, inv.GetIssueTime())
+	assert.Equal(t, inv.ValueDate, inv.GetValueDate())
+	assert.Equal(t, inv.Tax, inv.GetTax())
+	assert.Equal(t, inv.Preceding, inv.GetPreceding())
+	assert.Equal(t, inv.Currency, inv.GetCurrency())
+	assert.Equal(t, inv.ExchangeRates, inv.GetExchangeRates())
+	assert.Equal(t, inv.Supplier, inv.GetSupplier())
+	assert.Equal(t, inv.Customer, inv.GetCustomer())
+	assert.Equal(t, inv.Lines, inv.GetLines())
+	assert.Equal(t, inv.Discounts, inv.GetDiscounts())
+	assert.Equal(t, inv.Charges, inv.GetCharges())
+	assert.Equal(t, inv.Payment, inv.GetPaymentDetails())
+	assert.Equal(t, inv.Totals, inv.GetTotals())
+	assert.Equal(t, inv.Complements, inv.GetComplements())
+
+	inv.SetCode(cbc.Code("002"))
+	assert.Equal(t, cbc.Code("002"), inv.Code)
+
+	inv.SetIssueDate(cal.MakeDate(2023, 2, 1))
+	assert.Equal(t, cal.MakeDate(2023, 2, 1), inv.IssueDate)
+
+	inv.SetIssueTime(cal.NewTime(11, 30, 0))
+	assert.Equal(t, cal.NewTime(11, 30, 0), inv.IssueTime)
+
+	inv.SetCurrency(currency.USD)
+	assert.Equal(t, currency.USD, inv.Currency)
+
+	newTotals := &bill.Totals{}
+	inv.SetTotals(newTotals)
+	assert.Equal(t, newTotals, inv.GetTotals())
 }

--- a/bill/order.go
+++ b/bill/order.go
@@ -306,63 +306,120 @@ func (ord *Order) ConvertInto(cur currency.Code) (*Order, error) {
 	return &o2, nil
 }
 
-/** Calculation Interface Methods **/
+/** Billable interface implementation **/
 
-func (ord *Order) getIssueDate() cal.Date {
+// GetSeries returns the series of the order.
+func (ord *Order) GetSeries() cbc.Code {
+	return ord.Series
+}
+
+// GetCode returns the code of the order.
+func (ord *Order) GetCode() cbc.Code {
+	return ord.Code
+}
+
+// GetIssueDate returns the issue date of the order.
+func (ord *Order) GetIssueDate() cal.Date {
 	return ord.IssueDate
 }
-func (ord *Order) getIssueTime() *cal.Time {
+
+// GetIssueTime returns the issue time of the order.
+func (ord *Order) GetIssueTime() *cal.Time {
 	return ord.IssueTime
 }
-func (ord *Order) getValueDate() *cal.Date {
+
+// GetValueDate returns the value date of the order.
+func (ord *Order) GetValueDate() *cal.Date {
 	return ord.ValueDate
 }
-func (ord *Order) getTax() *Tax {
+
+// GetTax returns the tax configuration of the order.
+func (ord *Order) GetTax() *Tax {
 	return ord.Tax
 }
-func (ord *Order) getPreceding() []*org.DocumentRef {
+
+// GetPreceding returns the preceding document references of the order.
+func (ord *Order) GetPreceding() []*org.DocumentRef {
 	return ord.Preceding
 }
-func (ord *Order) getCustomer() *org.Party {
+
+// GetSupplier returns the supplier of the order.
+func (ord *Order) GetSupplier() *org.Party {
+	return ord.Supplier
+}
+
+// GetCustomer returns the customer of the order.
+func (ord *Order) GetCustomer() *org.Party {
 	return ord.Customer
 }
-func (ord *Order) getCurrency() currency.Code {
+
+// GetCurrency returns the currency of the order.
+func (ord *Order) GetCurrency() currency.Code {
 	return ord.Currency
 }
-func (ord *Order) getExchangeRates() []*currency.ExchangeRate {
+
+// GetExchangeRates returns the exchange rates of the order.
+func (ord *Order) GetExchangeRates() []*currency.ExchangeRate {
 	return ord.ExchangeRates
 }
-func (ord *Order) getLines() []*Line {
+
+// GetLines returns the lines of the order.
+func (ord *Order) GetLines() []*Line {
 	return ord.Lines
 }
-func (ord *Order) getDiscounts() []*Discount {
+
+// GetDiscounts returns the discounts of the order.
+func (ord *Order) GetDiscounts() []*Discount {
 	return ord.Discounts
 }
-func (ord *Order) getCharges() []*Charge {
+
+// GetCharges returns the charges of the order.
+func (ord *Order) GetCharges() []*Charge {
 	return ord.Charges
 }
-func (ord *Order) getPaymentDetails() *PaymentDetails {
+
+// GetPaymentDetails returns the payment details of the order.
+func (ord *Order) GetPaymentDetails() *PaymentDetails {
 	return ord.Payment
 }
-func (ord *Order) getTotals() *Totals {
+
+// GetTotals returns the totals of the order.
+func (ord *Order) GetTotals() *Totals {
 	return ord.Totals
 }
-func (ord *Order) getComplements() []*schema.Object {
+
+// GetComplements returns the complements of the order.
+func (ord *Order) GetComplements() []*schema.Object {
 	return ord.Complements
 }
 
-func (ord *Order) setIssueDate(d cal.Date) {
+// SetCode sets the code of the order.
+func (ord *Order) SetCode(c cbc.Code) {
+	ord.Code = c
+}
+
+// SetIssueDate sets the issue date of the order.
+func (ord *Order) SetIssueDate(d cal.Date) {
 	ord.IssueDate = d
 }
-func (ord *Order) setIssueTime(t *cal.Time) {
+
+// SetIssueTime sets the issue time of the order.
+func (ord *Order) SetIssueTime(t *cal.Time) {
 	ord.IssueTime = t
 }
-func (ord *Order) setCurrency(c currency.Code) {
+
+// SetCurrency sets the currency of the order.
+func (ord *Order) SetCurrency(c currency.Code) {
 	ord.Currency = c
 }
-func (ord *Order) setTotals(t *Totals) {
+
+// SetTotals sets the totals of the order.
+func (ord *Order) SetTotals(t *Totals) {
 	ord.Totals = t
 }
+
+// ensure the billable interface is fully implemented
+var _ billable = &Order{}
 
 /** ---- **/
 

--- a/bill/order_test.go
+++ b/bill/order_test.go
@@ -6,9 +6,11 @@ import (
 
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cal"
+	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/currency"
 	"github.com/invopop/gobl/num"
 	"github.com/invopop/gobl/org"
+	"github.com/invopop/gobl/schema"
 	"github.com/invopop/gobl/tax"
 	"github.com/invopop/jsonschema"
 	"github.com/stretchr/testify/assert"
@@ -190,4 +192,47 @@ func TestOrderJSONSchemaExtend(t *testing.T) {
 		assert.Equal(t, it.Key.String(), prop.OneOf[0].Const)
 	})
 
+}
+
+func TestOrderBillable(t *testing.T) {
+	ord := baseOrderWithLines(t)
+	ord.IssueTime = cal.NewTime(10, 30, 0)
+	ord.ValueDate = cal.NewDate(2023, 1, 15)
+	ord.Currency = currency.EUR
+	ord.ExchangeRates = []*currency.ExchangeRate{{}}
+	ord.Complements = []*schema.Object{{}}
+
+	assert.Equal(t, ord.Series, ord.GetSeries())
+	assert.Equal(t, ord.Code, ord.GetCode())
+	assert.Equal(t, ord.IssueDate, ord.GetIssueDate())
+	assert.Equal(t, ord.IssueTime, ord.GetIssueTime())
+	assert.Equal(t, ord.ValueDate, ord.GetValueDate())
+	assert.Equal(t, ord.Tax, ord.GetTax())
+	assert.Equal(t, ord.Preceding, ord.GetPreceding())
+	assert.Equal(t, ord.Currency, ord.GetCurrency())
+	assert.Equal(t, ord.ExchangeRates, ord.GetExchangeRates())
+	assert.Equal(t, ord.Supplier, ord.GetSupplier())
+	assert.Equal(t, ord.Customer, ord.GetCustomer())
+	assert.Equal(t, ord.Lines, ord.GetLines())
+	assert.Equal(t, ord.Discounts, ord.GetDiscounts())
+	assert.Equal(t, ord.Charges, ord.GetCharges())
+	assert.Equal(t, ord.Payment, ord.GetPaymentDetails())
+	assert.Equal(t, ord.Totals, ord.GetTotals())
+	assert.Equal(t, ord.Complements, ord.GetComplements())
+
+	ord.SetCode(cbc.Code("002"))
+	assert.Equal(t, cbc.Code("002"), ord.Code)
+
+	ord.SetIssueDate(cal.MakeDate(2023, 2, 1))
+	assert.Equal(t, cal.MakeDate(2023, 2, 1), ord.IssueDate)
+
+	ord.SetIssueTime(cal.NewTime(11, 30, 0))
+	assert.Equal(t, cal.NewTime(11, 30, 0), ord.IssueTime)
+
+	ord.SetCurrency(currency.USD)
+	assert.Equal(t, currency.USD, ord.Currency)
+
+	newTotals := &bill.Totals{}
+	ord.SetTotals(newTotals)
+	assert.Equal(t, newTotals, ord.GetTotals())
 }

--- a/bill/payment.go
+++ b/bill/payment.go
@@ -319,6 +319,123 @@ func (pmt *Payment) calculate() error {
 	return nil
 }
 
+/** Billable interface implementation **/
+
+// GetSeries returns the series of the payment.
+func (pmt *Payment) GetSeries() cbc.Code {
+	return pmt.Series
+}
+
+// GetCode returns the code of the payment.
+func (pmt *Payment) GetCode() cbc.Code {
+	return pmt.Code
+}
+
+// GetIssueDate returns the issue date of the payment.
+func (pmt *Payment) GetIssueDate() cal.Date {
+	return pmt.IssueDate
+}
+
+// GetIssueTime returns the issue time of the payment.
+func (pmt *Payment) GetIssueTime() *cal.Time {
+	return pmt.IssueTime
+}
+
+// GetValueDate returns the value date of the payment.
+func (pmt *Payment) GetValueDate() *cal.Date {
+	return pmt.ValueDate
+}
+
+// GetTax returns the tax configuration of the payment.
+func (pmt *Payment) GetTax() *Tax {
+	return nil // no tax for payments
+}
+
+// GetPreceding returns the preceding document references of the payment.
+func (pmt *Payment) GetPreceding() []*org.DocumentRef {
+	return pmt.Preceding
+}
+
+// GetSupplier returns the supplier of the payment.
+func (pmt *Payment) GetSupplier() *org.Party {
+	return pmt.Supplier
+}
+
+// GetCustomer returns the customer of the payment.
+func (pmt *Payment) GetCustomer() *org.Party {
+	return pmt.Customer
+}
+
+// GetCurrency returns the currency of the payment.
+func (pmt *Payment) GetCurrency() currency.Code {
+	return pmt.Currency
+}
+
+// GetExchangeRates returns the exchange rates of the payment.
+func (pmt *Payment) GetExchangeRates() []*currency.ExchangeRate {
+	return pmt.ExchangeRates
+}
+
+// GetLines returns the lines of the payment.
+func (pmt *Payment) GetLines() []*Line {
+	return nil // no lines for payments
+}
+
+// GetDiscounts returns the discounts of the payment.
+func (pmt *Payment) GetDiscounts() []*Discount {
+	return nil // no discounts for payments
+}
+
+// GetCharges returns the charges of the payment.
+func (pmt *Payment) GetCharges() []*Charge {
+	return nil // no charges for payments
+}
+
+// GetPaymentDetails returns the payment details of the payment.
+func (pmt *Payment) GetPaymentDetails() *PaymentDetails {
+	return nil // no payment details for deliveries
+}
+
+// GetTotals returns the totals of the payment.
+func (pmt *Payment) GetTotals() *Totals {
+	return nil // no totals for payments
+}
+
+// GetComplements returns the complements of the payment.
+func (pmt *Payment) GetComplements() []*schema.Object {
+	return pmt.Complements
+}
+
+// SetCode sets the code of the payment.
+func (pmt *Payment) SetCode(c cbc.Code) {
+	pmt.Code = c
+}
+
+// SetIssueDate sets the issue date of the payment.
+func (pmt *Payment) SetIssueDate(d cal.Date) {
+	pmt.IssueDate = d
+}
+
+// SetIssueTime sets the issue time of the payment.
+func (pmt *Payment) SetIssueTime(t *cal.Time) {
+	pmt.IssueTime = t
+}
+
+// SetCurrency sets the currency of the payment.
+func (pmt *Payment) SetCurrency(c currency.Code) {
+	pmt.Currency = c
+}
+
+// SetTotals sets the totals of the payment.
+func (pmt *Payment) SetTotals(_ *Totals) {
+	// no totals for payments
+}
+
+// ensure the billable interface is fully implemented
+var _ billable = &Payment{}
+
+/** ---- **/
+
 // JSONSchemaExtend extends the schema with additional property details
 func (pmt Payment) JSONSchemaExtend(js *jsonschema.Schema) {
 	props := js.Properties

--- a/bill/payment_test.go
+++ b/bill/payment_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/invopop/gobl/addons/es/tbai"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cal"
+	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/currency"
 	"github.com/invopop/gobl/num"
 	"github.com/invopop/gobl/org"
@@ -346,4 +347,47 @@ func TestPaymentJSONSchemaExtend(t *testing.T) {
 		assert.Len(t, js.Extras[schema.Recommended], 4)
 	})
 
+}
+
+func TestPaymentBillable(t *testing.T) {
+	pmt := testPaymentMinimal(t)
+	pmt.IssueTime = cal.NewTime(10, 30, 0)
+	pmt.ValueDate = cal.NewDate(2023, 1, 15)
+	pmt.Currency = currency.EUR
+	pmt.ExchangeRates = []*currency.ExchangeRate{{}}
+	pmt.Complements = []*schema.Object{{}}
+
+	assert.Equal(t, pmt.Series, pmt.GetSeries())
+	assert.Equal(t, pmt.Code, pmt.GetCode())
+	assert.Equal(t, pmt.IssueDate, pmt.GetIssueDate())
+	assert.Equal(t, pmt.IssueTime, pmt.GetIssueTime())
+	assert.Equal(t, pmt.ValueDate, pmt.GetValueDate())
+	assert.Equal(t, pmt.Preceding, pmt.GetPreceding())
+	assert.Equal(t, pmt.Currency, pmt.GetCurrency())
+	assert.Equal(t, pmt.ExchangeRates, pmt.GetExchangeRates())
+	assert.Equal(t, pmt.Supplier, pmt.GetSupplier())
+	assert.Equal(t, pmt.Customer, pmt.GetCustomer())
+	assert.Equal(t, pmt.Complements, pmt.GetComplements())
+	assert.Nil(t, pmt.GetDiscounts())
+	assert.Nil(t, pmt.GetCharges())
+	assert.Nil(t, pmt.GetPaymentDetails())
+	assert.Nil(t, pmt.GetTax())
+	assert.Nil(t, pmt.GetTotals())
+	assert.Nil(t, pmt.GetLines())
+
+	pmt.SetCode(cbc.Code("002"))
+	assert.Equal(t, cbc.Code("002"), pmt.Code)
+
+	pmt.SetIssueDate(cal.MakeDate(2023, 2, 1))
+	assert.Equal(t, cal.MakeDate(2023, 2, 1), pmt.IssueDate)
+
+	pmt.SetIssueTime(cal.NewTime(11, 30, 0))
+	assert.Equal(t, cal.NewTime(11, 30, 0), pmt.IssueTime)
+
+	pmt.SetCurrency(currency.USD)
+	assert.Equal(t, currency.USD, pmt.Currency)
+
+	newTotals := &bill.Totals{}
+	pmt.SetTotals(newTotals)
+	// Nothing to assert here
 }


### PR DESCRIPTION
- Extend and export the methods in the `billable` interface to allow for generic handling of bill documents (Invoice, Payment, Delivery and Order) outside of the package.

## Pre-Review Checklist

- [X] I have performed a self-review of my code.
- [x] I have added thorough tests with at **least** 90% code coverage.
- [ ] N/A I've modified or created example GOBL documents to show my changes in use, if appropriate.
- [ ] N/A When adding or modifying a tax regime or addon, I've added links to the source of the changes, either structured or in the comments.
- [ ] N/A I've run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [X] All linter warnings have been reviewed and fixed.
- [X] I've been obsessive with pointer nil checks to avoid panics.
- [X] The CHANGELOG.md has been updated with an overview of my changes.
- [x] Requested a review from @samlown.

