### PR TITLE
[MINOR] Add JP Regime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@
 *.out.json
 
 /gobl
+
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Added
+
+- `jp`: New Japanese regime, including consumption tax and withholding income tax
+- `doc`: Added README.md file with instructions about how to create new regimes
+
 ### Fixed
 
 - `gr-mydata-v1`: Corrected exemption codes 3 and 4 mapping to `outside-scope`

--- a/data/regimes/jp.json
+++ b/data/regimes/jp.json
@@ -1,0 +1,240 @@
+{
+  "$schema": "https://gobl.org/draft-0/tax/regime-def",
+  "name": {
+    "en": "Japan",
+    "ja": "日本"
+  },
+  "time_zone": "Asia/Tokyo",
+  "country": "JP",
+  "currency": "JPY",
+  "tax_scheme": "VAT",
+  "identities": [
+    {
+      "key": "jp-invoice-registration-number",
+      "name": {
+        "en": "Invoice Registration Number",
+        "ja": "適格請求書発行事業者登録番号"
+      }
+    }
+  ],
+  "scenarios": [
+    {
+      "schema": "bill/invoice",
+      "list": [
+        {
+          "tags": [
+            "reverse-charge"
+          ],
+          "note": {
+            "key": "legal",
+            "src": "reverse-charge",
+            "text": "Reverse Charge: The recipient is liable for the consumption tax on this transaction. / リバースチャージ方式：本取引の消費税は受領者が申告納付義務を負います。"
+          }
+        },
+        {
+          "tags": [
+            "simplified"
+          ],
+          "note": {
+            "key": "legal",
+            "src": "simplified",
+            "text": "Simplified Invoice / 簡易インボイス"
+          }
+        }
+      ]
+    }
+  ],
+  "corrections": [
+    {
+      "schema": "bill/invoice",
+      "types": [
+        "credit-note",
+        "debit-note"
+      ]
+    }
+  ],
+  "categories": [
+    {
+      "code": "VAT",
+      "name": {
+        "en": "CT",
+        "ja": "消費税"
+      },
+      "title": {
+        "en": "Consumption Tax",
+        "ja": "消費税"
+      },
+      "keys": [
+        {
+          "key": "standard",
+          "name": {
+            "en": "Standard"
+          }
+        },
+        {
+          "key": "zero",
+          "name": {
+            "en": "Zero"
+          }
+        },
+        {
+          "key": "reverse-charge",
+          "name": {
+            "en": "Reverse charge"
+          },
+          "no_percent": true
+        },
+        {
+          "key": "exempt",
+          "name": {
+            "en": "Exempt"
+          },
+          "no_percent": true
+        },
+        {
+          "key": "export",
+          "name": {
+            "en": "Export"
+          },
+          "no_percent": true
+        },
+        {
+          "key": "intra-community",
+          "name": {
+            "en": "Intra-community"
+          },
+          "no_percent": true
+        },
+        {
+          "key": "outside-scope",
+          "name": {
+            "en": "Outside scope"
+          },
+          "no_percent": true
+        }
+      ],
+      "rates": [
+        {
+          "rate": "general",
+          "keys": [
+            "standard"
+          ],
+          "name": {
+            "en": "Standard rate",
+            "ja": "標準税率"
+          },
+          "values": [
+            {
+              "since": "2019-10-01",
+              "percent": "10%"
+            },
+            {
+              "since": "2014-04-01",
+              "percent": "8%"
+            },
+            {
+              "since": "1997-04-01",
+              "percent": "5%"
+            },
+            {
+              "since": "1989-04-01",
+              "percent": "3%"
+            }
+          ]
+        },
+        {
+          "rate": "reduced",
+          "keys": [
+            "standard"
+          ],
+          "name": {
+            "en": "Reduced rate",
+            "ja": "軽減税率"
+          },
+          "desc": {
+            "en": "Applies to food and beverages (excluding dining out and alcohol) and newspaper subscriptions.",
+            "ja": "飲食料品（外食・酒類を除く）及び新聞の定期購読に適用。"
+          },
+          "values": [
+            {
+              "since": "2019-10-01",
+              "percent": "8%"
+            }
+          ]
+        }
+      ],
+      "sources": [
+        {
+          "title": {
+            "en": "Consumption Tax Trends - Japan"
+          },
+          "url": "https://www.oecd.org/tax/consumption/consumption-tax-trends-japan.pdf"
+        }
+      ]
+    },
+    {
+      "code": "WHT",
+      "name": {
+        "en": "WHT",
+        "ja": "源泉徴収"
+      },
+      "title": {
+        "en": "Withholding Income Tax",
+        "ja": "源泉徴収所得税"
+      },
+      "retained": true,
+      "rates": [
+        {
+          "rate": "pro",
+          "name": {
+            "en": "Professional Rate",
+            "ja": "専門家報酬"
+          },
+          "desc": {
+            "en": "Applies to professional service fees of ¥1,000,000 or less per payment. Includes 2.1% reconstruction surtax (2013-2037).",
+            "ja": "1回の支払金額が100万円以下の専門家報酬に適用。復興特別所得税2.1%を含む（2013年〜2037年）。"
+          },
+          "values": [
+            {
+              "since": "2013-01-01",
+              "percent": "10.21%"
+            },
+            {
+              "since": "1989-04-01",
+              "percent": "10%"
+            }
+          ]
+        },
+        {
+          "rate": "pro-over",
+          "name": {
+            "en": "Professional Rate (over ¥1M)",
+            "ja": "専門家報酬（100万円超）"
+          },
+          "desc": {
+            "en": "Applies to professional service fees exceeding ¥1,000,000 per payment. Includes 2.1% reconstruction surtax (2013-2037).",
+            "ja": "1回の支払金額が100万円を超える専門家報酬に適用。復興特別所得税2.1%を含む（2013年〜2037年）。"
+          },
+          "values": [
+            {
+              "since": "2013-01-01",
+              "percent": "20.42%"
+            },
+            {
+              "since": "1989-04-01",
+              "percent": "20%"
+            }
+          ]
+        }
+      ],
+      "sources": [
+        {
+          "title": {
+            "en": "Japan Withholding Taxes - PwC"
+          },
+          "url": "https://taxsummaries.pwc.com/japan/corporate/withholding-taxes"
+        }
+      ]
+    }
+  ]
+}

--- a/data/regimes/jp.json
+++ b/data/regimes/jp.json
@@ -28,7 +28,7 @@
           "note": {
             "key": "legal",
             "src": "reverse-charge",
-            "text": "Reverse Charge: The recipient is liable for the consumption tax on this transaction. / リバースチャージ方式：本取引の消費税は受領者が申告納付義務を負います。"
+            "text": "Reverse Charge: The recipient is liable for the consumption tax on this transaction"
           }
         },
         {
@@ -38,7 +38,7 @@
           "note": {
             "key": "legal",
             "src": "simplified",
-            "text": "Simplified Invoice / 簡易インボイス"
+            "text": "Simplified Invoice"
           }
         }
       ]
@@ -166,9 +166,9 @@
       "sources": [
         {
           "title": {
-            "en": "Consumption Tax Trends - Japan"
+            "en": "Consumption Tax Japan"
           },
-          "url": "https://www.oecd.org/tax/consumption/consumption-tax-trends-japan.pdf"
+          "url": "https://www.nta.go.jp/english/taxes/consumption_tax/01.htm#c01"
         }
       ]
     },

--- a/data/schemas/tax/regime-code.json
+++ b/data/schemas/tax/regime-code.json
@@ -71,6 +71,10 @@
       "title": "Italy"
     },
     {
+      "const": "JP",
+      "title": "Japan"
+    },
+    {
       "const": "MX",
       "title": "Mexico"
     },

--- a/examples/jp/invoice-jp-freelance.yaml
+++ b/examples/jp/invoice-jp-freelance.yaml
@@ -1,0 +1,71 @@
+$schema: "https://gobl.org/draft-0/bill/invoice"
+uuid: "5ca49c5f-22ef-40b6-883a-400055e57030"
+currency: "JPY"
+issue_date: "2024-03-15"
+series: "SAMPLE"
+code: "002"
+
+supplier:
+  tax_id:
+    country: "JP"
+    code: "5010401067252"
+  identities:
+    - key: "jp-invoice-registration-number"
+      code: "T5010401067252"
+  name: "田中太郎デザイン事務所"
+  emails:
+    - addr: "tanaka@design-office.jp"
+  addresses:
+    - num: "7-8-9"
+      street: "渋谷"
+      locality: "渋谷区"
+      region: "東京都"
+      code: "150-0002"
+      country: "JP"
+
+customer:
+  tax_id:
+    country: "JP"
+    code: "1130001011420"
+  name: "テスト株式会社"
+  emails:
+    - addr: "info@testcorp.jp"
+  addresses:
+    - num: "4-5-6"
+      street: "梅田"
+      locality: "大阪市北区"
+      region: "大阪府"
+      code: "530-0001"
+      country: "JP"
+
+lines:
+  - quantity: 1
+    item:
+      name: "Website design services"
+      price: "800000"
+      unit: "service"
+    taxes:
+      - cat: VAT
+        rate: standard
+      - cat: WHT
+        rate: pro
+
+  - quantity: 1
+    item:
+      name: "Logo design"
+      price: "150000"
+      unit: "service"
+    taxes:
+      - cat: VAT
+        rate: standard
+      - cat: WHT
+        rate: pro
+
+payment:
+  terms:
+    key: end-of-month
+  instructions:
+    key: credit-transfer
+    credit_transfer:
+      - name: "三菱UFJ銀行"
+        number: "1234567"

