### PR TITLE
Fix zero-percent handling in charges and discounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Fixed
 
-- `es`: IGIC now uses VAT keys.
+- `es`: IGIC now uses VAT keys
+- `bill`: fixed zero-percent handling in charges and discounts
 
 ## [v0.300.1] - 2025-09-12
 

--- a/bill/charges.go
+++ b/bill/charges.go
@@ -175,7 +175,7 @@ func calculateCharges(lines []*Charge, cur currency.Code, sum num.Amount, rr cbc
 			continue
 		}
 		l.Index = i + 1
-		if l.Percent != nil && !l.Percent.IsZero() {
+		if l.Percent != nil {
 			base := sum
 			if l.Base != nil {
 				base = l.Base.RescaleUp(zero.Exp() + linePrecisionExtra)

--- a/bill/charges_test.go
+++ b/bill/charges_test.go
@@ -187,4 +187,23 @@ func TestChargeTotals(t *testing.T) {
 		assert.Equal(t, "50.1234", ls[0].Base.String(), "should maintain original precision")
 		assert.Equal(t, "10.02", ls[0].Amount.String())
 	})
+
+	t.Run("with zero percent charge and inconsistent amount", func(t *testing.T) {
+		ls := []*Charge{
+			{
+				Reason:  "Zero percent charge",
+				Percent: num.NewPercentage(0, 2),
+				Amount:  num.MakeAmount(10, 2),
+			},
+		}
+		base := num.MakeAmount(10000, 2)
+		calculateCharges(ls, currency.EUR, base, tax.RoundingRulePrecise)
+		sum := calculateChargeSum(ls, currency.EUR)
+		require.NotNil(t, sum)
+		assert.Equal(t, "0%", ls[0].Percent.String())
+		assert.Equal(t, "0.00", ls[0].Amount.String())
+		assert.Equal(t, "0.00", sum.String())
+		roundCharges(ls, currency.EUR)
+		assert.Equal(t, "0.00", ls[0].Amount.String())
+	})
 }

--- a/bill/discounts.go
+++ b/bill/discounts.go
@@ -190,7 +190,7 @@ func calculateDiscounts(lines []*Discount, cur currency.Code, sum num.Amount, rr
 			continue
 		}
 		l.Index = i + 1
-		if l.Percent != nil && !l.Percent.IsZero() {
+		if l.Percent != nil {
 			base := sum
 			if l.Base != nil {
 				base = l.Base.RescaleUp(zero.Exp() + linePrecisionExtra)

--- a/bill/discounts_test.go
+++ b/bill/discounts_test.go
@@ -210,4 +210,23 @@ func TestDiscountTotals(t *testing.T) {
 		assert.Equal(t, "50.1234", ls[0].Base.String(), "maintain original precision")
 		assert.Equal(t, "10.02", ls[0].Amount.String())
 	})
+
+	t.Run("with zero percent discount and inconsistent amount", func(t *testing.T) {
+		ls := []*Discount{
+			{
+				Reason:  "Zero percent discount",
+				Percent: num.NewPercentage(0, 2),
+				Amount:  num.MakeAmount(10, 2),
+			},
+		}
+		base := num.MakeAmount(10000, 2)
+		calculateDiscounts(ls, currency.EUR, base, tax.RoundingRulePrecise)
+		sum := calculateDiscountSum(ls, currency.EUR)
+		require.NotNil(t, sum)
+		assert.Equal(t, "0%", ls[0].Percent.String())
+		assert.Equal(t, "0.00", ls[0].Amount.String())
+		assert.Equal(t, "0.00", sum.String())
+		roundDiscounts(ls, currency.EUR)
+		assert.Equal(t, "0.00", ls[0].Amount.String())
+	})
 }

--- a/bill/line_calculate.go
+++ b/bill/line_calculate.go
@@ -165,7 +165,7 @@ func calculateSubLine(sl *SubLine, cur currency.Code, rates []*currency.Exchange
 func calculateLineDiscounts(discounts []*LineDiscount, sum, total num.Amount, cur currency.Code, rr cbc.Key) num.Amount {
 	cd := cur.Def()
 	for _, d := range discounts {
-		if d.Percent != nil && !d.Percent.IsZero() {
+		if d.Percent != nil {
 			base := sum
 			if d.Base != nil {
 				b := d.Base.RescaleUp(cd.Subunits)
@@ -184,7 +184,7 @@ func calculateLineDiscounts(discounts []*LineDiscount, sum, total num.Amount, cu
 func calculateLineCharges(charges []*LineCharge, quantity, sum, total num.Amount, cur currency.Code, rr cbc.Key) num.Amount {
 	cd := cur.Def()
 	for _, c := range charges {
-		if c.Percent != nil && !c.Percent.IsZero() {
+		if c.Percent != nil {
 			base := sum
 			if c.Base != nil {
 				b := c.Base.RescaleUp(cd.Subunits)

--- a/bill/line_calculate_test.go
+++ b/bill/line_calculate_test.go
@@ -570,4 +570,62 @@ func TestLineCalculate(t *testing.T) {
 		assert.Equal(t, "37.77", lines[0].Sum.String())
 		assert.Equal(t, "39.77", lines[0].Total.String())
 	})
+
+	t.Run("lines with zero percent discount and inconsistent amount", func(t *testing.T) {
+		lines := []*Line{
+			{
+				Quantity: num.MakeAmount(3, 0),
+				Item: &org.Item{
+					Name:  "Test Item",
+					Price: num.NewAmount(1259, 2),
+				},
+				Discounts: []*LineDiscount{
+					{
+						Percent: num.NewPercentage(0, 2),
+						Amount:  num.MakeAmount(10, 2),
+					},
+				},
+			},
+		}
+		err := calculateLines(lines, currency.EUR, nil, tax.RoundingRulePrecise)
+		assert.NoError(t, err)
+		sum := calculateLineSum(lines, currency.EUR)
+		assert.Equal(t, "37.7700", sum.String())
+		assert.Equal(t, "0.0000", lines[0].Discounts[0].Amount.String())
+		assert.Equal(t, "37.7700", lines[0].Sum.String())
+		assert.Equal(t, "37.7700", lines[0].Total.String())
+		roundLines(lines)
+		assert.Equal(t, "0.00", lines[0].Discounts[0].Amount.String())
+		assert.Equal(t, "37.77", lines[0].Sum.String())
+		assert.Equal(t, "37.77", lines[0].Total.String())
+	})
+
+	t.Run("lines with zero percent charge and inconsistent amount", func(t *testing.T) {
+		lines := []*Line{
+			{
+				Quantity: num.MakeAmount(3, 0),
+				Item: &org.Item{
+					Name:  "Test Item",
+					Price: num.NewAmount(1259, 2),
+				},
+				Charges: []*LineCharge{
+					{
+						Percent: num.NewPercentage(0, 2),
+						Amount:  num.MakeAmount(10, 2),
+					},
+				},
+			},
+		}
+		err := calculateLines(lines, currency.EUR, nil, tax.RoundingRulePrecise)
+		assert.NoError(t, err)
+		sum := calculateLineSum(lines, currency.EUR)
+		assert.Equal(t, "37.7700", sum.String())
+		assert.Equal(t, "0.0000", lines[0].Charges[0].Amount.String())
+		assert.Equal(t, "37.7700", lines[0].Sum.String())
+		assert.Equal(t, "37.7700", lines[0].Total.String())
+		roundLines(lines)
+		assert.Equal(t, "0.00", lines[0].Charges[0].Amount.String())
+		assert.Equal(t, "37.77", lines[0].Sum.String())
+		assert.Equal(t, "37.77", lines[0].Total.String())
+	})
 }


### PR DESCRIPTION
- Fixes zero-percent handling in charges and discounts to ensure the amount is consistent with the percent

## Pre-Review Checklist

- [x] I've read the CONTRIBUTING.md guide.
- [x] I have performed a self-review of my code.
- [x] I have added thorough tests with at **least** 90% code coverage.
- _N/A_ I've modified or created example GOBL documents to show my changes in use, if appropriate.
- _N/A_ When adding or modifying a tax regime or addon, I've added links to the source of the changes, either structured or in the comments.
- _N/A_ I've run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [x] All linter warnings have been reviewed and fixed.
- [x] I've been obsessive with pointer nil checks to avoid panics.
- [x] The CHANGELOG.md has been updated with an overview of my changes.
- [x] Requested a review from @samlown.
