### PR TITLE
Fix panic on missing supplier normalizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Changed
+
+- `org.Party`: avoid panic when regime's normalizer is not present
+- `br`: set missing normalizer in regime definition
+
 ## [v0.220.5] - 2025-07-21
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 - `org.Party`: avoid panic when regime's normalizer is not present
 - `br`: set missing normalizer in regime definition
+- `tax`: `Normalizers()` method in `RegimeDef`
 
 ## [v0.220.5] - 2025-07-21
 

--- a/org/party.go
+++ b/org/party.go
@@ -58,7 +58,7 @@ func (p *Party) Calculate() error {
 }
 
 func (p *Party) normalizers() tax.Normalizers {
-	if r := p.RegimeDef(); r != nil {
+	if r := p.RegimeDef(); r != nil && r.Normalizer != nil {
 		return tax.Normalizers{r.Normalizer}
 	}
 	return nil

--- a/org/party.go
+++ b/org/party.go
@@ -58,10 +58,7 @@ func (p *Party) Calculate() error {
 }
 
 func (p *Party) normalizers() tax.Normalizers {
-	if r := p.RegimeDef(); r != nil && r.Normalizer != nil {
-		return tax.Normalizers{r.Normalizer}
-	}
-	return nil
+	return p.RegimeDef().Normalizers()
 }
 
 // Normalize will try to normalize the party's data.

--- a/org/party_test.go
+++ b/org/party_test.go
@@ -92,6 +92,19 @@ func TestPartyNormalize(t *testing.T) {
 		party.Normalize(nil)
 		assert.Equal(t, "+49 123 4567890", party.Telephones[0].Number)
 	})
+
+	t.Run("for regime without normalizer", func(t *testing.T) {
+		rd := tax.RegimeDefFor("US")
+		require.Nil(t, rd.Normalizer) // Ensure the regime has no normalizer
+
+		party := org.Party{
+			Regime: tax.WithRegime("US"),
+			Name:   "Invopop",
+		}
+		assert.NotPanics(t, func() {
+			party.Calculate()
+		})
+	})
 }
 
 func TestPartyAddressNill(t *testing.T) {

--- a/org/party_test.go
+++ b/org/party_test.go
@@ -102,7 +102,7 @@ func TestPartyNormalize(t *testing.T) {
 			Name:   "Invopop",
 		}
 		assert.NotPanics(t, func() {
-			party.Calculate()
+			assert.NoError(t, party.Calculate())
 		})
 	})
 }

--- a/regimes/br/br.go
+++ b/regimes/br/br.go
@@ -25,6 +25,7 @@ func New() *tax.RegimeDef {
 		},
 		TimeZone:   "America/Sao_Paulo",
 		Validator:  Validate,
+		Normalizer: Normalize,
 		Categories: taxCategories,
 		Corrections: []*tax.CorrectionDefinition{
 			{

--- a/tax/regime_def.go
+++ b/tax/regime_def.go
@@ -200,6 +200,15 @@ func (r *RegimeDef) WithContext(ctx context.Context) context.Context {
 	return ctx
 }
 
+// Normalizers returns the normalizers for this regime, if any,
+// handling any potential for nil pointers.
+func (r *RegimeDef) Normalizers() Normalizers {
+	if r == nil || r.Normalizer == nil {
+		return nil
+	}
+	return Normalizers{r.Normalizer}
+}
+
 // RegimeDefFromContext returns the regime from the given context, or nil.
 func RegimeDefFromContext(ctx context.Context) *RegimeDef {
 	r, ok := ctx.Value(keyRegime).(*RegimeDef)

--- a/tax/regime_def_test.go
+++ b/tax/regime_def_test.go
@@ -148,7 +148,7 @@ func TestRegimeDefNormalizers(t *testing.T) {
 
 	t.Run("with normalizer", func(t *testing.T) {
 		r := &tax.RegimeDef{
-			Normalizer: func(doc any) {
+			Normalizer: func(_ any) {
 				// nothing here
 			},
 		}

--- a/tax/regime_def_test.go
+++ b/tax/regime_def_test.go
@@ -139,3 +139,25 @@ func TestRateDefValue(t *testing.T) {
 		assert.Equal(t, "10.0%", rdv.Percent.String())
 	})
 }
+
+func TestRegimeDefNormalizers(t *testing.T) {
+	t.Run("nil regime", func(t *testing.T) {
+		var r *tax.RegimeDef
+		assert.Nil(t, r.Normalizers())
+	})
+
+	t.Run("with normalizer", func(t *testing.T) {
+		r := &tax.RegimeDef{
+			Normalizer: func(doc any) {
+				// nothing here
+			},
+		}
+		assert.NotNil(t, r.Normalizers())
+		assert.Len(t, r.Normalizers(), 1)
+	})
+
+	t.Run("without normalizer", func(t *testing.T) {
+		r := &tax.RegimeDef{}
+		assert.Nil(t, r.Normalizers())
+	})
+}


### PR DESCRIPTION
- Avoids panic calculating party documents when the regime's normalizer is missing
- Sets normalizer in BR regime definition

## Pre-Review Checklist

- [x] I've read the CONTRIBUTING.md guide.
- [x] I have performed a self-review of my code.
- [x] I have added thorough tests with at **least** 90% code coverage.
- [x] I've modified or created example GOBL documents to show my changes in use, if appropriate.
- [x] When adding or modifying a tax regime or addon, I've added links to the source of the changes, either structured or in the comments.
- [x] I've run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [x] All linter warnings have been reviewed and fixed.
- [x] I've been obsessive with pointer nil checks to avoid panics.
- [x] The CHANGELOG.md has been updated with an overview of my changes.
- [x] Requested a review from @samlown.
