### PR TITLE
Support for Tax Identity exceptions in France

### DIFF
--- a/regimes/fr/tax_identity_test.go
+++ b/regimes/fr/tax_identity_test.go
@@ -60,6 +60,8 @@ func TestValidateTaxIdentity(t *testing.T) {
 		{name: "good 1", code: "39356000000"},
 		{name: "good 2", code: "44732829320"},
 		{name: "good 3", code: "44391838042"},
+		{name: "good with letters", code: "0L433754066"}, // Special cases.
+		{name: "good La Poste", code: "11356000000"},     // "11" invented
 		{
 			name: "empty",
 			code: "",


### PR DESCRIPTION
- Replaces #591 
- Handles exception cases in French Tax IDs for Government and La Poste codes.

## Pre-Review Checklist

- [ ] I've read the CONTRIBUTING.md guide.
- [ ] I have performed a self-review of my code.
- [ ] I have added thorough tests with at **least** 90% code coverage.
- [ ] I've modified or created example GOBL documents to show my changes in use, if appropriate.
- [ ] When adding or modifying a tax regime or addon, I've added links to the source of the changes, either structured or in the comments.
- [ ] I've run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [ ] All linter warnings have been reviewed and fixed.
- [ ] I've been obsessive with pointer nil checks to avoid panics.
- [ ] The CHANGELOG.md has been updated with an overview of my changes.
- [ ] Requested a review from @samlown.
