### PR TITLE
Add validation for CPF in br tax regime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - `br`: set missing normalizer in regime definition
 - `tax`: `Normalizers()` method in `RegimeDef`
 
+### Added
+
+- `br`: tax identity validation for CPF code.
+
 ## [v0.220.5] - 2025-07-21
 
 ### Changed

--- a/regimes/br/br.go
+++ b/regimes/br/br.go
@@ -23,6 +23,9 @@ func New() *tax.RegimeDef {
 			i18n.EN: "Brazil",
 			i18n.PT: "Brasil",
 		},
+		Description: i18n.String{
+			i18n.EN: "Tax identification in Brazil is provided either through a CNPJ for businesses or a CPF for individuals. Both types are valid for the issuance of NFS-e (electronic service invoices).",
+		},
 		TimeZone:   "America/Sao_Paulo",
 		Validator:  Validate,
 		Normalizer: Normalize,

--- a/regimes/br/tax_identity.go
+++ b/regimes/br/tax_identity.go
@@ -9,7 +9,12 @@ import (
 	"github.com/invopop/validation"
 )
 
-// Reference: https://pt.wikipedia.org/wiki/Cadastro_Nacional_da_Pessoa_Jurídica
+// Both CNPJ and CPF are supported as tax identifiers because, in Brazil, service invoices (NFS-e) may be issued by either legal entities (CNPJ) or individuals (CPF).
+// CNPJ Reference: https://pt.wikipedia.org/wiki/Cadastro_Nacional_da_Pessoa_Jurídica
+// CPF validation uses the same Mod11 algorithm as CNPJ, with different weights.
+// Matches standard validators and test cases.
+// Ref: https://pt.wikipedia.org/wiki/Cadastro_de_Pessoas_F%C3%ADsicas
+// (Note: Some sources mention other variants, but Mod11 is the most consistent in practice.)
 
 func validateTaxIdentity(tID *tax.Identity) error {
 	return validation.ValidateStruct(tID,
@@ -24,30 +29,43 @@ func validateTaxCode(value interface{}) error {
 	}
 	val := code.String()
 
-	// Verify length
-	if len(val) != 14 {
-		return errors.New("must have 14 digits")
-	}
+	switch len(val) {
+	case 14:
+		// CNPJ validation
+		// Verify first verification digit
+		weights1 := []int{5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2}
+		if err := verifyDigit(val, weights1, 12); err != nil {
+			return err
+		}
 
-	// Verify first verification digit
-	weights1 := []int{5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2}
-	if err := verifyDigit(val, weights1, 12); err != nil {
-		return err
-	}
+		// Verify second verification digit
+		weights2 := []int{6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2}
+		if err := verifyDigit(val, weights2, 13); err != nil {
+			return err
+		}
 
-	// Verify second verification digit
-	weights2 := []int{6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2}
-	if err := verifyDigit(val, weights2, 13); err != nil {
-		return err
+		return nil
+	case 11:
+		// CPF validation
+		weights1 := []int{10, 9, 8, 7, 6, 5, 4, 3, 2}
+		if err := verifyDigit(val, weights1, 9); err != nil {
+			return err
+		}
+		weights2 := []int{11, 10, 9, 8, 7, 6, 5, 4, 3, 2}
+		if err := verifyDigit(val, weights2, 10); err != nil {
+			return err
+		}
+		//
+	default:
+		return errors.New("must have 11 (CPF) or 14 (CNPJ) digits")
 	}
-
 	return nil
 }
 
-func verifyDigit(cnpj string, weights []int, position int) error {
+func verifyDigit(val string, weights []int, position int) error {
 	sum := 0
 	for i := 0; i < len(weights); i++ {
-		digit, err := strconv.Atoi(string(cnpj[i]))
+		digit, err := strconv.Atoi(string(val[i]))
 		if err != nil {
 			return errors.New("must contain only digits")
 		}
@@ -62,7 +80,7 @@ func verifyDigit(cnpj string, weights []int, position int) error {
 		expectedDigit = 11 - remainder
 	}
 
-	actualDigit, err := strconv.Atoi(string(cnpj[position]))
+	actualDigit, err := strconv.Atoi(string(val[position]))
 	if err != nil {
 		return errors.New("must contain only digits")
 	}

--- a/regimes/br/tax_identity_test.go
+++ b/regimes/br/tax_identity_test.go
@@ -17,16 +17,9 @@ func TestTaxIdentityValidation(t *testing.T) {
 	}{
 		{name: "valid1", code: "05104582000170"},
 		{name: "valid2", code: "10909402000167"},
-		{
-			name: "too long",
-			code: "123456789012345",
-			err:  "must have 14 digits",
-		},
-		{
-			name: "too short",
-			code: "1234567890123",
-			err:  "must have 14 digits",
-		},
+		{name: "validCPF", code: "01234567890"},
+		{name: "validCPF", code: "35549549506"},
+
 		{
 			name: "non-numeric",
 			code: "A2345678901234",
@@ -46,6 +39,26 @@ func TestTaxIdentityValidation(t *testing.T) {
 			name: "second verification digit wrong",
 			code: "05104582000171",
 			err:  "verification digit mismatch",
+		},
+		{
+			name: "invalid CPF wrong checksum",
+			code: "11144477730",
+			err:  "verification digit mismatch",
+		},
+		{
+			name: "invalid CPF too short",
+			code: "1114447773",
+			err:  "must have 11 (CPF) or 14 (CNPJ) digits",
+		},
+		{
+			name: "invalid CPF too long",
+			code: "111444777356",
+			err:  "must have 11 (CPF) or 14 (CNPJ) digits",
+		},
+		{
+			name: "invalid CPF non-numeric",
+			code: "11A44477735",
+			err:  "must contain only digits",
 		},
 	}
 
@@ -74,6 +87,8 @@ func TestTaxIdentityNormalization(t *testing.T) {
 		{name: "valid2", code: "10909402000167", want: "10909402000167"},
 		{name: "valid3", code: "051.045.820/0017-0", want: "05104582000170"},
 		{name: "valid4", code: "109.094.020/0016-7", want: "10909402000167"},
+		{name: "valid5", code: "012.345.678-90", want: "01234567890"},
+		{name: "valid6", code: "125.217.532-97", want: "12521753297"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This PR adds support for CPF validation in the TaxID field. 

## Context 

There is evidence that suggests, in Brazil, individuals (Pessoa Física) can legally issue electronic service invoices (NFS-e) using their CPF, without needing a CNPJ.

### Official Support 

#### Nota Carioca (Rio de Janeiro’s NFS-e portal)

The system explicitly allows access using an e-CPF (digital certificate tied to a CPF):

<img width="1616" height="286" alt="image" src="https://github.com/user-attachments/assets/2f0fab6f-769d-4dde-b331-eca81cb8a07d" />

https://notacarioca.rio.gov.br/faq.aspx#faq0103

### Technical Implementation References

Invoices and XML payloads from the Maringá municipal system use a shared CPF/CNPJ field:
- XML schema: `<CpfCnpj>`
- PDF layout: Under "Prestador de Serviços" there's a section called "CPF/CNPJ: ...", suggesting both types of taxpayer IDs are valid.

## Pre-Review Checklist

- [x] I've read the CONTRIBUTING.md guide.
- [x] I have performed a self-review of my code.
- [x] I have added thorough tests with at **least** 90% code coverage.
- [ ] I've modified or created example GOBL documents to show my changes in use, if appropriate.
- [x] When adding or modifying a tax regime or addon, I've added links to the source of the changes, either structured or in the comments.
- [x] I've run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [x] All linter warnings have been reviewed and fixed.
- [x] I've been obsessive with pointer nil checks to avoid panics.
- [x] The CHANGELOG.md has been updated with an overview of my changes.
- [x] Requested a review from @samlown.
