### PR TITLE
Normalize verifactu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Changed
+
+- `es-verifactu-v1`: `[]*org.Note` validation will check the note's length if `key=general`.
+
 ## [v0.218.0] - 2025-06-12
 
 ### Changed

--- a/addons/es/verifactu/bill.go
+++ b/addons/es/verifactu/bill.go
@@ -79,7 +79,10 @@ func validateInvoice(inv *bill.Invoice) error {
 			validation.Skip,
 		),
 		validation.Field(&inv.Notes,
-			org.ValidateNotesHasKey(org.NoteKeyGeneral),
+			validation.Each(
+				validation.By(validateNote),
+				validation.Skip,
+			),
 			validation.Skip,
 		),
 	)
@@ -173,4 +176,17 @@ func validateInvoicePreceding(inv *bill.Invoice) validation.RuleFunc {
 			),
 		)
 	}
+}
+
+func validateNote(val any) error {
+	note, ok := val.(*org.Note)
+	if !ok || note == nil || note.Key != org.NoteKeyGeneral {
+		return nil
+	}
+	return validation.ValidateStruct(note,
+		validation.Field(&note.Text,
+			validation.Length(0, 500),
+			validation.Skip,
+		),
+	)
 }


### PR DESCRIPTION
- Changed `[]*org.Note` validation in Veri*Factu addon so that the length must be < 500.
## Pre-Review Checklist

- [ ] I've read the CONTRIBUTING.md guide.
- [ ] I have performed a self-review of my code.
- [ ] I have added thorough tests with at **least** 90% code coverage.
- [ ] I've modified or created example GOBL documents to show my changes in use, if appropriate.
- [ ] When adding or modifying a tax regime or addon, I've added links to the source of the changes, either structured or in the comments.
- [ ] I've run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [ ] All linter warnings have been reviewed and fixed.
- [ ] I've been obsessive with pointer nil checks to avoid panics.
- [ ] The CHANGELOG.md has been updated with an overview of my changes.
- [ ] Requested a review from @samlown.
