### PR TITLE
Country is required in identities in Verifactu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Fixed
 
 - `gr-mydata-v1`: Corrected exemption codes 3 and 4 mapping to `outside-scope`
+- `es-verifactu-v1`: Country is now required on customer identities when identity type is not NIF-VAT (`02`)
 
 ## [v0.308.0] - 2026-02-17
 

--- a/addons/es/verifactu/bill.go
+++ b/addons/es/verifactu/bill.go
@@ -173,6 +173,29 @@ func validateInvoiceCustomer(val any) error {
 			tax.RequireIdentityCode,
 			validation.Skip,
 		),
+		validation.Field(&p.Identities,
+			validation.Each(
+				validation.By(validateIdentityCountry),
+				validation.Skip,
+			),
+			validation.Skip,
+		),
+	)
+}
+
+func validateIdentityCountry(val any) error {
+	id, ok := val.(*org.Identity)
+	if !ok || id == nil {
+		return nil
+	}
+	return validation.ValidateStruct(id,
+		validation.Field(&id.Country,
+			validation.When(
+				id.Ext.Has(ExtKeyIdentityType) && !id.Ext.Get(ExtKeyIdentityType).In(ExtCodeIdentityTypeVAT),
+				validation.Required.Error("required when identity type is not NIF-VAT (02)"),
+			),
+			validation.Skip,
+		),
 	)
 }
 

--- a/addons/es/verifactu/bill_test.go
+++ b/addons/es/verifactu/bill_test.go
@@ -346,8 +346,35 @@ func TestInvoiceValidation(t *testing.T) {
 		inv.Customer.TaxID = nil
 		inv.Customer.Identities = []*org.Identity{
 			{
+				Key:     org.IdentityKeyPassport,
+				Code:    "AA123456",
+				Country: "GB",
+			},
+		}
+		require.NoError(t, inv.Calculate())
+		require.NoError(t, inv.Validate())
+	})
+	t.Run("customer with identity missing country", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Customer.TaxID = nil
+		inv.Customer.Identities = []*org.Identity{
+			{
 				Key:  org.IdentityKeyPassport,
 				Code: "AA123456",
+			},
+		}
+		require.NoError(t, inv.Calculate())
+		assert.ErrorContains(t, inv.Validate(), "customer: (identities: (0: (country: required when identity type is not NIF-VAT (02).).).).")
+	})
+	t.Run("customer with NIF-VAT identity without country is valid", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Customer.TaxID = nil
+		inv.Customer.Identities = []*org.Identity{
+			{
+				Ext: tax.Extensions{
+					verifactu.ExtKeyIdentityType: verifactu.ExtCodeIdentityTypeVAT,
+				},
+				Code: "FR12345678901",
 			},
 		}
 		require.NoError(t, inv.Calculate())


### PR DESCRIPTION
- Mapping the verifactu validation error: `El campo CodigoPais es obligatorio cuando IDType es distinto de NIF-IVA (02).`

## Pre-Review Checklist

- [x] Opened this PR as a draft
- [x] Read the CONTRIBUTING.md guide.
- [x] Performed a self-review of my code.
- [x] Added thorough tests with at **least** 90% code coverage.
- [x] Modified or created example GOBL documents to show my changes in use, if appropriate.
- [x] Added links to the source of the changes in tax regimes or addons, either structured or in the comments.
- [x] Run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [x] Reviewed and fixed all linter warnings.
- [x] Been obsessive with pointer nil checks to avoid panics.
- [x] Updated the CHANGELOG.md with an overview of my changes.
- [x] Requested a review from Copilot and fixed or dismissed (with a reason) all the feedback raised.

Only after checking off all the previous items:
- [x] Marked this PR as ready for review and requested one from @samlown.
