### PR TITLE
Add validation for CPF in br tax regime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Added
+
+- `br`: tax identity validation for CPF code.
+
 ## [v0.220.5] - 2025-07-21
 
 ### Changed

--- a/regimes/br/tax_identity.go
+++ b/regimes/br/tax_identity.go
@@ -9,7 +9,16 @@ import (
 	"github.com/invopop/validation"
 )
 
-// Reference: https://pt.wikipedia.org/wiki/Cadastro_Nacional_da_Pessoa_Jurídica
+// CNPJ Reference: https://pt.wikipedia.org/wiki/Cadastro_Nacional_da_Pessoa_Jurídica
+// CPF Reference: https://pt.wikipedia.org/wiki/Cadastro_de_Pessoas_F%C3%ADsicas
+// CPF Validator referenced in wikipedia: https://web.archive.org/web/20150626110648/http://geradorderg.com/gerador-de-cpf/
+// Note: The Wikipedia article describes a variant of the mod11 algorithm where the expected digit is calculated as: (sum % 11) % 10.
+// However, it also states that multiple algorithms can be used to validate (see Wikipedia)
+// Other sources, including the CPF Validator, use the same mod11 logic as CNPJ, with different weights:
+//     https://codegolf.stackexchange.com/questions/269151/validate-a-cpf-number
+//     https://www.macoratti.net/alg_cpf.htm
+// I've tested several CPFs from different generators and sources, and this approach works consistently.
+// I believe it's safer to follow the official mod11 algorithm used for CPF and CNPJ validation.
 
 func validateTaxIdentity(tID *tax.Identity) error {
 	return validation.ValidateStruct(tID,
@@ -24,30 +33,43 @@ func validateTaxCode(value interface{}) error {
 	}
 	val := code.String()
 
-	// Verify length
-	if len(val) != 14 {
-		return errors.New("must have 14 digits")
-	}
+	switch len(val) {
+	case 14:
+		// CNPJ validation
+		// Verify first verification digit
+		weights1 := []int{5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2}
+		if err := verifyDigit(val, weights1, 12); err != nil {
+			return err
+		}
 
-	// Verify first verification digit
-	weights1 := []int{5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2}
-	if err := verifyDigit(val, weights1, 12); err != nil {
-		return err
-	}
+		// Verify second verification digit
+		weights2 := []int{6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2}
+		if err := verifyDigit(val, weights2, 13); err != nil {
+			return err
+		}
 
-	// Verify second verification digit
-	weights2 := []int{6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2}
-	if err := verifyDigit(val, weights2, 13); err != nil {
-		return err
+		return nil
+	case 11:
+		// CPF validation
+		weights1 := []int{10, 9, 8, 7, 6, 5, 4, 3, 2}
+		if err := verifyDigit(val, weights1, 9); err != nil {
+			return err
+		}
+		weights2 := []int{11, 10, 9, 8, 7, 6, 5, 4, 3, 2}
+		if err := verifyDigit(val, weights2, 10); err != nil {
+			return err
+		}
+		//
+	default:
+		return errors.New("must have 11 (CPF) or 14 (CNPJ) digits")
 	}
-
 	return nil
 }
 
-func verifyDigit(cnpj string, weights []int, position int) error {
+func verifyDigit(val string, weights []int, position int) error {
 	sum := 0
 	for i := 0; i < len(weights); i++ {
-		digit, err := strconv.Atoi(string(cnpj[i]))
+		digit, err := strconv.Atoi(string(val[i]))
 		if err != nil {
 			return errors.New("must contain only digits")
 		}
@@ -62,7 +84,7 @@ func verifyDigit(cnpj string, weights []int, position int) error {
 		expectedDigit = 11 - remainder
 	}
 
-	actualDigit, err := strconv.Atoi(string(cnpj[position]))
+	actualDigit, err := strconv.Atoi(string(val[position]))
 	if err != nil {
 		return errors.New("must contain only digits")
 	}

--- a/regimes/br/tax_identity_test.go
+++ b/regimes/br/tax_identity_test.go
@@ -17,16 +17,9 @@ func TestTaxIdentityValidation(t *testing.T) {
 	}{
 		{name: "valid1", code: "05104582000170"},
 		{name: "valid2", code: "10909402000167"},
-		{
-			name: "too long",
-			code: "123456789012345",
-			err:  "must have 14 digits",
-		},
-		{
-			name: "too short",
-			code: "1234567890123",
-			err:  "must have 14 digits",
-		},
+		{name: "validCPF", code: "01234567890"},
+		{name: "validCPF", code: "35549549506"},
+
 		{
 			name: "non-numeric",
 			code: "A2345678901234",
@@ -46,6 +39,26 @@ func TestTaxIdentityValidation(t *testing.T) {
 			name: "second verification digit wrong",
 			code: "05104582000171",
 			err:  "verification digit mismatch",
+		},
+		{
+			name: "invalid CPF wrong checksum",
+			code: "11144477730",
+			err:  "verification digit mismatch",
+		},
+		{
+			name: "invalid CPF too short",
+			code: "1114447773",
+			err:  "must have 11 (CPF) or 14 (CNPJ) digits",
+		},
+		{
+			name: "invalid CPF too long",
+			code: "111444777356",
+			err:  "must have 11 (CPF) or 14 (CNPJ) digits",
+		},
+		{
+			name: "invalid CPF non-numeric",
+			code: "11A44477735",
+			err:  "must contain only digits",
 		},
 	}
 
@@ -74,6 +87,8 @@ func TestTaxIdentityNormalization(t *testing.T) {
 		{name: "valid2", code: "10909402000167", want: "10909402000167"},
 		{name: "valid3", code: "051.045.820/0017-0", want: "05104582000170"},
 		{name: "valid4", code: "109.094.020/0016-7", want: "10909402000167"},
+		{name: "valid5", code: "012.345.678-90", want: "01234567890"},
+		{name: "valid6", code: "125.217.532-97", want: "12521753297"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Add validation for CPF in br tax and tests

Link to Pylon Issue: [Issue #1640](https://app.usepylon.com/issues/views/all-issues?conversationID=c232e2ed-b10a-4994-a175-7607a5c2ba0e)

## Pre-Review Checklist

- [x]  I've read the CONTRIBUTING.md guide.
- [x]  I have performed a self-review of my code.
- [x]  I have added thorough tests with at least 90% code coverage.
- [x]  I've modified or created example GOBL documents to show my changes in use, if appropriate.
- [x]  When adding or modifying a tax regime or addon, I've added links to the source of the changes, either structured or in the comments.
- [x]  I've run go generate . to ensure that the Schemas and Regime data are up to date.
- [x]  All linter warnings have been reviewed and fixed.
- [x]  I've been obsessive with pointer nil checks to avoid panics.
- [x]  The CHANGELOG.md has been updated with an overview of my changes.
- [x]  Requested a review from @samlown.