### PR TITLE
fix: linting and build. eslint file format was not compatible with ES…

### DIFF
--- a/wasm/.eslintignore
+++ b/wasm/.eslintignore
@@ -1,1 +1,0 @@
-wasm_exec.js

--- a/wasm/.eslintrc.json
+++ b/wasm/.eslintrc.json
@@ -16,5 +16,8 @@
     "rules": {
         "no-unused-vars": "warn",
         "cypress/no-unnecessary-waiting": "warn"
-    }
+    },
+    "ignores": [
+        "wasm_exec.js"
+    ]
 }

--- a/wasm/build.sh
+++ b/wasm/build.sh
@@ -2,6 +2,10 @@
 
 GOOS=js GOARCH=wasm go build -o gobl.wasm
 
-cp "$(go env GOROOT)/misc/wasm/wasm_exec.js" .
+WASM_EXEC="$(go env GOROOT)/misc/wasm/wasm_exec.js"
+if [ ! -f "$WASM_EXEC" ]; then
+    WASM_EXEC="$(go env GOROOT)/lib/wasm/wasm_exec.js"
+fi
+cp "$WASM_EXEC" .
 
 go run ./serve


### PR DESCRIPTION
…Lint v9. Then, build on go version>1.24 outputs file somewhere else. Make script forward compatible

- Replace this bullet list with your changes

## Pre-Review Checklist

- [x] Opened this PR as a draft
- [x] Read the CONTRIBUTING.md guide.
- [x] Performed a self-review of my code.
- [ ] Added thorough tests with at **least** 90% code coverage.
- [ ] Modified or created example GOBL documents to show my changes in use, if appropriate.
- [ ] Added links to the source of the changes in tax regimes or addons, either structured or in the comments.
- [ ] Run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [ ] Reviewed and fixed all linter warnings.
- [ ] Been obsessive with pointer nil checks to avoid panics.
- [ ] Updated the CHANGELOG.md with an overview of my changes.
- [ ] Requested a review from Copilot and fixed or dismissed (with a reason) all the feedback raised.

Only after checking off all the previous items:
- [ ] Marked this PR as ready for review and requested one from @samlown.
