### PR TITLE
Australia regime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Added
+
+- `au`: Added the Australian GST regime
+
 ### Fixed
 
 - `gr-mydata-v1`: Corrected exemption codes 3 and 4 mapping to `outside-scope`

--- a/data/regimes/au.json
+++ b/data/regimes/au.json
@@ -1,0 +1,123 @@
+{
+  "$schema": "https://gobl.org/draft-0/tax/regime-def",
+  "name": {
+    "en": "Australia"
+  },
+  "time_zone": "Australia/Sydney",
+  "country": "AU",
+  "currency": "AUD",
+  "tax_scheme": "GST",
+  "categories": [
+    {
+      "code": "GST",
+      "name": {
+        "en": "GST"
+      },
+      "title": {
+        "en": "Goods and Services Tax"
+      },
+      "keys": [
+        {
+          "key": "standard",
+          "name": {
+            "en": "Standard"
+          }
+        },
+        {
+          "key": "zero",
+          "name": {
+            "en": "Zero"
+          }
+        },
+        {
+          "key": "exempt",
+          "name": {
+            "en": "Exempt"
+          },
+          "no_percent": true
+        },
+        {
+          "key": "outside-scope",
+          "name": {
+            "en": "Outside scope"
+          },
+          "no_percent": true
+        }
+      ],
+      "rates": [
+        {
+          "rate": "general",
+          "keys": [
+            "standard"
+          ],
+          "name": {
+            "en": "General rate"
+          },
+          "desc": {
+            "en": "GST is 10% on most goods and services consumed in Australia, including imports and digital products."
+          },
+          "values": [
+            {
+              "since": "2000-07-01",
+              "percent": "10%"
+            }
+          ]
+        },
+        {
+          "rate": "zero",
+          "keys": [
+            "zero"
+          ],
+          "name": {
+            "en": "GST-free"
+          },
+          "desc": {
+            "en": "GST-free sales are not taxed. Common examples include basic food, some health and education services, and exports."
+          },
+          "values": [
+            {
+              "percent": "0.0%"
+            }
+          ]
+        },
+        {
+          "rate": "zero",
+          "keys": [
+            "exempt"
+          ],
+          "name": {
+            "en": "Input-taxed"
+          },
+          "desc": {
+            "en": "Input-taxed sales do not include GST in the price and no GST credits can be claimed."
+          },
+          "values": [
+            {
+              "percent": "0.0%"
+            }
+          ]
+        }
+      ],
+      "sources": [
+        {
+          "title": {
+            "en": "GST overview"
+          },
+          "url": "https://www.ato.gov.au/about-ato/research-and-statistics/in-detail/tax-gap/goods-and-services-tax-gap/overview"
+        },
+        {
+          "title": {
+            "en": "GST-free sales"
+          },
+          "url": "https://www.ato.gov.au/businesses-and-organisations/gst-excise-and-indirect-taxes/gst/when-to-charge-gst-and-when-not-to/gst-free-sales"
+        },
+        {
+          "title": {
+            "en": "Input taxed sales"
+          },
+          "url": "https://www.ato.gov.au/businesses-and-organisations/gst-excise-and-indirect-taxes/gst/when-to-charge-gst-and-when-not-to/input-taxed-sales"
+        }
+      ]
+    }
+  ]
+}

--- a/data/schemas/tax/regime-code.json
+++ b/data/schemas/tax/regime-code.json
@@ -15,6 +15,10 @@
       "title": "Austria"
     },
     {
+      "const": "AU",
+      "title": "Australia"
+    },
+    {
       "const": "BE",
       "title": "Belgium"
     },

--- a/examples/au/invoice-au.yaml
+++ b/examples/au/invoice-au.yaml
@@ -22,7 +22,7 @@ supplier:
 customer:
   tax_id:
     country: "AU"
-    code: "51824053452"
+    code: "72787502421"
   name: "Customer Example"
   emails:
     - addr: "customer@example.com"

