### PR TITLE
Fix rules context collection for Embeddable types

### DIFF
--- a/addons/co/dian/bill_invoices.go
+++ b/addons/co/dian/bill_invoices.go
@@ -86,16 +86,18 @@ func billInvoiceRules() *rules.Set {
 		),
 		// Customer validation
 		// Code 05: customer tax_id required when not simplified
-		// Code 06: Colombian customer must have at least one address
-		// Code 07: Colombian customer with tax ID code must have municipality ext
-		// Code 08: Colombian customer must have fiscal responsibility ext
-		rules.Field("customer",
-			rules.When(
-				is.Func("not simplified", invoiceNotSimplified),
+		rules.When(
+			is.Func("not simplified", invoiceNotSimplified),
+			rules.Field("customer",
 				rules.Field("tax_id",
 					rules.Assert("05", "customer tax ID is required", is.Present),
 				),
 			),
+		),
+		// Code 06: Colombian customer must have at least one address
+		// Code 07: Colombian customer with tax ID code must have municipality ext
+		// Code 08: Colombian customer must have fiscal responsibility ext
+		rules.Field("customer",
 			rules.When(
 				is.Func("colombian customer", customerIsColombian),
 				rules.Field("addresses",

--- a/envelope_test.go
+++ b/envelope_test.go
@@ -264,6 +264,23 @@ func TestEnvelopeValidate(t *testing.T) {
 			},
 			want: "validation: [GOBL-ENVELOPE-11] envelope digest does not match document contents",
 		},
+		{
+			name: "with more complex document and rules",
+			env: func() *gobl.Envelope {
+				data, err := os.ReadFile("./examples/fr/invoice-fr-fr.yaml")
+				require.NoError(t, err)
+				inv := new(bill.Invoice)
+				err = yaml.Unmarshal(data, inv)
+				require.NoError(t, err)
+				inv.Supplier.TaxID.Code = ""
+
+				env := gobl.NewEnvelope()
+				require.NoError(t, env.Insert(inv))
+
+				return env
+			},
+			want: "validation: [GOBL-FR-BILL-INVOICE-01] ($.doc.supplier) invoice supplier must have a tax ID code or a SIREN/SIRET identity",
+		},
 	}
 
 	for _, tt := range tests {

--- a/examples/de/invoice-de-simplified.yaml
+++ b/examples/de/invoice-de-simplified.yaml
@@ -10,6 +10,9 @@ tax:
 supplier:
   tax_id:
     country: "DE"
+  identities:
+    - key: "de-tax-number"
+      code: "92/345/67894"
   name: "Provide One GmbH"
   emails:
     - addr: "billing@example.com"

--- a/examples/de/out/invoice-de-simplified.json
+++ b/examples/de/out/invoice-de-simplified.json
@@ -4,7 +4,7 @@
 		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
 		"dig": {
 			"alg": "sha256",
-			"val": "ff1fcfb2dcaa6153102097cd17fdbbcbfe49d2d6b2e0b8c6c094ad2d76537ee3"
+			"val": "3fd86af014779d93755efa5ee64e5dd44658e2986745a0ab86da489a353a2644"
 		}
 	},
 	"doc": {
@@ -25,6 +25,12 @@
 			"tax_id": {
 				"country": "DE"
 			},
+			"identities": [
+				{
+					"key": "de-tax-number",
+					"code": "92/345/67894"
+				}
+			],
 			"addresses": [
 				{
 					"num": "16",

--- a/examples/fr/invoice-fr-fr-ctc-b2b.yaml
+++ b/examples/fr/invoice-fr-fr-ctc-b2b.yaml
@@ -5,7 +5,7 @@ uuid: "3aea7b56-59d8-4beb-90bd-f8f280d852a0"
 currency: "EUR"
 issue_date: "2024-06-13"
 series: "FAC"
-code: "2024-001"
+code: "2024-00001"
 
 tax:
   ext:

--- a/examples/fr/out/invoice-fr-fr-ctc-b2b.json
+++ b/examples/fr/out/invoice-fr-fr-ctc-b2b.json
@@ -4,7 +4,7 @@
 		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
 		"dig": {
 			"alg": "sha256",
-			"val": "1b507759e64ef4b5db41cad09d2c2136d96a08820844f83e250eb02470ce2ed9"
+			"val": "414ec7ddd1f304e0c796d1f93be0c330e4a0502ab8cd88235a92a7c07d93b61c"
 		}
 	},
 	"doc": {
@@ -17,7 +17,7 @@
 		"uuid": "3aea7b56-59d8-4beb-90bd-f8f280d852a0",
 		"type": "standard",
 		"series": "FAC",
-		"code": "2024-001",
+		"code": "2024-00001",
 		"issue_date": "2024-06-13",
 		"currency": "EUR",
 		"tax": {

--- a/rules/context.go
+++ b/rules/context.go
@@ -134,5 +134,15 @@ func collectContext(rc *Context, obj any) {
 		if ca, ok := fieldObj.(ContextAdder); ok {
 			ca.RulesContext()(rc)
 		}
+		// If the field wraps an embedded payload (e.g. schema.Object),
+		// collect context from the inner value as well. Use fv.Interface()
+		// directly since fieldObj may be double-pointer for pointer fields.
+		if fv.Kind() != reflect.Ptr || !fv.IsNil() {
+			if emb, ok := fv.Interface().(Embeddable); ok {
+				if inner := emb.Embedded(); inner != nil {
+					collectContext(rc, inner)
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- `collectContext` in `rules/context.go` did not recurse into `Embeddable` types (e.g. `schema.Object`), so regime/addon context was never collected when validating an `Envelope`. This caused context-guarded rules (FR, DE, CO, etc.) to silently skip during envelope validation.
- Fixed CO DIAN `invoiceNotSimplified` guard which was incorrectly scoped inside `Field("customer")` — it received `*org.Party` instead of `*bill.Invoice`, making it always return true (never simplified).
- Updated DE and FR examples that were exposed as invalid by the fix.

## Test plan
- [x] `TestEnvelopeValidate/with_more_complex_document_and_rules` now passes
- [x] Full test suite passes (`go test ./...`)
- [x] Example golden files regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)