### PR TITLE
Add zero percent for VAT zero key

### DIFF
--- a/data/schemas/tax/set.json
+++ b/data/schemas/tax/set.json
@@ -52,15 +52,15 @@
         }
       ],
       "properties": {
-        "country": {
-          "$ref": "https://gobl.org/draft-0/l10n/tax-country-code",
-          "title": "Country",
-          "description": "Country code override when issuing with taxes applied from different countries."
-        },
         "cat": {
           "$ref": "https://gobl.org/draft-0/cbc/code",
           "title": "Category",
           "description": "Tax category code from those available inside a region."
+        },
+        "country": {
+          "$ref": "https://gobl.org/draft-0/l10n/tax-country-code",
+          "title": "Country",
+          "description": "Country code override when issuing with taxes applied from different countries."
         },
         "key": {
           "$ref": "https://gobl.org/draft-0/cbc/key",

--- a/data/schemas/tax/total.json
+++ b/data/schemas/tax/total.json
@@ -43,15 +43,15 @@
     },
     "RateTotal": {
       "properties": {
-        "key": {
-          "$ref": "https://gobl.org/draft-0/cbc/key",
-          "title": "Key",
-          "description": "Tax key if supported by the category."
-        },
         "country": {
           "$ref": "https://gobl.org/draft-0/l10n/tax-country-code",
           "title": "Country",
           "description": "Country code override when issuing with taxes applied from different countries,\nit'd be very strange to mix rates from different countries, but in theory\nthis would be possible."
+        },
+        "key": {
+          "$ref": "https://gobl.org/draft-0/cbc/key",
+          "title": "Key",
+          "description": "Tax key if supported by the category."
         },
         "ext": {
           "$ref": "https://gobl.org/draft-0/tax/extensions",

--- a/examples/es/out/invoice-es-nl-digital-b2c.json
+++ b/examples/es/out/invoice-es-nl-digital-b2c.json
@@ -58,8 +58,8 @@
 				"sum": "1000.00",
 				"taxes": [
 					{
-						"country": "NL",
 						"cat": "VAT",
+						"country": "NL",
 						"key": "standard",
 						"rate": "general",
 						"percent": "21.0%"
@@ -77,8 +77,8 @@
 						"code": "VAT",
 						"rates": [
 							{
-								"key": "standard",
 								"country": "NL",
+								"key": "standard",
 								"base": "1000.00",
 								"percent": "21.0%",
 								"amount": "210.00"

--- a/examples/es/out/invoice-es-nl-tbai-b2c.json
+++ b/examples/es/out/invoice-es-nl-tbai-b2c.json
@@ -77,8 +77,8 @@
 				],
 				"taxes": [
 					{
-						"country": "NL",
 						"cat": "VAT",
+						"country": "NL",
 						"key": "standard",
 						"rate": "general",
 						"percent": "21.0%",
@@ -99,8 +99,8 @@
 						"code": "VAT",
 						"rates": [
 							{
-								"key": "standard",
 								"country": "NL",
+								"key": "standard",
 								"ext": {
 									"es-tbai-product": "services"
 								},

--- a/examples/es/out/invoice-es-pt-digital.json
+++ b/examples/es/out/invoice-es-pt-digital.json
@@ -66,8 +66,8 @@
 				"sum": "200.00",
 				"taxes": [
 					{
-						"country": "PT",
 						"cat": "VAT",
+						"country": "PT",
 						"key": "standard",
 						"rate": "general",
 						"percent": "23.0%"
@@ -85,8 +85,8 @@
 				"sum": "375.00",
 				"taxes": [
 					{
-						"country": "PT",
 						"cat": "VAT",
+						"country": "PT",
 						"key": "standard",
 						"rate": "general",
 						"percent": "23.0%"
@@ -104,8 +104,8 @@
 						"code": "VAT",
 						"rates": [
 							{
-								"key": "standard",
 								"country": "PT",
+								"key": "standard",
 								"base": "575.00",
 								"percent": "23.0%",
 								"amount": "132.25"

--- a/examples/pt/out/invoice-b2c-es.json
+++ b/examples/pt/out/invoice-b2c-es.json
@@ -59,8 +59,8 @@
 				"sum": "200.00",
 				"taxes": [
 					{
-						"country": "ES",
 						"cat": "VAT",
+						"country": "ES",
 						"key": "standard",
 						"rate": "general",
 						"percent": "21.0%",
@@ -83,8 +83,8 @@
 						"code": "VAT",
 						"rates": [
 							{
-								"key": "standard",
 								"country": "ES",
+								"key": "standard",
 								"ext": {
 									"pt-region": "ES",
 									"pt-saft-exemption": "M99",

--- a/tax/combo.go
+++ b/tax/combo.go
@@ -17,10 +17,10 @@ import (
 // and retained attributes will be determined automatically from the Rate key if set
 // during calculation.
 type Combo struct {
-	// Country code override when issuing with taxes applied from different countries.
-	Country l10n.TaxCountryCode `json:"country,omitempty" jsonschema:"title=Country"`
 	// Tax category code from those available inside a region.
 	Category cbc.Code `json:"cat" jsonschema:"title=Category"`
+	// Country code override when issuing with taxes applied from different countries.
+	Country l10n.TaxCountryCode `json:"country,omitempty" jsonschema:"title=Country"`
 	// Key helps determine the tax situation within the category.
 	Key cbc.Key `json:"key,omitempty"`
 	// Rate within a category and for a given key to apply.
@@ -55,6 +55,7 @@ func (c *Combo) ValidateWithContext(ctx context.Context) error {
 			validation.Required,
 			r.InCategories(),
 		),
+		validation.Field(&c.Country),
 		validation.Field(&c.Key,
 			r.InCategoryKeys(c.Category),
 		),

--- a/tax/combo.go
+++ b/tax/combo.go
@@ -110,10 +110,16 @@ func (c *Combo) Normalize(normalizers Normalizers) {
 			}
 		}
 
-		if c.Key == cbc.KeyEmpty {
+		switch c.Key {
+		case cbc.KeyEmpty:
 			// Special case for zero percent which has no additional rates
 			if c.Percent != nil && c.Percent.IsZero() {
 				c.Key = KeyZero
+			}
+		case KeyZero:
+			if c.Percent == nil {
+				zp := num.PercentageZero
+				c.Percent = &zp
 			}
 		}
 	}

--- a/tax/combo_test.go
+++ b/tax/combo_test.go
@@ -51,6 +51,14 @@ func TestComboNormalize(t *testing.T) {
 		assert.Equal(t, c.Percent.String(), "0%")
 		assert.Empty(t, c.Rate)
 	})
+	t.Run("assign zero percent", func(t *testing.T) {
+		c := &tax.Combo{
+			Category: "VAT",
+			Key:      tax.KeyZero,
+		}
+		c.Normalize(nil)
+		assert.Equal(t, "0%", c.Percent.String())
+	})
 	t.Run("migrate exempt rate", func(t *testing.T) {
 		c := &tax.Combo{
 			Category: "VAT",

--- a/tax/regime_def.go
+++ b/tax/regime_def.go
@@ -319,6 +319,9 @@ func (r *RegimeDef) RequiresPercent(cat cbc.Code, key cbc.Key) validation.Rule {
 		if cd == nil {
 			return nil // nothing to lookup
 		}
+		if key == cbc.KeyEmpty && p == nil {
+			return validation.ErrRequired
+		}
 		kd := cd.KeyDef(key)
 		if kd == nil {
 			return nil // no key definition, no percent required

--- a/tax/set_test.go
+++ b/tax/set_test.go
@@ -57,6 +57,7 @@ func TestSetValidation(t *testing.T) {
 					Category: "VAT",
 					Country:  "NL",
 					Key:      "standard",
+					Rate:     "general",
 					Percent:  num.NewPercentage(20, 3),
 				},
 			},
@@ -68,10 +69,9 @@ func TestSetValidation(t *testing.T) {
 				{
 					Category: "VAT",
 					Country:  "NL",
-					Key:      "standard",
 				},
 			},
-			err: "0: (percent: required for 'standard' in 'VAT'.).",
+			err: "0: (percent: cannot be blank.).",
 		},
 		{
 			desc: "exempt rate with percent",
@@ -101,13 +101,32 @@ func TestSetValidation(t *testing.T) {
 			err: "duplicated",
 		},
 		{
-			desc: "missing percentage",
+			desc: "VAT missing percentage",
 			set: tax.Set{
 				{
 					Category: "VAT",
 				},
 			},
-			err: nil, // no percent implies exempt
+			err: "0: (percent: cannot be blank.)",
+		},
+		{
+			desc: "VAT missing percentage with key",
+			set: tax.Set{
+				{
+					Category: "VAT",
+					Key:      "standard",
+				},
+			},
+			err: "0: (percent: required for 'standard' in 'VAT'.).",
+		},
+		{
+			desc: "IRPF missing percentage",
+			set: tax.Set{
+				{
+					Category: "IRPF",
+				},
+			},
+			err: "0: (percent: cannot be blank.)",
 		},
 		{
 			desc: "missing percentage with exempt rate",
@@ -163,7 +182,7 @@ func TestSetValidation(t *testing.T) {
 			err: "surcharge: required with percent.",
 		},
 		{
-			desc: "exempt rate with reason",
+			desc: "exempt key with reason",
 			set: tax.Set{
 				{
 					Category: "VAT",
@@ -176,16 +195,18 @@ func TestSetValidation(t *testing.T) {
 			err: nil,
 		},
 		{
-			desc: "exempt, no rate, with extension",
+			desc: "exempt, no key, with extension",
 			set: tax.Set{
 				{
 					Category: "VAT",
+					// The correct key would be set
+					// here automatically in normalization.
 					Ext: tax.Extensions{
 						tbai.ExtKeyExemption: "E1",
 					},
 				},
 			},
-			err: nil,
+			err: "0: (percent: cannot be blank.).",
 		},
 		{
 			desc: "exempt rate with invalid reason",

--- a/tax/totals.go
+++ b/tax/totals.go
@@ -21,12 +21,12 @@ type CategoryTotal struct {
 // a matching category and rate. The Key is optional as we may be using
 // the percentage to group rates.
 type RateTotal struct {
-	// Tax key if supported by the category.
-	Key cbc.Key `json:"key,omitempty" jsonschema:"title=Key"`
 	// Country code override when issuing with taxes applied from different countries,
 	// it'd be very strange to mix rates from different countries, but in theory
 	// this would be possible.
 	Country l10n.TaxCountryCode `json:"country,omitempty" jsonschema:"title=Country"`
+	// Tax key if supported by the category.
+	Key cbc.Key `json:"key,omitempty" jsonschema:"title=Key"`
 	// If the rate is defined with extensions, they'll be used to group by also.
 	Ext Extensions `json:"ext,omitempty" jsonschema:"title=Extensions"`
 	// Base amount that the percentage is applied to.


### PR DESCRIPTION
- Quick fix to add zero percentage values in Tax Combos.

