### PR TITLE
Commas in codes, telephone as freetext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
-## Fixed
+### Changed
 
-- `es-verifactu-v1`: validate presence of tax in preceding rows, only for corrective types.
+- `cbc`: Allow `,` (comma) as separator.
+- `org`: Telephone normalized and removing format restrictions.
+
+### Fixed
+
+- `es-verifactu-v1`: only validate presence of tax in preceding rows for corrective types.
 
 ## [v0.216.3] - 2025-05-20
 

--- a/cbc/code.go
+++ b/cbc/code.go
@@ -16,12 +16,12 @@ const (
 )
 
 // Code represents a string used to uniquely identify the data we're looking
-// at. We use "code" instead of "id", to reenforce the fact that codes should
+// at. We use "code" instead of "id", to re-enforce the fact that codes should
 // be more easily set and used by humans within definitions than IDs or UUIDs.
-// Codes are standardised so that when validated they must contain between
-// 1 and 32 inclusive english alphabet letters or numbers with optional
+// Codes are standardized so that when validated they must contain between
+// 1 and 64 inclusive english alphabet letters or numbers with optional
 // periods (`.`), dashes (`-`), underscores (`_`), forward slashes (`/`),
-// colons (`:`) or spaces (` `) to separate blocks.
+// colons (`:`), commas (`,`), or spaces (` `) to separate blocks.
 // Each block must only be separated by a single symbol.
 //
 // The objective is to have a code that is easy to read and understand, while
@@ -34,15 +34,16 @@ type CodeMap map[Key]Code
 
 // Basic code constants.
 var (
-	CodePattern              = `^[A-Za-z0-9]+([\.\-\/ _\:]?[A-Za-z0-9]+)*$`
+	CodeSeparators           = `\.\-\:/,_ `
+	CodePattern              = `^[A-Za-z0-9]+([` + CodeSeparators + `]?[A-Za-z0-9]+)*$`
 	CodePatternRegexp        = regexp.MustCompile(CodePattern)
 	CodeMinLength     uint64 = 1
-	CodeMaxLength     uint64 = 32
+	CodeMaxLength     uint64 = 64
 )
 
 var (
-	codeSeparatorRegexp         = regexp.MustCompile(`([\.\-\/ _\:])[^A-Za-z0-9]+`)
-	codeInvalidCharsRegexp      = regexp.MustCompile(`[^A-Za-z0-9\.\-\/ _\:]`)
+	codeSeparatorRegexp         = regexp.MustCompile(`([` + CodeSeparators + `])[^A-Za-z0-9]+`)
+	codeInvalidCharsRegexp      = regexp.MustCompile(`[^A-Za-z0-9` + CodeSeparators + `]+`)
 	codeNonAlphanumericalRegexp = regexp.MustCompile(`[^A-Z\d]`)
 	codeNonNumericalRegexp      = regexp.MustCompile(`[^\d]`)
 )

--- a/cbc/code_test.go
+++ b/cbc/code_test.go
@@ -108,6 +108,11 @@ func TestNormalizeCode(t *testing.T) {
 			code: cbc.Code("0088:1234567891234"), // peppol example
 			want: cbc.Code("0088:1234567891234"),
 		},
+		{
+			name: "commas",
+			code: cbc.Code("FL-C 64-3,5"),
+			want: cbc.Code("FL-C 64-3,5"),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -340,7 +345,7 @@ func TestCode_Validate(t *testing.T) {
 		},
 		{
 			name:    "too long",
-			code:    cbc.Code("123456789012345678901234567890ABC"),
+			code:    cbc.Code("123456789012345678901234567890ABC123456789012345678901234567890ABC"),
 			wantErr: "length must be between",
 		},
 	}
