### PR TITLE
feat: add Norway (NO) tax regime

### DIFF
--- a/data/regimes/no.json
+++ b/data/regimes/no.json
@@ -1,0 +1,167 @@
+{
+  "$schema": "https://gobl.org/draft-0/tax/regime-def",
+  "name": {
+    "en": "Norway",
+    "nb": "Norge"
+  },
+  "description": {
+    "en": "Norway's tax system is administered by the Norwegian Tax Administration\n(Skatteetaten). While not an EU member state, Norway follows similar VAT\nrules through the EEA Agreement.\n\nVAT (Merverdiavgift, MVA) applies at a standard rate and two reduced rates.\nThe standard rate covers most goods and services, one reduced rate applies\nto foodstuffs and water supply, and another reduced rate covers passenger\ntransport, accommodation, broadcasting, and cultural events. Certain\nsupplies are zero-rated (e.g. exports, newspapers) or exempt (e.g.\nhealthcare, education, financial services).\n\nBusinesses are identified by their organization number\n(Organisasjonsnummer), a 9-digit number. The Norwegian VAT number uses the\nformat NO followed by the 9-digit organization number and the suffix MVA.\nE-invoicing via the PEPPOL network is mandatory for all B2G transactions."
+  },
+  "time_zone": "Europe/Oslo",
+  "country": "NO",
+  "currency": "NOK",
+  "tax_scheme": "VAT",
+  "identities": [
+    {
+      "code": "ORG",
+      "name": {
+        "en": "Organization Number",
+        "nb": "Organisasjonsnummer"
+      }
+    }
+  ],
+  "corrections": [
+    {
+      "schema": "bill/invoice",
+      "types": [
+        "credit-note"
+      ]
+    }
+  ],
+  "categories": [
+    {
+      "code": "VAT",
+      "name": {
+        "en": "VAT",
+        "nb": "MVA"
+      },
+      "title": {
+        "en": "Value Added Tax",
+        "nb": "Merverdiavgift"
+      },
+      "keys": [
+        {
+          "key": "standard",
+          "name": {
+            "en": "Standard"
+          }
+        },
+        {
+          "key": "zero",
+          "name": {
+            "en": "Zero"
+          }
+        },
+        {
+          "key": "reverse-charge",
+          "name": {
+            "en": "Reverse charge"
+          },
+          "no_percent": true
+        },
+        {
+          "key": "exempt",
+          "name": {
+            "en": "Exempt"
+          },
+          "no_percent": true
+        },
+        {
+          "key": "export",
+          "name": {
+            "en": "Export"
+          },
+          "no_percent": true
+        },
+        {
+          "key": "intra-community",
+          "name": {
+            "en": "Intra-community"
+          },
+          "no_percent": true
+        },
+        {
+          "key": "outside-scope",
+          "name": {
+            "en": "Outside scope"
+          },
+          "no_percent": true
+        }
+      ],
+      "rates": [
+        {
+          "rate": "general",
+          "keys": [
+            "standard"
+          ],
+          "name": {
+            "en": "General Rate",
+            "nb": "Alminnelig sats"
+          },
+          "values": [
+            {
+              "since": "1995-01-01",
+              "percent": "25.0%"
+            }
+          ]
+        },
+        {
+          "rate": "reduced",
+          "keys": [
+            "standard"
+          ],
+          "name": {
+            "en": "Reduced Rate (Food, Water Supply)",
+            "nb": "Redusert sats (mat, vannforsyning)"
+          },
+          "values": [
+            {
+              "since": "2005-01-01",
+              "percent": "15.0%"
+            }
+          ]
+        },
+        {
+          "rate": "super-reduced",
+          "keys": [
+            "standard"
+          ],
+          "name": {
+            "en": "Super-Reduced Rate (Transport, Accommodation)",
+            "nb": "Lav sats (transport, overnatting)"
+          },
+          "values": [
+            {
+              "since": "2018-01-01",
+              "percent": "12.0%"
+            }
+          ]
+        },
+        {
+          "rate": "zero",
+          "keys": [
+            "zero"
+          ],
+          "name": {
+            "en": "Zero Rate",
+            "nb": "Nullsats"
+          },
+          "values": [
+            {
+              "since": "1970-01-01",
+              "percent": "0.0%"
+            }
+          ]
+        }
+      ],
+      "sources": [
+        {
+          "title": {
+            "en": "Skatteetaten - VAT rates"
+          },
+          "url": "https://www.skatteetaten.no/en/rates/value-added-tax/"
+        }
+      ]
+    }
+  ]
+}

