### PR TITLE
changing translation from MwST to USt

### DIFF
--- a/data/regimes/de.json
+++ b/data/regimes/de.json
@@ -46,7 +46,7 @@
     {
       "code": "VAT",
       "name": {
-        "de": "MwSt",
+        "de": "USt",
         "en": "VAT"
       },
       "title": {


### PR DESCRIPTION
> I want to translate "VAT" into german, and I've found two alternatives, "MwSt" or "USt", which one is more accurate?

Both **MwSt** (*Mehrwertsteuer*) and **USt** (*Umsatzsteuer*) are used in German, but they carry slightly different connotations depending on context:

* **MwSt (Mehrwertsteuer)** = “value-added tax” in the strict sense, the consumer-facing term. You’ll see this on receipts, supermarket labels, restaurant bills. It’s the everyday way of talking about VAT.

* **USt (Umsatzsteuer)** = “turnover tax.” This is the *legal and administrative* term, used in legislation, tax returns, invoices, and dealings with the tax office.

In practice:

* If you’re translating **for an official, legal, or accounting context** (invoices, tax regulations, business reporting), use **USt**.
* If you’re translating **for consumers or general communication** (shop notices, marketing, price tags), **MwSt** is more natural.

So:

* “VAT ID” → **USt-IdNr.** (Umsatzsteuer-Identifikationsnummer).
* “incl. VAT” → **inkl. MwSt.**

👉 In short:

* **USt** = accurate in bureaucratic/legal/accounting contexts.
* **MwSt** = accurate in everyday consumer-facing contexts.

Do you want me to recommend which one to standardize on for your documentation work?

> suppose I have an invoice, would it state MwSt or USt?

On a **German invoice**, you will normally see **USt**.

A few details:

* The law governing invoices is the **Umsatzsteuergesetz (UStG)**, and invoices must show the **Umsatzsteuer** (USt) amount and rate.
* That said, many businesses—especially in retail or B2C—still write **MwSt** on invoices because it’s more familiar to customers. Both are accepted, but **USt** is technically more precise and compliant with the legal language.
* The **VAT ID** on invoices is always called **USt-IdNr.**, never *MwSt-IdNr.*

So:

* If you’re making invoices for official/commercial purposes → **USt** is the correct and professional choice.
* If it’s a simple consumer-facing bill or receipt → you might see **MwSt**, and no auditor will object.

Would you like me to give you a model invoice snippet in German showing the standard phrasing?
