### PR TITLE
Fix release workflow deprecations and npm bootstrap

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -81,9 +81,17 @@ jobs:
                   node-version: 22.x
                   registry-url: 'https://registry.npmjs.org'
 
-            # Ensure npm 11.5.1 or later is installed
-            - name: Update npm
-              run: npm install -g npm@latest
+            # The npm shipped with recent Node 22.x tool-cache images has a
+            # broken dependency tree (missing `promise-retry`), which breaks
+            # `npm install -g npm@latest`. Use corepack to install a working
+            # npm 11.x instead — this is the npm maintainers' recommended
+            # approach.
+            - name: Activate npm via corepack
+              if: ${{ steps.bump.new_tag == steps.bump.tag }}
+              run: |
+                  corepack enable
+                  corepack prepare npm@latest --activate
+                  npm --version
 
             - name: Run npm ci
               if: ${{ steps.bump.new_tag == steps.bump.tag }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,23 +21,26 @@ builds:
       - "wasm"
 archives:
   - id: cli
-    builds:
+    ids:
       - gobl.cli
-    format: tar.gz
+    formats:
+      - tar.gz
     name_template: "gobl.{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     wrap_in_directory: true
   - id: wasm
-    builds:
+    ids:
       - gobl.wasm
-    format: binary
+    formats:
+      - binary
     name_template: "gobl.{{ .Version }}"
     files:
       - none*
     wrap_in_directory: false
   - id: wasm-gz
-    builds:
+    ids:
       - gobl.wasm
-    format: gz
+    formats:
+      - gz
     name_template: "gobl.{{ .Version }}.wasm"
     files:
       - none*
@@ -66,7 +69,7 @@ checksum:
   name_template: "checksums.txt"
 
 snapshot:
-  name_template: "{{ .Tag }}"
+  version_template: "{{ .Tag }}"
 
 changelog:
   sort: asc


### PR DESCRIPTION
## Summary
- Update `.goreleaser.yml` to clear v2 deprecation warnings: `archives.builds` → `archives.ids`, `archives.format` → `archives.formats` (array), `snapshot.name_template` → `snapshot.version_template`.
- Replace the failing `npm install -g npm@latest` step with a corepack-based install. The npm bundled in the Node 22.22.2 tool-cache image is missing the `promise-retry` transitive dep, which crashes the global self-upgrade (see [actions/runner-images#13883](https://github.com/actions/runner-images/issues/13883)). Corepack is the npm maintainers' recommended path and sidesteps the broken global npm entirely.
- Gate the npm activation step on the same `steps.bump.new_tag == steps.bump.tag` condition as the other npm steps so it only runs during an actual release.

## Test plan
- [x] `goreleaser check` passes with no deprecation warnings
- [x] `goreleaser release --snapshot --clean --skip=publish` completes successfully against the latest image
- [ ] Next release run on GitHub Actions completes through the npm publish step

🤖 Generated with [Claude Code](https://claude.com/claude-code)