--- a/data/schemas/tax/regime-code.json
+++ b/data/schemas/tax/regime-code.json
@@ -82,6 +82,10 @@
           "title": "The Netherlands"
         },
         {
+          "const": "NO",
+          "title": "Norway"
+        },
+        {
           "const": "PL",
           "title": "Poland"
         },

--- a/regimes/no/identities.go
+++ b/regimes/no/identities.go
@@ -1,0 +1,33 @@
+package no
+
+import (
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/i18n"
+	"github.com/invopop/gobl/org"
+	"github.com/invopop/validation"
+)
+
+const (
+	// IdentityTypeORG represents the Norwegian "Organisasjonsnummer"
+	// (Organization Number) used to identify businesses in Norway.
+	IdentityTypeORG cbc.Code = "ORG"
+)
+
+var identityTypeDefinitions = []*cbc.Definition{
+	{
+		Code: IdentityTypeORG,
+		Name: i18n.String{
+			i18n.EN: "Organization Number",
+			i18n.NB: "Organisasjonsnummer",
+		},
+	},
+}
+
+func validateIdentity(id *org.Identity) error {
+	if id == nil || id.Type != IdentityTypeORG {
+		return nil
+	}
+	return validation.ValidateStruct(id,
+		validation.Field(&id.Code, validation.By(validateTaxCode)),
+	)
+}

