### PR TITLE
Require key or code in notes for Poland

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Changed
 
+- `pl-favat-v3`: Require key or code in notes. 
 - `addons/pl/favat`: Customer tax ID no longer required for FA(3) invoices. Polish NIP code still validated when a customer tax ID is present.
 - `schema`: `Object` model will now handle anonymous or undefined schemas and simply pass through the data. This is useful for complementary schema implementations that are very domain specific and cannot easily be included inside GOBL.
 - `pkg/api`: HTTP API handler promoted from `internal/api` to a public package so external projects can embed and compose it. `NewHandler` now accepts functional options (`WithMCP`, `WithFavicon`, `WithRoutes`) and exports helpers (`WithETag`, `WriteJSON`, `WriteError`, `WriteRawJSON`, `VersionPrefix`) for custom route handlers.

--- a/addons/pl/favat/bill.go
+++ b/addons/pl/favat/bill.go
@@ -32,6 +32,9 @@ func normalizeInvoice(inv *bill.Invoice) {
 }
 
 func isExemptionNote(n *org.Note) bool {
+	if n == nil {
+		return false
+	}
 	return n.Key == org.NoteKeyLegal && n.Src == ExtKeyExemption
 }
 
@@ -170,7 +173,7 @@ func hasIdentityWithRole(identities []*org.Identity, roleCode cbc.Code) bool {
 func noteHasKeyOrCode(val any) bool {
 	n, ok := val.(*org.Note)
 	if !ok || n == nil {
-		return true
+		return false
 	}
 	return n.Key != "" || n.Code != ""
 }

--- a/addons/pl/favat/bill.go
+++ b/addons/pl/favat/bill.go
@@ -101,6 +101,14 @@ func billInvoiceRules() *rules.Set {
 		rules.Assert("14", "too many exemption notes",
 			is.Func("single exemption note", invoiceSingleExemptionNote),
 		),
+		// Notes validation
+		rules.Field("notes",
+			rules.Each(
+				rules.Assert("15", "note key or code must be set",
+					is.Func("note has key or code", noteHasKeyOrCode),
+				),
+			),
+		),
 	)
 }
 
@@ -157,6 +165,14 @@ func hasIdentityWithRole(identities []*org.Identity, roleCode cbc.Code) bool {
 		}
 	}
 	return false
+}
+
+func noteHasKeyOrCode(val any) bool {
+	n, ok := val.(*org.Note)
+	if !ok || n == nil {
+		return true
+	}
+	return n.Key != "" || n.Code != ""
 }
 
 func invoiceExemptionNotePresent(val any) bool {

--- a/addons/pl/favat/bill_internal_test.go
+++ b/addons/pl/favat/bill_internal_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestNoteHasKeyOrCodeGuard(t *testing.T) {
-	assert.True(t, noteHasKeyOrCode("not a note"))
+	assert.False(t, noteHasKeyOrCode("not a note"))
 }

--- a/addons/pl/favat/bill_internal_test.go
+++ b/addons/pl/favat/bill_internal_test.go
@@ -1,0 +1,11 @@
+package favat
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNoteHasKeyOrCodeGuard(t *testing.T) {
+	assert.True(t, noteHasKeyOrCode("not a note"))
+}

--- a/addons/pl/favat/bill_test.go
+++ b/addons/pl/favat/bill_test.go
@@ -744,6 +744,14 @@ func TestInvoiceWithNotes(t *testing.T) {
 		assert.ErrorContains(t, err, "note key or code must be set")
 	})
 
+	t.Run("nil note element is invalid", func(t *testing.T) {
+		inv := standardInvoice()
+		inv.Notes = []*org.Note{nil}
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "note key or code must be set")
+	})
+
 	t.Run("invoice with legal note but different src", func(t *testing.T) {
 		inv := standardInvoice()
 		inv.Notes = []*org.Note{

--- a/addons/pl/favat/bill_test.go
+++ b/addons/pl/favat/bill_test.go
@@ -719,6 +719,31 @@ func TestInvoiceWithNotes(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	t.Run("note with only code is valid", func(t *testing.T) {
+		inv := standardInvoice()
+		inv.Notes = []*org.Note{
+			{
+				Code: "ABC",
+				Text: "Note with code only",
+			},
+		}
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.NoError(t, err)
+	})
+
+	t.Run("note without key or code is invalid", func(t *testing.T) {
+		inv := standardInvoice()
+		inv.Notes = []*org.Note{
+			{
+				Text: "Note without key or code",
+			},
+		}
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "note key or code must be set")
+	})
+
 	t.Run("invoice with legal note but different src", func(t *testing.T) {
 		inv := standardInvoice()
 		inv.Notes = []*org.Note{

--- a/data/rules/pl-favat-v3.json
+++ b/data/rules/pl-favat-v3.json
@@ -150,6 +150,21 @@
               ]
             }
           ]
+        },
+        {
+          "field": "notes",
+          "subsets": [
+            {
+              "each": true,
+              "assert": [
+                {
+                  "id": "GOBL-PL-FAVAT-V3-BILL-INVOICE-15",
+                  "desc": "note key or code must be set",
+                  "tests": "note has key or code"
+                }
+              ]
+            }
+          ]
         }
       ]
     },


### PR DESCRIPTION
Require key or code in notes for Poland to avoid issues in KSeF. 

KSeF requires notes to carry a Klucz (Key), which can be any value, and fails when it's missing. We need to validate that each note includes at least a code or key to use as the Klucz.

## Pre-Review Checklist

- [x] Opened this PR as a draft
- [x] Read the CONTRIBUTING.md guide.
- [x] Performed a self-review of my code.
- [x] Added thorough tests with at **least** 90% code coverage.
- [ ] Modified or created example GOBL documents to show my changes in use, if appropriate.
- [ ] Added links to the source of the changes in tax regimes or addons, either structured or in the comments.
- [x] Run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [x] Reviewed and fixed all linter warnings.
- [x] Been obsessive with pointer nil checks to avoid panics.
- [x] Updated the CHANGELOG.md with an overview of my changes.
- [x] Marked this PR as ready for review.

And if you are part of the org:
- [ ] Requested a review from Copilot and fixed or dismissed (with a reason) all the feedback raised.
- [ ] Requested a review from @samlown.
