### PR TITLE
Fix regex for frech VAT validation

### DIFF
--- a/regimes/fr/tax_identity.go
+++ b/regimes/fr/tax_identity.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	taxCodeVATRegexp   = regexp.MustCompile(`^\d{11}$`)
+	taxCodeVATRegexp = regexp.MustCompile(`^[A-Z0-9]{2}\d{9}$`)
 	taxCodeSIRENRegexp = regexp.MustCompile(`^\d{9}$`)
 )
 


### PR DESCRIPTION
- I updated the REGEX used for validating the 11-chars French VAT. 

In the current state of the code only 11 digits are valid but there can actually be 2 chars. 

> (Eng translation...) The structure of the intra-community VAT number is specific to each country. In France, the number begins with the letters FR, followed by a key (letters or digits assigned by the tax authorities of the company’s registered office location) and ends with the company’s SIREN number (a series of 9 digits).

source: https://www.economie.gouv.fr/cedef/fiches-pratiques/quest-ce-quun-numero-de-tva-intracommunautaire#:~:text=La%20structure%20du%20num%C3%A9ro%20de,(s%C3%A9rie%20de%209%20chiffres).

## Pre-Review Checklist

- [x] I've read the CONTRIBUTING.md guide.
- [x] I have performed a self-review of my code.
- [ ] I have added thorough tests with at **least** 90% code coverage.
- [ ] I've modified or created example GOBL documents to show my changes in use, if appropriate.
- [ ] When adding or modifying a tax regime or addon, I've added links to the source of the changes, either structured or in the comments.
- [ ] I've run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [ ] All linter warnings have been reviewed and fixed.
- [ ] I've been obsessive with pointer nil checks to avoid panics.
- [ ] The CHANGELOG.md has been updated with an overview of my changes.
- [ ] Requested a review from @samlown.
