### PR TITLE
Fixing usage of IGIC in ES tax regime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Fixed
+
+- `es`: IGIC now uses VAT keys.
+
 ## [v0.300.1] - 2025-09-12
 
 ### Fixed

--- a/addons/es/verifactu/extensions.go
+++ b/addons/es/verifactu/extensions.go
@@ -295,16 +295,14 @@ var extensions = []*cbc.Definition{
 				alongside the ~es-verifactu-op-class~ extension. Values correspond to the
 				L10 list.
 
-				The follow mappings will be made automatically by GOBL during normalization:
+				The follow mappings will be made automatically by GOBL during normalization.
 
-				| Exemption Code | Tax Key |
-				|----------------|---------|
-				| ~E1~           | ~exempt~ |
-				| ~E2~           | ~export~ |
-				| ~E3~           | ~export+transport~ |
-				| ~E4~           | ~export+triangular~ |
-				| ~E5~           | ~intra-community~ |
-				| ~E6~           | ~exempt+other~ |
+				| Tax Key           | Exemption Codes            |
+				|-------------------|----------------------------|
+				| ~exempt~          | ~E1~ (default), ~E6~       |
+				| ~export~          | ~E2~ (default), ~E3~, ~E4~ |
+				| ~intra-community~ | ~E5~                       |
+				| ~exempt~          | ~E6~                       |
 			`),
 		},
 		Values: []*cbc.Definition{
@@ -401,8 +399,8 @@ var extensions = []*cbc.Definition{
 
 				| Combo Context				| Regime Code |
 				|---------------------------|-------------|
-				| Rate ~standard~			| ~01~        |
-				| Rate has ~export~			| ~02~        |
+				| Key ~standard~			| ~01~        |
+				| Key ~export~			    | ~02~        |
 				| Has surcharge				| ~18~        |
 			`),
 		},

--- a/addons/es/verifactu/extensions.go
+++ b/addons/es/verifactu/extensions.go
@@ -302,7 +302,6 @@ var extensions = []*cbc.Definition{
 				| ~exempt~          | ~E1~ (default), ~E6~       |
 				| ~export~          | ~E2~ (default), ~E3~, ~E4~ |
 				| ~intra-community~ | ~E5~                       |
-				| ~exempt~          | ~E6~                       |
 			`),
 		},
 		Values: []*cbc.Definition{

--- a/examples/es/invoice-es-igic.yaml
+++ b/examples/es/invoice-es-igic.yaml
@@ -39,7 +39,6 @@ lines:
       discounts:
           - percent: "10%"
             reason: "Special discount"
-          - amount: "0.00"
       taxes:
           - cat: IGIC
             rate: general
@@ -49,4 +48,4 @@ lines:
           price: "10.00"
       taxes:
           - cat: VAT
-            rate: zero
+            rate: exempt

--- a/examples/es/out/invoice-es-igic.json
+++ b/examples/es/out/invoice-es-igic.json
@@ -4,7 +4,7 @@
 		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
 		"dig": {
 			"alg": "sha256",
-			"val": "276a0a06d6bd98ca6f2e1115586be7e25ac965f9f92f5c979c37ae4b8aff71a9"
+			"val": "5b7ed829f9c9835b8ce0f2d23ad84de34f0fa9165f9f203609cc2042e850c04e"
 		}
 	},
 	"doc": {
@@ -78,6 +78,7 @@
 				"taxes": [
 					{
 						"cat": "IGIC",
+						"key": "standard",
 						"rate": "general",
 						"percent": "7.0%"
 					}
@@ -95,8 +96,7 @@
 				"taxes": [
 					{
 						"cat": "VAT",
-						"key": "zero",
-						"percent": "0%"
+						"key": "exempt"
 					}
 				],
 				"total": "10.00"
@@ -111,6 +111,7 @@
 						"code": "IGIC",
 						"rates": [
 							{
+								"key": "standard",
 								"base": "1620.00",
 								"percent": "7.0%",
 								"amount": "113.40"
@@ -122,9 +123,8 @@
 						"code": "VAT",
 						"rates": [
 							{
-								"key": "zero",
+								"key": "exempt",
 								"base": "10.00",
-								"percent": "0%",
 								"amount": "0.00"
 							}
 						],

--- a/regimes/es/tax_categories.go
+++ b/regimes/es/tax_categories.go
@@ -178,9 +178,15 @@ func taxCategories() []*tax.CategoryDef {
 				i18n.EN: "Canary Island General Indirect Tax",
 				i18n.ES: "Impuesto General Indirecto Canario",
 			},
-			// This is a subset of the possible rates.
+			// Use the same global VAT keys as IGIC is effectively a local VAT, unlike
+			// IPSI which has more in common with a sales tax.
+			Keys: tax.GlobalVATKeys(),
+			// This is a subset of the possible rates, notably the "increased" rates applied on luxury
+			// items and some professional services are not included here. Users are recommended to include whatever
+			// percentage applies to their situation directly in the invoice.
 			Rates: []*tax.RateDef{
 				{
+					Keys: []cbc.Key{tax.KeyStandard},
 					Rate: tax.RateGeneral,
 					Name: i18n.String{
 						i18n.EN: "General Rate",
@@ -193,6 +199,7 @@ func taxCategories() []*tax.CategoryDef {
 					},
 				},
 				{
+					Keys: []cbc.Key{tax.KeyStandard},
 					Rate: tax.RateReduced,
 					Name: i18n.String{
 						i18n.EN: "Reduced Rate",


### PR DESCRIPTION
- Fixes usage of IGIC in the Spanish regime which requires the usage of VAT keys.

## Pre-Review Checklist

- [ ] I've read the CONTRIBUTING.md guide.
- [ ] I have performed a self-review of my code.
- [ ] I have added thorough tests with at **least** 90% code coverage.
- [ ] I've modified or created example GOBL documents to show my changes in use, if appropriate.
- [ ] When adding or modifying a tax regime or addon, I've added links to the source of the changes, either structured or in the comments.
- [ ] I've run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [ ] All linter warnings have been reviewed and fixed.
- [ ] I've been obsessive with pointer nil checks to avoid panics.
- [ ] The CHANGELOG.md has been updated with an overview of my changes.
- [ ] Requested a review from @samlown.