--- a/examples/jp/invoice-jp-jp.yaml
+++ b/examples/jp/invoice-jp-jp.yaml
@@ -1,0 +1,57 @@
+$schema: "https://gobl.org/draft-0/bill/invoice"
+uuid: "3aea7b56-59d8-4beb-90bd-f8f280d852a0"
+currency: "JPY"
+issue_date: "2024-02-13"
+series: "SAMPLE"
+code: "001"
+
+supplier:
+  tax_id:
+    country: "JP"
+    code: "5010401067252"
+  identities:
+    - key: "jp-invoice-registration-number"
+      code: "T5010401067252"
+  name: "株式会社サンプルテック"
+  emails:
+    - addr: "billing@sampletech.jp"
+  addresses:
+    - num: "1-2-3"
+      street: "丸の内"
+      locality: "千代田区"
+      region: "東京都"
+      code: "100-0005"
+      country: "JP"
+
+customer:
+  tax_id:
+    country: "JP"
+    code: "1130001011420"
+  name: "テスト株式会社"
+  emails:
+    - addr: "info@testcorp.jp"
+  addresses:
+    - num: "4-5-6"
+      street: "梅田"
+      locality: "大阪市北区"
+      region: "大阪府"
+      code: "530-0001"
+      country: "JP"
+
+lines:
+  - quantity: 40
+    item:
+      name: "Software development services"
+      price: "8000"
+      unit: "h"
+    taxes:
+      - cat: VAT
+        rate: standard
+  - quantity: 100
+    item:
+      name: "Bottled green tea"
+      price: "150"
+      unit: "pkg"
+    taxes:
+      - cat: VAT
+        rate: reduced

--- a/examples/jp/invoice-jp-reverse-charge.yaml
+++ b/examples/jp/invoice-jp-reverse-charge.yaml
@@ -1,4 +1,5 @@
 $schema: "https://gobl.org/draft-0/bill/invoice"
+$regime: "JP"
 uuid: "95224c34-d841-4790-8430-9176b4847f4b"
 currency: "JPY"
 issue_date: "2024-05-20"
@@ -8,26 +9,31 @@ tax:
   tags:
     - reverse-charge
 
+# Foreign supplier providing B2B digital services to a Japanese business.
+# Under Japan's reverse charge mechanism, the Japanese customer (buyer)
+# is responsible for self-assessing and remitting the consumption tax.
 supplier:
   tax_id:
-    country: "JP"
-    code: "5010401067252"
-  identities:
-    - key: "jp-invoice-registration-number"
-      code: "T5010401067252"
-  name: "株式会社グローバルテック"
+    country: "US"
+    code: "123456789"
+  name: "Acme Cloud Services Inc."
+  emails:
+    - addr: "billing@acmecloud.com"
   addresses:
-    - num: "1-1"
-      street: "六本木"
-      locality: "港区"
-      region: "東京都"
-      code: "106-0032"
-      country: "JP"
+    - num: "500"
+      street: "Market Street"
+      locality: "San Francisco"
+      region: "CA"
+      code: "94105"
+      country: "US"
 
 customer:
   tax_id:
     country: "JP"
     code: "1130001011420"
+  identities:
+    - key: "jp-invoice-registration-number"
+      code: "T1130001011420"
   name: "テスト株式会社"
   addresses:
     - num: "4-5-6"

--- a/examples/jp/invoice-jp-reverse-charge.yaml
+++ b/examples/jp/invoice-jp-reverse-charge.yaml
@@ -1,0 +1,56 @@
+$schema: "https://gobl.org/draft-0/bill/invoice"
+uuid: "95224c34-d841-4790-8430-9176b4847f4b"
+currency: "JPY"
+issue_date: "2024-05-20"
+series: "SAMPLE"
+code: "004"
+tax:
+  tags:
+    - reverse-charge
+
+supplier:
+  tax_id:
+    country: "JP"
+    code: "5010401067252"
+  identities:
+    - key: "jp-invoice-registration-number"
+      code: "T5010401067252"
+  name: "株式会社グローバルテック"
+  addresses:
+    - num: "1-1"
+      street: "六本木"
+      locality: "港区"
+      region: "東京都"
+      code: "106-0032"
+      country: "JP"
+
+customer:
+  tax_id:
+    country: "JP"
+    code: "1130001011420"
+  name: "テスト株式会社"
+  addresses:
+    - num: "4-5-6"
+      street: "梅田"
+      locality: "大阪市北区"
+      region: "大阪府"
+      code: "530-0001"
+      country: "JP"
+
+lines:
+  - quantity: 1
+    item:
+      name: "Cloud platform subscription (annual)"
+      price: "2400000"
+      unit: "service"
+    taxes:
+      - cat: VAT
+        rate: standard
+  - quantity: 12
+    item:
+      name: "Technical support (monthly)"
+      price: "50000"
+      unit: "service"
+    taxes:
+      - cat: VAT
+        rate: standard

--- a/examples/jp/invoice-jp-simplified.yaml
+++ b/examples/jp/invoice-jp-simplified.yaml
@@ -1,0 +1,42 @@
+$schema: "https://gobl.org/draft-0/bill/invoice"
+uuid: "235b8e6d-d581-48aa-bb61-7710cfcb66ac"
+currency: "JPY"
+issue_date: "2024-04-01"
+series: "SAMPLE"
+code: "003"
+tax:
+  tags:
+    - simplified
+
+supplier:
+  tax_id:
+    country: "JP"
+    code: "5010401067252"
+  identities:
+    - key: "jp-invoice-registration-number"
+      code: "T5010401067252"
+  name: "サンプル食堂"
+  addresses:
+    - num: "10-11"
+      street: "新宿"
+      locality: "新宿区"
+      region: "東京都"
+      code: "160-0022"
+      country: "JP"
+
+lines:
+  - quantity: 2
+    item:
+      name: "ランチセット（店内飲食）"
+      price: "1200"
+    taxes:
+      - cat: VAT
+        rate: standard
+
+  - quantity: 3
+    item:
+      name: "ペットボトル飲料（持ち帰り）"
+      price: "160"
+    taxes:
+      - cat: VAT
+        rate: reduced

--- a/examples/jp/out/invoice-jp-freelance.json
+++ b/examples/jp/out/invoice-jp-freelance.json
@@ -1,0 +1,172 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
+		"dig": {
+			"alg": "sha256",
+			"val": "04f8780c913deb54de301049a7e2a0573a3fb73ea7f886c41595667a93154aec"
+		}
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"$regime": "JP",
+		"uuid": "5ca49c5f-22ef-40b6-883a-400055e57030",
+		"type": "standard",
+		"series": "SAMPLE",
+		"code": "002",
+		"issue_date": "2024-03-15",
+		"currency": "JPY",
+		"supplier": {
+			"name": "田中太郎デザイン事務所",
+			"tax_id": {
+				"country": "JP",
+				"code": "5010401067252"
+			},
+			"identities": [
+				{
+					"key": "jp-invoice-registration-number",
+					"code": "T5010401067252"
+				}
+			],
+			"addresses": [
+				{
+					"num": "7-8-9",
+					"street": "渋谷",
+					"locality": "渋谷区",
+					"region": "東京都",
+					"code": "150-0002",
+					"country": "JP"
+				}
+			],
+			"emails": [
+				{
+					"addr": "tanaka@design-office.jp"
+				}
+			]
+		},
+		"customer": {
+			"name": "テスト株式会社",
+			"tax_id": {
+				"country": "JP",
+				"code": "1130001011420"
+			},
+			"addresses": [
+				{
+					"num": "4-5-6",
+					"street": "梅田",
+					"locality": "大阪市北区",
+					"region": "大阪府",
+					"code": "530-0001",
+					"country": "JP"
+				}
+			],
+			"emails": [
+				{
+					"addr": "info@testcorp.jp"
+				}
+			]
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "1",
+				"item": {
+					"name": "Website design services",
+					"price": "800000",
+					"unit": "service"
+				},
+				"sum": "800000",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "general",
+						"percent": "10%"
+					},
+					{
+						"cat": "WHT",
+						"rate": "pro",
+						"percent": "10.21%"
+					}
+				],
+				"total": "800000"
+			},
+			{
+				"i": 2,
+				"quantity": "1",
+				"item": {
+					"name": "Logo design",
+					"price": "150000",
+					"unit": "service"
+				},
+				"sum": "150000",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "general",
+						"percent": "10%"
+					},
+					{
+						"cat": "WHT",
+						"rate": "pro",
+						"percent": "10.21%"
+					}
+				],
+				"total": "150000"
+			}
+		],
+		"payment": {
+			"terms": {
+				"key": "end-of-month"
+			},
+			"instructions": {
+				"key": "credit-transfer",
+				"credit_transfer": [
+					{
+						"number": "1234567",
+						"name": "三菱UFJ銀行"
+					}
+				]
+			}
+		},
+		"totals": {
+			"sum": "950000",
+			"total": "950000",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"base": "950000",
+								"percent": "10%",
+								"amount": "95000"
+							}
+						],
+						"amount": "95000"
+					},
+					{
+						"code": "WHT",
+						"retained": true,
+						"rates": [
+							{
+								"base": "950000",
+								"percent": "10.21%",
+								"amount": "96995"
+							}
+						],
+						"amount": "96995"
+					}
+				],
+				"sum": "95000",
+				"retained": "96995"
+			},
+			"tax": "95000",
+			"total_with_tax": "1045000",
+			"retained_tax": "96995",
+			"payable": "948005"
+		}
+	}
+}