--- a/examples/au/invoice-au.yaml
+++ b/examples/au/invoice-au.yaml
@@ -1,0 +1,45 @@
+$schema: "https://gobl.org/draft-0/bill/invoice"
+issue_date: "2026-02-21"
+code: "001"
+currency: "AUD"
+
+supplier:
+  tax_id:
+    country: "AU"
+    code: "51824753556"
+  name: "Example Ltd"
+  emails:
+    - addr: "billing@example.com"
+  addresses:
+    - num: "88"
+      street: "George Street"
+      locality: "Sydney"
+      region: "NSW"
+      code: "2000"
+      country: "AU"
+
+customer:
+  tax_id:
+    country: "AU"
+    code: "51824053452"
+  name: "Customer Example"
+  emails:
+    - addr: "customer@example.com"
+  addresses:
+    - num: "15"
+      street: "Smith Street"
+      locality: "Melbourne"
+      region: "VIC"
+      code: "3000"
+      country: "AU"
+
+lines:
+  - quantity: 20
+    item:
+      name: "Example Item"
+      price: "90.00"
+    discounts:
+      - percent: "10%"
+    taxes:
+      - cat: "GST"
+        rate: "general"

--- a/examples/au/invoice-au.yaml
+++ b/examples/au/invoice-au.yaml
@@ -1,4 +1,5 @@
 $schema: "https://gobl.org/draft-0/bill/invoice"
+uuid: "e59a888a-08db-4827-b143-e78b062b94ce"
 issue_date: "2026-02-21"
 code: "001"
 currency: "AUD"

--- a/examples/au/out/invoice-au.json
+++ b/examples/au/out/invoice-au.json
@@ -1,0 +1,113 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
+		"dig": {
+			"alg": "sha256",
+			"val": "d85c2c82a692c3771473789cc9918a8dcf52c3c147aeba3bc39efab131ef1e3d"
+		}
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"$regime": "AU",
+		"uuid": "019c80b3-2967-70a8-8a4f-2fcec887797a",
+		"type": "standard",
+		"code": "001",
+		"issue_date": "2026-02-21",
+		"currency": "AUD",
+		"supplier": {
+			"name": "Example Ltd",
+			"tax_id": {
+				"country": "AU",
+				"code": "51824753556"
+			},
+			"addresses": [
+				{
+					"num": "88",
+					"street": "George Street",
+					"locality": "Sydney",
+					"region": "NSW",
+					"code": "2000",
+					"country": "AU"
+				}
+			],
+			"emails": [
+				{
+					"addr": "billing@example.com"
+				}
+			]
+		},
+		"customer": {
+			"name": "Customer Example",
+			"tax_id": {
+				"country": "AU",
+				"code": "51824053452"
+			},
+			"addresses": [
+				{
+					"num": "15",
+					"street": "Smith Street",
+					"locality": "Melbourne",
+					"region": "VIC",
+					"code": "3000",
+					"country": "AU"
+				}
+			],
+			"emails": [
+				{
+					"addr": "customer@example.com"
+				}
+			]
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "20",
+				"item": {
+					"name": "Example Item",
+					"price": "90.00"
+				},
+				"sum": "1800.00",
+				"discounts": [
+					{
+						"percent": "10%",
+						"amount": "180.00"
+					}
+				],
+				"taxes": [
+					{
+						"cat": "GST",
+						"key": "standard",
+						"rate": "general",
+						"percent": "10%"
+					}
+				],
+				"total": "1620.00"
+			}
+		],
+		"totals": {
+			"sum": "1620.00",
+			"total": "1620.00",
+			"taxes": {
+				"categories": [
+					{
+						"code": "GST",
+						"rates": [
+							{
+								"key": "standard",
+								"base": "1620.00",
+								"percent": "10%",
+								"amount": "162.00"
+							}
+						],
+						"amount": "162.00"
+					}
+				],
+				"sum": "162.00"
+			},
+			"tax": "162.00",
+			"total_with_tax": "1782.00",
+			"payable": "1782.00"
+		}
+	}
+}

