### PR TITLE
Adding Ordering Issuer and Verifactu Extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Added
+
+- `bill`: `Ordering` now includes an `issuer` field.
+- `es/verifactu`: Support for `es-verifactu-simplified-art7273` and `es-verifactu-issuer-type` extensions.
+
 ### Changed
 
 - `bill`: All invoices will now have a default set of `$tags` that can be used.

--- a/addons/es/verifactu/bill.go
+++ b/addons/es/verifactu/bill.go
@@ -55,6 +55,18 @@ func normalizeInvoice(inv *bill.Invoice) {
 		}
 	}
 
+	// Normalize the third party details
+	if inv.HasTags(tax.TagSelfBilled) {
+		inv.Tax = inv.Tax.MergeExtensions(tax.Extensions{
+			ExtKeyIssuerType: ExtCodeIssuerTypeCustomer,
+		})
+	}
+	if inv.Ordering != nil && inv.Ordering.Issuer != nil {
+		inv.Tax = inv.Tax.MergeExtensions(tax.Extensions{
+			ExtKeyIssuerType: ExtCodeIssuerTypeThirdParty,
+		})
+	}
+
 	normalizeInvoicePartyIdentity(inv.Customer)
 }
 

--- a/addons/es/verifactu/bill_test.go
+++ b/addons/es/verifactu/bill_test.go
@@ -125,6 +125,28 @@ func TestInvoicePartyNormalization(t *testing.T) {
 		assert.Equal(t, verifactu.ExtCodeIdentityTypePassport, inv.Customer.Identities[0].Ext[verifactu.ExtKeyIdentityType])
 		assert.Empty(t, inv.Customer.Identities[1].Ext)
 	})