--- a/examples/jp/out/invoice-jp-jp.json
+++ b/examples/jp/out/invoice-jp-jp.json
@@ -1,0 +1,140 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
+		"dig": {
+			"alg": "sha256",
+			"val": "e118781f8484d4080a2cb1c145c64bdff1a0801c1bac790e966a97b3847079bf"
+		}
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"$regime": "JP",
+		"uuid": "3aea7b56-59d8-4beb-90bd-f8f280d852a0",
+		"type": "standard",
+		"series": "SAMPLE",
+		"code": "001",
+		"issue_date": "2024-02-13",
+		"currency": "JPY",
+		"supplier": {
+			"name": "株式会社サンプルテック",
+			"tax_id": {
+				"country": "JP",
+				"code": "5010401067252"
+			},
+			"identities": [
+				{
+					"key": "jp-invoice-registration-number",
+					"code": "T5010401067252"
+				}
+			],
+			"addresses": [
+				{
+					"num": "1-2-3",
+					"street": "丸の内",
+					"locality": "千代田区",
+					"region": "東京都",
+					"code": "100-0005",
+					"country": "JP"
+				}
+			],
+			"emails": [
+				{
+					"addr": "billing@sampletech.jp"
+				}
+			]
+		},
+		"customer": {
+			"name": "テスト株式会社",
+			"tax_id": {
+				"country": "JP",
+				"code": "1130001011420"
+			},
+			"addresses": [
+				{
+					"num": "4-5-6",
+					"street": "梅田",
+					"locality": "大阪市北区",
+					"region": "大阪府",
+					"code": "530-0001",
+					"country": "JP"
+				}
+			],
+			"emails": [
+				{
+					"addr": "info@testcorp.jp"
+				}
+			]
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "40",
+				"item": {
+					"name": "Software development services",
+					"price": "8000",
+					"unit": "h"
+				},
+				"sum": "320000",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "general",
+						"percent": "10%"
+					}
+				],
+				"total": "320000"
+			},
+			{
+				"i": 2,
+				"quantity": "100",
+				"item": {
+					"name": "Bottled green tea",
+					"price": "150",
+					"unit": "pkg"
+				},
+				"sum": "15000",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "reduced",
+						"percent": "8%"
+					}
+				],
+				"total": "15000"
+			}
+		],
+		"totals": {
+			"sum": "335000",
+			"total": "335000",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"base": "320000",
+								"percent": "10%",
+								"amount": "32000"
+							},
+							{
+								"key": "standard",
+								"base": "15000",
+								"percent": "8%",
+								"amount": "1200"
+							}
+						],
+						"amount": "33200"
+					}
+				],
+				"sum": "33200"
+			},
+			"tax": "33200",
+			"total_with_tax": "368200",
+			"payable": "368200"
+		}
+	}
+}

--- a/examples/jp/out/invoice-jp-reverse-charge.json
+++ b/examples/jp/out/invoice-jp-reverse-charge.json
@@ -1,0 +1,135 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
+		"dig": {
+			"alg": "sha256",
+			"val": "cbb4ffe501ac2cb307e858db3f6b352acd9984b0f3ee7a81b67a5947afe88a6c"
+		}
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"$regime": "JP",
+		"$tags": [
+			"reverse-charge"
+		],
+		"uuid": "95224c34-d841-4790-8430-9176b4847f4b",
+		"type": "standard",
+		"series": "SAMPLE",
+		"code": "004",
+		"issue_date": "2024-05-20",
+		"currency": "JPY",
+		"tax": {},
+		"supplier": {
+			"name": "株式会社グローバルテック",
+			"tax_id": {
+				"country": "JP",
+				"code": "5010401067252"
+			},
+			"identities": [
+				{
+					"key": "jp-invoice-registration-number",
+					"code": "T5010401067252"
+				}
+			],
+			"addresses": [
+				{
+					"num": "1-1",
+					"street": "六本木",
+					"locality": "港区",
+					"region": "東京都",
+					"code": "106-0032",
+					"country": "JP"
+				}
+			]
+		},
+		"customer": {
+			"name": "テスト株式会社",
+			"tax_id": {
+				"country": "JP",
+				"code": "1130001011420"
+			},
+			"addresses": [
+				{
+					"num": "4-5-6",
+					"street": "梅田",
+					"locality": "大阪市北区",
+					"region": "大阪府",
+					"code": "530-0001",
+					"country": "JP"
+				}
+			]
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "1",
+				"item": {
+					"name": "Cloud platform subscription (annual)",
+					"price": "2400000",
+					"unit": "service"
+				},
+				"sum": "2400000",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "general",
+						"percent": "10%"
+					}
+				],
+				"total": "2400000"
+			},
+			{
+				"i": 2,
+				"quantity": "12",
+				"item": {
+					"name": "Technical support (monthly)",
+					"price": "50000",
+					"unit": "service"
+				},
+				"sum": "600000",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "general",
+						"percent": "10%"
+					}
+				],
+				"total": "600000"
+			}
+		],
+		"totals": {
+			"sum": "3000000",
+			"total": "3000000",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"base": "3000000",
+								"percent": "10%",
+								"amount": "300000"
+							}
+						],
+						"amount": "300000"
+					}
+				],
+				"sum": "300000"
+			},
+			"tax": "300000",
+			"total_with_tax": "3300000",
+			"payable": "3300000"
+		},
+		"notes": [
+			{
+				"key": "legal",
+				"src": "reverse-charge",
+				"text": "Reverse Charge: The recipient is liable for the consumption tax on this transaction"
+			}
+		]
+	}
+}

--- a/examples/jp/out/invoice-jp-reverse-charge.json
+++ b/examples/jp/out/invoice-jp-reverse-charge.json
@@ -4,7 +4,7 @@
 		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
 		"dig": {
 			"alg": "sha256",
-			"val": "cbb4ffe501ac2cb307e858db3f6b352acd9984b0f3ee7a81b67a5947afe88a6c"
+			"val": "81ad5f24b488954461cdc2cb3a65ce36647c655855ae61da3bf6c0c9825d0866"
 		}
 	},
 	"doc": {
@@ -21,25 +21,24 @@
 		"currency": "JPY",
 		"tax": {},
 		"supplier": {
-			"name": "株式会社グローバルテック",
+			"name": "Acme Cloud Services Inc.",
 			"tax_id": {
-				"country": "JP",
-				"code": "5010401067252"
+				"country": "US",
+				"code": "123456789"
 			},
-			"identities": [
-				{
-					"key": "jp-invoice-registration-number",
-					"code": "T5010401067252"
-				}
-			],
 			"addresses": [
 				{
-					"num": "1-1",
-					"street": "六本木",
-					"locality": "港区",
-					"region": "東京都",
-					"code": "106-0032",
-					"country": "JP"
+					"num": "500",
+					"street": "Market Street",
+					"locality": "San Francisco",
+					"region": "CA",
+					"code": "94105",
+					"country": "US"
+				}
+			],
+			"emails": [
+				{
+					"addr": "billing@acmecloud.com"
 				}
 			]
 		},
@@ -49,6 +48,12 @@
 				"country": "JP",
 				"code": "1130001011420"
 			},
+			"identities": [
+				{
+					"key": "jp-invoice-registration-number",
+					"code": "T1130001011420"
+				}
+			],
 			"addresses": [
 				{
 					"num": "4-5-6",

--- a/examples/jp/out/invoice-jp-simplified.json
+++ b/examples/jp/out/invoice-jp-simplified.json
@@ -1,0 +1,122 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
+		"dig": {
+			"alg": "sha256",
+			"val": "aa03dea2037fe1107fa6213aab2df0c3e8a27f5cb28e23ad7838ccdfdf7ec8f5"
+		}
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"$regime": "JP",
+		"$tags": [
+			"simplified"
+		],
+		"uuid": "235b8e6d-d581-48aa-bb61-7710cfcb66ac",
+		"type": "standard",
+		"series": "SAMPLE",
+		"code": "003",
+		"issue_date": "2024-04-01",
+		"currency": "JPY",
+		"tax": {},
+		"supplier": {
+			"name": "サンプル食堂",
+			"tax_id": {
+				"country": "JP",
+				"code": "5010401067252"
+			},
+			"identities": [
+				{
+					"key": "jp-invoice-registration-number",
+					"code": "T5010401067252"
+				}
+			],
+			"addresses": [
+				{
+					"num": "10-11",
+					"street": "新宿",
+					"locality": "新宿区",
+					"region": "東京都",
+					"code": "160-0022",
+					"country": "JP"
+				}
+			]
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "2",
+				"item": {
+					"name": "ランチセット（店内飲食）",
+					"price": "1200"
+				},
+				"sum": "2400",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "general",
+						"percent": "10%"
+					}
+				],
+				"total": "2400"
+			},
+			{
+				"i": 2,
+				"quantity": "3",
+				"item": {
+					"name": "ペットボトル飲料（持ち帰り）",
+					"price": "160"
+				},
+				"sum": "480",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "reduced",
+						"percent": "8%"
+					}
+				],
+				"total": "480"
+			}
+		],
+		"totals": {
+			"sum": "2880",
+			"total": "2880",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"base": "2400",
+								"percent": "10%",
+								"amount": "240"
+							},
+							{
+								"key": "standard",
+								"base": "480",
+								"percent": "8%",
+								"amount": "38"
+							}
+						],
+						"amount": "278"
+					}
+				],
+				"sum": "278"
+			},
+			"tax": "278",
+			"total_with_tax": "3158",
+			"payable": "3158"
+		},
+		"notes": [
+			{
+				"key": "legal",
+				"src": "simplified",
+				"text": "Simplified Invoice"
+			}
+		]
+	}
+}

