### PR TITLE
Add CopyExt and DocExtensions to correction framework + fix ARCA credit note flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Added
 
+- `tax`: Added `CopyExt` field to `CorrectionDefinition` to automatically copy tax extensions from the invoice to preceding.
 - `eu-en16931-v2017`: BR-32 validation requiring taxes on document-level discounts.
 
 ### Changed
@@ -23,6 +24,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Fixed
 
+- `ar-arca-v4`: Fixed correction flow to automatically copy tax extensions to preceding, removing need for manual extension input.
 - `tax`: Fixed `Since` date comparison to be inclusive
 - `gr-mydata-v1`: Corrected exemption codes 3 and 4 mapping to `outside-scope`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Added
 
+- `tax`: Added `DocExtensions` field to `CorrectionDefinition` to route extension keys to the invoice's `Tax.Ext` during corrections.
 - `tax`: Added `CopyExt` field to `CorrectionDefinition` to automatically copy tax extensions from the invoice to preceding.
 - `eu-en16931-v2017`: BR-32 validation requiring taxes on document-level discounts.
 
@@ -24,7 +25,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Fixed
 
-- `ar-arca-v4`: Fixed correction flow to automatically copy tax extensions to preceding, removing need for manual extension input.
+- `ar-arca-v4`: Correction flow uses `DocExtensions` and `CopyExt`
 - `tax`: Fixed `Since` date comparison to be inclusive
 - `gr-mydata-v1`: Corrected exemption codes 3 and 4 mapping to `outside-scope`
 

