### PR TITLE
Restore generic note for all exemptions in SAFT

### DIFF
--- a/addons/pt/saft/scenarios.go
+++ b/addons/pt/saft/scenarios.go
@@ -201,7 +201,7 @@ var invoiceScenarios = &tax.ScenarioSet{
 			Note: &tax.ScenarioNote{
 				Key:  org.NoteKeyLegal,
 				Src:  ExtKeyExemption,
-				Text: "", // Outras isenções – must be provided by the user
+				Text: "Outras isenções", // default text, to be overridden by the user
 			},
 		},
 		{
@@ -327,7 +327,7 @@ var invoiceScenarios = &tax.ScenarioSet{
 			Note: &tax.ScenarioNote{
 				Key:  org.NoteKeyLegal,
 				Src:  ExtKeyExemption,
-				Text: "", // Não sujeito ou não tributado – must be provided by the user
+				Text: "Não sujeito ou não tributado", // default text, to be overridden by the user
 			},
 		},
 	},


### PR DESCRIPTION
- Restores generic notes for M99 and M19 exemptions in the SAFT addon for backwards compatibility.

## Pre-Review Checklist

- [ ] I've read the CONTRIBUTING.md guide.
- [ ] I have performed a self-review of my code.
- [ ] I have added thorough tests with at **least** 90% code coverage.
- [ ] I've modified or created example GOBL documents to show my changes in use, if appropriate.
- [ ] When adding or modifying a tax regime or addon, I've added links to the source of the changes, either structured or in the comments.
- [ ] I've run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [ ] All linter warnings have been reviewed and fixed.
- [ ] I've been obsessive with pointer nil checks to avoid panics.
- [ ] The CHANGELOG.md has been updated with an overview of my changes.
- [ ] Requested a review from @samlown.