--- a/regimes/README.md
+++ b/regimes/README.md
@@ -1,0 +1,466 @@
+# Tax Regimes
+
+Tax regimes in GOBL define country-specific tax rules, rates, validation logic, and normalization behavior. Each regime is a self-contained Go package inside the `regimes/` directory, named after its [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country code (e.g., `es` for Spain, `de` for Germany).
+
+## Existing Regimes
+
+| Code | Country |
+|------|---------|
+| `ae` | United Arab Emirates |
+| `ar` | Argentina |
+| `at` | Austria |
+| `be` | Belgium |
+| `br` | Brazil |
+| `ca` | Canada |
+| `ch` | Switzerland |
+| `co` | Colombia |
+| `de` | Germany |
+| `dk` | Denmark |
+| `es` | Spain |
+| `fr` | France |
+| `gb` | United Kingdom |
+| `gr` | Greece |
+| `ie` | Ireland |
+| `in` | India |
+| `it` | Italy |
+| `mx` | Mexico |
+| `nl` | Netherlands |
+| `pl` | Poland |
+| `pt` | Portugal |
+| `se` | Sweden |
+| `sg` | Singapore |
+| `us` | United States |
+
+## How Regimes Work
+
+When a regime package is imported, its `init()` function calls `tax.RegisterRegimeDef()` to register the regime definition globally. The `regimes/regimes.go` file uses blank imports to ensure all regimes are loaded:
+
+```go
+import (
+    _ "github.com/invopop/gobl/regimes/es"
+    _ "github.com/invopop/gobl/regimes/de"
+    // ...
+)
+```
+
+Once registered, GOBL automatically applies the correct regime's normalization, validation, tax rates, and scenarios when processing documents for that country.
+
+## Creating a New Regime
+
+### Step 1: Copy the Template
+
+Duplicate the `template/` directory and rename it to the 2-letter country code:
+
+```bash
+cp -r regimes/template regimes/xx
+```
+
+Replace `xx` with the actual country code (e.g., `jp` for Japan).
+
+### Step 2: Define the Main Regime File
+
+Rename `template.go` to `xx.go` (matching your country code). This file is the entry point for the regime and must contain three things:
+
+**1. An `init()` function that registers the regime:**
+
+```go
+func init() {
+    tax.RegisterRegimeDef(New())
+}
+```
+
+**2. A `New()` function that returns a `*tax.RegimeDef`:**
+
+```go
+func New() *tax.RegimeDef {
+    return &tax.RegimeDef{
+        Country:  "XX",
+        Currency: currency.XXX,
+        Name: i18n.String{
+            i18n.EN: "Country Name",
+            // i18n.XX: "Local Name",
+        },
+        TimeZone:   "Region/City",           // IANA Time Zone
+        TaxScheme:  tax.CategoryVAT,          // or omit (e.g., US has no scheme)
+        Tags:       []*tax.TagSet{...},       // optional
+        Identities: identityDefinitions(),    // optional, from identities.go
+        Extensions: extensionDefinitions,     // optional, from extensions.go
+        Categories: taxCategories(),          // required, from tax_categories.go
+        Scenarios:  []*tax.ScenarioSet{...},  // optional, from scenarios.go
+        Corrections: correctionDefinitions(), // optional, from corrections.go
+        Normalizer: Normalize,
+        Validator:  Validate,
+    }
+}
+```
+
+**3. `Normalize` and `Validate` functions** that use type-switching to route to specific handlers:
+
+```go
+func Normalize(doc any) {
+    switch obj := doc.(type) {
+    case *tax.Identity:
+        normalizeTaxIdentity(obj)
+    case *org.Identity:
+        normalizeOrgIdentity(obj)
+    }
+}
+
+func Validate(doc any) error {
+    switch obj := doc.(type) {
+    case *tax.Identity:
+        return validateTaxIdentity(obj)
+    case *bill.Invoice:
+        return validateInvoice(obj)
+    case *org.Party:
+        return validateParty(obj)
+    }
+    return nil
+}
+```
+
+The supported types you can normalize and validate include:
+
+- `*tax.Identity` - Tax identification numbers
+- `*org.Identity` - Organization identity documents (passport, national ID, etc.)
+- `*org.Party` - Supplier/customer party data
+- `*bill.Invoice` - Invoice-level rules
+- `*bill.Line` - Line item validation
+- `*tax.Combo` - Tax combination validation
+
+### Step 3: Define Tax Categories
+
+Create `tax_categories.go` to define all tax categories and their rates. This is the most important data file in a regime:
+
+```go
+package xx
+
+import (
+    "github.com/invopop/gobl/cal"
+    "github.com/invopop/gobl/cbc"
+    "github.com/invopop/gobl/i18n"
+    "github.com/invopop/gobl/num"
+    "github.com/invopop/gobl/tax"
+)
+
+func taxCategories() []*tax.CategoryDef {
+    return []*tax.CategoryDef{
+        {
+            Code: tax.CategoryVAT,
+            Name: i18n.String{
+                i18n.EN: "VAT",
+                // i18n.XX: "Local abbreviation",
+            },
+            Title: i18n.String{
+                i18n.EN: "Value Added Tax",
+                // i18n.XX: "Local full name",
+            },
+            Retained: false,
+            Keys:     tax.GlobalVATKeys(),
+            Rates: []*tax.RateDef{
+                {
+                    Keys: []cbc.Key{tax.KeyStandard},
+                    Rate: tax.RateGeneral,
+                    Name: i18n.String{
+                        i18n.EN: "Standard rate",
+                    },
+                    Values: []*tax.RateValueDef{
+                        {
+                            Since:   cal.NewDate(2024, 1, 1),
+                            Percent: num.MakePercentage(20, 2), // 20%
+                        },
+                    },
+                },
+                {
+                    Keys: []cbc.Key{tax.KeyStandard},
+                    Rate: tax.RateReduced,
+                    Name: i18n.String{
+                        i18n.EN: "Reduced rate",
+                    },
+                    Values: []*tax.RateValueDef{
+                        {
+                            Since:   cal.NewDate(2024, 1, 1),
+                            Percent: num.MakePercentage(10, 2), // 10%
+                        },
+                    },
+                },
+            },
+        },
+    }
+}
+```
+
+Key points about tax categories:
+
+- **`Code`**: Use predefined codes like `tax.CategoryVAT`, `tax.CategoryGST`, `tax.CategoryST`, or define custom ones (e.g., `"IRPF"`, `"IGIC"`).
+- **`Retained`**: Set to `true` for withholding taxes (e.g., income tax withheld at source).
+- **`Keys`**: Use `tax.GlobalVATKeys()` for standard VAT/GST regimes.
+- **`Rates`**: Each rate has `Keys` (e.g., `tax.KeyStandard`, `tax.KeyExempt`, `tax.KeySuperReduced`) and historical `Values` with effective dates.
+- **Historical rates**: Include multiple `Values` entries with different `Since` dates to support historical tax rate lookups. Order them newest first.
+
+### Step 4: Define Tax Identity Validation
+
+Create `tax_identity.go` to handle normalization and validation of tax identification numbers:
+
+```go
+package xx
+
+import (
+    "github.com/invopop/gobl/cbc"
+    "github.com/invopop/gobl/tax"
+    "github.com/invopop/validation"
+)
+
+func normalizeTaxIdentity(tID *tax.Identity) {
+    if tID == nil {
+        return
+    }
+    // Typical normalizations:
+    // - Remove country prefix: tax.NormalizeIdentity(tID)
+    // - Uppercase: strings.ToUpper()
+    // - Remove whitespace/separators
+}
+
+func validateTaxIdentity(tID *tax.Identity) error {
+    return validation.ValidateStruct(tID,
+        validation.Field(&tID.Code, validation.By(validateTaxCode)),
+    )
+}
+
+func validateTaxCode(value interface{}) error {
+    code, ok := value.(cbc.Code)
+    if !ok || code == "" {
+        return nil
+    }
+    // Validate format (regex), length, and checksum
+    return nil
+}
+```
+
+### Step 5: Optional Files
+
+Depending on the complexity of the regime, add any of these files:
+
+#### `scenarios.go` - Invoice Scenarios
+
+Scenarios automatically apply notes to documents based on tags:
+
+```go
+package xx
+
+import (
+    "github.com/invopop/gobl/bill"
+    "github.com/invopop/gobl/cbc"
+    "github.com/invopop/gobl/org"
+    "github.com/invopop/gobl/tax"
+)
+
+func invoiceScenarios() *tax.ScenarioSet {
+    return &tax.ScenarioSet{
+        Schema: bill.ShortSchemaInvoice,
+        List: []*tax.Scenario{
+            {
+                Tags: []cbc.Key{tax.TagReverseCharge},
+                Note: &tax.ScenarioNote{
+                    Key:  org.NoteKeyLegal,
+                    Src:  tax.TagReverseCharge,
+                    Text: "Reverse Charge / Local translation.",
+                },
+            },
+        },
+    }
+}
+```
+
+#### `corrections.go` - Correction Definitions
+
+Define which correction types (credit notes, debit notes, corrective invoices) the regime supports:
+
+```go
+package xx
+
+import (
+    "github.com/invopop/gobl/bill"
+    "github.com/invopop/gobl/cbc"
+    "github.com/invopop/gobl/tax"
+)
+
+func correctionDefinitions() []*tax.CorrectionDefinition {
+    return []*tax.CorrectionDefinition{
+        {
+            Schema: bill.ShortSchemaInvoice,
+            Types: []cbc.Key{
+                bill.InvoiceTypeCreditNote,
+                bill.InvoiceTypeDebitNote,
+                // bill.InvoiceTypeCorrective, // if supported
+            },
+        },
+    }
+}
+```
+
+#### `identities.go` - Organization Identity Types
+
+Define non-tax identity types recognized by the regime (passports, national IDs, etc.):
+
+```go
+package xx
+
+import (
+    "github.com/invopop/gobl/cbc"
+    "github.com/invopop/gobl/i18n"
+    "github.com/invopop/gobl/org"
+)
+
+func identityDefinitions() []*cbc.Definition {
+    return []*cbc.Definition{
+        {
+            Key: org.IdentityKeyPassport,
+            Name: i18n.String{
+                i18n.EN: "Passport",
+            },
+        },
+    }
+}
+```
+
+#### `invoices.go` - Invoice-Specific Validation
+
+Add custom validation rules for invoices (e.g., requiring supplier tax IDs):
+
+```go
+package xx
+
+import (
+    "github.com/invopop/gobl/bill"
+    "github.com/invopop/validation"
+)
+
+func validateInvoice(inv *bill.Invoice) error {
+    return validation.ValidateStruct(inv,
+        // Add regime-specific invoice validation rules
+    )
+}
+```
+
+#### `extensions.go` - Custom Extension Keys
+
+Define regime-specific extension codes for data that doesn't fit standard GOBL structures:
+
+```go
+package xx
+
+import (
+    "github.com/invopop/gobl/cbc"
+    "github.com/invopop/gobl/i18n"
+)
+
+var extensionDefinitions = []*cbc.Definition{
+    {
+        Key: "xx-custom-code",
+        Name: i18n.String{
+            i18n.EN: "Custom Code",
+        },
+        Pattern: `^\d{7}$`, // optional regex for validation
+    },
+}
+```
+
+#### `party.go` - Party-Specific Logic
+
+Normalization and validation for supplier/customer parties.
+
+### Step 6: Register the Regime
+
+Add a blank import for the new regime in `regimes/regimes.go`:
+
+```go
+import (
+    // ... existing imports ...
+    _ "github.com/invopop/gobl/regimes/xx"
+)
+```
+
+### Step 7: Write Tests
+
+Every `.go` file with logic should have a corresponding `_test.go` file. At minimum:
+
+- `xx_test.go` - Test the `New()` function produces a valid regime definition
+- `tax_identity_test.go` - Test normalization and validation of tax IDs
+
+The regime will also be automatically tested by `regimes_test.go`, which validates all registered regime definitions.
+
+### Step 8: Add a README
+
+Create a `README.md` inside your regime directory. Document:
+
+- Overview of the country's tax system
+- Tax categories and rates
+- Tax identity format and validation rules
+- Any special features (scenarios, extensions, corrections)
+- Reference links to official government sources
+
+### Step 9: Generate and Test
+
+Run the following commands from the repository root:
+
+```bash
+go generate .
+go test ./regimes/xx/...
+go test ./regimes/...
+```
+
+## `RegimeDef` Field Reference
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `Country` | `l10n.TaxCountryCode` | Yes | ISO 3166-1 alpha-2 country code |
+| `Currency` | `currency.Code` | Yes | ISO 4217 currency code |
+| `Name` | `i18n.String` | Yes | Localized regime name |
+| `TimeZone` | `string` | Yes | IANA Time Zone (e.g., `"Europe/Madrid"`) |
+| `TaxScheme` | `cbc.Code` | No | Principal tax scheme (e.g., `tax.CategoryVAT`) |
+| `Description` | `i18n.String` | No | Detailed regime description |
+| `AltCountryCodes` | `[]l10n.Code` | No | Alternative country codes |
+| `Zone` | `l10n.Code` | No | Sub-country locality or region |
+| `CalculatorRoundingRule` | `cbc.Key` | No | Rounding rule override (default: `sum-then-round`) |
+| `Tags` | `[]*tax.TagSet` | No | Document-level tag definitions |
+| `Extensions` | `[]*cbc.Definition` | No | Custom extension key definitions |
+| `Identities` | `[]*cbc.Definition` | No | Organization identity type definitions |
+| `PaymentMeansKeys` | `[]*cbc.Definition` | No | Regime-specific payment means keys |
+| `InboxKeys` | `[]*cbc.Definition` | No | Regime-specific inbox routing keys |
+| `Scenarios` | `[]*tax.ScenarioSet` | No | Conditional scenario rules |
+| `Corrections` | `[]*tax.CorrectionDefinition` | No | Supported correction types |
+| `Categories` | `[]*tax.CategoryDef` | Yes | Tax category definitions with rates |
+| `Normalizer` | `tax.Normalizer` | No | Function to normalize regime-specific data |
+| `Validator` | `tax.Validator` | No | Function to validate regime-specific data |
+
+## Typical File Structure
+
+Regimes range from minimal to complex depending on the country's tax requirements:
+
+```
+regimes/xx/
+  xx.go                  # Required: regime definition, init(), New(), Normalize, Validate
+  xx_test.go             # Required: tests
+  tax_categories.go      # Required: tax category and rate definitions
+  tax_identity.go        # Common: tax ID normalization and validation
+  tax_identity_test.go   # Common: tax ID tests
+  identities.go          # Optional: organization identity type definitions
+  scenarios.go           # Optional: tag-based scenario rules
+  corrections.go         # Optional: credit/debit note definitions
+  invoices.go            # Optional: invoice-specific validation
+  party.go               # Optional: party-specific logic
+  extensions.go          # Optional: custom extension keys
+  README.md              # Recommended: regime documentation
+```
+
+## Best Practices
+
+- **Use `i18n.String` for all user-facing text.** Always include at least an English (`i18n.EN`) translation, and add the official local language translation.
+- **Include historical tax rates.** Add multiple `Values` entries with `Since` dates to handle rate changes over time, ordered newest first.
+- **Include sources.** Reference official government documentation URLs using `cbc.Source` in tax categories and extensions.
+- **Use functions to build definitions** (e.g., `taxCategories()` instead of `var taxCategories = ...`). This prevents accidental modification of shared data, although both patterns are used in existing regimes.
+- **Keep normalization idempotent.** Running `Normalize` multiple times should produce the same result.
+- **Return `nil` for unknown types** in both `Validate` and `Normalize`. Only handle types relevant to the regime.
+- **Follow the validation library patterns.** Use `github.com/invopop/validation` for struct validation, consistent with the rest of the codebase.
+- **Write comprehensive tests**, especially for tax identity validation with edge cases, checksum verification, and format variations.

--- a/regimes/jp/README.md
+++ b/regimes/jp/README.md
@@ -1,0 +1,68 @@
+# GOBL Japan Tax Regime — `JP`
+
+Japan's tax regime for GOBL covering the Consumption Tax, Withholding Incom  and the Qualified Invoice System.
+
+## Tax Categories
+
+### Consumption Tax (JCT - Japanese Consumption Tax, 消費税, Shōhizei)
+
+- [What is the Japanese Consumption Tax?](https://stripe.com/en-es/resources/more/what-is-japanese-consumption-tax)
+- [Consumption Tax](https://www.nta.go.jp/english/taxes/consumption_tax/01.htm#c01)
+
+Japan's consumption tax is equivalent to VAT, applied to goods and services sales.
+
+| Rate | Percentage | Since |
+|------|-----------|-------|
+| Standard | 10% | 2019-10-01 |
+| Standard | 8% | 2014-04-01 |
+| Standard | 5% | 1997-04-01 |
+| Standard | 3% | 1989-04-01 |
+| Reduced | 8% | 2019-10-01 |
+
+The reduced rate of 8% applies to food and beverages (excluding dining out and alcohol) and newspaper subscriptions.
+
+### Withholding Income Tax (源泉徴収, Gensen Chōshū)
+
+- [Japan Withholding Taxes](https://taxsummaries.pwc.com/japan/corporate/withholding-taxes)
+- [Withholding Tax Rates - National Tax Agency](https://www.nta.go.jp/publication/pamph/gensen/shikata_r08/pdf/15.pdf)
+
+Japan does have a withholding tax system where businesses must withhold income tax from payments to certain service 
+providers (freelancers, lawyers, accountants, etc.). This is similar to Spain's IRPF in GOBL — a retained tax that does appear on invoices.
+
+| Rate | Percentage | Since | Notes |
+|------|-----------|-------|-------|
+| Professional | 10.21% | 2013-01-01 | Includes 2.1% reconstruction surtax |
+| Professional | 10% | 1989-04-01 | Base rate |
+| Professional (over ¥1M) | 20.42% | 2013-01-01 | Includes 2.1% reconstruction surtax |
+| Professional (over ¥1M) | 20% | 1989-04-01 | Base rate |
+
+
+## Tax Identity
+
+- [Corporate Number System](https://www.houjin-bangou.nta.go.jp/en/shitsumon/shosai.html?selQaId=00001)
+- [Japan Corporate Number](https://en.wikipedia.org/wiki/Corporate_Number)
+
+The Corporate Numbers (Japanese: 法人番号, Hepburn: hōjin bangō) are 13-digit identifiers assigned by the National Tax Agency 
+to companies and other organizations registered in Japan. When filing tax returns or other forms related to taxation, 
+employment or social insurance, assignees are required to print their own Corporate Number on the document.
+
+
+- 13 digits, numeric only
+- First digit is a check digit (1-9)
+- Checksum: `9 - ((Σ Pn × Qn) mod 9)`
+
+Corporate numbers are publicly searchable on the [NTA Corporate Number Publication Site](https://www.houjin-bangou.nta.go.jp/en/).
+
+## Qualified Invoice System (QIS)
+
+- [EU-Japan Centre - Qualified Invoice System](https://www.eu-japan.eu/qualified-invoice-system)
+- [Qualified Invoice System Instructions](https://www.nta.go.jp/taxes/shiraberu/zeimokubetsu/shohi/keigenzeiritsu/pdf/0024006-039_01.pdf)
+- 
+Since October 1, 2023, Japan's Qualified Invoice System (適格請求書等保存方式) requires registered issuers to include their registration number on invoices for customers to claim input tax credits.
+Businesses must deliver and retain a qualified invoice (commonly just called an invoice) that meets the system’s requirements to correctly apply tax credits for purchases and accurately pay consumption tax.
+
+The **Invoice Registration Number** (適格請求書発行事業者登録番号) has the format `T` followed by 13 digits. For corporations, this is `T` + their corporate number.
+
+This is modeled as an organization identity with the key `jp-invoice-registration-number`.
+
+

--- a/regimes/jp/identities.go
+++ b/regimes/jp/identities.go
@@ -1,0 +1,52 @@
+package jp
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/i18n"
+	"github.com/invopop/gobl/org"
+	"github.com/invopop/validation"
+)
+
+const (
+	// IdentityKeyRegistrationNumber represents the Qualified Invoice Issuer
+	// Registration Number (適格請求書発行事業者登録番号) assigned under
+	// Japan's Qualified Invoice System (QIS), effective October 1, 2023.
+	// Format: "T" followed by 13 digits.
+	IdentityKeyRegistrationNumber cbc.Key = "jp-invoice-registration-number"
+)
+
+var registrationNumberPattern = regexp.MustCompile(`^T\d{13}$`)
+
+var identityDefinitions = []*cbc.Definition{
+	{
+		Key: IdentityKeyRegistrationNumber,
+		Name: i18n.String{
+			i18n.EN: "Invoice Registration Number",
+			i18n.JA: "適格請求書発行事業者登録番号",
+		},
+	},
+}
+
+func normalizeRegistrationNumber(id *org.Identity) {
+	if id == nil || id.Key != IdentityKeyRegistrationNumber {
+		return
+	}
+	code := strings.ToUpper(strings.TrimSpace(id.Code.String()))
+	id.Code = cbc.Code(code)
+}
+
+func validateRegistrationNumber(id *org.Identity) error {
+	if id == nil || id.Key != IdentityKeyRegistrationNumber {
+		return nil
+	}
+	return validation.ValidateStruct(id,
+		validation.Field(&id.Code,
+			validation.Required,
+			validation.Match(registrationNumberPattern),
+			validation.Skip,
+		),
+	)
+}

--- a/regimes/jp/identities_test.go
+++ b/regimes/jp/identities_test.go
@@ -1,0 +1,75 @@
+package jp_test
+
+import (
+	"testing"
+
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/org"
+	"github.com/invopop/gobl/regimes/jp"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizeRegistrationNumber(t *testing.T) {
+	tests := []struct {
+		name     string
+		code     string
+		expected string
+	}{
+		{name: "already valid", code: "T5010401067252", expected: "T5010401067252"},
+		{name: "lowercase t", code: "t5010401067252", expected: "T5010401067252"},
+		{name: "with spaces", code: " T5010401067252 ", expected: "T5010401067252"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id := &org.Identity{Key: jp.IdentityKeyRegistrationNumber, Code: cbc.Code(tt.code)}
+			jp.Normalize(id)
+			assert.Equal(t, tt.expected, id.Code.String())
+		})
+	}
+}
+
+func TestValidateRegistrationNumber(t *testing.T) {
+	tests := []struct {
+		name string
+		code string
+		err  string
+	}{
+		{name: "valid sony", code: "T5010401067252"},
+		{name: "valid nintendo", code: "T1130001011420"},
+		{
+			name: "missing T prefix",
+			code: "5010401067252",
+			err:  "code",
+		},
+		{
+			name: "too short",
+			code: "T12345",
+			err:  "code",
+		},
+		{
+			name: "too long",
+			code: "T12345678901234",
+			err:  "code",
+		},
+		{
+			name: "empty",
+			code: "",
+			err:  "code",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id := &org.Identity{Key: jp.IdentityKeyRegistrationNumber, Code: cbc.Code(tt.code)}
+			err := jp.Validate(id)
+			if tt.err == "" {
+				assert.NoError(t, err)
+			} else {
+				if assert.Error(t, err) {
+					assert.Contains(t, err.Error(), tt.err)
+				}
+			}
+		})
+	}
+}

--- a/regimes/jp/invoices.go
+++ b/regimes/jp/invoices.go
@@ -1,0 +1,38 @@
+package jp
+
+import (
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/org"
+	"github.com/invopop/gobl/tax"
+	"github.com/invopop/validation"
+)
+
+func validateInvoice(inv *bill.Invoice) error {
+	return validation.ValidateStruct(inv,
+		validation.Field(&inv.Supplier,
+			validation.When(
+				!isSimplified(inv),
+				validation.By(validateInvoiceSupplier),
+			),
+			validation.Skip,
+		),
+	)
+}
+
+func validateInvoiceSupplier(value any) error {
+	p, ok := value.(*org.Party)
+	if !ok || p == nil {
+		return nil
+	}
+	return validation.ValidateStruct(p,
+		validation.Field(&p.TaxID,
+			validation.Required,
+			tax.RequireIdentityCode,
+			validation.Skip,
+		),
+	)
+}
+
+func isSimplified(inv *bill.Invoice) bool {
+	return inv.HasTags(tax.TagSimplified)
+}

--- a/regimes/jp/invoices_test.go
+++ b/regimes/jp/invoices_test.go
@@ -1,0 +1,173 @@
+package jp_test
+
+import (
+	"testing"
+
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/num"
+	"github.com/invopop/gobl/org"
+	"github.com/invopop/gobl/regimes/jp"
+	"github.com/invopop/gobl/tax"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInvoiceSupplierValidation(t *testing.T) {
+	t.Run("valid with tax ID", func(t *testing.T) {
+		inv := validInvoice()
+		require.NoError(t, inv.Calculate())
+		assert.NoError(t, inv.Validate())
+	})
+
+	t.Run("missing supplier tax ID", func(t *testing.T) {
+		inv := validInvoice()
+		inv.Supplier.TaxID = nil
+		require.NoError(t, inv.Calculate())
+		assert.ErrorContains(t, inv.Validate(), "supplier: (tax_id: cannot be blank.).")
+	})
+
+	t.Run("missing supplier tax ID code", func(t *testing.T) {
+		inv := validInvoice()
+		inv.Supplier.TaxID.Code = ""
+		require.NoError(t, inv.Calculate())
+		assert.ErrorContains(t, inv.Validate(), "supplier: (tax_id: (code: cannot be blank.).).")
+	})
+}
+
+func TestInvoiceSimplified(t *testing.T) {
+	t.Run("simplified - no supplier tax ID code", func(t *testing.T) {
+		inv := validInvoice()
+		inv.SetTags("simplified")
+		inv.Supplier.TaxID.Code = ""
+		inv.Customer = nil
+		require.NoError(t, inv.Calculate())
+		assert.NoError(t, inv.Validate())
+	})
+
+	t.Run("simplified - no supplier tax ID", func(t *testing.T) {
+		inv := validInvoice()
+		inv.SetTags("simplified")
+		inv.Supplier.TaxID = nil
+		inv.Customer = nil
+		require.NoError(t, inv.Calculate())
+		assert.NoError(t, inv.Validate())
+	})
+}
+
+func TestInvoiceWithRegistrationNumber(t *testing.T) {
+	t.Run("valid with registration number", func(t *testing.T) {
+		inv := validInvoice()
+		inv.Supplier.Identities = []*org.Identity{
+			{
+				Key:  jp.IdentityKeyRegistrationNumber,
+				Code: "T5010401067252",
+			},
+		}
+		require.NoError(t, inv.Calculate())
+		assert.NoError(t, inv.Validate())
+	})
+
+	t.Run("normalized during calculation", func(t *testing.T) {
+		inv := validInvoice()
+		inv.Supplier.Identities = []*org.Identity{
+			{
+				Key:  jp.IdentityKeyRegistrationNumber,
+				Code: "t5010401067252",
+			},
+		}
+		require.NoError(t, inv.Calculate())
+		assert.Equal(t, "T5010401067252", inv.Supplier.Identities[0].Code.String())
+		assert.NoError(t, inv.Validate())
+	})
+
+	t.Run("invalid registration number format", func(t *testing.T) {
+		inv := validInvoice()
+		inv.Supplier.Identities = []*org.Identity{
+			{
+				Key:  jp.IdentityKeyRegistrationNumber,
+				Code: "INVALID",
+			},
+		}
+		require.NoError(t, inv.Calculate())
+		assert.ErrorContains(t, inv.Validate(), "code")
+	})
+
+	t.Run("missing T prefix", func(t *testing.T) {
+		inv := validInvoice()
+		inv.Supplier.Identities = []*org.Identity{
+			{
+				Key:  jp.IdentityKeyRegistrationNumber,
+				Code: "5010401067252",
+			},
+		}
+		require.NoError(t, inv.Calculate())
+		assert.ErrorContains(t, inv.Validate(), "code")
+	})
+}
+
+func TestInvoiceWithWithholdingTax(t *testing.T) {
+	t.Run("invoice with WHT", func(t *testing.T) {
+		inv := &bill.Invoice{
+			Regime: tax.WithRegime("JP"),
+			Series: "TEST",
+			Code:   "0002",
+			Supplier: &org.Party{
+				Name: "Test Supplier",
+				TaxID: &tax.Identity{
+					Country: "JP",
+					Code:    "5010401067252",
+				},
+			},
+			Customer: &org.Party{
+				Name: "Test Customer",
+				TaxID: &tax.Identity{
+					Country: "JP",
+					Code:    "1130001011420",
+				},
+			},
+			Lines: []*bill.Line{
+				{
+					Quantity: num.MakeAmount(1, 0),
+					Item: &org.Item{
+						Name:  "Consulting Service",
+						Price: num.NewAmount(500000, 0),
+						Unit:  org.UnitPackage,
+					},
+					Taxes: tax.Set{
+						{
+							Category: "VAT",
+							Rate:     "general",
+						},
+						{
+							Category: jp.TaxCategoryWHT,
+							Rate:     jp.TaxRatePro,
+						},
+					},
+				},
+			},
+		}
+		require.NoError(t, inv.Calculate())
+		assert.NoError(t, inv.Validate())
+
+		// Verify tax totals include both VAT and retained WHT
+		require.NotNil(t, inv.Totals)
+		require.NotNil(t, inv.Totals.Taxes)
+		assert.Len(t, inv.Totals.Taxes.Categories, 2)
+
+		// Check consumption tax category
+		vatCat := inv.Totals.Taxes.Categories[0]
+		assert.Equal(t, tax.CategoryVAT, vatCat.Code)
+		assert.False(t, vatCat.Retained)
+		assert.Equal(t, "50000", vatCat.Amount.String())
+
+		// Check withholding tax category
+		whtCat := inv.Totals.Taxes.Categories[1]
+		assert.Equal(t, jp.TaxCategoryWHT, whtCat.Code)
+		assert.True(t, whtCat.Retained)
+		assert.Equal(t, "51050", whtCat.Amount.String())
+
+		// Retained total should be set
+		require.NotNil(t, inv.Totals.Taxes.Retained)
+		assert.Equal(t, "51050", inv.Totals.Taxes.Retained.String())
+	})
+}

--- a/regimes/jp/jp.go
+++ b/regimes/jp/jp.go
@@ -1,0 +1,80 @@
+// Package jp provides the tax regime definition for Japan.
+package jp
+
+import (
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/currency"
+	"github.com/invopop/gobl/i18n"
+	"github.com/invopop/gobl/org"
+	"github.com/invopop/gobl/tax"
+)
+
+func init() {
+	tax.RegisterRegimeDef(New())
+}
+
+// Local tax category definitions which are not considered standard.
+const (
+	// TaxCategoryWHT is the code for Japan's Withholding Income Tax
+	TaxCategoryWHT cbc.Code = "WHT"
+)
+
+// Specific withholding tax rate keys.
+const (
+	TaxRatePro     cbc.Key = "pro"      // Professional services (≤ ¥1,000,000)
+	TaxRateProOver cbc.Key = "pro-over" // Professional services (> ¥1,000,000)
+)
+
+// New provides the tax regime definition for Japan.
+func New() *tax.RegimeDef {
+	return &tax.RegimeDef{
+		Country:   "JP",
+		Currency:  currency.JPY,
+		TaxScheme: tax.CategoryVAT,
+		Name: i18n.String{
+			i18n.EN: "Japan",
+			i18n.JA: "日本",
+		},
+		TimeZone:   "Asia/Tokyo",
+		Identities: identityDefinitions,
+		Scenarios: []*tax.ScenarioSet{
+			invoiceScenarios,
+		},
+		Corrections: []*tax.CorrectionDefinition{
+			{
+				Schema: bill.ShortSchemaInvoice,
+				Types: []cbc.Key{
+					bill.InvoiceTypeCreditNote,
+					bill.InvoiceTypeDebitNote,
+				},
+			},
+		},
+		Categories: taxCategories,
+		Validator:  Validate,
+		Normalizer: Normalize,
+	}
+}
+
+// Validate checks the document type and determines if it can be validated.
+func Validate(doc any) error {
+	switch obj := doc.(type) {
+	case *bill.Invoice:
+		return validateInvoice(obj)
+	case *tax.Identity:
+		return validateTaxIdentity(obj)
+	case *org.Identity:
+		return validateRegistrationNumber(obj)
+	}
+	return nil
+}
+
+// Normalize will attempt to clean the object passed to it.
+func Normalize(doc any) {
+	switch obj := doc.(type) {
+	case *tax.Identity:
+		tax.NormalizeIdentity(obj)
+	case *org.Identity:
+		normalizeRegistrationNumber(obj)
+	}
+}

--- a/regimes/jp/jp_test.go
+++ b/regimes/jp/jp_test.go
@@ -1,0 +1,58 @@
+package jp_test
+
+import (
+	"testing"
+
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/num"
+	"github.com/invopop/gobl/org"
+	"github.com/invopop/gobl/tax"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func validInvoice() *bill.Invoice {
+	return &bill.Invoice{
+		Regime: tax.WithRegime("JP"),
+		Series: "TEST",
+		Code:   "0001",
+		Supplier: &org.Party{
+			Name: "Test Supplier",
+			TaxID: &tax.Identity{
+				Country: "JP",
+				Code:    "5010401067252",
+			},
+		},
+		Customer: &org.Party{
+			Name: "Test Customer",
+			TaxID: &tax.Identity{
+				Country: "JP",
+				Code:    "1130001011420",
+			},
+		},
+		Lines: []*bill.Line{
+			{
+				Quantity: num.MakeAmount(1, 0),
+				Item: &org.Item{
+					Name:  "Test Item",
+					Price: num.NewAmount(10000, 0),
+					Unit:  org.UnitPackage,
+				},
+				Taxes: tax.Set{
+					{
+						Category: "VAT",
+						Rate:     "general",
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestRegimeBasic(t *testing.T) {
+	t.Run("valid invoice calculates and validates", func(t *testing.T) {
+		inv := validInvoice()
+		require.NoError(t, inv.Calculate())
+		assert.NoError(t, inv.Validate())
+	})
+}

--- a/regimes/jp/scenarios.go
+++ b/regimes/jp/scenarios.go
@@ -1,0 +1,32 @@
+package jp
+
+import (
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/org"
+	"github.com/invopop/gobl/tax"
+)
+
+var invoiceScenarios = &tax.ScenarioSet{
+	Schema: bill.ShortSchemaInvoice,
+	List: []*tax.Scenario{
+		// Reverse Charge
+		{
+			Tags: []cbc.Key{tax.TagReverseCharge},
+			Note: &tax.ScenarioNote{
+				Key:  org.NoteKeyLegal,
+				Src:  tax.TagReverseCharge,
+				Text: "Reverse Charge: The recipient is liable for the consumption tax on this transaction",
+			},
+		},
+		// Simplified Invoice
+		{
+			Tags: []cbc.Key{tax.TagSimplified},
+			Note: &tax.ScenarioNote{
+				Key:  org.NoteKeyLegal,
+				Src:  tax.TagSimplified,
+				Text: "Simplified Invoice",
+			},
+		},
+	},
+}

--- a/regimes/jp/scenarios_test.go
+++ b/regimes/jp/scenarios_test.go
@@ -1,0 +1,81 @@
+package jp_test
+
+import (
+	"testing"
+
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/num"
+	"github.com/invopop/gobl/org"
+	"github.com/invopop/gobl/tax"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testInvoiceWithTags(t *testing.T, tags ...cbc.Key) *bill.Invoice {
+	t.Helper()
+	return &bill.Invoice{
+		Regime: tax.WithRegime("JP"),
+		Series: "TEST",
+		Code:   "0001",
+		Tags:   tax.WithTags(tags...),
+		Supplier: &org.Party{
+			Name: "Test Supplier",
+			TaxID: &tax.Identity{
+				Country: "JP",
+				Code:    "5010401067252",
+			},
+		},
+		Customer: &org.Party{
+			Name: "Test Customer",
+			TaxID: &tax.Identity{
+				Country: "JP",
+				Code:    "1130001011420",
+			},
+		},
+		Lines: []*bill.Line{
+			{
+				Quantity: num.MakeAmount(1, 0),
+				Item: &org.Item{
+					Name:  "Test Item",
+					Price: num.NewAmount(10000, 0),
+					Unit:  org.UnitPackage,
+				},
+				Taxes: tax.Set{
+					{
+						Category: "VAT",
+						Rate:     "general",
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestScenarios(t *testing.T) {
+	t.Run("reverse charge", func(t *testing.T) {
+		inv := testInvoiceWithTags(t, tax.TagReverseCharge)
+		require.NoError(t, inv.Calculate())
+		require.NoError(t, inv.Validate())
+		assert.Len(t, inv.Notes, 1)
+		assert.Equal(t, tax.TagReverseCharge, inv.Notes[0].Src)
+		assert.Equal(t, "Reverse Charge: The recipient is liable for the consumption tax on this transaction", inv.Notes[0].Text)
+	})
+
+	t.Run("simplified invoice", func(t *testing.T) {
+		inv := testInvoiceWithTags(t, tax.TagSimplified)
+		inv.Customer = nil
+		require.NoError(t, inv.Calculate())
+		require.NoError(t, inv.Validate())
+		assert.Len(t, inv.Notes, 1)
+		assert.Equal(t, tax.TagSimplified, inv.Notes[0].Src)
+		assert.Equal(t, "Simplified Invoice", inv.Notes[0].Text)
+	})
+
+	t.Run("no tags - no notes", func(t *testing.T) {
+		inv := testInvoiceWithTags(t)
+		require.NoError(t, inv.Calculate())
+		require.NoError(t, inv.Validate())
+		assert.Empty(t, inv.Notes)
+	})
+}

--- a/regimes/jp/tax_categories.go
+++ b/regimes/jp/tax_categories.go
@@ -1,0 +1,150 @@
+package jp
+
+import (
+	"github.com/invopop/gobl/cal"
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/i18n"
+	"github.com/invopop/gobl/num"
+	"github.com/invopop/gobl/tax"
+)
+
+var taxCategories = []*tax.CategoryDef{
+	//
+	// Consumption Tax (消費税)
+	//
+	{
+		Code: tax.CategoryVAT,
+		Name: i18n.String{
+			i18n.EN: "CT",
+			i18n.JA: "消費税",
+		},
+		Title: i18n.String{
+			i18n.EN: "Consumption Tax",
+			i18n.JA: "消費税",
+		},
+		Sources: []*cbc.Source{
+			{
+				Title: i18n.String{
+					i18n.EN: "Consumption Tax Trends - Japan",
+				},
+				URL: "https://www.nta.go.jp/english/taxes/consumption_tax/01.htm#c01",
+			},
+		},
+		Retained: false,
+		Keys:     tax.GlobalVATKeys(),
+		Rates: []*tax.RateDef{
+			{
+				Keys: []cbc.Key{tax.KeyStandard},
+				Rate: tax.RateGeneral,
+				Name: i18n.String{
+					i18n.EN: "Standard rate",
+					i18n.JA: "標準税率",
+				},
+				Values: []*tax.RateValueDef{
+					{
+						Since:   cal.NewDate(2019, 10, 1),
+						Percent: num.MakePercentage(10, 2),
+					},
+					{
+						Since:   cal.NewDate(2014, 4, 1),
+						Percent: num.MakePercentage(8, 2),
+					},
+					{
+						Since:   cal.NewDate(1997, 4, 1),
+						Percent: num.MakePercentage(5, 2),
+					},
+					{
+						Since:   cal.NewDate(1989, 4, 1),
+						Percent: num.MakePercentage(3, 2),
+					},
+				},
+			},
+			{
+				Keys: []cbc.Key{tax.KeyStandard},
+				Rate: tax.RateReduced,
+				Name: i18n.String{
+					i18n.EN: "Reduced rate",
+					i18n.JA: "軽減税率",
+				},
+				Description: i18n.String{
+					i18n.EN: "Applies to food and beverages (excluding dining out and alcohol) and newspaper subscriptions.",
+					i18n.JA: "飲食料品（外食・酒類を除く）及び新聞の定期購読に適用。",
+				},
+				Values: []*tax.RateValueDef{
+					{
+						Since:   cal.NewDate(2019, 10, 1),
+						Percent: num.MakePercentage(8, 2),
+					},
+				},
+			},
+		},
+	},
+
+	//
+	// Withholding Income Tax (源泉徴収)
+	//
+	{
+		Code:     TaxCategoryWHT,
+		Retained: true,
+		Name: i18n.String{
+			i18n.EN: "WHT",
+			i18n.JA: "源泉徴収",
+		},
+		Title: i18n.String{
+			i18n.EN: "Withholding Income Tax",
+			i18n.JA: "源泉徴収所得税",
+		},
+		Sources: []*cbc.Source{
+			{
+				Title: i18n.String{
+					i18n.EN: "Japan Withholding Taxes - PwC",
+				},
+				URL: "https://taxsummaries.pwc.com/japan/corporate/withholding-taxes",
+			},
+		},
+		Rates: []*tax.RateDef{
+			{
+				Rate: TaxRatePro,
+				Name: i18n.String{
+					i18n.EN: "Professional Rate",
+					i18n.JA: "専門家報酬",
+				},
+				Description: i18n.String{
+					i18n.EN: "Applies to professional service fees of ¥1,000,000 or less per payment. Includes 2.1% reconstruction surtax (2013-2037).",
+					i18n.JA: "1回の支払金額が100万円以下の専門家報酬に適用。復興特別所得税2.1%を含む（2013年〜2037年）。",
+				},
+				Values: []*tax.RateValueDef{
+					{
+						Since:   cal.NewDate(2013, 1, 1),
+						Percent: num.MakePercentage(1021, 4),
+					},
+					{
+						Since:   cal.NewDate(1989, 4, 1),
+						Percent: num.MakePercentage(10, 2),
+					},
+				},
+			},
+			{
+				Rate: TaxRateProOver,
+				Name: i18n.String{
+					i18n.EN: "Professional Rate (over ¥1M)",
+					i18n.JA: "専門家報酬（100万円超）",
+				},
+				Description: i18n.String{
+					i18n.EN: "Applies to professional service fees exceeding ¥1,000,000 per payment. Includes 2.1% reconstruction surtax (2013-2037).",
+					i18n.JA: "1回の支払金額が100万円を超える専門家報酬に適用。復興特別所得税2.1%を含む（2013年〜2037年）。",
+				},
+				Values: []*tax.RateValueDef{
+					{
+						Since:   cal.NewDate(2013, 1, 1),
+						Percent: num.MakePercentage(2042, 4),
+					},
+					{
+						Since:   cal.NewDate(1989, 4, 1),
+						Percent: num.MakePercentage(20, 2),
+					},
+				},
+			},
+		},
+	},
+}

--- a/regimes/jp/tax_categories.go
+++ b/regimes/jp/tax_categories.go
@@ -25,7 +25,7 @@ var taxCategories = []*tax.CategoryDef{
 		Sources: []*cbc.Source{
 			{
 				Title: i18n.String{
-					i18n.EN: "Consumption Tax Trends - Japan",
+					i18n.EN: "Consumption Tax Japan",
 				},
 				URL: "https://www.nta.go.jp/english/taxes/consumption_tax/01.htm#c01",
 			},

--- a/regimes/jp/tax_identity.go
+++ b/regimes/jp/tax_identity.go
@@ -1,0 +1,85 @@
+package jp
+
+import (
+	"errors"
+	"regexp"
+	"strconv"
+
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/tax"
+	"github.com/invopop/validation"
+)
+
+var (
+	taxCodePattern = regexp.MustCompile(`^\d{13}$`)
+
+	errInvalidFormat   = errors.New("invalid format")
+	errInvalidChecksum = errors.New("checksum mismatch")
+)
+
+func validateTaxIdentity(tID *tax.Identity) error {
+	return validation.ValidateStruct(tID,
+		validation.Field(&tID.Code, validation.By(validateTaxCode)),
+	)
+}
+
+func validateTaxCode(value interface{}) error {
+	code, ok := value.(cbc.Code)
+	if !ok || code == "" {
+		return nil
+	}
+	val := code.String()
+
+	if !taxCodePattern.MatchString(val) {
+		return errInvalidFormat
+	}
+
+	// First digit must be non-zero (it's the check digit)
+	if val[0] == '0' {
+		return errInvalidFormat
+	}
+
+	return validateCorporateNumberChecksum(val)
+}
+
+// validateCorporateNumberChecksum validates the check digit of a 13-digit Japanese Corporate Number
+// https://www.houjin-bangou.nta.go.jp/documents/checkdigit.pdf
+// https://github.com/kufu/tsubaki/blob/master/lib/tsubaki/corporate_number.rb
+//
+// The check digit (first digit) is calculated as:
+//
+//	9 - ((Σ Pn × Qn) mod 9)
+//
+// where Pn is the n-th digit of the 12-digit base number (counting from
+// the lowest/rightmost digit), and Qn = 1 if n is odd, 2 if n is even.
+func validateCorporateNumberChecksum(val string) error {
+	sum := 0
+	base := val[1:] // 12-digit base number (digits 2-13)
+
+	for i := 0; i < 12; i++ {
+		digit, err := strconv.Atoi(string(base[11-i]))
+		if err != nil {
+			return errInvalidFormat
+		}
+		// n is 1-indexed: position 1 is the rightmost digit
+		n := i + 1
+		q := 1
+		if n%2 == 0 {
+			q = 2
+		}
+		sum += digit * q
+	}
+
+	expected := 9 - (sum % 9)
+
+	checkDigit, err := strconv.Atoi(string(val[0]))
+	if err != nil {
+		return errInvalidFormat
+	}
+
+	if checkDigit != expected {
+		return errInvalidChecksum
+	}
+
+	return nil
+}

--- a/regimes/jp/tax_identity_test.go
+++ b/regimes/jp/tax_identity_test.go
@@ -1,0 +1,68 @@
+package jp_test
+
+import (
+	"testing"
+
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/regimes/jp"
+	"github.com/invopop/gobl/tax"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateTaxIdentity(t *testing.T) {
+	tests := []struct {
+		name string
+		code cbc.Code
+		err  string
+	}{
+		// Known valid corporate numbers
+		{name: "valid sony corporate number", code: "5010401067252"}, // https://www.houjin-bangou.nta.go.jp/henkorireki-johoto.html?selHouzinNo=1130001011420
+		{name: "valid nintendo corporate number", code: "1130001011420"},
+		// Invalid format
+		{
+			name: "too short",
+			code: "123456789",
+			err:  "invalid format",
+		},
+		{
+			name: "too long",
+			code: "12345678901234",
+			err:  "invalid format",
+		},
+		{
+			name: "leading zero",
+			code: "0123456789012",
+			err:  "invalid format",
+		},
+		{
+			name: "contains letters",
+			code: "A123456789012",
+			err:  "invalid format",
+		},
+		// Invalid checksum
+		{
+			name: "bad checksum",
+			code: "2010401067252",
+			err:  "checksum mismatch",
+		},
+		{
+			name: "bad checksum 2",
+			code: "1130001011421",
+			err:  "checksum mismatch",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tID := &tax.Identity{Country: "JP", Code: tt.code}
+			err := jp.Validate(tID)
+			if tt.err == "" {
+				assert.NoError(t, err)
+			} else {
+				if assert.Error(t, err) {
+					assert.Contains(t, err.Error(), tt.err)
+				}
+			}
+		})
+	}
+}

--- a/regimes/regimes.go
+++ b/regimes/regimes.go
@@ -22,6 +22,7 @@ import (
 	_ "github.com/invopop/gobl/regimes/ie"
 	_ "github.com/invopop/gobl/regimes/in"
 	_ "github.com/invopop/gobl/regimes/it"
+	_ "github.com/invopop/gobl/regimes/jp"
 	_ "github.com/invopop/gobl/regimes/mx"
 	_ "github.com/invopop/gobl/regimes/nl"
 	_ "github.com/invopop/gobl/regimes/pl"


### PR DESCRIPTION
## Summary

- Adds a new tax regime for Japan (JP) implementing the Japanese Consumption Tax (JCT), Withholding Income Tax, and the Qualified Invoice System (QIS).
- Added a new README.md describing a tep by step process to add new regimes

### Tax Categories

- **Consumption Tax (JCT)** — Standard rate at 10% and reduced rate at 8% (food/beverages, newspapers), with full historical rates back to the original 3% in 1989.
- **Withholding Income Tax (源泉徴収)** — Professional rates at 10.21% (includes 2.1% reconstruction surtax) and 20.42% for amounts over ¥1M, with historical rates.

### Tax Identity

- Validates 13-digit Corporate Numbers (法人番号) issued by the National Tax Agency, including check digit verification.

### Qualified Invoice System (QIS)

- Models the Invoice Registration Number (`T` + 13 digits) as an organization identity (`jp-invoice-registration-number`), required since October 2023 for input tax credit claims.

### Scenarios

- **Reverse Charge** (`reverse-charge`) — Adds legal note for reverse charge mechanism on cross-border B2B services.
- **Simplified Invoice** (`simplified`) — Supports simplified invoices for transactions under ¥10,000.

### Corrections

- Supports credit and debit notes via the `credit-note` and `debit-note` extension types.

### Examples

- `invoice-jp-jp.yaml` — Standard domestic B2B invoice
- `invoice-jp-freelance.yaml` — Freelancer invoice with withholding tax
- `invoice-jp-reverse-charge.yaml` — Cross-border reverse charge invoice
- `invoice-jp-simplified.yaml` — Simplified invoice

### Files Added

| Path | Description |
|------|-------------|
| `regimes/jp/jp.go` | Regime definition, init, normalize, validate |
| `regimes/jp/tax_categories.go` | JCT and withholding tax category definitions |
| `regimes/jp/tax_identity.go` | Corporate number normalization and validation |
| `regimes/jp/scenarios.go` | Reverse charge and simplified invoice scenarios |
| `regimes/jp/invoices.go` | Invoice-level validation |
| `regimes/jp/identities.go` | Organization identity types (invoice registration number) |
| `regimes/jp/README.md` | Regime documentation |
| `regimes/jp/*_test.go` | Tests for all components |
| `examples/jp/*.yaml` | Example invoices with generated JSON output |
| `data/regimes/jp.json` | Generated regime data |

## Test plan

- [X] `go test ./regimes/jp/...` passes
- [X] `go test ./...` passes (no regressions)
- [X] Example YAML files calculate and validate correctly
- [X] Tax identity validation covers valid/invalid corporate numbers
- [X] Withholding tax applies correctly on freelancer invoices
- [X] Reverse charge scenario adds appropriate legal notes

## Pre-Review Checklist

- [X] Opened this PR as a draft
- [X] Read the CONTRIBUTING.md guide.
- [X] Performed a self-review of my code.
- [X] Added thorough tests with at **least** 90% code coverage.
- [X] Modified or created example GOBL documents to show my changes in use, if appropriate.
- [X] Added links to the source of the changes in tax regimes or addons, either structured or in the comments.
- [X]  Run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [X] Reviewed and fixed all linter warnings.
- [ ] Been obsessive with pointer nil checks to avoid panics.
- [X] Updated the CHANGELOG.md with an overview of my changes.
- [ ] Requested a review from Copilot and fixed or dismissed (with a reason) all the feedback raised.

Only after checking off all the previous items:
- [ ] Marked this PR as ready for review and requested one from @samlown.