--- a/addons/ar/arca/bill.go
+++ b/addons/ar/arca/bill.go
@@ -24,14 +24,8 @@ const (
 
 var invoiceCorrectionDefinitions = tax.CorrectionSet{
 	{
-		Schema: bill.ShortSchemaInvoice,
-		Types: []cbc.Key{
-			bill.InvoiceTypeCreditNote,
-			bill.InvoiceTypeDebitNote,
-		},
-		Extensions: []cbc.Key{
-			ExtKeyDocType,
-		},
+		Schema:  bill.ShortSchemaInvoice,
+		CopyExt: true,
 	},
 }
 
@@ -98,9 +92,15 @@ func normalizeBillInvoiceTaxDocType(inv *bill.Invoice) {
 		inv.Tax = new(bill.Tax)
 	}
 
-	// Skip if doc type is already set
-	if inv.Tax.GetExt(ExtKeyDocType) != "" {
-		return
+	// If doc type is already set and consistent with the invoice type, keep it.
+	// Otherwise clear it so it gets re-derived below. This handles cases like
+	// corrections (where the type changes but the old doc type remains),
+	// API uploads with mismatched values, or any other source.
+	if existing := inv.Tax.GetExt(ExtKeyDocType); existing != "" {
+		if isDocTypeConsistent(existing, inv.Type) {
+			return
+		}
+		inv.Tax.Ext = inv.Tax.Ext.Delete(ExtKeyDocType)
 	}
 
 	// Determine the doc type category (A, B, or C)
@@ -165,6 +165,20 @@ func getDocTypeForCategory(category string, invType cbc.Key) cbc.Code {
 		}
 	}
 	return ""
+}
+
+// isDocTypeConsistent checks if the existing doc type matches the invoice type.
+func isDocTypeConsistent(docType cbc.Code, invType cbc.Key) bool {
+	switch invType {
+	case bill.InvoiceTypeCreditNote:
+		return docType.In(DocTypesCreditNote...)
+	case bill.InvoiceTypeDebitNote:
+		return docType.In(DocTypesDebitNote...)
+	case bill.InvoiceTypeStandard:
+		return !docType.In(DocTypesCreditNote...) && !docType.In(DocTypesDebitNote...)
+	default:
+		return true
+	}
 }
 
 func normalizeBillInvoiceTaxConcept(inv *bill.Invoice) {

--- a/addons/ar/arca/bill.go
+++ b/addons/ar/arca/bill.go
@@ -24,8 +24,9 @@ const (
 
 var invoiceCorrectionDefinitions = tax.CorrectionSet{
 	{
-		Schema:  bill.ShortSchemaInvoice,
-		CopyExt: true,
+		Schema:        bill.ShortSchemaInvoice,
+		CopyExt:       true,
+		DocExtensions: []cbc.Key{ExtKeyDocType},
 	},
 }
 
@@ -92,15 +93,8 @@ func normalizeBillInvoiceTaxDocType(inv *bill.Invoice) {
 		inv.Tax = new(bill.Tax)
 	}
 
-	// If doc type is already set and consistent with the invoice type, keep it.
-	// Otherwise clear it so it gets re-derived below. This handles cases like
-	// corrections (where the type changes but the old doc type remains),
-	// API uploads with mismatched values, or any other source.
-	if existing := inv.Tax.GetExt(ExtKeyDocType); existing != "" {
-		if isDocTypeConsistent(existing, inv.Type) {
-			return
-		}
-		inv.Tax.Ext = inv.Tax.Ext.Delete(ExtKeyDocType)
+	if inv.Tax.GetExt(ExtKeyDocType) != "" {
+		return
 	}
 
 	// Determine the doc type category (A, B, or C)
@@ -165,20 +159,6 @@ func getDocTypeForCategory(category string, invType cbc.Key) cbc.Code {
 		}
 	}
 	return ""
-}
-
-// isDocTypeConsistent checks if the existing doc type matches the invoice type.
-func isDocTypeConsistent(docType cbc.Code, invType cbc.Key) bool {
-	switch invType {
-	case bill.InvoiceTypeCreditNote:
-		return docType.In(DocTypesCreditNote...)
-	case bill.InvoiceTypeDebitNote:
-		return docType.In(DocTypesDebitNote...)
-	case bill.InvoiceTypeStandard:
-		return !docType.In(DocTypesCreditNote...) && !docType.In(DocTypesDebitNote...)
-	default:
-		return true
-	}
 }
 
 func normalizeBillInvoiceTaxConcept(inv *bill.Invoice) {

--- a/addons/ar/arca/bill_test.go
+++ b/addons/ar/arca/bill_test.go
@@ -1067,15 +1067,15 @@ func TestInvoiceTypeDocTypeValidation(t *testing.T) {
 		require.NoError(t, inv.Validate())
 	})
 
-	t.Run("credit note with standard doc type fails", func(t *testing.T) {
+	t.Run("credit note with standard doc type gets re-derived", func(t *testing.T) {
 		inv := testInvoiceWithGoods(t)
 		inv.Type = bill.InvoiceTypeCreditNote
-		inv.Tax.Ext[arca.ExtKeyDocType] = "1" // Standard Invoice A
+		inv.Tax.Ext[arca.ExtKeyDocType] = "1" // Standard Invoice A (inconsistent)
 		inv.Preceding = testPreceding()
 		require.NoError(t, inv.Calculate())
-		err := inv.Validate()
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "invoice type is credit-note but ar-arca-doc-type is not a credit note")
+		// Normalization clears the inconsistent doc type and re-derives it
+		assert.Equal(t, cbc.Code("3"), inv.Tax.Ext[arca.ExtKeyDocType]) // Credit Note A
+		require.NoError(t, inv.Validate())
 	})
 
 	t.Run("debit note with debit note doc type passes", func(t *testing.T) {
@@ -1087,35 +1087,32 @@ func TestInvoiceTypeDocTypeValidation(t *testing.T) {
 		require.NoError(t, inv.Validate())
 	})
 
-	t.Run("debit note with standard doc type fails", func(t *testing.T) {
+	t.Run("debit note with standard doc type gets re-derived", func(t *testing.T) {
 		inv := testInvoiceWithGoods(t)
 		inv.Type = bill.InvoiceTypeDebitNote
-		inv.Tax.Ext[arca.ExtKeyDocType] = "1" // Standard Invoice A
+		inv.Tax.Ext[arca.ExtKeyDocType] = "1" // Standard Invoice A (inconsistent)
 		inv.Preceding = testPreceding()
 		require.NoError(t, inv.Calculate())
-		err := inv.Validate()
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "invoice type is debit-note but ar-arca-doc-type is not a debit note")
+		assert.Equal(t, cbc.Code("2"), inv.Tax.Ext[arca.ExtKeyDocType]) // Debit Note A
+		require.NoError(t, inv.Validate())
 	})
 
-	t.Run("standard invoice with credit note doc type fails", func(t *testing.T) {
+	t.Run("standard invoice with credit note doc type gets re-derived", func(t *testing.T) {
 		inv := testInvoiceWithGoods(t)
 		inv.Type = bill.InvoiceTypeStandard
-		inv.Tax.Ext[arca.ExtKeyDocType] = "3" // Credit Note A
+		inv.Tax.Ext[arca.ExtKeyDocType] = "3" // Credit Note A (inconsistent)
 		require.NoError(t, inv.Calculate())
-		err := inv.Validate()
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "ar-arca-doc-type is a credit note but invoice type is not credit-note")
+		assert.Equal(t, cbc.Code("1"), inv.Tax.Ext[arca.ExtKeyDocType]) // Invoice A
+		require.NoError(t, inv.Validate())
 	})
 
-	t.Run("standard invoice with debit note doc type fails", func(t *testing.T) {
+	t.Run("standard invoice with debit note doc type gets re-derived", func(t *testing.T) {
 		inv := testInvoiceWithGoods(t)
 		inv.Type = bill.InvoiceTypeStandard
-		inv.Tax.Ext[arca.ExtKeyDocType] = "2" // Debit Note A
+		inv.Tax.Ext[arca.ExtKeyDocType] = "2" // Debit Note A (inconsistent)
 		require.NoError(t, inv.Calculate())
-		err := inv.Validate()
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "doc type is a debit note but invoice type is not debit-note")
+		assert.Equal(t, cbc.Code("1"), inv.Tax.Ext[arca.ExtKeyDocType]) // Invoice A
+		require.NoError(t, inv.Validate())
 	})
 
 	t.Run("credit note with FCE credit note doc type passes", func(t *testing.T) {
@@ -1134,6 +1131,16 @@ func TestInvoiceTypeDocTypeValidation(t *testing.T) {
 		inv.Preceding = testPreceding()
 		require.NoError(t, inv.Calculate())
 		require.NoError(t, inv.Validate())
+	})
+
+	t.Run("corrective type preserves standard doc type during normalization", func(t *testing.T) {
+		ad := tax.AddonForKey(arca.V4)
+		inv := testInvoiceWithGoods(t)
+		inv.Type = bill.InvoiceTypeCorrective
+		inv.Tax.Ext[arca.ExtKeyDocType] = "1" // Standard doc type
+		ad.Normalizer(inv)
+		// Normalization does not re-derive doc types for unrecognized invoice types
+		assert.Equal(t, cbc.Code("1"), inv.Tax.Ext[arca.ExtKeyDocType])
 	})
 }
 
@@ -1285,16 +1292,168 @@ func TestValidateFunctionsWithNilValues(t *testing.T) {
 	})
 }
 
+func TestInvoiceTypeDocTypeDirectValidation(t *testing.T) {
+	ad := tax.AddonForKey(arca.V4)
+
+	t.Run("credit note type with standard doc type fails validation", func(t *testing.T) {
+		inv := testInvoiceWithGoods(t)
+		require.NoError(t, inv.Calculate())
+		// Tamper after normalization to create inconsistency
+		inv.Type = bill.InvoiceTypeCreditNote
+		inv.Preceding = testPreceding()
+		err := ad.Validator(inv)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "invoice type is credit-note but ar-arca-doc-type is not a credit note")
+	})
+
+	t.Run("debit note type with standard doc type fails validation", func(t *testing.T) {
+		inv := testInvoiceWithGoods(t)
+		require.NoError(t, inv.Calculate())
+		inv.Type = bill.InvoiceTypeDebitNote
+		inv.Preceding = testPreceding()
+		err := ad.Validator(inv)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "invoice type is debit-note but ar-arca-doc-type is not a debit note")
+	})
+
+	t.Run("standard type with credit note doc type fails validation", func(t *testing.T) {
+		inv := testInvoiceWithGoods(t)
+		require.NoError(t, inv.Calculate())
+		inv.Tax.Ext[arca.ExtKeyDocType] = "3" // Credit Note A
+		err := ad.Validator(inv)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "ar-arca-doc-type is a credit note but invoice type is not credit-note")
+	})
+
+	t.Run("standard type with debit note doc type fails validation", func(t *testing.T) {
+		inv := testInvoiceWithGoods(t)
+		require.NoError(t, inv.Calculate())
+		inv.Tax.Ext[arca.ExtKeyDocType] = "2" // Debit Note A
+		err := ad.Validator(inv)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "doc type is a debit note but invoice type is not debit-note")
+	})
+}
+
 func TestCorrectionDefinitions(t *testing.T) {
-	t.Run("correction definitions exist for credit and debit notes", func(t *testing.T) {
+	t.Run("correction definitions have copy ext", func(t *testing.T) {
 		ad := tax.AddonForKey(arca.V4)
 		require.NotNil(t, ad.Corrections)
-		// Check that invoice correction definition exists
 		def := ad.Corrections.Def(bill.ShortSchemaInvoice)
 		require.NotNil(t, def)
-		assert.True(t, def.HasType(bill.InvoiceTypeCreditNote))
-		assert.True(t, def.HasType(bill.InvoiceTypeDebitNote))
-		assert.True(t, def.HasExtension(arca.ExtKeyDocType))
+		assert.True(t, def.CopyExt)
+	})
+}
+
+func TestCorrectionFlow(t *testing.T) {
+	t.Run("correction re-derives doc type for credit note", func(t *testing.T) {
+		inv := testInvoiceWithGoods(t)
+		require.NoError(t, inv.Calculate())
+		assert.Equal(t, cbc.Code("1"), inv.Tax.Ext[arca.ExtKeyDocType]) // Invoice A
+
+		err := inv.Correct(bill.Credit)
+		require.NoError(t, err)
+
+		// Doc type re-derived from Invoice A to Credit Note A
+		assert.Equal(t, cbc.Code("3"), inv.Tax.Ext[arca.ExtKeyDocType])
+		// Original doc type automatically copied to preceding via CopyExt
+		assert.Equal(t, cbc.Code("1"), inv.Preceding[0].Ext[arca.ExtKeyDocType])
+		require.NoError(t, inv.Validate())
+	})
+
+	t.Run("correction re-derives doc type for debit note", func(t *testing.T) {
+		inv := testInvoiceWithGoods(t)
+		require.NoError(t, inv.Calculate())
+
+		err := inv.Correct(bill.Debit)
+		require.NoError(t, err)
+
+		// Doc type re-derived from Invoice A to Debit Note A
+		assert.Equal(t, cbc.Code("2"), inv.Tax.Ext[arca.ExtKeyDocType])
+		assert.Equal(t, cbc.Code("1"), inv.Preceding[0].Ext[arca.ExtKeyDocType])
+		require.NoError(t, inv.Validate())
+	})
+
+	t.Run("correction type B invoice to credit note", func(t *testing.T) {
+		inv := testInvoiceSimplified(t)
+		require.NoError(t, inv.Calculate())
+		assert.Equal(t, cbc.Code("6"), inv.Tax.Ext[arca.ExtKeyDocType]) // Invoice B
+
+		err := inv.Correct(bill.Credit)
+		require.NoError(t, err)
+
+		// Doc type re-derived from Invoice B to Credit Note B
+		assert.Equal(t, cbc.Code("8"), inv.Tax.Ext[arca.ExtKeyDocType])
+		assert.Equal(t, cbc.Code("6"), inv.Preceding[0].Ext[arca.ExtKeyDocType])
+		require.NoError(t, inv.Validate())
+	})
+
+	t.Run("correction type C invoice to credit note", func(t *testing.T) {
+		inv := testInvoiceTypeC(t)
+		require.NoError(t, inv.Calculate())
+		assert.Equal(t, cbc.Code("11"), inv.Tax.Ext[arca.ExtKeyDocType]) // Invoice C
+
+		err := inv.Correct(bill.Credit)
+		require.NoError(t, err)
+
+		// Doc type re-derived from Invoice C to Credit Note C
+		assert.Equal(t, cbc.Code("13"), inv.Tax.Ext[arca.ExtKeyDocType])
+		assert.Equal(t, cbc.Code("11"), inv.Preceding[0].Ext[arca.ExtKeyDocType])
+		require.NoError(t, inv.Validate())
+	})
+
+	t.Run("correction type C invoice to debit note", func(t *testing.T) {
+		inv := testInvoiceTypeC(t)
+		require.NoError(t, inv.Calculate())
+
+		err := inv.Correct(bill.Debit)
+		require.NoError(t, err)
+
+		assert.Equal(t, cbc.Code("12"), inv.Tax.Ext[arca.ExtKeyDocType])
+		assert.Equal(t, cbc.Code("11"), inv.Preceding[0].Ext[arca.ExtKeyDocType])
+		require.NoError(t, inv.Validate())
+	})
+
+	t.Run("correction copies concept extension to preceding", func(t *testing.T) {
+		inv := testInvoiceWithGoods(t)
+		require.NoError(t, inv.Calculate())
+		assert.Equal(t, cbc.Code("1"), inv.Tax.Ext[arca.ExtKeyConcept]) // Products
+
+		err := inv.Correct(bill.Credit)
+		require.NoError(t, err)
+
+		// Concept should be copied to preceding
+		assert.Equal(t, cbc.Code("1"), inv.Preceding[0].Ext[arca.ExtKeyConcept])
+	})
+
+	t.Run("correction with explicit ext override in preceding", func(t *testing.T) {
+		inv := testInvoiceWithGoods(t)
+		require.NoError(t, inv.Calculate())
+
+		err := inv.Correct(
+			bill.Credit,
+			bill.WithExtension(arca.ExtKeyDocType, "6"), // Override: use B doc type for preceding
+		)
+		require.NoError(t, err)
+
+		// User-provided extension overrides CopyExt for that key
+		assert.Equal(t, cbc.Code("6"), inv.Preceding[0].Ext[arca.ExtKeyDocType])
+		// Invoice gets re-derived doc type
+		assert.Equal(t, cbc.Code("3"), inv.Tax.Ext[arca.ExtKeyDocType])
+	})
+
+	t.Run("correction is idempotent on recalculate", func(t *testing.T) {
+		inv := testInvoiceWithGoods(t)
+		require.NoError(t, inv.Calculate())
+
+		err := inv.Correct(bill.Credit)
+		require.NoError(t, err)
+		assert.Equal(t, cbc.Code("3"), inv.Tax.Ext[arca.ExtKeyDocType])
+
+		// Recalculate should not change the doc type
+		require.NoError(t, inv.Calculate())
+		assert.Equal(t, cbc.Code("3"), inv.Tax.Ext[arca.ExtKeyDocType])
+		assert.Equal(t, cbc.Code("1"), inv.Preceding[0].Ext[arca.ExtKeyDocType])
 	})
 }
 

--- a/addons/ar/arca/bill_test.go
+++ b/addons/ar/arca/bill_test.go
@@ -1067,15 +1067,17 @@ func TestInvoiceTypeDocTypeValidation(t *testing.T) {
 		require.NoError(t, inv.Validate())
 	})
 
-	t.Run("credit note with standard doc type gets re-derived", func(t *testing.T) {
+	t.Run("credit note with standard doc type fails validation", func(t *testing.T) {
 		inv := testInvoiceWithGoods(t)
 		inv.Type = bill.InvoiceTypeCreditNote
 		inv.Tax.Ext[arca.ExtKeyDocType] = "1" // Standard Invoice A (inconsistent)
 		inv.Preceding = testPreceding()
 		require.NoError(t, inv.Calculate())
-		// Normalization clears the inconsistent doc type and re-derives it
-		assert.Equal(t, cbc.Code("3"), inv.Tax.Ext[arca.ExtKeyDocType]) // Credit Note A
-		require.NoError(t, inv.Validate())
+		// Doc type kept as-is, validation catches the mismatch
+		assert.Equal(t, cbc.Code("1"), inv.Tax.Ext[arca.ExtKeyDocType])
+		err := inv.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invoice type is credit-note but ar-arca-doc-type is not a credit note")
 	})
 
 	t.Run("debit note with debit note doc type passes", func(t *testing.T) {
@@ -1087,32 +1089,41 @@ func TestInvoiceTypeDocTypeValidation(t *testing.T) {
 		require.NoError(t, inv.Validate())
 	})
 
-	t.Run("debit note with standard doc type gets re-derived", func(t *testing.T) {
+	t.Run("debit note with standard doc type fails validation", func(t *testing.T) {
 		inv := testInvoiceWithGoods(t)
 		inv.Type = bill.InvoiceTypeDebitNote
 		inv.Tax.Ext[arca.ExtKeyDocType] = "1" // Standard Invoice A (inconsistent)
 		inv.Preceding = testPreceding()
 		require.NoError(t, inv.Calculate())
-		assert.Equal(t, cbc.Code("2"), inv.Tax.Ext[arca.ExtKeyDocType]) // Debit Note A
-		require.NoError(t, inv.Validate())
+		// Doc type kept as-is, validation catches the mismatch
+		assert.Equal(t, cbc.Code("1"), inv.Tax.Ext[arca.ExtKeyDocType])
+		err := inv.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invoice type is debit-note but ar-arca-doc-type is not a debit note")
 	})
 
-	t.Run("standard invoice with credit note doc type gets re-derived", func(t *testing.T) {
+	t.Run("standard invoice with credit note doc type fails validation", func(t *testing.T) {
 		inv := testInvoiceWithGoods(t)
 		inv.Type = bill.InvoiceTypeStandard
 		inv.Tax.Ext[arca.ExtKeyDocType] = "3" // Credit Note A (inconsistent)
 		require.NoError(t, inv.Calculate())
-		assert.Equal(t, cbc.Code("1"), inv.Tax.Ext[arca.ExtKeyDocType]) // Invoice A
-		require.NoError(t, inv.Validate())
+		// Doc type kept as-is, validation catches the mismatch
+		assert.Equal(t, cbc.Code("3"), inv.Tax.Ext[arca.ExtKeyDocType])
+		err := inv.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "ar-arca-doc-type is a credit note but invoice type is not credit-note")
 	})
 
-	t.Run("standard invoice with debit note doc type gets re-derived", func(t *testing.T) {
+	t.Run("standard invoice with debit note doc type fails validation", func(t *testing.T) {
 		inv := testInvoiceWithGoods(t)
 		inv.Type = bill.InvoiceTypeStandard
 		inv.Tax.Ext[arca.ExtKeyDocType] = "2" // Debit Note A (inconsistent)
 		require.NoError(t, inv.Calculate())
-		assert.Equal(t, cbc.Code("1"), inv.Tax.Ext[arca.ExtKeyDocType]) // Invoice A
-		require.NoError(t, inv.Validate())
+		// Doc type kept as-is, validation catches the mismatch
+		assert.Equal(t, cbc.Code("2"), inv.Tax.Ext[arca.ExtKeyDocType])
+		err := inv.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "doc type is a debit note but invoice type is not debit-note")
 	})
 
 	t.Run("credit note with FCE credit note doc type passes", func(t *testing.T) {
@@ -1336,39 +1347,45 @@ func TestInvoiceTypeDocTypeDirectValidation(t *testing.T) {
 }
 
 func TestCorrectionDefinitions(t *testing.T) {
-	t.Run("correction definitions have copy ext", func(t *testing.T) {
+	t.Run("correction definitions have copy ext and doc extensions", func(t *testing.T) {
 		ad := tax.AddonForKey(arca.V4)
 		require.NotNil(t, ad.Corrections)
 		def := ad.Corrections.Def(bill.ShortSchemaInvoice)
 		require.NotNil(t, def)
 		assert.True(t, def.CopyExt)
+		assert.Contains(t, def.DocExtensions, arca.ExtKeyDocType)
 	})
 }
 
 func TestCorrectionFlow(t *testing.T) {
-	t.Run("correction re-derives doc type for credit note", func(t *testing.T) {
+	t.Run("correction with doc type via DocExtensions", func(t *testing.T) {
 		inv := testInvoiceWithGoods(t)
 		require.NoError(t, inv.Calculate())
 		assert.Equal(t, cbc.Code("1"), inv.Tax.Ext[arca.ExtKeyDocType]) // Invoice A
 
-		err := inv.Correct(bill.Credit)
+		err := inv.Correct(
+			bill.Credit,
+			bill.WithExtension(arca.ExtKeyDocType, "3"), // Credit Note A
+		)
 		require.NoError(t, err)
 
-		// Doc type re-derived from Invoice A to Credit Note A
+		// Doc type set on invoice via DocExtensions
 		assert.Equal(t, cbc.Code("3"), inv.Tax.Ext[arca.ExtKeyDocType])
 		// Original doc type automatically copied to preceding via CopyExt
 		assert.Equal(t, cbc.Code("1"), inv.Preceding[0].Ext[arca.ExtKeyDocType])
 		require.NoError(t, inv.Validate())
 	})
 
-	t.Run("correction re-derives doc type for debit note", func(t *testing.T) {
+	t.Run("correction debit note with doc type", func(t *testing.T) {
 		inv := testInvoiceWithGoods(t)
 		require.NoError(t, inv.Calculate())
 
-		err := inv.Correct(bill.Debit)
+		err := inv.Correct(
+			bill.Debit,
+			bill.WithExtension(arca.ExtKeyDocType, "2"), // Debit Note A
+		)
 		require.NoError(t, err)
 
-		// Doc type re-derived from Invoice A to Debit Note A
 		assert.Equal(t, cbc.Code("2"), inv.Tax.Ext[arca.ExtKeyDocType])
 		assert.Equal(t, cbc.Code("1"), inv.Preceding[0].Ext[arca.ExtKeyDocType])
 		require.NoError(t, inv.Validate())
@@ -1379,10 +1396,12 @@ func TestCorrectionFlow(t *testing.T) {
 		require.NoError(t, inv.Calculate())
 		assert.Equal(t, cbc.Code("6"), inv.Tax.Ext[arca.ExtKeyDocType]) // Invoice B
 
-		err := inv.Correct(bill.Credit)
+		err := inv.Correct(
+			bill.Credit,
+			bill.WithExtension(arca.ExtKeyDocType, "8"), // Credit Note B
+		)
 		require.NoError(t, err)
 
-		// Doc type re-derived from Invoice B to Credit Note B
 		assert.Equal(t, cbc.Code("8"), inv.Tax.Ext[arca.ExtKeyDocType])
 		assert.Equal(t, cbc.Code("6"), inv.Preceding[0].Ext[arca.ExtKeyDocType])
 		require.NoError(t, inv.Validate())
@@ -1393,10 +1412,12 @@ func TestCorrectionFlow(t *testing.T) {
 		require.NoError(t, inv.Calculate())
 		assert.Equal(t, cbc.Code("11"), inv.Tax.Ext[arca.ExtKeyDocType]) // Invoice C
 
-		err := inv.Correct(bill.Credit)
+		err := inv.Correct(
+			bill.Credit,
+			bill.WithExtension(arca.ExtKeyDocType, "13"), // Credit Note C
+		)
 		require.NoError(t, err)
 
-		// Doc type re-derived from Invoice C to Credit Note C
 		assert.Equal(t, cbc.Code("13"), inv.Tax.Ext[arca.ExtKeyDocType])
 		assert.Equal(t, cbc.Code("11"), inv.Preceding[0].Ext[arca.ExtKeyDocType])
 		require.NoError(t, inv.Validate())
@@ -1406,7 +1427,10 @@ func TestCorrectionFlow(t *testing.T) {
 		inv := testInvoiceTypeC(t)
 		require.NoError(t, inv.Calculate())
 
-		err := inv.Correct(bill.Debit)
+		err := inv.Correct(
+			bill.Debit,
+			bill.WithExtension(arca.ExtKeyDocType, "12"), // Debit Note C
+		)
 		require.NoError(t, err)
 
 		assert.Equal(t, cbc.Code("12"), inv.Tax.Ext[arca.ExtKeyDocType])
@@ -1419,34 +1443,40 @@ func TestCorrectionFlow(t *testing.T) {
 		require.NoError(t, inv.Calculate())
 		assert.Equal(t, cbc.Code("1"), inv.Tax.Ext[arca.ExtKeyConcept]) // Products
 
-		err := inv.Correct(bill.Credit)
+		err := inv.Correct(
+			bill.Credit,
+			bill.WithExtension(arca.ExtKeyDocType, "3"), // Credit Note A
+		)
 		require.NoError(t, err)
 
 		// Concept should be copied to preceding
 		assert.Equal(t, cbc.Code("1"), inv.Preceding[0].Ext[arca.ExtKeyConcept])
 	})
 
-	t.Run("correction with explicit ext override in preceding", func(t *testing.T) {
+	t.Run("correction with explicit doc type routed to invoice", func(t *testing.T) {
 		inv := testInvoiceWithGoods(t)
 		require.NoError(t, inv.Calculate())
 
 		err := inv.Correct(
 			bill.Credit,
-			bill.WithExtension(arca.ExtKeyDocType, "6"), // Override: use B doc type for preceding
+			bill.WithExtension(arca.ExtKeyDocType, "8"), // Credit Note B
 		)
 		require.NoError(t, err)
 
-		// User-provided extension overrides CopyExt for that key
-		assert.Equal(t, cbc.Code("6"), inv.Preceding[0].Ext[arca.ExtKeyDocType])
-		// Invoice gets re-derived doc type
-		assert.Equal(t, cbc.Code("3"), inv.Tax.Ext[arca.ExtKeyDocType])
+		// DocExtension routes to invoice
+		assert.Equal(t, cbc.Code("8"), inv.Tax.Ext[arca.ExtKeyDocType])
+		// Original doc type in preceding via CopyExt
+		assert.Equal(t, cbc.Code("1"), inv.Preceding[0].Ext[arca.ExtKeyDocType])
 	})
 
 	t.Run("correction is idempotent on recalculate", func(t *testing.T) {
 		inv := testInvoiceWithGoods(t)
 		require.NoError(t, inv.Calculate())
 
-		err := inv.Correct(bill.Credit)
+		err := inv.Correct(
+			bill.Credit,
+			bill.WithExtension(arca.ExtKeyDocType, "3"), // Credit Note A
+		)
 		require.NoError(t, err)
 		assert.Equal(t, cbc.Code("3"), inv.Tax.Ext[arca.ExtKeyDocType])
 

--- a/bill/invoice_correct.go
+++ b/bill/invoice_correct.go
@@ -201,13 +201,14 @@ func (inv *Invoice) CorrectionOptionsSchema() (interface{}, error) {
 	}
 
 	// Try to add all the specific options for the extensions
-	if len(cd.Extensions) > 0 {
+	allExtKeys := append(cd.Extensions, cd.DocExtensions...)
+	if len(allExtKeys) > 0 {
 		if ext, ok := cos.Properties.Get("ext"); ok {
 			ext.Ref = "" // remove the ref
 			ext.Type = "object"
 			ext.Properties = jsonschema.NewProperties()
 			rcmd := make([]string, 0)
-			for _, pk := range cd.Extensions {
+			for _, pk := range allExtKeys {
 				re := tax.ExtensionForKey(pk)
 				if re == nil {
 					continue
@@ -283,6 +284,22 @@ func (inv *Invoice) Correct(opts ...schema.Option) error {
 		return errors.New("cannot correct an invoice without a code")
 	}
 
+	cd := inv.correctionDef()
+
+	// Separate doc-level extension keys from preceding-level extensions.
+	// DocExtension values are routed to inv.Tax.Ext after CopyExt preserves
+	// the original values in preceding.
+	preExt := o.Ext
+	docExt := make(tax.Extensions)
+	if cd != nil && len(cd.DocExtensions) > 0 {
+		for _, key := range cd.DocExtensions {
+			if val, ok := o.Ext[key]; ok {
+				docExt[key] = val
+				preExt = preExt.Delete(key)
+			}
+		}
+	}
+
 	// Copy and prepare the basic fields
 	pre := &org.DocumentRef{
 		Identify:  uuid.Identify{UUID: inv.UUID},
@@ -291,7 +308,7 @@ func (inv *Invoice) Correct(opts ...schema.Option) error {
 		Code:      inv.Code,
 		IssueDate: inv.IssueDate.Clone(),
 		Reason:    o.Reason,
-		Ext:       o.Ext,
+		Ext:       preExt,
 	}
 	if o.CopyTax && inv.Totals != nil {
 		pre.Tax = inv.Totals.Taxes.Clone()
@@ -308,11 +325,17 @@ func (inv *Invoice) Correct(opts ...schema.Option) error {
 		inv.IssueDate = cal.Today()
 	}
 
-	cd := inv.correctionDef()
 	if cd != nil && cd.CopyExt && inv.Tax != nil && len(inv.Tax.Ext) > 0 {
 		// Copy the invoice's tax extensions to preceding, then merge
 		// user-provided options on top (so they take precedence).
 		pre.Ext = inv.Tax.Ext.Merge(pre.Ext)
+	}
+	// Now apply doc-level extensions to the invoice
+	for key, val := range docExt {
+		if inv.Tax == nil {
+			inv.Tax = new(Tax)
+		}
+		inv.Tax.Ext = inv.Tax.Ext.Set(key, val)
 	}
 	if err := inv.validatePrecedingData(o, cd, pre); err != nil {
 		return err

--- a/bill/invoice_correct.go
+++ b/bill/invoice_correct.go
@@ -309,6 +309,11 @@ func (inv *Invoice) Correct(opts ...schema.Option) error {
 	}
 
 	cd := inv.correctionDef()
+	if cd != nil && cd.CopyExt && inv.Tax != nil && len(inv.Tax.Ext) > 0 {
+		// Copy the invoice's tax extensions to preceding, then merge
+		// user-provided options on top (so they take precedence).
+		pre.Ext = inv.Tax.Ext.Merge(pre.Ext)
+	}
 	if err := inv.validatePrecedingData(o, cd, pre); err != nil {
 		return err
 	}

--- a/bill/invoice_correct_test.go
+++ b/bill/invoice_correct_test.go
@@ -154,7 +154,10 @@ func TestCorrectWithCopyExt(t *testing.T) {
 		assert.Equal(t, cbc.Code("1"), inv.Tax.Ext[arca.ExtKeyDocType])
 		assert.Equal(t, cbc.Code("1"), inv.Tax.Ext[arca.ExtKeyConcept])
 
-		err := inv.Correct(bill.Credit)
+		err := inv.Correct(
+			bill.Credit,
+			bill.WithExtension(arca.ExtKeyDocType, "3"), // Credit Note A
+		)
 		require.NoError(t, err)
 
 		// Original extensions copied to preceding
@@ -162,7 +165,7 @@ func TestCorrectWithCopyExt(t *testing.T) {
 		assert.Equal(t, cbc.Code("1"), pre.Ext[arca.ExtKeyDocType])
 		assert.Equal(t, cbc.Code("1"), pre.Ext[arca.ExtKeyConcept])
 
-		// Invoice doc type re-derived for credit note
+		// Invoice doc type set via DocExtensions
 		assert.Equal(t, cbc.Code("3"), inv.Tax.Ext[arca.ExtKeyDocType])
 	})
 
@@ -172,14 +175,33 @@ func TestCorrectWithCopyExt(t *testing.T) {
 
 		err := inv.Correct(
 			bill.Credit,
-			bill.WithExtension(arca.ExtKeyDocType, "6"), // Override
+			bill.WithExtension(arca.ExtKeyDocType, "8"), // Credit Note B
 		)
 		require.NoError(t, err)
 
-		// User override wins for preceding
-		assert.Equal(t, cbc.Code("6"), inv.Preceding[0].Ext[arca.ExtKeyDocType])
+		// DocExtension routes to inv.Tax.Ext
+		assert.Equal(t, cbc.Code("8"), inv.Tax.Ext[arca.ExtKeyDocType])
+		// Original doc type still copied to preceding via CopyExt
+		assert.Equal(t, cbc.Code("1"), inv.Preceding[0].Ext[arca.ExtKeyDocType])
 		// Concept still copied
 		assert.Equal(t, cbc.Code("1"), inv.Preceding[0].Ext[arca.ExtKeyConcept])
+	})
+
+	t.Run("doc extension routes to invoice tax ext", func(t *testing.T) {
+		inv := testInvoiceARForCorrection(t)
+		require.NoError(t, inv.Calculate())
+		assert.Equal(t, cbc.Code("1"), inv.Tax.Ext[arca.ExtKeyDocType])
+
+		err := inv.Correct(
+			bill.Credit,
+			bill.WithExtension(arca.ExtKeyDocType, "3"), // Credit Note A
+		)
+		require.NoError(t, err)
+
+		// User-provided doc type routed to invoice via DocExtensions
+		assert.Equal(t, cbc.Code("3"), inv.Tax.Ext[arca.ExtKeyDocType])
+		// Original doc type in preceding via CopyExt
+		assert.Equal(t, cbc.Code("1"), inv.Preceding[0].Ext[arca.ExtKeyDocType])
 	})
 }
 

--- a/bill/invoice_correct_test.go
+++ b/bill/invoice_correct_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/invopop/gobl/addons/ar/arca"
 	"github.com/invopop/gobl/addons/co/dian"
 	"github.com/invopop/gobl/addons/es/facturae"
 	"github.com/invopop/gobl/addons/es/tbai"
@@ -144,6 +145,42 @@ func TestInvoiceCorrect(t *testing.T) {
 	require.Len(t, pre.Stamps, 1)
 	assert.Equal(t, pre.Stamps[0].Provider, dian.StampCUDE)
 	// assert.Equal(t, pre.CorrectionMethod, co.CorrectionMethodKeyRevoked)
+}
+
+func TestCorrectWithCopyExt(t *testing.T) {
+	t.Run("copies tax extensions to preceding", func(t *testing.T) {
+		inv := testInvoiceARForCorrection(t)
+		require.NoError(t, inv.Calculate())
+		assert.Equal(t, cbc.Code("1"), inv.Tax.Ext[arca.ExtKeyDocType])
+		assert.Equal(t, cbc.Code("1"), inv.Tax.Ext[arca.ExtKeyConcept])
+
+		err := inv.Correct(bill.Credit)
+		require.NoError(t, err)
+
+		// Original extensions copied to preceding
+		pre := inv.Preceding[0]
+		assert.Equal(t, cbc.Code("1"), pre.Ext[arca.ExtKeyDocType])
+		assert.Equal(t, cbc.Code("1"), pre.Ext[arca.ExtKeyConcept])
+
+		// Invoice doc type re-derived for credit note
+		assert.Equal(t, cbc.Code("3"), inv.Tax.Ext[arca.ExtKeyDocType])
+	})
+
+	t.Run("user-provided ext overrides copied ext", func(t *testing.T) {
+		inv := testInvoiceARForCorrection(t)
+		require.NoError(t, inv.Calculate())
+
+		err := inv.Correct(
+			bill.Credit,
+			bill.WithExtension(arca.ExtKeyDocType, "6"), // Override
+		)
+		require.NoError(t, err)
+
+		// User override wins for preceding
+		assert.Equal(t, cbc.Code("6"), inv.Preceding[0].Ext[arca.ExtKeyDocType])
+		// Concept still copied
+		assert.Equal(t, cbc.Code("1"), inv.Preceding[0].Ext[arca.ExtKeyConcept])
+	})
 }
 
 func TestCorrectWithOptions(t *testing.T) {
@@ -424,4 +461,43 @@ func testInvoiceCOForCorrection(t *testing.T) *bill.Invoice {
 		},
 	}
 	return i
+}
+
+func testInvoiceARForCorrection(t *testing.T) *bill.Invoice {
+	t.Helper()
+	return &bill.Invoice{
+		Regime:    tax.WithRegime("AR"),
+		Addons:    tax.WithAddons(arca.V4),
+		Series:    "1",
+		Code:      "123",
+		IssueDate: cal.MakeDate(2024, 1, 15),
+		Supplier: &org.Party{
+			TaxID: &tax.Identity{
+				Country: "AR",
+				Code:    "20345678904",
+			},
+		},
+		Customer: &org.Party{
+			TaxID: &tax.Identity{
+				Country: "AR",
+				Code:    "30500010912",
+			},
+		},
+		Lines: []*bill.Line{
+			{
+				Quantity: num.MakeAmount(10, 0),
+				Item: &org.Item{
+					Name:  "Test Item",
+					Price: num.NewAmount(10000, 2),
+					Key:   org.ItemKeyGoods,
+				},
+				Taxes: tax.Set{
+					{
+						Category: "VAT",
+						Rate:     "standard",
+					},
+				},
+			},
+		},
+	}
 }

--- a/data/addons/ar-arca-v4.json
+++ b/data/addons/ar-arca-v4.json
@@ -868,13 +868,7 @@
   "corrections": [
     {
       "schema": "bill/invoice",
-      "types": [
-        "credit-note",
-        "debit-note"
-      ],
-      "extensions": [
-        "ar-arca-doc-type"
-      ]
+      "copy_ext": true
     }
   ]
 }

--- a/data/addons/ar-arca-v4.json
+++ b/data/addons/ar-arca-v4.json
@@ -868,6 +868,9 @@
   "corrections": [
     {
       "schema": "bill/invoice",
+      "doc_extensions": [
+        "ar-arca-doc-type"
+      ],
       "copy_ext": true
     }
   ]

--- a/data/schemas/tax/addon-def.json
+++ b/data/schemas/tax/addon-def.json
@@ -132,6 +132,11 @@
           "type": "boolean",
           "title": "Copy Tax Totals",
           "description": "Copy tax from the preceding document to the document ref."
+        },
+        "copy_ext": {
+          "type": "boolean",
+          "title": "Copy Tax Extensions",
+          "description": "CopyExt when set will copy the tax extensions from the document to\nthe preceding document reference."
         }
       },
       "type": "object",

--- a/data/schemas/tax/addon-def.json
+++ b/data/schemas/tax/addon-def.json
@@ -115,6 +115,14 @@
           "title": "Extensions",
           "description": "Extension keys that can be included"
         },
+        "doc_extensions": {
+          "items": {
+            "$ref": "https://gobl.org/draft-0/cbc/key"
+          },
+          "type": "array",
+          "title": "Document Extensions",
+          "description": "DocExtensions lists extension keys that should be set on the invoice's\nTax.Ext (rather than on the preceding document reference) when provided\nin the correction options."
+        },
         "reason_required": {
           "type": "boolean",
           "title": "Reason Required",

--- a/data/schemas/tax/regime-def.json
+++ b/data/schemas/tax/regime-def.json
@@ -130,6 +130,11 @@
           "type": "boolean",
           "title": "Copy Tax Totals",
           "description": "Copy tax from the preceding document to the document ref."
+        },
+        "copy_ext": {
+          "type": "boolean",
+          "title": "Copy Tax Extensions",
+          "description": "CopyExt when set will copy the tax extensions from the document to\nthe preceding document reference."
         }
       },
       "type": "object",

--- a/data/schemas/tax/regime-def.json
+++ b/data/schemas/tax/regime-def.json
@@ -113,6 +113,14 @@
           "title": "Extensions",
           "description": "Extension keys that can be included"
         },
+        "doc_extensions": {
+          "items": {
+            "$ref": "https://gobl.org/draft-0/cbc/key"
+          },
+          "type": "array",
+          "title": "Document Extensions",
+          "description": "DocExtensions lists extension keys that should be set on the invoice's\nTax.Ext (rather than on the preceding document reference) when provided\nin the correction options."
+        },
         "reason_required": {
           "type": "boolean",
           "title": "Reason Required",

--- a/tax/corrections.go
+++ b/tax/corrections.go
@@ -25,6 +25,9 @@ type CorrectionDefinition struct {
 	Stamps []cbc.Key `json:"stamps,omitempty" jsonschema:"title=Stamps"`
 	// Copy tax from the preceding document to the document ref.
 	CopyTax bool `json:"copy_tax,omitempty" jsonschema:"title=Copy Tax Totals"`
+	// CopyExt when set will copy the tax extensions from the document to
+	// the preceding document reference.
+	CopyExt bool `json:"copy_ext,omitempty" jsonschema:"title=Copy Tax Extensions"`
 }
 
 // Def provides the correction definition in the set for the
@@ -55,6 +58,9 @@ func (cd *CorrectionDefinition) Merge(other *CorrectionDefinition) *CorrectionDe
 	if other.CopyTax {
 		cd.CopyTax = other.CopyTax
 	}
+	if other.CopyExt {
+		cd.CopyExt = other.CopyExt
+	}
 	cd = &CorrectionDefinition{
 		Schema:         cd.Schema,
 		Types:          append(cd.Types, other.Types...),
@@ -62,6 +68,7 @@ func (cd *CorrectionDefinition) Merge(other *CorrectionDefinition) *CorrectionDe
 		ReasonRequired: cd.ReasonRequired || other.ReasonRequired,
 		Stamps:         append(cd.Stamps, other.Stamps...),
 		CopyTax:        cd.CopyTax,
+		CopyExt:        cd.CopyExt,
 	}
 	return cd
 }

--- a/tax/corrections.go
+++ b/tax/corrections.go
@@ -19,6 +19,10 @@ type CorrectionDefinition struct {
 	Types []cbc.Key `json:"types,omitempty" jsonschema:"title=Types"`
 	// Extension keys that can be included
 	Extensions []cbc.Key `json:"extensions,omitempty" jsonschema:"title=Extensions"`
+	// DocExtensions lists extension keys that should be set on the invoice's
+	// Tax.Ext (rather than on the preceding document reference) when provided
+	// in the correction options.
+	DocExtensions []cbc.Key `json:"doc_extensions,omitempty" jsonschema:"title=Document Extensions"`
 	// ReasonRequired when true implies that a reason must be provided
 	ReasonRequired bool `json:"reason_required,omitempty" jsonschema:"title=Reason Required"`
 	// Stamps that must be copied from the preceding document.
@@ -65,6 +69,7 @@ func (cd *CorrectionDefinition) Merge(other *CorrectionDefinition) *CorrectionDe
 		Schema:         cd.Schema,
 		Types:          append(cd.Types, other.Types...),
 		Extensions:     append(cd.Extensions, other.Extensions...),
+		DocExtensions:  append(cd.DocExtensions, other.DocExtensions...),
 		ReasonRequired: cd.ReasonRequired || other.ReasonRequired,
 		Stamps:         append(cd.Stamps, other.Stamps...),
 		CopyTax:        cd.CopyTax,
@@ -81,12 +86,21 @@ func (cd *CorrectionDefinition) HasType(t cbc.Key) bool {
 	return t.In(cd.Types...)
 }
 
-// HasExtension returns true if the correction definition has the change key provided.
+// HasExtension returns true if the correction definition has the change key provided,
+// either as a regular extension or a document extension.
 func (cd *CorrectionDefinition) HasExtension(key cbc.Key) bool {
 	if cd == nil {
 		return false // no correction definitions
 	}
-	return key.In(cd.Extensions...)
+	return key.In(cd.Extensions...) || key.In(cd.DocExtensions...)
+}
+
+// HasDocExtension returns true if the key is defined as a document extension.
+func (cd *CorrectionDefinition) HasDocExtension(key cbc.Key) bool {
+	if cd == nil {
+		return false
+	}
+	return key.In(cd.DocExtensions...)
 }
 
 // Validate ensures the key definition looks correct in the context of the regime.
@@ -96,6 +110,7 @@ func (cd *CorrectionDefinition) Validate() error {
 		validation.Field(&cd.Types),
 		validation.Field(&cd.Stamps),
 		validation.Field(&cd.Extensions),
+		validation.Field(&cd.DocExtensions),
 	)
 	return err
 }

--- a/tax/corrections_test.go
+++ b/tax/corrections_test.go
@@ -48,4 +48,15 @@ func TestCorrections(t *testing.T) {
 	assert.Contains(t, cd3.Extensions, facturae.ExtKeyCorrection)
 	assert.Contains(t, cd3.Extensions, tbai.ExtKeyCorrection)
 	assert.True(t, cd3.CopyTax)
+	assert.False(t, cd3.CopyExt)
+
+	cds3 := tax.CorrectionSet{
+		{
+			Schema:  bill.ShortSchemaInvoice,
+			CopyExt: true,
+		},
+	}
+	cd4 := cd3.Merge(cds3.Def(bill.ShortSchemaInvoice))
+	assert.True(t, cd4.CopyExt)
+	assert.True(t, cd4.CopyTax) // preserved from previous merge
 }

--- a/tax/corrections_test.go
+++ b/tax/corrections_test.go
@@ -59,4 +59,23 @@ func TestCorrections(t *testing.T) {
 	cd4 := cd3.Merge(cds3.Def(bill.ShortSchemaInvoice))
 	assert.True(t, cd4.CopyExt)
 	assert.True(t, cd4.CopyTax) // preserved from previous merge
+
+	// Test DocExtensions merge
+	cds4 := tax.CorrectionSet{
+		{
+			Schema:        bill.ShortSchemaInvoice,
+			DocExtensions: []cbc.Key{"doc-ext-1"},
+		},
+	}
+	cd5 := cd4.Merge(cds4.Def(bill.ShortSchemaInvoice))
+	assert.Len(t, cd5.DocExtensions, 1)
+	assert.Contains(t, cd5.DocExtensions, cbc.Key("doc-ext-1"))
+
+	// Test HasExtension covers DocExtensions
+	assert.True(t, cd5.HasExtension("doc-ext-1"))
+	assert.True(t, cd5.HasExtension(facturae.ExtKeyCorrection)) // regular extension
+
+	// Test HasDocExtension
+	assert.True(t, cd5.HasDocExtension("doc-ext-1"))
+	assert.False(t, cd5.HasDocExtension(facturae.ExtKeyCorrection))
 }


### PR DESCRIPTION
When correcting an ARCA invoice (e.g., standard → credit note), extension values needed to go to two different places:
  - The original doc type ("1" Invoice A) belongs on the preceding document reference
  - The new doc type ("3" Credit Note A) belongs on the invoice itself (inv.Tax.Ext)

There was no routing mechanism for this.  ES addons (SII, Verifactu) have a  hack where they loop through preceding refs, find extensions, move them to inv.Tax.Ext, and delete from preceding.

To solve this, I included 2 new fields in CorrectionDefinition:

- **CopyExt** bool : When true, automatically copies the invoice's Tax.Ext to the preceding document reference during correction. User-provided extensions in CorrectionOptions.Ext merge on top (taking precedence).

- **DocExtensions** []cbc.Key: Lists extension keys that should be routed to inv.Tax.Ext (not preceding) when the user provides them in CorrectionOptions.Ext. These keys are stripped from pre.Ext before CopyExt runs, so the original values are preserved in preceding.

## Pre-Review Checklist

- [x] Opened this PR as a draft
- [x] Read the CONTRIBUTING.md guide.
- [x] Performed a self-review of my code.
- [x] Added thorough tests with at **least** 90% code coverage.
- [x] Modified or created example GOBL documents to show my changes in use, if appropriate.
- [x] Added links to the source of the changes in tax regimes or addons, either structured or in the comments.
- [x] Run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [x] Reviewed and fixed all linter warnings.
- [x] Been obsessive with pointer nil checks to avoid panics.
- [x] Updated the CHANGELOG.md with an overview of my changes.
- [x] Marked this PR as ready for review.

And if you are part of the org:
- [x] Requested a review from Copilot and fixed or dismissed (with a reason) all the feedback raised.
- [x] Requested a review from @samlown.