+
+	t.Run("self-billed", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.SetTags(tax.TagSelfBilled)
+		require.NoError(t, inv.Calculate())
+		assert.Equal(t, verifactu.ExtCodeIssuerTypeCustomer, inv.Tax.Ext[verifactu.ExtKeyIssuerType])
+	})
+
+	t.Run("with issuer", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Ordering = &bill.Ordering{
+			Issuer: &org.Party{
+				Name: "Test Issuer",
+				TaxID: &tax.Identity{
+					Country: "ES",
+					Code:    "B12345678",
+				},
+			},
+		}
+		require.NoError(t, inv.Calculate())
+		assert.Equal(t, verifactu.ExtCodeIssuerTypeThirdParty, inv.Tax.Ext[verifactu.ExtKeyIssuerType])
+	})
 }
 
 func TestInvoiceValidation(t *testing.T) {

--- a/addons/es/verifactu/extensions.go
+++ b/addons/es/verifactu/extensions.go
@@ -8,12 +8,14 @@ import (
 
 // Extension keys for Verifactu
 const (
-	ExtKeyDocType        cbc.Key = "es-verifactu-doc-type"
-	ExtKeyOpClass        cbc.Key = "es-verifactu-op-class"
-	ExtKeyCorrectionType cbc.Key = "es-verifactu-correction-type"
-	ExtKeyExempt         cbc.Key = "es-verifactu-exempt"
-	ExtKeyRegime         cbc.Key = "es-verifactu-regime"
-	ExtKeyIdentityType   cbc.Key = "es-verifactu-identity-type"
+	ExtKeyDocType           cbc.Key = "es-verifactu-doc-type"
+	ExtKeyOpClass           cbc.Key = "es-verifactu-op-class"
+	ExtKeyCorrectionType    cbc.Key = "es-verifactu-correction-type"
+	ExtKeyExempt            cbc.Key = "es-verifactu-exempt"
+	ExtKeyRegime            cbc.Key = "es-verifactu-regime"
+	ExtKeyIdentityType      cbc.Key = "es-verifactu-identity-type"
+	ExtKeySimplifiedArt7273 cbc.Key = "es-verifactu-simplified-art7273"
+	ExtKeyIssuerType        cbc.Key = "es-verifactu-issuer-type"
 )
 
 // Identity Type Codes
@@ -24,6 +26,12 @@ const (
 	ExtCodeIdentityTypeResident      cbc.Code = "05" // Spanish Resident Foreigner Identity Card
 	ExtCodeIdentityTypeOther         cbc.Code = "06" // Other Identity Document
 	ExtCodeIdentityTypeNotRegistered cbc.Code = "07" // Not registered in census
+)
+
+// Issuer Type Codes
+const (
+	ExtCodeIssuerTypeThirdParty cbc.Code = "T" // Issued by Third Party
+	ExtCodeIssuerTypeCustomer   cbc.Code = "D" // Issued by Customer
 )
 
 var extensions = []*cbc.Definition{
@@ -414,6 +422,76 @@ var extensions = []*cbc.Definition{
 				Name: i18n.String{
 					i18n.EN: "Not registered in census",
 					i18n.ES: "No censado",
+				},
+			},
+		},
+	},
+	{
+		Key: ExtKeySimplifiedArt7273,
+		Name: i18n.String{
+			i18n.EN: "Simplified Invoice Art. 7.2 and 7.3, RD 1619/2012",
+			i18n.ES: "Factura Simplificada Articulo 7,2 y 7,3 RD 1619/2012",
+		},
+		Desc: i18n.String{
+			i18n.EN: here.Doc(`
+				This extensions covers a specific use-case when the customer specifically
+				requests that the invoice includes their fiscal details, but they are
+				not registered for tax.
+
+				Maps to the ~FacturaSimplificadaArt7273~ field in Verifactu documents.
+
+				Can only be true when the invoice type (~TipoFactura~) is one of: ~F1~,
+				~F3~, ~R1~, ~R2~, ~R3~, or ~R4~.
+			`),
+		},
+		Values: []*cbc.Definition{
+			{
+				Code: "S",
+				Name: i18n.String{
+					i18n.EN: "Yes",
+					i18n.ES: "Sí",
+				},
+			},
+			{
+				Code: "N",
+				Name: i18n.String{
+					i18n.EN: "No",
+					i18n.ES: "No",
+				},
+			},
+		},
+	},
+	{
+		Key: ExtKeyIssuerType,
+		Name: i18n.String{
+			i18n.EN: "Issuer Type Code - L6",
+			i18n.ES: "Emitida por Tercero o Destinatario - L6",
+		},
+		Desc: i18n.String{
+			i18n.EN: here.Doc(`
+				Indicates whether the invoice is issued by a third party or by the customer
+				themselves.
+
+				The ~self-billed~ tag will automatically be set this extension in the invoice
+				to ~D~.
+
+				If the ~issuer~ field is set in the invoice's ordering section, then this
+				extension will be set to ~T~.
+			`),
+		},
+		Values: []*cbc.Definition{
+			{
+				Code: ExtCodeIssuerTypeThirdParty,
+				Name: i18n.String{
+					i18n.EN: "Issued by Third Party",
+					i18n.ES: "Emitida por Tercero",
+				},
+			},
+			{
+				Code: ExtCodeIssuerTypeCustomer,
+				Name: i18n.String{
+					i18n.EN: "Issued by Customer",
+					i18n.ES: "Emitida por Destinatario",
 				},
 			},
 		},

--- a/addons/es/verifactu/verifactu.go
+++ b/addons/es/verifactu/verifactu.go
@@ -27,7 +27,13 @@ func newAddon() *tax.AddonDef {
 	return &tax.AddonDef{
 		Key: V1,
 		Name: i18n.String{
-			i18n.EN: "Spain Verifactu V1",
+			i18n.EN: "Spain VERI*FACTU V1",
+		},
+		Sources: []*cbc.Source{
+			{
+				Title: i18n.NewString("VERI*FACTU error response code list"),
+				URL:   "https://prewww2.aeat.es/static_files/common/internet/dep/aplicaciones/es/aeat/tikeV1.0/cont/ws/errores.properties",
+			},
 		},
 		Extensions:  extensions,
 		Validator:   validate,

--- a/bill/ordering.go
+++ b/bill/ordering.go
@@ -25,6 +25,9 @@ type Ordering struct {
 	Buyer *org.Party `json:"buyer,omitempty" jsonschema:"title=Buyer"`
 	// Seller is the party liable to pay taxes on the transaction if not the same as the supplier.
 	Seller *org.Party `json:"seller,omitempty" jsonschema:"title=Seller"`
+	// Issuer represents a third party responsible for issuing the invoice, but is not
+	// responsible for tax. Some tax regimes and formats require this field.
+	Issuer *org.Party `json:"issuer,omitempty" jsonschema:"title=Issuer"`
 	// Projects this invoice refers to.
 	Projects []*org.DocumentRef `json:"projects,omitempty" jsonschema:"title=Projects"`
 	// The identification of contracts.
@@ -59,6 +62,7 @@ func (o *Ordering) Normalize(normalizers tax.Normalizers) {
 	tax.Normalize(normalizers, o.Tender)
 	tax.Normalize(normalizers, o.Buyer)
 	tax.Normalize(normalizers, o.Seller)
+	tax.Normalize(normalizers, o.Issuer)
 }
 
 // Validate the ordering details.
@@ -76,5 +80,6 @@ func (o *Ordering) Validate() error {
 		validation.Field(&o.Tender),
 		validation.Field(&o.Buyer),
 		validation.Field(&o.Seller),
+		validation.Field(&o.Issuer),
 	)
 }

--- a/data/addons/es-verifactu-v1.json
+++ b/data/addons/es-verifactu-v1.json
@@ -2,8 +2,16 @@
   "$schema": "https://gobl.org/draft-0/tax/addon-def",
   "key": "es-verifactu-v1",
   "name": {
-    "en": "Spain Verifactu V1"
+    "en": "Spain VERI*FACTU V1"
   },
+  "sources": [
+    {
+      "title": {
+        "en": "VERI*FACTU error response code list"
+      },
+      "url": "https://prewww2.aeat.es/static_files/common/internet/dep/aplicaciones/es/aeat/tikeV1.0/cont/ws/errores.properties"
+    }
+  ],
   "extensions": [
     {
       "key": "es-verifactu-doc-type",
@@ -367,6 +375,58 @@
           "name": {
             "en": "Not registered in census",
             "es": "No censado"
+          }
+        }
+      ]
+    },
+    {
+      "key": "es-verifactu-simplified-art7273",
+      "name": {
+        "en": "Simplified Invoice Art. 7.2 and 7.3, RD 1619/2012",
+        "es": "Factura Simplificada Articulo 7,2 y 7,3 RD 1619/2012"
+      },
+      "desc": {
+        "en": "This extensions covers a specific use-case when the customer specifically\nrequests that the invoice includes their fiscal details, but they are\nnot registered for tax.\n\nMaps to the `FacturaSimplificadaArt7273` field in Verifactu documents.\n\nCan only be true when the invoice type (`TipoFactura`) is one of: `F1`,\n`F3`, `R1`, `R2`, `R3`, or `R4`."
+      },
+      "values": [
+        {
+          "code": "S",
+          "name": {
+            "en": "Yes",
+            "es": "Sí"
+          }
+        },
+        {
+          "code": "N",
+          "name": {
+            "en": "No",
+            "es": "No"
+          }
+        }
+      ]
+    },
+    {
+      "key": "es-verifactu-issuer-type",
+      "name": {
+        "en": "Issuer Type Code - L6",
+        "es": "Emitida por Tercero o Destinatario - L6"
+      },
+      "desc": {
+        "en": "Indicates whether the invoice is issued by a third party or by the customer\nthemselves.\n\nThe `self-billed` tag will automatically be set this extension in the invoice\nto `D`.\n\nIf the `issuer` field is set in the invoice's ordering section, then this\nextension will be set to `T`."
+      },
+      "values": [
+        {
+          "code": "T",
+          "name": {
+            "en": "Issued by Third Party",
+            "es": "Emitida por Tercero"
+          }
+        },
+        {
+          "code": "D",
+          "name": {
+            "en": "Issued by Customer",
+            "es": "Emitida por Destinatario"
           }
         }
       ]

--- a/data/schemas/bill/delivery.json
+++ b/data/schemas/bill/delivery.json
@@ -117,7 +117,7 @@
               },
               {
                 "const": "es-verifactu-v1",
-                "title": "Spain Verifactu V1"
+                "title": "Spain VERI*FACTU V1"
               },
               {
                 "const": "eu-en16931-v2017",
@@ -163,7 +163,7 @@
           },
           "type": "array",
           "title": "Tags",
-          "description": "Tags are used to help identify specific tax scenarios or requirements that may\napply changes to the contents of the document or imply a specific meaning.\nConvertors may use tags to help identify specific situations that do not have\na specific extension, for example; self-billed or partial invoices may be\nidentified by their respective tags."
+          "description": "Tags are used to help identify specific tax scenarios or requirements that may\napply changes to the contents of the document or imply a specific meaning.\nConverters may use tags to help identify specific situations that do not have\na specific extension, for example; self-billed or partial invoices may be\nidentified by their respective tags."
         },
         "uuid": {
           "type": "string",

--- a/data/schemas/bill/invoice.json
+++ b/data/schemas/bill/invoice.json
@@ -117,7 +117,7 @@
               },
               {
                 "const": "es-verifactu-v1",
-                "title": "Spain Verifactu V1"
+                "title": "Spain VERI*FACTU V1"
               },
               {
                 "const": "eu-en16931-v2017",
@@ -189,7 +189,7 @@
           },
           "type": "array",
           "title": "Tags",
-          "description": "Tags are used to help identify specific tax scenarios or requirements that may\napply changes to the contents of the document or imply a specific meaning.\nConvertors may use tags to help identify specific situations that do not have\na specific extension, for example; self-billed or partial invoices may be\nidentified by their respective tags."
+          "description": "Tags are used to help identify specific tax scenarios or requirements that may\napply changes to the contents of the document or imply a specific meaning.\nConverters may use tags to help identify specific situations that do not have\na specific extension, for example; self-billed or partial invoices may be\nidentified by their respective tags."
         },
         "uuid": {
           "type": "string",

--- a/data/schemas/bill/order.json
+++ b/data/schemas/bill/order.json
@@ -117,7 +117,7 @@
               },
               {
                 "const": "es-verifactu-v1",
-                "title": "Spain Verifactu V1"
+                "title": "Spain VERI*FACTU V1"
               },
               {
                 "const": "eu-en16931-v2017",
@@ -163,7 +163,7 @@
           },
           "type": "array",
           "title": "Tags",
-          "description": "Tags are used to help identify specific tax scenarios or requirements that may\napply changes to the contents of the document or imply a specific meaning.\nConvertors may use tags to help identify specific situations that do not have\na specific extension, for example; self-billed or partial invoices may be\nidentified by their respective tags."
+          "description": "Tags are used to help identify specific tax scenarios or requirements that may\napply changes to the contents of the document or imply a specific meaning.\nConverters may use tags to help identify specific situations that do not have\na specific extension, for example; self-billed or partial invoices may be\nidentified by their respective tags."
         },
         "uuid": {
           "type": "string",

--- a/data/schemas/bill/ordering.json
+++ b/data/schemas/bill/ordering.json
@@ -38,6 +38,11 @@
           "title": "Seller",
           "description": "Seller is the party liable to pay taxes on the transaction if not the same as the supplier."
         },
