### PR TITLE
Add: Line seller field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 - `sg`: Singaporean regime
 - `tax`: `keys` for GST
+- `bill`: `Line` with `seller` property, to be used in Mexico.
 
 ### Fixed
 

--- a/bill/line.go
+++ b/bill/line.go
@@ -51,6 +51,11 @@ type Line struct {
 	// This is for purely informative purposes, and will not be used for calculations.
 	Substituted []*SubLine `json:"substituted,omitempty" jsonschema:"title=Substituted"`
 
+	// Seller of the item if different from the supplier or ordering seller. This can be
+	// useful for marketplace or drop-ship scenarios in locations that require the
+	// original seller to be indicated.
+	Seller *org.Party `json:"seller,omitempty" jsonschema:"title=Seller"`
+
 	// Set of specific notes for this line that may be required for
 	// clarification.
 	Notes []*org.Note `json:"notes,omitempty" jsonschema:"title=Notes"`
@@ -142,6 +147,7 @@ func (l *Line) ValidateWithContext(ctx context.Context) error {
 			),
 		),
 		validation.Field(&l.Substituted),
+		validation.Field(&l.Seller),
 		validation.Field(&l.Notes),
 	)
 }
@@ -192,6 +198,7 @@ func (l *Line) Normalize(normalizers tax.Normalizers) {
 	tax.Normalize(normalizers, l.Discounts)
 	tax.Normalize(normalizers, l.Charges)
 	tax.Normalize(normalizers, l.Substituted)
+	tax.Normalize(normalizers, l.Seller)
 	normalizers.Each(l)
 }
 

--- a/data/schemas/bill/line.json
+++ b/data/schemas/bill/line.json
@@ -96,6 +96,11 @@
           "title": "Substituted",
           "description": "List of substituted lines. Useful for deliveries or corrective documents in order\nto indicate to the recipient which of the requested lines are being replaced.\nThis is for purely informative purposes, and will not be used for calculations."
         },
+        "seller": {
+          "$ref": "https://gobl.org/draft-0/org/party",
+          "title": "Seller",
+          "description": "Seller of the item if different from the supplier or ordering seller. This can be\nuseful for marketplace or drop-ship scenarios in locations that require the\noriginal seller to be indicated."
+        },
         "notes": {
           "items": {
             "$ref": "https://gobl.org/draft-0/org/note"


### PR DESCRIPTION
- Line seller field added with link to org party for usage mainly in Mexico, but also potentially other locations that require details about the entity actually selling the goods.

## Pre-Review Checklist

- [x] I've read the CONTRIBUTING.md guide.
- [x] I have performed a self-review of my code.
- [x] I have added thorough tests with at **least** 90% code coverage.
- [ ] I've modified or created example GOBL documents to show my changes in use, if appropriate.
- [ ] When adding or modifying a tax regime or addon, I've added links to the source of the changes, either structured or in the comments.
- [x] I've run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [ ] All linter warnings have been reviewed and fixed.
- [ ] I've been obsessive with pointer nil checks to avoid panics.
- [ ] The CHANGELOG.md has been updated with an overview of my changes.
- [ ] Requested a review from @samlown.