--- a/examples/au/out/invoice-au.json
+++ b/examples/au/out/invoice-au.json
@@ -4,7 +4,7 @@
 		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
 		"dig": {
 			"alg": "sha256",
-			"val": "7a56c5b361a8bd385f447b21f1df37885c4228a29a3ca19da00d8bfd4ee146e6"
+			"val": "a15dae2b6f9f14dc48734e79fb9ebfa9a77958fc1702248afc96cd205a66a3e8"
 		}
 	},
 	"doc": {
@@ -41,7 +41,7 @@
 			"name": "Customer Example",
 			"tax_id": {
 				"country": "AU",
-				"code": "51824053452"
+				"code": "72787502421"
 			},
 			"addresses": [
 				{

--- a/examples/au/out/invoice-au.json
+++ b/examples/au/out/invoice-au.json
@@ -4,13 +4,13 @@
 		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
 		"dig": {
 			"alg": "sha256",
-			"val": "d85c2c82a692c3771473789cc9918a8dcf52c3c147aeba3bc39efab131ef1e3d"
+			"val": "7a56c5b361a8bd385f447b21f1df37885c4228a29a3ca19da00d8bfd4ee146e6"
 		}
 	},
 	"doc": {
 		"$schema": "https://gobl.org/draft-0/bill/invoice",
 		"$regime": "AU",
-		"uuid": "019c80b3-2967-70a8-8a4f-2fcec887797a",
+		"uuid": "e59a888a-08db-4827-b143-e78b062b94ce",
 		"type": "standard",
 		"code": "001",
 		"issue_date": "2026-02-21",

--- a/regimes/au/README.md
+++ b/regimes/au/README.md
@@ -1,0 +1,17 @@
+# 🇦🇺 GOBL Australia Tax Regime
+
+This document provides an overview of the tax regime in Australia.
+
+Find example AU GOBL files in the `examples` and `examples/out` subdirectories.
+
+## Rates
+
+1. Standard rate of **10%** (since 01/07/2000).
+2. GST-free supplies (0%) such as basic food, some health and education services, and exports.
+3. Input-taxed supplies (0%) where no GST is charged and no input tax credits can be claimed.
+
+### References
+
+- https://www.ato.gov.au/about-ato/research-and-statistics/in-detail/tax-gap/goods-and-services-tax-gap/overview
+- https://www.ato.gov.au/businesses-and-organisations/gst-excise-and-indirect-taxes/gst/when-to-charge-gst-and-when-not-to/gst-free-sales
+- https://www.ato.gov.au/businesses-and-organisations/gst-excise-and-indirect-taxes/gst/when-to-charge-gst-and-when-not-to/input-taxed-sales

--- a/regimes/au/au.go
+++ b/regimes/au/au.go
@@ -1,0 +1,45 @@
+// Package au provides the Australian tax regime.
+package au
+
+import (
+	"github.com/invopop/gobl/currency"
+	"github.com/invopop/gobl/i18n"
+	"github.com/invopop/gobl/tax"
+)
+
+func init() {
+	tax.RegisterRegimeDef(New())
+}
+
+// New provides the tax region definition for Australia.
+func New() *tax.RegimeDef {
+	return &tax.RegimeDef{
+		Country:   "AU",
+		Currency:  currency.AUD,
+		TaxScheme: tax.CategoryGST,
+		Name: i18n.String{
+			i18n.EN: "Australia",
+		},
+		TimeZone:   "Australia/Sydney",
+		Validator:  Validate,
+		Normalizer: Normalize,
+		Categories: taxCategories,
+	}
+}
+
+// Validate checks the document type and determines if it can be validated.
+func Validate(doc interface{}) error {
+	switch obj := doc.(type) {
+	case *tax.Identity:
+		return validateTaxIdentity(obj)
+	}
+	return nil
+}
+
+// Normalize will attempt to clean the object passed to it.
+func Normalize(doc interface{}) {
+	switch obj := doc.(type) {
+	case *tax.Identity:
+		tax.NormalizeIdentity(obj)
+	}
+}

--- a/regimes/au/au_test.go
+++ b/regimes/au/au_test.go
@@ -1,0 +1,20 @@
+package au_test
+
+import (
+	"testing"
+
+	"github.com/invopop/gobl/regimes/au"
+	"github.com/invopop/gobl/tax"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalize(t *testing.T) {
+	t.Run("normalize tax IDs", func(t *testing.T) {
+		tID := &tax.Identity{
+			Country: "AU",
+			Code:    "51 824 753 556",
+		}
+		au.New().Normalizer(tID)
+		assert.Equal(t, "51824753556", tID.Code.String())
+	})
+}

--- a/regimes/au/au_test.go
+++ b/regimes/au/au_test.go
@@ -3,6 +3,7 @@ package au_test
 import (
 	"testing"
 
+	"github.com/invopop/gobl/currency"
 	"github.com/invopop/gobl/regimes/au"
 	"github.com/invopop/gobl/tax"
 	"github.com/stretchr/testify/assert"
@@ -17,4 +18,21 @@ func TestNormalize(t *testing.T) {
 		au.New().Normalizer(tID)
 		assert.Equal(t, "51824753556", tID.Code.String())
 	})
+
+	t.Run("other object", func(_ *testing.T) {
+		// Ensure Normalize ignores non-tax identity objects without panic.
+		au.New().Normalizer(struct{}{})
+	})
+}
+
+func TestNewRegimeDef(t *testing.T) {
+	r := au.New()
+	if assert.NotNil(t, r) {
+		assert.Equal(t, "AU", r.Country.String())
+		assert.Equal(t, currency.AUD, r.Currency)
+		assert.Equal(t, tax.CategoryGST, r.TaxScheme)
+		assert.Equal(t, "Australia/Sydney", r.TimeZone)
+		assert.NotEmpty(t, r.Categories)
+		assert.Equal(t, "Australia", r.Name.String())
+	}
 }

--- a/regimes/au/au_test.go
+++ b/regimes/au/au_test.go
@@ -1,10 +1,9 @@
-package au_test
+package au
 
 import (
 	"testing"
 
 	"github.com/invopop/gobl/currency"
-	"github.com/invopop/gobl/regimes/au"
 	"github.com/invopop/gobl/tax"
 	"github.com/stretchr/testify/assert"
 )
@@ -15,18 +14,18 @@ func TestNormalize(t *testing.T) {
 			Country: "AU",
 			Code:    "51 824 753 556",
 		}
-		au.New().Normalizer(tID)
+		New().Normalizer(tID)
 		assert.Equal(t, "51824753556", tID.Code.String())
 	})
 
 	t.Run("other object", func(_ *testing.T) {
 		// Ensure Normalize ignores non-tax identity objects without panic.
-		au.New().Normalizer(struct{}{})
+		New().Normalizer(struct{}{})
 	})
 }
 
 func TestNewRegimeDef(t *testing.T) {
-	r := au.New()
+	r := New()
 	if assert.NotNil(t, r) {
 		assert.Equal(t, "AU", r.Country.String())
 		assert.Equal(t, currency.AUD, r.Currency)
@@ -34,5 +33,23 @@ func TestNewRegimeDef(t *testing.T) {
 		assert.Equal(t, "Australia/Sydney", r.TimeZone)
 		assert.NotEmpty(t, r.Categories)
 		assert.Equal(t, "Australia", r.Name.String())
+	}
+}
+
+func TestTaxCategories(t *testing.T) {
+	if assert.Len(t, taxCategories, 1) {
+		cat := taxCategories[0]
+		assert.Equal(t, tax.CategoryGST, cat.Code)
+		assert.False(t, cat.Retained)
+		assert.NotEmpty(t, cat.Keys)
+
+		std := cat.RateDef(tax.KeyStandard, tax.RateGeneral)
+		assert.NotNil(t, std)
+
+		zero := cat.RateDef(tax.KeyZero, tax.RateZero)
+		assert.NotNil(t, zero)
+
+		exempt := cat.RateDef(tax.KeyExempt, tax.RateZero)
+		assert.NotNil(t, exempt)
 	}
 }

--- a/regimes/au/tax_categories.go
+++ b/regimes/au/tax_categories.go
@@ -1,0 +1,92 @@
+package au
+
+import (
+	"github.com/invopop/gobl/cal"
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/i18n"
+	"github.com/invopop/gobl/num"
+	"github.com/invopop/gobl/tax"
+)
+
+var taxCategories = []*tax.CategoryDef{
+	// GST
+	{
+		Code: tax.CategoryGST,
+		Name: i18n.String{
+			i18n.EN: "GST",
+		},
+		Title: i18n.String{
+			i18n.EN: "Goods and Services Tax",
+		},
+		Sources: []*cbc.Source{
+			{
+				Title: i18n.String{
+					i18n.EN: "GST overview",
+				},
+				URL: "https://www.ato.gov.au/about-ato/research-and-statistics/in-detail/tax-gap/goods-and-services-tax-gap/overview",
+			},
+			{
+				Title: i18n.String{
+					i18n.EN: "GST-free sales",
+				},
+				URL: "https://www.ato.gov.au/businesses-and-organisations/gst-excise-and-indirect-taxes/gst/when-to-charge-gst-and-when-not-to/gst-free-sales",
+			},
+			{
+				Title: i18n.String{
+					i18n.EN: "Input taxed sales",
+				},
+				URL: "https://www.ato.gov.au/businesses-and-organisations/gst-excise-and-indirect-taxes/gst/when-to-charge-gst-and-when-not-to/input-taxed-sales",
+			},
+		},
+		Retained: false,
+		Keys:     tax.GlobalGSTKeys(),
+		Rates: []*tax.RateDef{
+			{
+				Keys: []cbc.Key{tax.KeyStandard},
+				Rate: tax.RateGeneral,
+				Name: i18n.String{
+					i18n.EN: "General rate",
+				},
+				Description: i18n.String{
+					i18n.EN: "GST is 10% on most goods and services consumed in Australia, including imports and digital products.",
+				},
+				Values: []*tax.RateValueDef{
+					{
+						Since:   cal.NewDate(2000, 7, 1),
+						Percent: num.MakePercentage(10, 2),
+					},
+				},
+			},
+			{
+				Keys: []cbc.Key{tax.KeyZero},
+				Rate: tax.RateZero,
+				Name: i18n.String{
+					i18n.EN: "GST-free",
+				},
+				Description: i18n.String{
+					i18n.EN: "GST-free sales are not taxed. Common examples include basic food, some health and education services, and exports.",
+				},
+				Values: []*tax.RateValueDef{
+					{
+						Percent: num.MakePercentage(0, 3),
+					},
+				},
+			},
+			{
+				Keys: []cbc.Key{tax.KeyExempt},
+				Rate: tax.RateZero,
+				Name: i18n.String{
+					i18n.EN: "Input-taxed",
+				},
+				Description: i18n.String{
+					i18n.EN: "Input-taxed sales do not include GST in the price and no GST credits can be claimed.",
+				},
+				Values: []*tax.RateValueDef{
+					{
+						Percent: num.MakePercentage(0, 3),
+					},
+				},
+			},
+		},
+	},
+}

--- a/regimes/au/tax_categories.go
+++ b/regimes/au/tax_categories.go
@@ -9,7 +9,6 @@ import (
 )
 
 var taxCategories = []*tax.CategoryDef{
-	// GST
 	{
 		Code: tax.CategoryGST,
 		Name: i18n.String{

--- a/regimes/au/tax_identity.go
+++ b/regimes/au/tax_identity.go
@@ -30,8 +30,30 @@ func validateTaxCode(value any) error {
 	if !ok || code == "" {
 		return nil
 	}
-	if !regexpABN.MatchString(code.String()) {
+	val := code.String()
+	if !regexpABN.MatchString(val) {
 		return errors.New("invalid format")
 	}
+	if !validABNChecksum(val) {
+		return errors.New("invalid checksum")
+	}
 	return nil
+}
+
+func validABNChecksum(abn string) bool {
+	// ABN checksum: subtract 1 from first digit, multiply by weights,
+	// sum, and ensure divisible by 89.
+	weights := []int{10, 1, 3, 5, 7, 9, 11, 13, 15, 17, 19}
+	if len(abn) != len(weights) {
+		return false
+	}
+	sum := 0
+	for i := 0; i < len(weights); i++ {
+		d := int(abn[i] - '0')
+		if i == 0 {
+			d--
+		}
+		sum += d * weights[i]
+	}
+	return sum%89 == 0
 }

--- a/regimes/au/tax_identity.go
+++ b/regimes/au/tax_identity.go
@@ -1,0 +1,37 @@
+package au
+
+import (
+	"errors"
+	"regexp"
+
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/tax"
+	"github.com/invopop/validation"
+)
+
+// Reference: https://www.ato.gov.au/businesses-and-organisations/preparing-lodging-and-paying/business-activity-statements-bass/instructions/checking-the-validity-of-an-abn
+var regexpABN = regexp.MustCompile(`^[1-9]\d{10}$`)
+
+// validateTaxIdentity checks to ensure the ABN format looks correct.
+func validateTaxIdentity(tID *tax.Identity) error {
+	if tID == nil {
+		return nil
+	}
+	return validation.ValidateStruct(tID,
+		validation.Field(&tID.Code,
+			validation.By(validateTaxCode),
+			validation.Skip,
+		),
+	)
+}
+
+func validateTaxCode(value any) error {
+	code, ok := value.(cbc.Code)
+	if !ok || code == "" {
+		return nil
+	}
+	if !regexpABN.MatchString(code.String()) {
+		return errors.New("invalid format")
+	}
+	return nil
+}

--- a/regimes/au/tax_identity_test.go
+++ b/regimes/au/tax_identity_test.go
@@ -52,4 +52,16 @@ func TestValidateIdentity(t *testing.T) {
 		assert.NoError(t, validateTaxCode(cbc.Code("51824753556")))
 		assert.Error(t, validateTaxCode(cbc.Code("51824753555")))
 	})
+
+	t.Run("tax code validator ignores unsupported value type", func(t *testing.T) {
+		assert.NoError(t, validateTaxCode("not-a-cbc-code"))
+	})
+
+	t.Run("tax code validator ignores empty code", func(t *testing.T) {
+		assert.NoError(t, validateTaxCode(cbc.Code("")))
+	})
+
+	t.Run("checksum rejects invalid length", func(t *testing.T) {
+		assert.False(t, validABNChecksum("5182475355"))
+	})
 }

--- a/regimes/au/tax_identity_test.go
+++ b/regimes/au/tax_identity_test.go
@@ -1,10 +1,9 @@
-package au_test
+package au
 
 import (
 	"testing"
 
 	"github.com/invopop/gobl/cbc"
-	"github.com/invopop/gobl/regimes/au"
 	"github.com/invopop/gobl/tax"
 	"github.com/stretchr/testify/assert"
 )
@@ -29,7 +28,7 @@ func TestValidateIdentity(t *testing.T) {
 				Country: "AU",
 				Code:    tt.code,
 			}
-			err := au.Validate(id)
+			err := Validate(id)
 			if tt.err {
 				assert.Error(t, err)
 			} else {
@@ -40,12 +39,17 @@ func TestValidateIdentity(t *testing.T) {
 
 	t.Run("nil", func(t *testing.T) {
 		var id *tax.Identity
-		err := au.Validate(id)
+		err := Validate(id)
 		assert.NoError(t, err)
 	})
 
 	t.Run("non tax identity", func(t *testing.T) {
-		err := au.Validate(struct{}{})
+		err := Validate(struct{}{})
 		assert.NoError(t, err)
+	})
+
+	t.Run("checksum validation", func(t *testing.T) {
+		assert.NoError(t, validateTaxCode(cbc.Code("51824753556")))
+		assert.Error(t, validateTaxCode(cbc.Code("51824753555")))
 	})
 }

--- a/regimes/au/tax_identity_test.go
+++ b/regimes/au/tax_identity_test.go
@@ -1,0 +1,46 @@
+package au_test
+
+import (
+	"testing"
+
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/regimes/au"
+	"github.com/invopop/gobl/tax"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateIdentity(t *testing.T) {
+	tests := []struct {
+		name string
+		code cbc.Code
+		err  bool
+	}{
+		{name: "valid ABN", code: "51824753556", err: false},
+		{name: "valid ABN 2", code: "53004085616", err: false},
+		{name: "invalid ABN short", code: "5182475355", err: true},
+		{name: "invalid ABN long", code: "518247535566", err: true},
+		{name: "invalid ABN leading zero", code: "01824753556", err: true},
+		{name: "invalid ABN letters", code: "51A24753556", err: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id := &tax.Identity{
+				Country: "AU",
+				Code:    tt.code,
+			}
+			err := au.Validate(id)
+			if tt.err {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+
+	t.Run("nil", func(t *testing.T) {
+		var id *tax.Identity
+		err := au.Validate(id)
+		assert.NoError(t, err)
+	})
+}

--- a/regimes/au/tax_identity_test.go
+++ b/regimes/au/tax_identity_test.go
@@ -43,4 +43,9 @@ func TestValidateIdentity(t *testing.T) {
 		err := au.Validate(id)
 		assert.NoError(t, err)
 	})
+
+	t.Run("non tax identity", func(t *testing.T) {
+		err := au.Validate(struct{}{})
+		assert.NoError(t, err)
+	})
 }

--- a/regimes/regimes.go
+++ b/regimes/regimes.go
@@ -8,6 +8,7 @@ import (
 	_ "github.com/invopop/gobl/regimes/ae"
 	_ "github.com/invopop/gobl/regimes/ar"
 	_ "github.com/invopop/gobl/regimes/at"
+	_ "github.com/invopop/gobl/regimes/au"
 	_ "github.com/invopop/gobl/regimes/be"
 	_ "github.com/invopop/gobl/regimes/br"
 	_ "github.com/invopop/gobl/regimes/ca"


### PR DESCRIPTION
## Summary
- Add Australia (**au**) GST regime with standard, GST‑free, and input‑taxed rates.
- Implement AU tax identity normalization/validation (ABN format).
- Add AU example invoice and generated output.
- Add AU regime tests and update changelog.

## Changes
- `regimes/au/au.go`: New AU regime definition.
- `regimes/au/tax_categories.go`: GST category and rates.
- `regimes/au/tax_identity.go`: ABN validation.
- `regimes/au/tax_identity_test.go`: ABN validation tests.
- `regimes/au/au_test.go`: Regime normalize test.
- `examples/au/invoice-au-au.yaml`: AU invoice example.
- `examples/au/out/invoice-au.json`: Generated example output.
- `CHANGELOG.md`: Added AU regime under Unreleased.

## Pre-Review Checklist

- [x] Opened this PR as a draft
- [x] Read the CONTRIBUTING.md guide.
- [x] Performed a self-review of my code.
- [x] Added thorough tests with at **least** 90% code coverage.
- [x] Modified or created example GOBL documents to show my changes in use, if appropriate.
- [x] Added links to the source of the changes in tax regimes or addons, either structured or in the comments.
- [x] Run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [x] Reviewed and fixed all linter warnings.
- [x] Been obsessive with pointer nil checks to avoid panics.
- [x] Updated the CHANGELOG.md with an overview of my changes.
- [x] Requested a review from Copilot and fixed or dismissed (with a reason) all the feedback raised.
_Link to the fork PR where I did the codex review: [Australia Regime](https://github.com/angelvido/gobl/pull/1)_

Only after checking off all the previous items:
- [x] Marked this PR as ready for review and requested one from @samlown.