+        "issuer": {
+          "$ref": "https://gobl.org/draft-0/org/party",
+          "title": "Issuer",
+          "description": "Issuer represents a third party responsible for issuing the invoice, but is not\nresponsible for tax. Some tax regimes and formats require this field."
+        },
         "projects": {
           "items": {
             "$ref": "https://gobl.org/draft-0/org/document-ref"

--- a/data/schemas/bill/payment.json
+++ b/data/schemas/bill/payment.json
@@ -117,7 +117,7 @@
               },
               {
                 "const": "es-verifactu-v1",
-                "title": "Spain Verifactu V1"
+                "title": "Spain VERI*FACTU V1"
               },
               {
                 "const": "eu-en16931-v2017",
@@ -163,7 +163,7 @@
           },
           "type": "array",
           "title": "Tags",
-          "description": "Tags are used to help identify specific tax scenarios or requirements that may\napply changes to the contents of the document or imply a specific meaning.\nConvertors may use tags to help identify specific situations that do not have\na specific extension, for example; self-billed or partial invoices may be\nidentified by their respective tags."
+          "description": "Tags are used to help identify specific tax scenarios or requirements that may\napply changes to the contents of the document or imply a specific meaning.\nConverters may use tags to help identify specific situations that do not have\na specific extension, for example; self-billed or partial invoices may be\nidentified by their respective tags."
         },
         "uuid": {
           "type": "string",


### PR DESCRIPTION
- New extensions for handling self and third party billing in the Verifactu addon.

## Pre-Review Checklist

- [ ] I've read the CONTRIBUTING.md guide.
- [ ] I have performed a self-review of my code.
- [ ] I have added thorough tests with at **least** 90% code coverage.
- [ ] I've modified or created example GOBL documents to show my changes in use, if appropriate.
- [ ] When adding or modifying a tax regime or addon, I've added links to the source of the changes, either structured or in the comments.
- [ ] I've run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [ ] All linter warnings have been reviewed and fixed.
- [ ] I've been obsessive with pointer nil checks to avoid panics.
- [ ] The CHANGELOG.md has been updated with an overview of my changes.
- [ ] Requested a review from @samlown.
