### PR TITLE
Split NPM publish into its own workflow

### DIFF
--- a/.github/workflows/publish-npm.yaml
+++ b/.github/workflows/publish-npm.yaml
@@ -1,0 +1,84 @@
+#
+# Publish the gobl-worker package to NPM. Runs automatically after a
+# successful Release, and can be re-run manually to retry a failed
+# publish without re-running the full release.
+#
+# Authentication is via NPM Trusted Publisher (OIDC) — no secret
+# needed. `id-token: write` is required so that the runner can exchange
+# its GitHub OIDC token for a short-lived npm publish token.
+#
+
+name: Publish NPM
+
+on:
+    workflow_run:
+        workflows: ["Release"]
+        types: [completed]
+    workflow_dispatch:
+
+permissions:
+    id-token: write
+    contents: read
+
+jobs:
+    publish:
+        name: Publish gobl-worker
+        # Run on successful upstream Release, or whenever triggered manually.
+        if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+              with:
+                  # Pin to the commit the upstream Release ran against so
+                  # we publish the same version. Falls back to the manually
+                  # selected ref for workflow_dispatch.
+                  ref: ${{ github.event.workflow_run.head_sha || github.ref }}
+
+            - name: Read current version
+              run: |
+                  grep 'const VERSION' version.go | sed -e 's/const VERSION Version = "\(v[^"]*\)"/GOBL_VERSION=\1/' >> $GITHUB_ENV
+
+            - name: Set up Go
+              uses: actions/setup-go@v5
+              with:
+                  go-version-file: "go.mod"
+
+            # wasm_exec.js is gitignored and must be copied from the active
+            # Go install before the npm build bundles it into the package.
+            - name: Copy Go WASM Exec
+              run: cp "$(go env GOROOT)/lib/wasm/wasm_exec.js" ./wasm/worker/src
+
+            - name: Install Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 22.x
+                  registry-url: 'https://registry.npmjs.org'
+
+            # The npm shipped with recent Node 22.x tool-cache images has a
+            # broken dependency tree (missing `promise-retry`), which breaks
+            # `npm install -g npm@latest`. Use corepack to install a working
+            # npm 11.x instead — this is the npm maintainers' recommended
+            # approach.
+            - name: Activate npm via corepack
+              run: |
+                  corepack enable
+                  corepack prepare npm@latest --activate
+                  npm --version
+
+            - name: Run npm ci
+              working-directory: ./wasm/worker
+              run: npm ci
+
+            - name: Update gobl-worker version
+              working-directory: ./wasm/worker
+              run: npm version --no-git-tag-version ${{ env.GOBL_VERSION }}
+
+            - name: Build gobl-worker
+              working-directory: ./wasm/worker
+              run: npm run build
+
+            - name: Publish gobl-worker to NPM registry
+              working-directory: ./wasm/worker
+              run: npm publish

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,6 @@
 #  * `GITHUB_TOKEN` - A GitHub token with access to the repository.
 #  * `AWS_ACCESS_KEY_ID` - An AWS access key with write access to the CDN bucket.
 #  * `AWS_SECRET_ACCESS_KEY` - The secret for the AWS access key
-#  * `NPM_TOKEN` - An NPM token with access to the package.
 #
 
 name: Release
@@ -48,9 +47,7 @@ jobs:
             - name: Set up Go
               uses: actions/setup-go@v5
               with:
-                  # Use fixed go version to avoid issues with lib/wasm location
-                  go-version: "1.24"
-                  # go-version-file: "go.mod"
+                  go-version-file: "go.mod"
 
             # Ensure we have a wasm_exec.js for the current version of Go
             - name: Copy Go WASM Exec
@@ -71,44 +68,7 @@ jobs:
                   # Your GoReleaser Pro key, if you are using the 'goreleaser-pro' distribution
                   # GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
 
-            # Following actions are to release a new version of gobl-worker to NPM
-            # using the new wasm version in the CDN.
-
-            - name: Install Node.js
-              uses: actions/setup-node@v4
-              if: ${{ steps.bump.new_tag == steps.bump.tag }}
-              with:
-                  node-version: 22.x
-                  registry-url: 'https://registry.npmjs.org'
-
-            # The npm shipped with recent Node 22.x tool-cache images has a
-            # broken dependency tree (missing `promise-retry`), which breaks
-            # `npm install -g npm@latest`. Use corepack to install a working
-            # npm 11.x instead — this is the npm maintainers' recommended
-            # approach.
-            - name: Activate npm via corepack
-              if: ${{ steps.bump.new_tag == steps.bump.tag }}
-              run: |
-                  corepack enable
-                  corepack prepare npm@latest --activate
-                  npm --version
-
-            - name: Run npm ci
-              if: ${{ steps.bump.new_tag == steps.bump.tag }}
-              working-directory: ./wasm/worker
-              run: npm ci
-
-            - name: Update gobl-worker version
-              if: ${{ steps.bump.new_tag == steps.bump.tag }}
-              working-directory: ./wasm/worker
-              run: npm version --no-git-tag-version ${{ steps.bump.outputs.new_tag }}
-
-            - name: Build gobl-worker
-              if: ${{ steps.bump.new_tag == steps.bump.tag }}
-              working-directory: ./wasm/worker
-              run: npm run build
-
-            - name: Publish gobl-worker to NPM registry
-              if: ${{ steps.bump.new_tag == steps.bump.tag }}
-              working-directory: ./wasm/worker
-              run: npm publish
+            # The gobl-worker NPM package is published by the Publish NPM
+            # workflow (publish-npm.yaml), which runs on successful
+            # completion of this workflow and can be re-run manually to
+            # retry a failed publish independently of the release.


### PR DESCRIPTION
## Summary
- Move the `gobl-worker` npm publish steps out of the Release workflow into a dedicated `Publish NPM` workflow (`.github/workflows/publish-npm.yaml`).
- The new workflow triggers on successful completion of `Release` (via `workflow_run`) or manually via `workflow_dispatch`, so a failed npm publish can be retried independently without re-running goreleaser or bumping tags again. Same pattern as `deploy-api.yaml`.
- Switch `setup-go` in the Release workflow to `go-version-file: go.mod`.
- Drop the now-unused `NPM_TOKEN` line from the `Release` secrets doc comment. Auth is via npm Trusted Publisher (OIDC) — `id-token: write` is granted on the publish job so no secret is required.

## Notes
- The new workflow checks out `workflow_run.head_sha` so it publishes the exact commit the Release ran against. On manual runs it falls back to the selected ref.
- `wasm_exec.js` is gitignored and needs to be copied from the Go install before `npm run build`, so the publish job also sets up Go and runs the same copy step.

## Test plan
- [ ] Next release run completes through goreleaser, then `Publish NPM` is automatically kicked off and publishes
- [ ] If `Publish NPM` fails, it can be re-run manually from the Actions tab without re-running `Release`

🤖 Generated with [Claude Code](https://claude.com/claude-code)