@@ -428,7 +433,7 @@ func TestCodeJSONSchema(t *testing.T) {
 	assert.Equal(t, "string", s.Type)
 	assert.Equal(t, "Code", s.Title)
 	assert.Equal(t, uint64(1), *s.MinLength)
-	assert.Equal(t, uint64(32), *s.MaxLength)
+	assert.Equal(t, uint64(64), *s.MaxLength)
 }
 
 func TestCodeMapJSONSchemaExtend(t *testing.T) {

--- a/org/item.go
+++ b/org/item.go
@@ -62,6 +62,7 @@ func (i *Item) Normalize(normalizers tax.Normalizers) {
 	if i == nil {
 		return
 	}
+	i.Ref = cbc.NormalizeCode(i.Ref)
 	i.Ext = tax.CleanExtensions(i.Ext)
 	normalizers.Each(i)
 	tax.Normalize(normalizers, i.Identities)

--- a/org/item_test.go
+++ b/org/item_test.go
@@ -30,6 +30,14 @@ func TestItemNormalization(t *testing.T) {
 		assert.Equal(t, num.NewAmount(100, 2), i.Price)
 		assert.Nil(t, i.Ext)
 	})
+	t.Run("clean ref", func(t *testing.T) {
+		i := &org.Item{
+			Name: "test item",
+			Ref:  "  test-ref  ",
+		}
+		i.Normalize(nil)
+		assert.Equal(t, "test-ref", i.Ref.String())
+	})
 }
 
 func TestItemValidation(t *testing.T) {

--- a/org/party.go
+++ b/org/party.go
@@ -82,6 +82,7 @@ func (p *Party) Normalize(normalizers tax.Normalizers) {
 	tax.Normalize(normalizers, p.Identities)
 	tax.Normalize(normalizers, p.Inboxes)
 	tax.Normalize(normalizers, p.Addresses)
+	tax.Normalize(normalizers, p.Telephones)
 	tax.Normalize(normalizers, p.Emails)
 }
 

--- a/org/telephone.go
+++ b/org/telephone.go
@@ -2,11 +2,11 @@ package org
 
 import (
 	"context"
+	"strings"
 
 	"github.com/invopop/gobl/tax"
 	"github.com/invopop/gobl/uuid"
 	"github.com/invopop/validation"
-	"github.com/invopop/validation/is"
 )
 
 // Telephone describes what is expected for a telephone number.
@@ -14,7 +14,7 @@ type Telephone struct {
 	uuid.Identify
 	// Identifier for this number.
 	Label string `json:"label,omitempty" jsonschema:"title=Label"`
-	// The number to be dialed in ITU E.164 international format.
+	// Number to call.
 	Number string `json:"num" jsonschema:"title=Number"`
 }
 
@@ -23,10 +23,15 @@ func (t *Telephone) Validate() error {
 	return t.ValidateWithContext(context.Background())
 }
 
+// Normalize will try to remove any unnecessary whitespace from the telephone number.
+func (t *Telephone) Normalize() {
+	t.Number = strings.TrimSpace(t.Number)
+}
+
 // ValidateWithContext checks the telephone objects number to ensure it looks correct inside the provided context.
 func (t *Telephone) ValidateWithContext(ctx context.Context) error {
 	return tax.ValidateStructWithContext(ctx, t,
 		validation.Field(&t.UUID),
-		validation.Field(&t.Number, validation.Required, is.E164),
+		validation.Field(&t.Number, validation.Required),
 	)
 }

--- a/org/telephone_test.go
+++ b/org/telephone_test.go
@@ -1,0 +1,37 @@
+package org_test
+
+import (
+	"testing"
+
+	"github.com/invopop/gobl/org"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTelephoneNormalizeAndValidate(t *testing.T) {
+	t.Run("basic normalization", func(t *testing.T) {
+		tel := &org.Telephone{
+			Number: "  +123 456 7890  ",
+		}
+		tel.Normalize()
+		assert.Equal(t, "+123 456 7890", tel.Number)
+		assert.NoError(t, tel.Validate())
+	})
+
+	t.Run("empty number", func(t *testing.T) {
+		tel := &org.Telephone{
+			Number: "   ",
+		}
+		tel.Normalize()
+		assert.Equal(t, "", tel.Number)
+		assert.ErrorContains(t, tel.Validate(), "num: cannot be blank")
+	})
+
+	t.Run("allow complex numbers", func(t *testing.T) {
+		tel := &org.Telephone{
+			Number: "+1 (123) 456-7890 ext. 123",
+		}
+		tel.Normalize()
+		assert.Equal(t, "+1 (123) 456-7890 ext. 123", tel.Number)
+		assert.NoError(t, tel.Validate())
+	})
+}


### PR DESCRIPTION
- `org.Telephone` number is now a freetext with normalization to remove preceding whitespace.
- `org.Item` normalizing Ref field.
- `cbc.Code` added support for comma separator

## Pre-Review Checklist

- [ ] I've read the CONTRIBUTING.md guide.
- [ ] I have performed a self-review of my code.
- [ ] I have added thorough tests with at **least** 90% code coverage.
- [ ] I've modified or created example GOBL documents to show my changes in use, if appropriate.
- [ ] When adding or modifying a tax regime or addon, I've added links to the source of the changes, either structured or in the comments.
- [ ] I've run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [ ] All linter warnings have been reviewed and fixed.
- [ ] I've been obsessive with pointer nil checks to avoid panics.
- [ ] The CHANGELOG.md has been updated with an overview of my changes.
- [ ] Requested a review from @samlown.
