### PR TITLE
Support for storing images alongside items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Added
+
+- `org`: `Item` - `images` field for storing links to images of the item.
+
 ### Fixed
 
 - `es`: IGIC now uses VAT keys.

--- a/data/schemas/org/item.json
+++ b/data/schemas/org/item.json
@@ -45,7 +45,7 @@
           },
           "type": "array",
           "title": "Images",
-          "description": "Images associated with the item"
+          "description": "Images associated with the item."
         },
         "currency": {
           "$ref": "https://gobl.org/draft-0/currency/code",

--- a/data/schemas/org/item.json
+++ b/data/schemas/org/item.json
@@ -39,6 +39,14 @@
           "title": "Description",
           "description": "Detailed description of the item."
         },
+        "images": {
+          "items": {
+            "$ref": "https://gobl.org/draft-0/org/image"
+          },
+          "type": "array",
+          "title": "Images",
+          "description": "Images associated with the item"
+        },
         "currency": {
           "$ref": "https://gobl.org/draft-0/currency/code",
           "title": "Currency",

--- a/org/item.go
+++ b/org/item.go
@@ -35,7 +35,7 @@ type Item struct {
 	Identities []*Identity `json:"identities,omitempty" jsonschema:"title=Identities"`
 	// Detailed description of the item.
 	Description string `json:"description,omitempty" jsonschema:"title=Description"`
-	// Images associated with the item
+	// Images associated with the item.
 	Images []*Image `json:"images,omitempty" jsonschema:"title=Images"`
 	// Currency used for the item's price.
 	Currency currency.Code `json:"currency,omitempty" jsonschema:"title=Currency"`

--- a/org/item.go
+++ b/org/item.go
@@ -35,6 +35,8 @@ type Item struct {
 	Identities []*Identity `json:"identities,omitempty" jsonschema:"title=Identities"`
 	// Detailed description of the item.
 	Description string `json:"description,omitempty" jsonschema:"title=Description"`
+	// Images associated with the item
+	Images []*Image `json:"images,omitempty" jsonschema:"title=Images"`
 	// Currency used for the item's price.
 	Currency currency.Code `json:"currency,omitempty" jsonschema:"title=Currency"`
 	// Base price of a single unit to be sold.
@@ -69,6 +71,7 @@ func (i *Item) Normalize(normalizers tax.Normalizers) {
 
 	normalizers.Each(i)
 	tax.Normalize(normalizers, i.Identities)
+	tax.Normalize(normalizers, i.Images)
 }
 
 // ValidateWithContext checks that the Item looks okay inside the provided context.
@@ -78,6 +81,8 @@ func (i *Item) ValidateWithContext(ctx context.Context) error {
 		validation.Field(&i.Ref),
 		validation.Field(&i.Key),
 		validation.Field(&i.Name, validation.Required),
+		validation.Field(&i.Description),
+		validation.Field(&i.Images),
 		validation.Field(&i.Identities),
 		validation.Field(&i.Currency),
 		validation.Field(&i.Price),


### PR DESCRIPTION
- Simple addition to `org.Item` for an array of images.

## Pre-Review Checklist

- [ ] I've read the CONTRIBUTING.md guide.
- [ ] I have performed a self-review of my code.
- [ ] I have added thorough tests with at **least** 90% code coverage.
- [ ] I've modified or created example GOBL documents to show my changes in use, if appropriate.
- [ ] When adding or modifying a tax regime or addon, I've added links to the source of the changes, either structured or in the comments.
- [ ] I've run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [ ] All linter warnings have been reviewed and fixed.
- [ ] I've been obsessive with pointer nil checks to avoid panics.
- [ ] The CHANGELOG.md has been updated with an overview of my changes.
- [ ] Requested a review from @samlown.
