### PR TITLE
Preparing set of default invoice tags independent from Regime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Changed
+
+- `bill`: All invoices will now have a default set of `$tags` that can be used.
+
 ## [v0.219.0] - 2025-07-08
 
 ### Changed

--- a/bill/invoice.go
+++ b/bill/invoice.go
@@ -325,7 +325,7 @@ func (inv *Invoice) Normalize(normalizers tax.Normalizers) {
 }
 
 func (inv *Invoice) supportedTags() []cbc.Key {
-	var ts *tax.TagSet
+	ts := defaultInvoiceTags
 	if r := inv.RegimeDef(); r != nil {
 		ts = ts.Merge(tax.TagSetForSchema(r.Tags, ShortSchemaInvoice))
 	}
@@ -454,6 +454,7 @@ func (inv Invoice) JSONSchemaExtend(js *jsonschema.Schema) {
 	}
 	inv.Regime.JSONSchemaExtend(js)
 	inv.Addons.JSONSchemaExtend(js)
+	inv.Tags.JSONSchemaExtendWithDefs(js, defaultInvoiceTags.List)
 	// Recommendations
 	js.Extras = map[string]any{
 		schema.Recommended: []string{

--- a/bill/invoice_tags.go
+++ b/bill/invoice_tags.go
@@ -3,10 +3,11 @@ package bill
 import (
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/i18n"
+	"github.com/invopop/gobl/pkg/here"
 	"github.com/invopop/gobl/tax"
 )
 
-var invoiceTags = &tax.TagSet{
+var defaultInvoiceTags = &tax.TagSet{
 	Schema: ShortSchemaInvoice,
 	List: []*cbc.Definition{
 		// Simplified invoices are issued when the complete fiscal details of
@@ -15,15 +16,12 @@ var invoiceTags = &tax.TagSet{
 			Key: tax.TagSimplified,
 			Name: i18n.String{
 				i18n.EN: "Simplified Invoice",
-				i18n.ES: "Factura Simplificada",
-				i18n.IT: "Fattura Semplificata",
-				i18n.DE: "Vereinfachte Rechnung",
 			},
 			Desc: i18n.String{
-				i18n.EN: "Used for B2C transactions when the client details are not available, check with local authorities for limits.",
-				i18n.ES: "Usado para transacciones B2C cuando los detalles del cliente no están disponibles, consulte con las autoridades locales para los límites.",
-				i18n.IT: "Utilizzato per le transazioni B2C quando i dettagli del cliente non sono disponibili, controllare con le autorità locali per i limiti.",
-				i18n.DE: "Wird für B2C-Transaktionen verwendet, wenn die Kundendaten nicht verfügbar sind. Bitte wenden Sie sich an die örtlichen Behörden, um die Grenzwerte zu ermitteln.",
+				i18n.EN: here.Doc(`
+					Used for B2C transactions when the client details are not available, check with
+					local authorities for limits.
+				`),
 			},
 		},
 
@@ -34,9 +32,13 @@ var invoiceTags = &tax.TagSet{
 			Key: tax.TagReverseCharge,
 			Name: i18n.String{
 				i18n.EN: "Reverse Charge",
-				i18n.ES: "Inversión del Sujeto Pasivo",
-				i18n.IT: "Inversione del soggetto passivo",
-				i18n.DE: "Umkehr der Steuerschuld",
+			},
+			Desc: i18n.String{
+				i18n.EN: here.Doc(`
+					Applied when the *customer* is responsible for paying taxes to the tax authorities. Often used
+					when the supplier is not registered for tax in the customer's country, or for special cases
+					inside the same country when the seller is unlikely to be able to collect the tax.
+				`),
 			},
 		},
 
@@ -47,9 +49,11 @@ var invoiceTags = &tax.TagSet{
 			Key: tax.TagSelfBilled,
 			Name: i18n.String{
 				i18n.EN: "Self-billed",
-				i18n.ES: "Facturación por el destinatario",
-				i18n.IT: "Autofattura",
-				i18n.DE: "Rechnung durch den Leistungsempfänger",
+			},
+			Desc: i18n.String{
+				i18n.EN: here.Doc(`
+					Used when the customer or third party issues the invoice on behalf of the supplier.
+				`),
 			},
 		},
 
@@ -58,9 +62,12 @@ var invoiceTags = &tax.TagSet{
 			Key: tax.TagCustomerRates,
 			Name: i18n.String{
 				i18n.EN: "Customer rates",
-				i18n.ES: "Tarifas aplicables al destinatario",
-				i18n.IT: "Aliquote applicabili al destinatario",
-				i18n.DE: "Kundensätze",
+			},
+			Desc: i18n.String{
+				i18n.EN: here.Doc(`
+					When set, implies that taxes rates should be determined from the customer's location
+					as opposed to the supplier's. This is typically used for digital goods and services.
+				`),
 			},
 		},
 
@@ -71,15 +78,19 @@ var invoiceTags = &tax.TagSet{
 			Key: tax.TagPartial,
 			Name: i18n.String{
 				i18n.EN: "Partial",
-				i18n.ES: "Parcial",
-				i18n.IT: "Parziale",
-				i18n.DE: "Teilweise",
+			},
+			Desc: i18n.String{
+				i18n.EN: here.Doc(`
+					Indicates that this invoice is a partial document, meaning it is not the final invoice
+					for the transaction. This is often used in construction or large projects where multiple
+					invoices are issued for different stages of the work.
+				`),
 			},
 		},
 	},
 }
 
-// InvoiceTags returns a base tag set for invoices.
-func InvoiceTags() *tax.TagSet {
-	return invoiceTags
+// DefaultInvoiceTags is a convenience function to get the default invoice tags.
+func DefaultInvoiceTags() *tax.TagSet {
+	return defaultInvoiceTags
 }

--- a/data/regimes/ae.json
+++ b/data/regimes/ae.json
@@ -8,64 +8,6 @@
   "country": "AE",
   "currency": "AED",
   "tax_scheme": "VAT",
-  "tags": [
-    {
-      "schema": "bill/invoice",
-      "list": [
-        {
-          "key": "simplified",
-          "name": {
-            "de": "Vereinfachte Rechnung",
-            "en": "Simplified Invoice",
-            "es": "Factura Simplificada",
-            "it": "Fattura Semplificata"
-          },
-          "desc": {
-            "de": "Wird für B2C-Transaktionen verwendet, wenn die Kundendaten nicht verfügbar sind. Bitte wenden Sie sich an die örtlichen Behörden, um die Grenzwerte zu ermitteln.",
-            "en": "Used for B2C transactions when the client details are not available, check with local authorities for limits.",
-            "es": "Usado para transacciones B2C cuando los detalles del cliente no están disponibles, consulte con las autoridades locales para los límites.",
-            "it": "Utilizzato per le transazioni B2C quando i dettagli del cliente non sono disponibili, controllare con le autorità locali per i limiti."
-          }
-        },
-        {
-          "key": "reverse-charge",
-          "name": {
-            "de": "Umkehr der Steuerschuld",
-            "en": "Reverse Charge",
-            "es": "Inversión del Sujeto Pasivo",
-            "it": "Inversione del soggetto passivo"
-          }
-        },
-        {
-          "key": "self-billed",
-          "name": {
-            "de": "Rechnung durch den Leistungsempfänger",
-            "en": "Self-billed",
-            "es": "Facturación por el destinatario",
-            "it": "Autofattura"
-          }
-        },
-        {
-          "key": "customer-rates",
-          "name": {
-            "de": "Kundensätze",
-            "en": "Customer rates",
-            "es": "Tarifas aplicables al destinatario",
-            "it": "Aliquote applicabili al destinatario"
-          }
-        },
-        {
-          "key": "partial",
-          "name": {
-            "de": "Teilweise",
-            "en": "Partial",
-            "es": "Parcial",
-            "it": "Parziale"
-          }
-        }
-      ]
-    }
-  ],
   "scenarios": [
     {
       "schema": "bill/invoice",

--- a/data/regimes/at.json
+++ b/data/regimes/at.json
@@ -7,64 +7,6 @@
   "country": "AT",
   "currency": "EUR",
   "tax_scheme": "VAT",
-  "tags": [
-    {
-      "schema": "bill/invoice",
-      "list": [
-        {
-          "key": "simplified",
-          "name": {
-            "de": "Vereinfachte Rechnung",
-            "en": "Simplified Invoice",
-            "es": "Factura Simplificada",
-            "it": "Fattura Semplificata"
-          },
-          "desc": {
-            "de": "Wird für B2C-Transaktionen verwendet, wenn die Kundendaten nicht verfügbar sind. Bitte wenden Sie sich an die örtlichen Behörden, um die Grenzwerte zu ermitteln.",
-            "en": "Used for B2C transactions when the client details are not available, check with local authorities for limits.",
-            "es": "Usado para transacciones B2C cuando los detalles del cliente no están disponibles, consulte con las autoridades locales para los límites.",
-            "it": "Utilizzato per le transazioni B2C quando i dettagli del cliente non sono disponibili, controllare con le autorità locali per i limiti."
-          }
-        },
-        {
-          "key": "reverse-charge",
-          "name": {
-            "de": "Umkehr der Steuerschuld",
-            "en": "Reverse Charge",
-            "es": "Inversión del Sujeto Pasivo",
-            "it": "Inversione del soggetto passivo"
-          }
-        },
-        {
-          "key": "self-billed",
-          "name": {
-            "de": "Rechnung durch den Leistungsempfänger",
-            "en": "Self-billed",
-            "es": "Facturación por el destinatario",
-            "it": "Autofattura"
-          }
-        },
-        {
-          "key": "customer-rates",
-          "name": {
-            "de": "Kundensätze",
-            "en": "Customer rates",
-            "es": "Tarifas aplicables al destinatario",
-            "it": "Aliquote applicabili al destinatario"
-          }
-        },
-        {
-          "key": "partial",
-          "name": {
-            "de": "Teilweise",
-            "en": "Partial",
-            "es": "Parcial",
-            "it": "Parziale"
-          }
-        }
-      ]
-    }
-  ],
   "scenarios": [
     {
       "schema": "bill/invoice",

--- a/data/regimes/be.json
+++ b/data/regimes/be.json
@@ -7,64 +7,6 @@
   "country": "BE",
   "currency": "EUR",
   "tax_scheme": "VAT",
-  "tags": [
-    {
-      "schema": "bill/invoice",
-      "list": [
-        {
-          "key": "simplified",
-          "name": {
-            "de": "Vereinfachte Rechnung",
-            "en": "Simplified Invoice",
-            "es": "Factura Simplificada",
-            "it": "Fattura Semplificata"
-          },
-          "desc": {
-            "de": "Wird für B2C-Transaktionen verwendet, wenn die Kundendaten nicht verfügbar sind. Bitte wenden Sie sich an die örtlichen Behörden, um die Grenzwerte zu ermitteln.",
-            "en": "Used for B2C transactions when the client details are not available, check with local authorities for limits.",
-            "es": "Usado para transacciones B2C cuando los detalles del cliente no están disponibles, consulte con las autoridades locales para los límites.",
-            "it": "Utilizzato per le transazioni B2C quando i dettagli del cliente non sono disponibili, controllare con le autorità locali per i limiti."
-          }
-        },
-        {
-          "key": "reverse-charge",
-          "name": {
-            "de": "Umkehr der Steuerschuld",
-            "en": "Reverse Charge",
-            "es": "Inversión del Sujeto Pasivo",
-            "it": "Inversione del soggetto passivo"
-          }
-        },
-        {
-          "key": "self-billed",
-          "name": {
-            "de": "Rechnung durch den Leistungsempfänger",
-            "en": "Self-billed",
-            "es": "Facturación por el destinatario",
-            "it": "Autofattura"
-          }
-        },
-        {
-          "key": "customer-rates",
-          "name": {
-            "de": "Kundensätze",
-            "en": "Customer rates",
-            "es": "Tarifas aplicables al destinatario",
-            "it": "Aliquote applicabili al destinatario"
-          }
-        },
-        {
-          "key": "partial",
-          "name": {
-            "de": "Teilweise",
-            "en": "Partial",
-            "es": "Parcial",
-            "it": "Parziale"
-          }
-        }
-      ]
-    }
-  ],
   "scenarios": [
     {
       "schema": "bill/invoice",

--- a/data/regimes/br.json
+++ b/data/regimes/br.json
@@ -7,64 +7,6 @@
   "time_zone": "America/Sao_Paulo",
   "country": "BR",
   "currency": "BRL",
-  "tags": [
-    {
-      "schema": "bill/invoice",
-      "list": [
-        {
-          "key": "simplified",
-          "name": {
-            "de": "Vereinfachte Rechnung",
-            "en": "Simplified Invoice",
-            "es": "Factura Simplificada",
-            "it": "Fattura Semplificata"
-          },
-          "desc": {
-            "de": "Wird für B2C-Transaktionen verwendet, wenn die Kundendaten nicht verfügbar sind. Bitte wenden Sie sich an die örtlichen Behörden, um die Grenzwerte zu ermitteln.",
-            "en": "Used for B2C transactions when the client details are not available, check with local authorities for limits.",
-            "es": "Usado para transacciones B2C cuando los detalles del cliente no están disponibles, consulte con las autoridades locales para los límites.",
-            "it": "Utilizzato per le transazioni B2C quando i dettagli del cliente non sono disponibili, controllare con le autorità locali per i limiti."
-          }
-        },
-        {
-          "key": "reverse-charge",
-          "name": {
-            "de": "Umkehr der Steuerschuld",
-            "en": "Reverse Charge",
-            "es": "Inversión del Sujeto Pasivo",
-            "it": "Inversione del soggetto passivo"
-          }
-        },
-        {
-          "key": "self-billed",
-          "name": {
-            "de": "Rechnung durch den Leistungsempfänger",
-            "en": "Self-billed",
-            "es": "Facturación por el destinatario",
-            "it": "Autofattura"
-          }
-        },
-        {
-          "key": "customer-rates",
-          "name": {
-            "de": "Kundensätze",
-            "en": "Customer rates",
-            "es": "Tarifas aplicables al destinatario",
-            "it": "Aliquote applicabili al destinatario"
-          }
-        },
-        {
-          "key": "partial",
-          "name": {
-            "de": "Teilweise",
-            "en": "Partial",
-            "es": "Parcial",
-            "it": "Parziale"
-          }
-        }
-      ]
-    }
-  ],
   "corrections": [
     {
       "schema": "bill/invoice",

--- a/data/regimes/ch.json
+++ b/data/regimes/ch.json
@@ -7,64 +7,6 @@
   "country": "CH",
   "currency": "CHF",
   "tax_scheme": "VAT",
-  "tags": [
-    {
-      "schema": "bill/invoice",
-      "list": [
-        {
-          "key": "simplified",
-          "name": {
-            "de": "Vereinfachte Rechnung",
-            "en": "Simplified Invoice",
-            "es": "Factura Simplificada",
-            "it": "Fattura Semplificata"
-          },
-          "desc": {
-            "de": "Wird für B2C-Transaktionen verwendet, wenn die Kundendaten nicht verfügbar sind. Bitte wenden Sie sich an die örtlichen Behörden, um die Grenzwerte zu ermitteln.",
-            "en": "Used for B2C transactions when the client details are not available, check with local authorities for limits.",
-            "es": "Usado para transacciones B2C cuando los detalles del cliente no están disponibles, consulte con las autoridades locales para los límites.",
-            "it": "Utilizzato per le transazioni B2C quando i dettagli del cliente non sono disponibili, controllare con le autorità locali per i limiti."
-          }
-        },
-        {
-          "key": "reverse-charge",
-          "name": {
-            "de": "Umkehr der Steuerschuld",
-            "en": "Reverse Charge",
-            "es": "Inversión del Sujeto Pasivo",
-            "it": "Inversione del soggetto passivo"
-          }
-        },
-        {
-          "key": "self-billed",
-          "name": {
-            "de": "Rechnung durch den Leistungsempfänger",
-            "en": "Self-billed",
-            "es": "Facturación por el destinatario",
-            "it": "Autofattura"
-          }
-        },
-        {
-          "key": "customer-rates",
-          "name": {
-            "de": "Kundensätze",
-            "en": "Customer rates",
-            "es": "Tarifas aplicables al destinatario",
-            "it": "Aliquote applicabili al destinatario"
-          }
-        },
-        {
-          "key": "partial",
-          "name": {
-            "de": "Teilweise",
-            "en": "Partial",
-            "es": "Parcial",
-            "it": "Parziale"
-          }
-        }
-      ]
-    }
-  ],
   "scenarios": [
     {
       "schema": "bill/invoice",

--- a/data/regimes/co.json
+++ b/data/regimes/co.json
@@ -7,64 +7,6 @@
   "time_zone": "America/Bogota",
   "country": "CO",
   "currency": "COP",
-  "tags": [
-    {
-      "schema": "bill/invoice",
-      "list": [
-        {
-          "key": "simplified",
-          "name": {
-            "de": "Vereinfachte Rechnung",
-            "en": "Simplified Invoice",
-            "es": "Factura Simplificada",
-            "it": "Fattura Semplificata"
-          },
-          "desc": {
-            "de": "Wird für B2C-Transaktionen verwendet, wenn die Kundendaten nicht verfügbar sind. Bitte wenden Sie sich an die örtlichen Behörden, um die Grenzwerte zu ermitteln.",
-            "en": "Used for B2C transactions when the client details are not available, check with local authorities for limits.",
-            "es": "Usado para transacciones B2C cuando los detalles del cliente no están disponibles, consulte con las autoridades locales para los límites.",
-            "it": "Utilizzato per le transazioni B2C quando i dettagli del cliente non sono disponibili, controllare con le autorità locali per i limiti."
-          }
-        },
-        {
-          "key": "reverse-charge",
-          "name": {
-            "de": "Umkehr der Steuerschuld",
-            "en": "Reverse Charge",
-            "es": "Inversión del Sujeto Pasivo",
-            "it": "Inversione del soggetto passivo"
-          }
-        },
-        {
-          "key": "self-billed",
-          "name": {
-            "de": "Rechnung durch den Leistungsempfänger",
-            "en": "Self-billed",
-            "es": "Facturación por el destinatario",
-            "it": "Autofattura"
-          }
-        },
-        {
-          "key": "customer-rates",
-          "name": {
-            "de": "Kundensätze",
-            "en": "Customer rates",
-            "es": "Tarifas aplicables al destinatario",
-            "it": "Aliquote applicabili al destinatario"
-          }
-        },
-        {
-          "key": "partial",
-          "name": {
-            "de": "Teilweise",
-            "en": "Partial",
-            "es": "Parcial",
-            "it": "Parziale"
-          }
-        }
-      ]
-    }
-  ],
   "corrections": [
     {
       "schema": "bill/invoice",

--- a/data/regimes/de.json
+++ b/data/regimes/de.json
@@ -8,64 +8,6 @@
   "country": "DE",
   "currency": "EUR",
   "tax_scheme": "VAT",
-  "tags": [
-    {
-      "schema": "bill/invoice",
-      "list": [
-        {
-          "key": "simplified",
-          "name": {
-            "de": "Vereinfachte Rechnung",
-            "en": "Simplified Invoice",
-            "es": "Factura Simplificada",
-            "it": "Fattura Semplificata"
-          },
-          "desc": {
-            "de": "Wird für B2C-Transaktionen verwendet, wenn die Kundendaten nicht verfügbar sind. Bitte wenden Sie sich an die örtlichen Behörden, um die Grenzwerte zu ermitteln.",
-            "en": "Used for B2C transactions when the client details are not available, check with local authorities for limits.",
-            "es": "Usado para transacciones B2C cuando los detalles del cliente no están disponibles, consulte con las autoridades locales para los límites.",
-            "it": "Utilizzato per le transazioni B2C quando i dettagli del cliente non sono disponibili, controllare con le autorità locali per i limiti."
-          }
-        },
-        {
-          "key": "reverse-charge",
-          "name": {
-            "de": "Umkehr der Steuerschuld",
-            "en": "Reverse Charge",
-            "es": "Inversión del Sujeto Pasivo",
-            "it": "Inversione del soggetto passivo"
-          }
-        },
-        {
-          "key": "self-billed",
-          "name": {
-            "de": "Rechnung durch den Leistungsempfänger",
-            "en": "Self-billed",
-            "es": "Facturación por el destinatario",
-            "it": "Autofattura"
-          }
-        },
-        {
-          "key": "customer-rates",
-          "name": {
-            "de": "Kundensätze",
-            "en": "Customer rates",
-            "es": "Tarifas aplicables al destinatario",
-            "it": "Aliquote applicabili al destinatario"
-          }
-        },
-        {
-          "key": "partial",
-          "name": {
-            "de": "Teilweise",
-            "en": "Partial",
-            "es": "Parcial",
-            "it": "Parziale"
-          }
-        }
-      ]
-    }
-  ],
   "identities": [
     {
       "key": "de-tax-number",

--- a/data/regimes/el.json
+++ b/data/regimes/el.json
@@ -12,64 +12,6 @@
   "currency": "EUR",
   "tax_scheme": "VAT",
   "calculator_rounding_rule": "currency",
-  "tags": [
-    {
-      "schema": "bill/invoice",
-      "list": [
-        {
-          "key": "simplified",
-          "name": {
-            "de": "Vereinfachte Rechnung",
-            "en": "Simplified Invoice",
-            "es": "Factura Simplificada",
-            "it": "Fattura Semplificata"
-          },
-          "desc": {
-            "de": "Wird für B2C-Transaktionen verwendet, wenn die Kundendaten nicht verfügbar sind. Bitte wenden Sie sich an die örtlichen Behörden, um die Grenzwerte zu ermitteln.",
-            "en": "Used for B2C transactions when the client details are not available, check with local authorities for limits.",
-            "es": "Usado para transacciones B2C cuando los detalles del cliente no están disponibles, consulte con las autoridades locales para los límites.",
-            "it": "Utilizzato per le transazioni B2C quando i dettagli del cliente non sono disponibili, controllare con le autorità locali per i limiti."
-          }
-        },
-        {
-          "key": "reverse-charge",
-          "name": {
-            "de": "Umkehr der Steuerschuld",
-            "en": "Reverse Charge",
-            "es": "Inversión del Sujeto Pasivo",
-            "it": "Inversione del soggetto passivo"
-          }
-        },
-        {
-          "key": "self-billed",
-          "name": {
-            "de": "Rechnung durch den Leistungsempfänger",
-            "en": "Self-billed",
-            "es": "Facturación por el destinatario",
-            "it": "Autofattura"
-          }
-        },
-        {
-          "key": "customer-rates",
-          "name": {
-            "de": "Kundensätze",
-            "en": "Customer rates",
-            "es": "Tarifas aplicables al destinatario",
-            "it": "Aliquote applicabili al destinatario"
-          }
-        },
-        {
-          "key": "partial",
-          "name": {
-            "de": "Teilweise",
-            "en": "Partial",
-            "es": "Parcial",
-            "it": "Parziale"
-          }
-        }
-      ]
-    }
-  ],
   "scenarios": [
     {
       "schema": "bill/invoice",

--- a/data/regimes/es.json
+++ b/data/regimes/es.json
@@ -13,57 +13,6 @@
       "schema": "bill/invoice",
       "list": [
         {
-          "key": "simplified",
-          "name": {
-            "de": "Vereinfachte Rechnung",
-            "en": "Simplified Invoice",
-            "es": "Factura Simplificada",
-            "it": "Fattura Semplificata"
-          },
-          "desc": {
-            "de": "Wird für B2C-Transaktionen verwendet, wenn die Kundendaten nicht verfügbar sind. Bitte wenden Sie sich an die örtlichen Behörden, um die Grenzwerte zu ermitteln.",
-            "en": "Used for B2C transactions when the client details are not available, check with local authorities for limits.",
-            "es": "Usado para transacciones B2C cuando los detalles del cliente no están disponibles, consulte con las autoridades locales para los límites.",
-            "it": "Utilizzato per le transazioni B2C quando i dettagli del cliente non sono disponibili, controllare con le autorità locali per i limiti."
-          }
-        },
-        {
-          "key": "reverse-charge",
-          "name": {
-            "de": "Umkehr der Steuerschuld",
-            "en": "Reverse Charge",
-            "es": "Inversión del Sujeto Pasivo",
-            "it": "Inversione del soggetto passivo"
-          }
-        },
-        {
-          "key": "self-billed",
-          "name": {
-            "de": "Rechnung durch den Leistungsempfänger",
-            "en": "Self-billed",
-            "es": "Facturación por el destinatario",
-            "it": "Autofattura"
-          }
-        },
-        {
-          "key": "customer-rates",
-          "name": {
-            "de": "Kundensätze",
-            "en": "Customer rates",
-            "es": "Tarifas aplicables al destinatario",
-            "it": "Aliquote applicabili al destinatario"
-          }
-        },
-        {
-          "key": "partial",
-          "name": {
-            "de": "Teilweise",
-            "en": "Partial",
-            "es": "Parcial",
-            "it": "Parziale"
-          }
-        },
-        {
           "key": "copy",
           "name": {
             "en": "Copy",

--- a/data/regimes/fr.json
+++ b/data/regimes/fr.json
@@ -11,64 +11,6 @@
   "country": "FR",
   "currency": "EUR",
   "tax_scheme": "VAT",
-  "tags": [
-    {
-      "schema": "bill/invoice",
-      "list": [
-        {
-          "key": "simplified",
-          "name": {
-            "de": "Vereinfachte Rechnung",
-            "en": "Simplified Invoice",
-            "es": "Factura Simplificada",
-            "it": "Fattura Semplificata"
-          },
-          "desc": {
-            "de": "Wird für B2C-Transaktionen verwendet, wenn die Kundendaten nicht verfügbar sind. Bitte wenden Sie sich an die örtlichen Behörden, um die Grenzwerte zu ermitteln.",
-            "en": "Used for B2C transactions when the client details are not available, check with local authorities for limits.",
-            "es": "Usado para transacciones B2C cuando los detalles del cliente no están disponibles, consulte con las autoridades locales para los límites.",
-            "it": "Utilizzato per le transazioni B2C quando i dettagli del cliente non sono disponibili, controllare con le autorità locali per i limiti."
-          }
-        },
-        {
-          "key": "reverse-charge",
-          "name": {
-            "de": "Umkehr der Steuerschuld",
-            "en": "Reverse Charge",
-            "es": "Inversión del Sujeto Pasivo",
-            "it": "Inversione del soggetto passivo"
-          }
-        },
-        {
-          "key": "self-billed",
-          "name": {
-            "de": "Rechnung durch den Leistungsempfänger",
-            "en": "Self-billed",
-            "es": "Facturación por el destinatario",
-            "it": "Autofattura"
-          }
-        },
-        {
-          "key": "customer-rates",
-          "name": {
-            "de": "Kundensätze",
-            "en": "Customer rates",
-            "es": "Tarifas aplicables al destinatario",
-            "it": "Aliquote applicabili al destinatario"
-          }
-        },
-        {
-          "key": "partial",
-          "name": {
-            "de": "Teilweise",
-            "en": "Partial",
-            "es": "Parcial",
-            "it": "Parziale"
-          }
-        }
-      ]
-    }
-  ],
   "scenarios": [
     {
       "schema": "bill/invoice",

--- a/data/regimes/gb.json
+++ b/data/regimes/gb.json
@@ -11,64 +11,6 @@
   ],
   "currency": "GBP",
   "tax_scheme": "VAT",
-  "tags": [
-    {
-      "schema": "bill/invoice",
-      "list": [
-        {
-          "key": "simplified",
-          "name": {
-            "de": "Vereinfachte Rechnung",
-            "en": "Simplified Invoice",
-            "es": "Factura Simplificada",
-            "it": "Fattura Semplificata"
-          },
-          "desc": {
-            "de": "Wird für B2C-Transaktionen verwendet, wenn die Kundendaten nicht verfügbar sind. Bitte wenden Sie sich an die örtlichen Behörden, um die Grenzwerte zu ermitteln.",
-            "en": "Used for B2C transactions when the client details are not available, check with local authorities for limits.",
-            "es": "Usado para transacciones B2C cuando los detalles del cliente no están disponibles, consulte con las autoridades locales para los límites.",
-            "it": "Utilizzato per le transazioni B2C quando i dettagli del cliente non sono disponibili, controllare con le autorità locali per i limiti."
-          }
-        },
-        {
-          "key": "reverse-charge",
-          "name": {
-            "de": "Umkehr der Steuerschuld",
-            "en": "Reverse Charge",
-            "es": "Inversión del Sujeto Pasivo",
-            "it": "Inversione del soggetto passivo"
-          }
-        },
-        {
-          "key": "self-billed",
-          "name": {
-            "de": "Rechnung durch den Leistungsempfänger",
-            "en": "Self-billed",
-            "es": "Facturación por el destinatario",
-            "it": "Autofattura"
-          }
-        },
-        {
-          "key": "customer-rates",
-          "name": {
-            "de": "Kundensätze",
-            "en": "Customer rates",
-            "es": "Tarifas aplicables al destinatario",
-            "it": "Aliquote applicabili al destinatario"
-          }
-        },
-        {
-          "key": "partial",
-          "name": {
-            "de": "Teilweise",
-            "en": "Partial",
-            "es": "Parcial",
-            "it": "Parziale"
-          }
-        }
-      ]
-    }
-  ],
   "scenarios": [
     {
       "schema": "bill/invoice",

--- a/data/regimes/it.json
+++ b/data/regimes/it.json
@@ -8,64 +8,6 @@
   "country": "IT",
   "currency": "EUR",
   "tax_scheme": "VAT",
-  "tags": [
-    {
-      "schema": "bill/invoice",
-      "list": [
-        {
-          "key": "simplified",
-          "name": {
-            "de": "Vereinfachte Rechnung",
-            "en": "Simplified Invoice",
-            "es": "Factura Simplificada",
-            "it": "Fattura Semplificata"
-          },
-          "desc": {
-            "de": "Wird für B2C-Transaktionen verwendet, wenn die Kundendaten nicht verfügbar sind. Bitte wenden Sie sich an die örtlichen Behörden, um die Grenzwerte zu ermitteln.",
-            "en": "Used for B2C transactions when the client details are not available, check with local authorities for limits.",
-            "es": "Usado para transacciones B2C cuando los detalles del cliente no están disponibles, consulte con las autoridades locales para los límites.",
-            "it": "Utilizzato per le transazioni B2C quando i dettagli del cliente non sono disponibili, controllare con le autorità locali per i limiti."
-          }
-        },
-        {
-          "key": "reverse-charge",
-          "name": {
-            "de": "Umkehr der Steuerschuld",
-            "en": "Reverse Charge",
-            "es": "Inversión del Sujeto Pasivo",
-            "it": "Inversione del soggetto passivo"
-          }
-        },
-        {
-          "key": "self-billed",
-          "name": {
-            "de": "Rechnung durch den Leistungsempfänger",
-            "en": "Self-billed",
-            "es": "Facturación por el destinatario",
-            "it": "Autofattura"
-          }
-        },
-        {
-          "key": "customer-rates",
-          "name": {
-            "de": "Kundensätze",
-            "en": "Customer rates",
-            "es": "Tarifas aplicables al destinatario",
-            "it": "Aliquote applicabili al destinatario"
-          }
-        },
-        {
-          "key": "partial",
-          "name": {
-            "de": "Teilweise",
-            "en": "Partial",
-            "es": "Parcial",
-            "it": "Parziale"
-          }
-        }
-      ]
-    }
-  ],
   "identities": [
     {
       "key": "it-fiscal-code",

--- a/data/regimes/mx.json
+++ b/data/regimes/mx.json
@@ -8,64 +8,6 @@
   "country": "MX",
   "currency": "MXN",
   "tax_scheme": "VAT",
-  "tags": [
-    {
-      "schema": "bill/invoice",
-      "list": [
-        {
-          "key": "simplified",
-          "name": {
-            "de": "Vereinfachte Rechnung",
-            "en": "Simplified Invoice",
-            "es": "Factura Simplificada",
-            "it": "Fattura Semplificata"
-          },
-          "desc": {
-            "de": "Wird für B2C-Transaktionen verwendet, wenn die Kundendaten nicht verfügbar sind. Bitte wenden Sie sich an die örtlichen Behörden, um die Grenzwerte zu ermitteln.",
-            "en": "Used for B2C transactions when the client details are not available, check with local authorities for limits.",
-            "es": "Usado para transacciones B2C cuando los detalles del cliente no están disponibles, consulte con las autoridades locales para los límites.",
-            "it": "Utilizzato per le transazioni B2C quando i dettagli del cliente non sono disponibili, controllare con le autorità locali per i limiti."
-          }
-        },
-        {
-          "key": "reverse-charge",
-          "name": {
-            "de": "Umkehr der Steuerschuld",
-            "en": "Reverse Charge",
-            "es": "Inversión del Sujeto Pasivo",
-            "it": "Inversione del soggetto passivo"
-          }
-        },
-        {
-          "key": "self-billed",
-          "name": {
-            "de": "Rechnung durch den Leistungsempfänger",
-            "en": "Self-billed",
-            "es": "Facturación por el destinatario",
-            "it": "Autofattura"
-          }
-        },
-        {
-          "key": "customer-rates",
-          "name": {
-            "de": "Kundensätze",
-            "en": "Customer rates",
-            "es": "Tarifas aplicables al destinatario",
-            "it": "Aliquote applicabili al destinatario"
-          }
-        },
-        {
-          "key": "partial",
-          "name": {
-            "de": "Teilweise",
-            "en": "Partial",
-            "es": "Parcial",
-            "it": "Parziale"
-          }
-        }
-      ]
-    }
-  ],
   "corrections": [
     {
       "schema": "bill/invoice",

--- a/data/regimes/nl.json
+++ b/data/regimes/nl.json
@@ -8,64 +8,6 @@
   "country": "NL",
   "currency": "EUR",
   "tax_scheme": "VAT",
-  "tags": [
-    {
-      "schema": "bill/invoice",
-      "list": [
-        {
-          "key": "simplified",
-          "name": {
-            "de": "Vereinfachte Rechnung",
-            "en": "Simplified Invoice",
-            "es": "Factura Simplificada",
-            "it": "Fattura Semplificata"
-          },
-          "desc": {
-            "de": "Wird für B2C-Transaktionen verwendet, wenn die Kundendaten nicht verfügbar sind. Bitte wenden Sie sich an die örtlichen Behörden, um die Grenzwerte zu ermitteln.",
-            "en": "Used for B2C transactions when the client details are not available, check with local authorities for limits.",
-            "es": "Usado para transacciones B2C cuando los detalles del cliente no están disponibles, consulte con las autoridades locales para los límites.",
-            "it": "Utilizzato per le transazioni B2C quando i dettagli del cliente non sono disponibili, controllare con le autorità locali per i limiti."
-          }
-        },
-        {
-          "key": "reverse-charge",
-          "name": {
-            "de": "Umkehr der Steuerschuld",
-            "en": "Reverse Charge",
-            "es": "Inversión del Sujeto Pasivo",
-            "it": "Inversione del soggetto passivo"
-          }
-        },
-        {
-          "key": "self-billed",
-          "name": {
-            "de": "Rechnung durch den Leistungsempfänger",
-            "en": "Self-billed",
-            "es": "Facturación por el destinatario",
-            "it": "Autofattura"
-          }
-        },
-        {
-          "key": "customer-rates",
-          "name": {
-            "de": "Kundensätze",
-            "en": "Customer rates",
-            "es": "Tarifas aplicables al destinatario",
-            "it": "Aliquote applicabili al destinatario"
-          }
-        },
-        {
-          "key": "partial",
-          "name": {
-            "de": "Teilweise",
-            "en": "Partial",
-            "es": "Parcial",
-            "it": "Parziale"
-          }
-        }
-      ]
-    }
-  ],
   "scenarios": [
     {
       "schema": "bill/invoice",

--- a/data/regimes/pl.json
+++ b/data/regimes/pl.json
@@ -13,57 +13,6 @@
       "schema": "bill/invoice",
       "list": [
         {
-          "key": "simplified",
-          "name": {
-            "de": "Vereinfachte Rechnung",
-            "en": "Simplified Invoice",
-            "es": "Factura Simplificada",
-            "it": "Fattura Semplificata"
-          },
-          "desc": {
-            "de": "Wird für B2C-Transaktionen verwendet, wenn die Kundendaten nicht verfügbar sind. Bitte wenden Sie sich an die örtlichen Behörden, um die Grenzwerte zu ermitteln.",
-            "en": "Used for B2C transactions when the client details are not available, check with local authorities for limits.",
-            "es": "Usado para transacciones B2C cuando los detalles del cliente no están disponibles, consulte con las autoridades locales para los límites.",
-            "it": "Utilizzato per le transazioni B2C quando i dettagli del cliente non sono disponibili, controllare con le autorità locali per i limiti."
-          }
-        },
-        {
-          "key": "reverse-charge",
-          "name": {
-            "de": "Umkehr der Steuerschuld",
-            "en": "Reverse Charge",
-            "es": "Inversión del Sujeto Pasivo",
-            "it": "Inversione del soggetto passivo"
-          }
-        },
-        {
-          "key": "self-billed",
-          "name": {
-            "de": "Rechnung durch den Leistungsempfänger",
-            "en": "Self-billed",
-            "es": "Facturación por el destinatario",
-            "it": "Autofattura"
-          }
-        },
-        {
-          "key": "customer-rates",
-          "name": {
-            "de": "Kundensätze",
-            "en": "Customer rates",
-            "es": "Tarifas aplicables al destinatario",
-            "it": "Aliquote applicabili al destinatario"
-          }
-        },
-        {
-          "key": "partial",
-          "name": {
-            "de": "Teilweise",
-            "en": "Partial",
-            "es": "Parcial",
-            "it": "Parziale"
-          }
-        },
-        {
           "key": "settlement",
           "name": {
             "en": "Settlement Invoice",

--- a/data/regimes/pt.json
+++ b/data/regimes/pt.json
@@ -13,57 +13,6 @@
       "schema": "bill/invoice",
       "list": [
         {
-          "key": "simplified",
-          "name": {
-            "de": "Vereinfachte Rechnung",
-            "en": "Simplified Invoice",
-            "es": "Factura Simplificada",
-            "it": "Fattura Semplificata"
-          },
-          "desc": {
-            "de": "Wird für B2C-Transaktionen verwendet, wenn die Kundendaten nicht verfügbar sind. Bitte wenden Sie sich an die örtlichen Behörden, um die Grenzwerte zu ermitteln.",
-            "en": "Used for B2C transactions when the client details are not available, check with local authorities for limits.",
-            "es": "Usado para transacciones B2C cuando los detalles del cliente no están disponibles, consulte con las autoridades locales para los límites.",
-            "it": "Utilizzato per le transazioni B2C quando i dettagli del cliente non sono disponibili, controllare con le autorità locali per i limiti."
-          }
-        },
-        {
-          "key": "reverse-charge",
-          "name": {
-            "de": "Umkehr der Steuerschuld",
-            "en": "Reverse Charge",
-            "es": "Inversión del Sujeto Pasivo",
-            "it": "Inversione del soggetto passivo"
-          }
-        },
-        {
-          "key": "self-billed",
-          "name": {
-            "de": "Rechnung durch den Leistungsempfänger",
-            "en": "Self-billed",
-            "es": "Facturación por el destinatario",
-            "it": "Autofattura"
-          }
-        },
-        {
-          "key": "customer-rates",
-          "name": {
-            "de": "Kundensätze",
-            "en": "Customer rates",
-            "es": "Tarifas aplicables al destinatario",
-            "it": "Aliquote applicabili al destinatario"
-          }
-        },
-        {
-          "key": "partial",
-          "name": {
-            "de": "Teilweise",
-            "en": "Partial",
-            "es": "Parcial",
-            "it": "Parziale"
-          }
-        },
-        {
           "key": "invoice-receipt",
           "name": {
             "en": "Invoice-receipt",

--- a/data/regimes/us.json
+++ b/data/regimes/us.json
@@ -6,64 +6,6 @@
   "time_zone": "America/Chicago",
   "country": "US",
   "currency": "USD",
-  "tags": [
-    {
-      "schema": "bill/invoice",
-      "list": [
-        {
-          "key": "simplified",
-          "name": {
-            "de": "Vereinfachte Rechnung",
-            "en": "Simplified Invoice",
-            "es": "Factura Simplificada",
-            "it": "Fattura Semplificata"
-          },
-          "desc": {
-            "de": "Wird für B2C-Transaktionen verwendet, wenn die Kundendaten nicht verfügbar sind. Bitte wenden Sie sich an die örtlichen Behörden, um die Grenzwerte zu ermitteln.",
-            "en": "Used for B2C transactions when the client details are not available, check with local authorities for limits.",
-            "es": "Usado para transacciones B2C cuando los detalles del cliente no están disponibles, consulte con las autoridades locales para los límites.",
-            "it": "Utilizzato per le transazioni B2C quando i dettagli del cliente non sono disponibili, controllare con le autorità locali per i limiti."
-          }
-        },
-        {
-          "key": "reverse-charge",
-          "name": {
-            "de": "Umkehr der Steuerschuld",
-            "en": "Reverse Charge",
-            "es": "Inversión del Sujeto Pasivo",
-            "it": "Inversione del soggetto passivo"
-          }
-        },
-        {
-          "key": "self-billed",
-          "name": {
-            "de": "Rechnung durch den Leistungsempfänger",
-            "en": "Self-billed",
-            "es": "Facturación por el destinatario",
-            "it": "Autofattura"
-          }
-        },
-        {
-          "key": "customer-rates",
-          "name": {
-            "de": "Kundensätze",
-            "en": "Customer rates",
-            "es": "Tarifas aplicables al destinatario",
-            "it": "Aliquote applicabili al destinatario"
-          }
-        },
-        {
-          "key": "partial",
-          "name": {
-            "de": "Teilweise",
-            "en": "Partial",
-            "es": "Parcial",
-            "it": "Parziale"
-          }
-        }
-      ]
-    }
-  ],
   "corrections": [
     {
       "schema": "bill/invoice",

--- a/data/schemas/bill/delivery.json
+++ b/data/schemas/bill/delivery.json
@@ -163,7 +163,7 @@
           },
           "type": "array",
           "title": "Tags",
-          "description": "Tags are used to help identify specific tax scenarios or requirements that will\napply changes to the contents of the invoice. Tags by design should always be optional,\nit should always be possible to build a valid invoice without any tags."
+          "description": "Tags are used to help identify specific tax scenarios or requirements that may\napply changes to the contents of the document or imply a specific meaning.\nConvertors may use tags to help identify specific situations that do not have\na specific extension, for example; self-billed or partial invoices may be\nidentified by their respective tags."
         },
         "uuid": {
           "type": "string",

--- a/data/schemas/bill/invoice.json
+++ b/data/schemas/bill/invoice.json
@@ -159,11 +159,37 @@
         },
         "$tags": {
           "items": {
-            "$ref": "https://gobl.org/draft-0/cbc/key"
+            "$ref": "https://gobl.org/draft-0/cbc/key",
+            "oneOf": [
+              {
+                "const": "simplified",
+                "title": "Simplified Invoice"
+              },
+              {
+                "const": "reverse-charge",
+                "title": "Reverse Charge"
+              },
+              {
+                "const": "self-billed",
+                "title": "Self-billed"
+              },
+              {
+                "const": "customer-rates",
+                "title": "Customer rates"
+              },
+              {
+                "const": "partial",
+                "title": "Partial"
+              },
+              {
+                "pattern": "^(?:[a-z]|[a-z0-9][a-z0-9-+]*[a-z0-9])$",
+                "title": "Any"
+              }
+            ]
           },
           "type": "array",
           "title": "Tags",
-          "description": "Tags are used to help identify specific tax scenarios or requirements that will\napply changes to the contents of the invoice. Tags by design should always be optional,\nit should always be possible to build a valid invoice without any tags."
+          "description": "Tags are used to help identify specific tax scenarios or requirements that may\napply changes to the contents of the document or imply a specific meaning.\nConvertors may use tags to help identify specific situations that do not have\na specific extension, for example; self-billed or partial invoices may be\nidentified by their respective tags."
         },
         "uuid": {
           "type": "string",

--- a/data/schemas/bill/order.json
+++ b/data/schemas/bill/order.json
@@ -163,7 +163,7 @@
           },
           "type": "array",
           "title": "Tags",
-          "description": "Tags are used to help identify specific tax scenarios or requirements that will\napply changes to the contents of the invoice. Tags by design should always be optional,\nit should always be possible to build a valid invoice without any tags."
+          "description": "Tags are used to help identify specific tax scenarios or requirements that may\napply changes to the contents of the document or imply a specific meaning.\nConvertors may use tags to help identify specific situations that do not have\na specific extension, for example; self-billed or partial invoices may be\nidentified by their respective tags."
         },
         "uuid": {
           "type": "string",

--- a/data/schemas/bill/payment.json
+++ b/data/schemas/bill/payment.json
@@ -163,7 +163,7 @@
           },
           "type": "array",
           "title": "Tags",
-          "description": "Tags are used to help identify specific tax scenarios or requirements that will\napply changes to the contents of the invoice. Tags by design should always be optional,\nit should always be possible to build a valid invoice without any tags."
+          "description": "Tags are used to help identify specific tax scenarios or requirements that may\napply changes to the contents of the document or imply a specific meaning.\nConvertors may use tags to help identify specific situations that do not have\na specific extension, for example; self-billed or partial invoices may be\nidentified by their respective tags."
         },
         "uuid": {
           "type": "string",

--- a/regimes/ae/ae.go
+++ b/regimes/ae/ae.go
@@ -24,9 +24,6 @@ func New() *tax.RegimeDef {
 			i18n.AR: "الإمارات العربية المتحدة",
 		},
 		TimeZone: "Asia/Dubai",
-		Tags: []*tax.TagSet{
-			bill.InvoiceTags(),
-		},
 		Scenarios: []*tax.ScenarioSet{
 			invoiceScenarios,
 		},

--- a/regimes/at/at.go
+++ b/regimes/at/at.go
@@ -28,9 +28,6 @@ func New() *tax.RegimeDef {
 		Scenarios: []*tax.ScenarioSet{
 			bill.InvoiceScenarios(),
 		},
-		Tags: []*tax.TagSet{
-			bill.InvoiceTags(),
-		},
 		Categories: taxCategories,
 		Corrections: []*tax.CorrectionDefinition{
 			{

--- a/regimes/be/be.go
+++ b/regimes/be/be.go
@@ -28,9 +28,6 @@ func New() *tax.RegimeDef {
 		Scenarios: []*tax.ScenarioSet{
 			bill.InvoiceScenarios(),
 		},
-		Tags: []*tax.TagSet{
-			bill.InvoiceTags(),
-		},
 		Categories: taxCategories,
 		Corrections: []*tax.CorrectionDefinition{
 			{

--- a/regimes/br/br.go
+++ b/regimes/br/br.go
@@ -23,11 +23,8 @@ func New() *tax.RegimeDef {
 			i18n.EN: "Brazil",
 			i18n.PT: "Brasil",
 		},
-		TimeZone:  "America/Sao_Paulo",
-		Validator: Validate,
-		Tags: []*tax.TagSet{
-			bill.InvoiceTags(),
-		},
+		TimeZone:   "America/Sao_Paulo",
+		Validator:  Validate,
 		Categories: taxCategories,
 		Corrections: []*tax.CorrectionDefinition{
 			{

--- a/regimes/ch/ch.go
+++ b/regimes/ch/ch.go
@@ -28,9 +28,6 @@ func New() *tax.RegimeDef {
 		Scenarios: []*tax.ScenarioSet{
 			bill.InvoiceScenarios(),
 		},
-		Tags: []*tax.TagSet{
-			bill.InvoiceTags(),
-		},
 		Categories: taxCategories,
 		Corrections: []*tax.CorrectionDefinition{
 			{

--- a/regimes/co/co.go
+++ b/regimes/co/co.go
@@ -22,10 +22,7 @@ func New() *tax.RegimeDef {
 			i18n.EN: "Colombia",
 			i18n.ES: "Colombia",
 		},
-		TimeZone: "America/Bogota",
-		Tags: []*tax.TagSet{
-			bill.InvoiceTags(),
-		},
+		TimeZone:   "America/Bogota",
 		Validator:  Validate,
 		Normalizer: Normalize,
 		Corrections: []*tax.CorrectionDefinition{

--- a/regimes/de/de.go
+++ b/regimes/de/de.go
@@ -25,9 +25,6 @@ func New() *tax.RegimeDef {
 			i18n.DE: "Deutschland",
 		},
 		TimeZone: "Europe/Berlin",
-		Tags: []*tax.TagSet{
-			bill.InvoiceTags(),
-		},
 		Scenarios: []*tax.ScenarioSet{
 			invoiceScenarios,
 		},

--- a/regimes/es/es.go
+++ b/regimes/es/es.go
@@ -59,7 +59,7 @@ func New() *tax.RegimeDef {
 		},
 		TimeZone: "Europe/Madrid",
 		Tags: []*tax.TagSet{
-			bill.InvoiceTags().Merge(invoiceTags),
+			invoiceTags,
 		},
 		Identities: identityDefinitions,
 		Categories: taxCategories,

--- a/regimes/fr/fr.go
+++ b/regimes/fr/fr.go
@@ -40,9 +40,6 @@ func New() *tax.RegimeDef {
 			`),
 		},
 		TimeZone: "Europe/Paris",
-		Tags: []*tax.TagSet{
-			bill.InvoiceTags(),
-		},
 		Scenarios: []*tax.ScenarioSet{
 			invoiceScenarios,
 		},

--- a/regimes/gb/gb.go
+++ b/regimes/gb/gb.go
@@ -42,9 +42,6 @@ func New() *tax.RegimeDef {
 		Scenarios: []*tax.ScenarioSet{
 			bill.InvoiceScenarios(),
 		},
-		Tags: []*tax.TagSet{
-			bill.InvoiceTags(),
-		},
 		Categories: taxCategories,
 		Corrections: []*tax.CorrectionDefinition{
 			{

--- a/regimes/gr/gr.go
+++ b/regimes/gr/gr.go
@@ -2,7 +2,6 @@
 package gr
 
 import (
-	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/currency"
 	"github.com/invopop/gobl/i18n"
@@ -38,14 +37,11 @@ func New() *tax.RegimeDef {
 		},
 		TimeZone:               "Europe/Athens",
 		CalculatorRoundingRule: tax.RoundingRuleCurrency,
-		Tags: []*tax.TagSet{
-			bill.InvoiceTags(),
-		},
-		Scenarios:   scenarios,
-		Corrections: corrections,
-		Validator:   Validate,
-		Normalizer:  Normalize,
-		Categories:  taxCategories,
+		Scenarios:              scenarios,
+		Corrections:            corrections,
+		Validator:              Validate,
+		Normalizer:             Normalize,
+		Categories:             taxCategories,
 	}
 }
 

--- a/regimes/it/it.go
+++ b/regimes/it/it.go
@@ -27,9 +27,6 @@ func New() *tax.RegimeDef {
 		TimeZone:   "Europe/Rome",
 		Identities: identityKeyDefinitions, // identities.go
 		Scenarios:  scenarios,              // scenarios.go
-		Tags: []*tax.TagSet{
-			bill.InvoiceTags(),
-		},
 		Validator:  Validate,
 		Normalizer: Normalize,
 		Categories: categories, // categories.go

--- a/regimes/mx/mx.go
+++ b/regimes/mx/mx.go
@@ -41,12 +41,9 @@ func New() *tax.RegimeDef {
 			i18n.EN: "Mexico",
 			i18n.ES: "México",
 		},
-		TimeZone:   "America/Mexico_City",
-		Validator:  Validate,
-		Normalizer: Normalize,
-		Tags: []*tax.TagSet{
-			bill.InvoiceTags(),
-		},
+		TimeZone:    "America/Mexico_City",
+		Validator:   Validate,
+		Normalizer:  Normalize,
 		Categories:  taxCategories,
 		Corrections: correctionDefinitions,
 	}

--- a/regimes/nl/nl.go
+++ b/regimes/nl/nl.go
@@ -30,9 +30,6 @@ func New() *tax.RegimeDef {
 		Scenarios: []*tax.ScenarioSet{
 			bill.InvoiceScenarios(),
 		},
-		Tags: []*tax.TagSet{
-			bill.InvoiceTags(),
-		},
 		Corrections: []*tax.CorrectionDefinition{
 			{
 				Schema: bill.ShortSchemaInvoice,

--- a/regimes/pl/pl.go
+++ b/regimes/pl/pl.go
@@ -41,7 +41,7 @@ func New() *tax.RegimeDef {
 		PaymentMeansKeys: paymentMeansKeyDefinitions, // pay.go
 		Extensions:       extensionKeys,              // extensions.go
 		Tags: []*tax.TagSet{
-			bill.InvoiceTags().Merge(invoiceTags),
+			invoiceTags,
 		},
 		Scenarios:  scenarios, // scenarios.go
 		Validator:  Validate,

--- a/regimes/pt/pt.go
+++ b/regimes/pt/pt.go
@@ -46,7 +46,7 @@ func New() *tax.RegimeDef {
 		Validator:  Validate,
 		Normalizer: Normalize,
 		Tags: []*tax.TagSet{
-			bill.InvoiceTags().Merge(invoiceTags),
+			invoiceTags,
 		},
 		Corrections: []*tax.CorrectionDefinition{
 			{

--- a/regimes/us/us.go
+++ b/regimes/us/us.go
@@ -28,9 +28,6 @@ func New() *tax.RegimeDef {
 		},
 		TimeZone:  "America/Chicago", // Around the middle
 		Validator: Validate,
-		Tags: []*tax.TagSet{
-			bill.InvoiceTags(),
-		},
 		Categories: []*tax.CategoryDef{
 			//
 			// Sales Tax

--- a/tax/constants.go
+++ b/tax/constants.go
@@ -22,7 +22,7 @@ const (
 	RateOther        cbc.Key = "other"
 )
 
-// Standard tax tags
+// Standard tax tags that can be used to indicate special circumstances.
 const (
 	TagSimplified    cbc.Key = "simplified"
 	TagReverseCharge cbc.Key = "reverse-charge"

--- a/tax/tags.go
+++ b/tax/tags.go
@@ -14,7 +14,7 @@ import (
 type Tags struct {
 	// Tags are used to help identify specific tax scenarios or requirements that may
 	// apply changes to the contents of the document or imply a specific meaning.
-	// Convertors may use tags to help identify specific situations that do not have
+	// Converters may use tags to help identify specific situations that do not have
 	// a specific extension, for example; self-billed or partial invoices may be
 	// identified by their respective tags.
 	List []cbc.Key `json:"$tags,omitempty" jsonschema:"title=Tags"`
@@ -146,7 +146,7 @@ func (tv *tagValidation) Validate(val interface{}) error {
 // JSONSchemaExtendWithDefs will add the provided set of tags to the JSON schema
 // as default options for the `$tags` property. A default catch-all will also
 // be available.
-func (t Tags) JSONSchemaExtendWithDefs(js *jsonschema.Schema, defs []*cbc.Definition) {
+func (ts Tags) JSONSchemaExtendWithDefs(js *jsonschema.Schema, defs []*cbc.Definition) {
 	props := js.Properties
 	if asl, ok := props.Get("$tags"); ok {
 		list := make([]*jsonschema.Schema, len(defs))

--- a/tax/tags_test.go
+++ b/tax/tags_test.go
@@ -182,9 +182,6 @@ func TestTagsJSONSchemaEmbedWithDefs(t *testing.T) {
 	ts := tax.Tags{}
 	ts.JSONSchemaExtendWithDefs(js, bill.DefaultInvoiceTags().List)
 
-	data, _ := json.Marshal(js)
-	t.Logf("JSON Schema: %s", data)
-
 	prop, ok := js.Properties.Get("$tags")
 	require.True(t, ok)
 	assert.Equal(t, 6, len(prop.Items.OneOf), "should have 5 tags plus 1 catch-all")

--- a/tax/tags_test.go
+++ b/tax/tags_test.go
@@ -1,13 +1,17 @@
 package tax_test
 
 import (
+	"encoding/json"
 	"testing"
 
+	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/i18n"
 	"github.com/invopop/gobl/tax"
+	"github.com/invopop/jsonschema"
 	"github.com/invopop/validation"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTagSetForSchema(t *testing.T) {
@@ -158,4 +162,32 @@ func TestTaxSetKeys(t *testing.T) {
 		},
 	}
 	assert.Equal(t, ts1.Keys(), []cbc.Key{"test1", "test2"})
+}
+
+func TestTagsJSONSchemaEmbedWithDefs(t *testing.T) {
+	eg := `{
+		"properties": {
+			"$tags": {
+				"items": {
+            		"$ref": "https://gobl.org/draft-0/cbc/key",
+					"type": "array",
+					"title": "Tags"
+				}
+			}
+		}
+	}`
+	js := new(jsonschema.Schema)
+	require.NoError(t, json.Unmarshal([]byte(eg), js))
+
+	ts := tax.Tags{}
+	ts.JSONSchemaExtendWithDefs(js, bill.DefaultInvoiceTags().List)
+
+	data, _ := json.Marshal(js)
+	t.Logf("JSON Schema: %s", data)
+
+	prop, ok := js.Properties.Get("$tags")
+	require.True(t, ok)
+	assert.Equal(t, 6, len(prop.Items.OneOf), "should have 5 tags plus 1 catch-all")
+	assert.Equal(t, "simplified", prop.Items.OneOf[0].Const)
+	assert.Equal(t, "Any", prop.Items.OneOf[5].Title)
 }


### PR DESCRIPTION
- Moves the default set of invoice tags into the JSON Schema making them easier to auto-suggest and use.
- Removed the default invoice tags from all the regimes, since they're always already present.

## Pre-Review Checklist

- [ ] I've read the CONTRIBUTING.md guide.
- [x] I have performed a self-review of my code.
- [x] I have added thorough tests with at **least** 90% code coverage.
- [x] I've modified or created example GOBL documents to show my changes in use, if appropriate.
- [ ] When adding or modifying a tax regime or addon, I've added links to the source of the changes, either structured or in the comments.
- [x] I've run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [ ] All linter warnings have been reviewed and fixed.
- [x] I've been obsessive with pointer nil checks to avoid panics.
- [x] The CHANGELOG.md has been updated with an overview of my changes.
- [ ] Requested a review from @samlown.