--- a/regimes/no/identities_test.go
+++ b/regimes/no/identities_test.go
@@ -1,0 +1,102 @@
+package no_test
+
+import (
+	"testing"
+
+	"github.com/invopop/gobl/org"
+	"github.com/invopop/gobl/regimes/no"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIdentityTypeDefinitions(t *testing.T) {
+	assert.Equal(t, "ORG", string(no.IdentityTypeORG))
+}
+
+func TestValidateIdentity(t *testing.T) {
+	tests := []struct {
+		name     string
+		identity *org.Identity
+		err      string
+	}{
+		{
+			name: "valid ORG 1",
+			identity: &org.Identity{
+				Type: "ORG",
+				Code: "923609016",
+			},
+		},
+		{
+			name: "valid ORG 2",
+			identity: &org.Identity{
+				Type: "ORG",
+				Code: "982463718",
+			},
+		},
+		{
+			name: "valid ORG 3",
+			identity: &org.Identity{
+				Type: "ORG",
+				Code: "889640782",
+			},
+		},
+		{
+			name: "empty code",
+			identity: &org.Identity{
+				Type: "ORG",
+				Code: "",
+			},
+		},
+		{
+			name: "too short",
+			identity: &org.Identity{
+				Type: "ORG",
+				Code: "12345678",
+			},
+			err: "invalid format",
+		},
+		{
+			name: "too long",
+			identity: &org.Identity{
+				Type: "ORG",
+				Code: "1234567890",
+			},
+			err: "invalid format",
+		},
+		{
+			name: "contains letters",
+			identity: &org.Identity{
+				Type: "ORG",
+				Code: "12345678A",
+			},
+			err: "invalid format",
+		},
+		{
+			name: "bad checksum",
+			identity: &org.Identity{
+				Type: "ORG",
+				Code: "923609017",
+			},
+			err: "checksum mismatch",
+		},
+		{
+			name: "non-ORG identity",
+			identity: &org.Identity{
+				Type: "other",
+				Code: "invalid",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := no.Validate(tt.identity)
+			if tt.err == "" {
+				assert.NoError(t, err)
+			} else {
+				if assert.Error(t, err) {
+					assert.Contains(t, err.Error(), tt.err)
+				}
+			}
+		})
+	}
+}

--- a/regimes/no/invoices.go
+++ b/regimes/no/invoices.go
@@ -1,0 +1,53 @@
+package no
+
+import (
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/org"
+	"github.com/invopop/gobl/tax"
+	"github.com/invopop/validation"
+)
+
+func validateInvoice(inv *bill.Invoice) error {
+	return validation.ValidateStruct(inv,
+		validation.Field(&inv.Supplier,
+			validation.By(validateInvoiceSupplier),
+			validation.Skip,
+		),
+	)
+}
+
+func validateInvoiceSupplier(value any) error {
+	p, ok := value.(*org.Party)
+	if !ok || p == nil {
+		return nil
+	}
+	return validation.ValidateStruct(p,
+		validation.Field(&p.TaxID,
+			validation.When(
+				!hasIdentityORG(p),
+				validation.Required,
+				tax.RequireIdentityCode,
+			),
+			validation.Skip,
+		),
+		validation.Field(&p.Identities,
+			validation.When(
+				!hasTaxIDCode(p),
+				org.RequireIdentityType(IdentityTypeORG),
+			),
+			validation.Skip,
+		),
+	)
+}
+
+func hasTaxIDCode(party *org.Party) bool {
+	return party != nil && party.TaxID != nil && party.TaxID.Code != ""
+}
+
+func hasIdentityORG(party *org.Party) bool {
+	if party == nil || len(party.Identities) == 0 {
+		return false
+	}
+	id := org.IdentityForType(party.Identities, IdentityTypeORG)
+	return id != nil && id.Code != ""
+}

--- a/regimes/no/invoices_test.go
+++ b/regimes/no/invoices_test.go
@@ -1,0 +1,113 @@
+package no_test
+
+import (
+	"testing"
+
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/num"
+	"github.com/invopop/gobl/org"
+	"github.com/invopop/gobl/regimes/no"
+	"github.com/invopop/gobl/tax"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func validInvoice() *bill.Invoice {
+	return &bill.Invoice{
+		Regime: tax.WithRegime("NO"),
+		Series: "TEST",
+		Code:   "0002",
+		Supplier: &org.Party{
+			Name: "Test Supplier",
+			TaxID: &tax.Identity{
+				Country: "NO",
+				Code:    "923609016",
+			},
+		},
+		Customer: &org.Party{
+			Name: "Test Customer",
+			TaxID: &tax.Identity{
+				Country: "NO",
+				Code:    "982463718",
+			},
+		},
+		Lines: []*bill.Line{
+			{
+				Quantity: num.MakeAmount(1, 0),
+				Item: &org.Item{
+					Name:  "bogus",
+					Price: num.NewAmount(10000, 2),
+					Unit:  org.UnitPackage,
+				},
+				Taxes: tax.Set{
+					{
+						Category: "VAT",
+						Rate:     "standard",
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestInvoiceValidation(t *testing.T) {
+	t.Run("valid invoice with tax ID", func(t *testing.T) {
+		inv := validInvoice()
+		require.NoError(t, inv.Calculate())
+		assert.NoError(t, inv.Validate())
+	})
+
+	t.Run("missing supplier tax ID code", func(t *testing.T) {
+		inv := validInvoice()
+		inv.Supplier.TaxID.Code = ""
+		require.NoError(t, inv.Calculate())
+		assert.ErrorContains(t, inv.Validate(), "supplier: (identities: missing type 'ORG'; tax_id: (code: cannot be blank.).).")
+	})
+
+	t.Run("supplier with ORG identity instead of tax ID", func(t *testing.T) {
+		inv := validInvoice()
+		inv.Supplier.TaxID.Code = ""
+		inv.Supplier.Identities = []*org.Identity{
+			{
+				Type: no.IdentityTypeORG,
+				Code: "923609016",
+			},
+		}
+		require.NoError(t, inv.Calculate())
+		assert.NoError(t, inv.Validate())
+	})
+
+	t.Run("supplier with nil tax ID and ORG identity", func(t *testing.T) {
+		inv := validInvoice()
+		inv.Supplier.TaxID = nil
+		inv.Supplier.Identities = []*org.Identity{
+			{
+				Type: no.IdentityTypeORG,
+				Code: "923609016",
+			},
+		}
+		require.NoError(t, inv.Calculate())
+		assert.NoError(t, inv.Validate())
+	})
+
+	t.Run("supplier with ORG identity but empty code", func(t *testing.T) {
+		inv := validInvoice()
+		inv.Supplier.TaxID.Code = ""
+		inv.Supplier.Identities = []*org.Identity{
+			{
+				Type: no.IdentityTypeORG,
+				Code: "",
+			},
+		}
+		require.NoError(t, inv.Calculate())
+		assert.ErrorContains(t, inv.Validate(), "supplier:")
+	})
+
+	t.Run("supplier with no identification at all", func(t *testing.T) {
+		inv := validInvoice()
+		inv.Supplier.TaxID = nil
+		inv.Supplier.Identities = nil
+		require.NoError(t, inv.Calculate())
+		assert.ErrorContains(t, inv.Validate(), "supplier:")
+	})
+}

--- a/regimes/no/no.go
+++ b/regimes/no/no.go
@@ -1,0 +1,86 @@
+// Package no provides a regime definition for Norway.
+package no
+
+import (
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/currency"
+	"github.com/invopop/gobl/i18n"
+	"github.com/invopop/gobl/l10n"
+	"github.com/invopop/gobl/org"
+	"github.com/invopop/gobl/pkg/here"
+	"github.com/invopop/gobl/tax"
+
+	"github.com/invopop/gobl/cbc"
+)
+
+func init() {
+	tax.RegisterRegimeDef(New())
+}
+
+// New instantiates a new Norwegian regime.
+func New() *tax.RegimeDef {
+	return &tax.RegimeDef{
+		Country:   l10n.NO.Tax(),
+		Currency:  currency.NOK,
+		TaxScheme: tax.CategoryVAT,
+		Name: i18n.String{
+			i18n.EN: "Norway",
+			i18n.NB: "Norge",
+		},
+		Description: i18n.String{
+			i18n.EN: here.Doc(`
+				Norway's tax system is administered by the Norwegian Tax Administration
+				(Skatteetaten). While not an EU member state, Norway follows similar VAT
+				rules through the EEA Agreement.
+
+				VAT (Merverdiavgift, MVA) applies at a standard rate and two reduced rates.
+				The standard rate covers most goods and services, one reduced rate applies
+				to foodstuffs and water supply, and another reduced rate covers passenger
+				transport, accommodation, broadcasting, and cultural events. Certain
+				supplies are zero-rated (e.g. exports, newspapers) or exempt (e.g.
+				healthcare, education, financial services).
+
+				Businesses are identified by their organization number
+				(Organisasjonsnummer), a 9-digit number. The Norwegian VAT number uses the
+				format NO followed by the 9-digit organization number and the suffix MVA.
+				E-invoicing via the PEPPOL network is mandatory for all B2G transactions.
+			`),
+		},
+		TimeZone:   "Europe/Oslo",
+		Identities: identityTypeDefinitions,
+		Categories: taxCategories,
+		Corrections: []*tax.CorrectionDefinition{
+			{
+				Schema: bill.ShortSchemaInvoice,
+				Types: []cbc.Key{
+					bill.InvoiceTypeCreditNote,
+				},
+			},
+		},
+		Validator:  Validate,
+		Normalizer: Normalize,
+	}
+}
+
+// Validate checks the document type and determines if it can be validated.
+func Validate(doc any) error {
+	switch obj := doc.(type) {
+	case *bill.Invoice:
+		return validateInvoice(obj)
+	case *tax.Identity:
+		return validateTaxIdentity(obj)
+	case *org.Identity:
+		return validateIdentity(obj)
+	}
+	return nil
+}
+
+// Normalize will perform any regime specific normalization.
+func Normalize(doc any) {
+	switch obj := doc.(type) {
+	case *tax.Identity:
+		normalizeTaxIdentity(obj)
+	case *org.Identity:
+		normalizeOrgIdentity(obj)
+	}
+}

--- a/regimes/no/tax_categories.go
+++ b/regimes/no/tax_categories.go
@@ -1,0 +1,91 @@
+package no
+
+import (
+	"github.com/invopop/gobl/cal"
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/i18n"
+	"github.com/invopop/gobl/num"
+	"github.com/invopop/gobl/tax"
+)
+
+var taxCategories = []*tax.CategoryDef{
+	{
+		Code: tax.CategoryVAT,
+		Name: i18n.String{
+			i18n.EN: "VAT",
+			i18n.NB: "MVA",
+		},
+		Title: i18n.String{
+			i18n.EN: "Value Added Tax",
+			i18n.NB: "Merverdiavgift",
+		},
+		Sources: []*cbc.Source{
+			{
+				Title: i18n.String{
+					i18n.EN: "Skatteetaten - VAT rates",
+				},
+				URL: "https://www.skatteetaten.no/en/rates/value-added-tax/",
+			},
+		},
+		Retained: false,
+		Keys:     tax.GlobalVATKeys(),
+		Rates: []*tax.RateDef{
+			{
+				Keys: []cbc.Key{tax.KeyStandard},
+				Rate: tax.RateGeneral,
+				Name: i18n.String{
+					i18n.EN: "General Rate",
+					i18n.NB: "Alminnelig sats",
+				},
+				Values: []*tax.RateValueDef{
+					{
+						Since:   cal.NewDate(1995, 1, 1),
+						Percent: num.MakePercentage(250, 3),
+					},
+				},
+			},
+			{
+				Keys: []cbc.Key{tax.KeyStandard},
+				Rate: tax.RateReduced,
+				Name: i18n.String{
+					i18n.EN: "Reduced Rate (Food, Water Supply)",
+					i18n.NB: "Redusert sats (mat, vannforsyning)",
+				},
+				Values: []*tax.RateValueDef{
+					{
+						Since:   cal.NewDate(2005, 1, 1),
+						Percent: num.MakePercentage(150, 3),
+					},
+				},
+			},
+			{
+				Keys: []cbc.Key{tax.KeyStandard},
+				Rate: tax.RateSuperReduced,
+				Name: i18n.String{
+					i18n.EN: "Super-Reduced Rate (Transport, Accommodation)",
+					i18n.NB: "Lav sats (transport, overnatting)",
+				},
+				Values: []*tax.RateValueDef{
+					{
+						Since:   cal.NewDate(2018, 1, 1),
+						Percent: num.MakePercentage(120, 3),
+					},
+				},
+			},
+			{
+				Keys: []cbc.Key{tax.KeyZero},
+				Rate: tax.RateZero,
+				Name: i18n.String{
+					i18n.EN: "Zero Rate",
+					i18n.NB: "Nullsats",
+				},
+				Values: []*tax.RateValueDef{
+					{
+						Since:   cal.NewDate(1970, 1, 1),
+						Percent: num.MakePercentage(0, 3),
+					},
+				},
+			},
+		},
+	},
+}

--- a/regimes/no/tax_identity.go
+++ b/regimes/no/tax_identity.go
@@ -1,0 +1,102 @@
+package no
+
+import (
+	"errors"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/org"
+	"github.com/invopop/gobl/tax"
+	"github.com/invopop/validation"
+)
+
+var (
+	taxCodeRegexps = []*regexp.Regexp{
+		regexp.MustCompile(`^\d{9}$`),
+	}
+)
+
+func normalizeTaxIdentity(tID *tax.Identity) {
+	if tID == nil {
+		return
+	}
+	tax.NormalizeIdentity(tID)
+	tID.Code = cbc.Code(strings.TrimSuffix(tID.Code.String(), "MVA"))
+}
+
+func normalizeOrgIdentity(id *org.Identity) {
+	if id == nil || id.Type != IdentityTypeORG {
+		return
+	}
+	code := strings.ToUpper(id.Code.String())
+	code = tax.IdentityCodeBadCharsRegexp.ReplaceAllString(code, "")
+	code = strings.TrimPrefix(code, "NO")
+	code = strings.TrimSuffix(code, "MVA")
+	id.Code = cbc.Code(code)
+}
+
+func validateTaxIdentity(tID *tax.Identity) error {
+	return validation.ValidateStruct(tID,
+		validation.Field(&tID.Code, validation.By(validateTaxCode)),
+	)
+}
+
+func validateTaxCode(value any) error {
+	code, ok := value.(cbc.Code)
+	if !ok || code == "" {
+		return nil
+	}
+	val := code.String()
+
+	match := false
+	for _, re := range taxCodeRegexps {
+		if re.MatchString(val) {
+			match = true
+			break
+		}
+	}
+	if !match {
+		return errors.New("invalid format")
+	}
+
+	return validateTaxCodeChecksum(val)
+}
+
+func validateTaxCodeChecksum(val string) error {
+	// Norwegian organization numbers use modulo-11 checksum.
+	// The check digit is the last (9th) digit, calculated from the first 8 digits
+	// using weights [3, 2, 7, 6, 5, 4, 3, 2].
+	weights := []int{3, 2, 7, 6, 5, 4, 3, 2}
+	total := 0
+
+	for i := range 8 {
+		digit, err := strconv.Atoi(string(val[i]))
+		if err != nil {
+			return errors.New("invalid digit")
+		}
+		total += digit * weights[i]
+	}
+
+	remainder := total % 11
+	if remainder == 1 {
+		return errors.New("invalid number: no valid check digit exists")
+	}
+
+	checkDigit := 0
+	if remainder != 0 {
+		checkDigit = 11 - remainder
+	}
+
+	lastDigit, err := strconv.Atoi(string(val[8]))
+	if err != nil {
+		return errors.New("invalid digit")
+	}
+
+	if lastDigit != checkDigit {
+		return errors.New("checksum mismatch")
+	}
+
+	return nil
+}

--- a/regimes/no/tax_identity_test.go
+++ b/regimes/no/tax_identity_test.go
@@ -1,0 +1,123 @@
+package no_test
+
+import (
+	"testing"
+
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/regimes/no"
+	"github.com/invopop/gobl/tax"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateTaxIdentity(t *testing.T) {
+	tests := []struct {
+		name string
+		code cbc.Code
+		err  string
+	}{
+		{name: "valid 1", code: "923609016"},
+		{name: "valid 2", code: "982463718"},
+		{name: "valid 3", code: "889640782"},
+		{name: "valid with check digit 0", code: "100000040"},
+		{
+			name: "empty code",
+			code: "",
+		},
+		{
+			name: "too short",
+			code: "12345678",
+			err:  "invalid format",
+		},
+		{
+			name: "too long",
+			code: "1234567890",
+			err:  "invalid format",
+		},
+		{
+			name: "contains letters",
+			code: "12345678A",
+			err:  "invalid format",
+		},
+		{
+			name: "bad checksum",
+			code: "923609017",
+			err:  "checksum mismatch",
+		},
+		{
+			name: "remainder 1 - no valid check digit",
+			code: "100000130",
+			err:  "invalid number",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tID := &tax.Identity{Country: "NO", Code: tt.code}
+			err := no.Validate(tID)
+			if tt.err == "" {
+				assert.NoError(t, err)
+			} else {
+				if assert.Error(t, err) {
+					assert.Contains(t, err.Error(), tt.err)
+				}
+			}
+		})
+	}
+}
+
+func TestNormalizeTaxIdentity(t *testing.T) {
+	tests := []struct {
+		name     string
+		code     cbc.Code
+		expected cbc.Code
+	}{
+		{
+			name:     "with NO prefix",
+			code:     "NO923609016",
+			expected: "923609016",
+		},
+		{
+			name:     "with spaces",
+			code:     "923 609 016",
+			expected: "923609016",
+		},
+		{
+			name:     "with dashes",
+			code:     "923-609-016",
+			expected: "923609016",
+		},
+		{
+			name:     "with MVA suffix",
+			code:     "923609016MVA",
+			expected: "923609016",
+		},
+		{
+			name:     "with NO prefix and MVA suffix",
+			code:     "NO923609016MVA",
+			expected: "923609016",
+		},
+		{
+			name:     "lowercase input",
+			code:     "no923609016mva",
+			expected: "923609016",
+		},
+		{
+			name:     "already normalized",
+			code:     "923609016",
+			expected: "923609016",
+		},
+		{
+			name:     "empty",
+			code:     "",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tID := &tax.Identity{Country: "NO", Code: tt.code}
+			no.Normalize(tID)
+			assert.Equal(t, tt.expected, tID.Code)
+		})
+	}
+}

--- a/regimes/regimes.go
+++ b/regimes/regimes.go
@@ -24,6 +24,7 @@ import (
 	_ "github.com/invopop/gobl/regimes/it"
 	_ "github.com/invopop/gobl/regimes/mx"
 	_ "github.com/invopop/gobl/regimes/nl"
+	_ "github.com/invopop/gobl/regimes/no"
 	_ "github.com/invopop/gobl/regimes/pl"
 	_ "github.com/invopop/gobl/regimes/pt"
 	_ "github.com/invopop/gobl/regimes/se"


### PR DESCRIPTION
Add a new tax regime for Norway with:
- VAT categories: general 25%, reduced 15% (food), super-reduced 12% (transport, accommodation, broadcasting)
- Organization number (Organisasjonsnummer) validation with mod-11 checksum
- Tax identity normalization stripping NO prefix and MVA suffix
- Invoice validation requiring supplier tax ID or ORG identity
- Credit note correction support

Norway is not an EU member but follows similar VAT rules through the EEA Agreement. E-invoicing via PEPPOL is mandatory for B2G transactions.

- Replace this bullet list with your changes

## Pre-Review Checklist

- [ ] Opened this PR as a draft
- [ ] Read the CONTRIBUTING.md guide.
- [ ] Performed a self-review of my code.
- [ ] Added thorough tests with at **least** 90% code coverage.
- [ ] Modified or created example GOBL documents to show my changes in use, if appropriate.
- [ ] Added links to the source of the changes in tax regimes or addons, either structured or in the comments.
- [ ] Run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [ ] Reviewed and fixed all linter warnings.
- [ ] Been obsessive with pointer nil checks to avoid panics.
- [ ] Updated the CHANGELOG.md with an overview of my changes.
- [ ] Marked this PR as ready for review.

And if you are part of the org:
- [ ] Requested a review from Copilot and fixed or dismissed (with a reason) all the feedback raised.
- [ ] Requested a review from @samlown.
