### PR TITLE
Drop registry-url from setup-node to unblock OIDC publish

### DIFF
--- a/.github/workflows/publish-npm.yaml
+++ b/.github/workflows/publish-npm.yaml
@@ -54,7 +54,11 @@ jobs:
               uses: actions/setup-node@v4
               with:
                   node-version: 22.x
-                  registry-url: 'https://registry.npmjs.org'
+                  # Intentionally no `registry-url`: setup-node would
+                  # otherwise write a `.npmrc` with an `_authToken` entry
+                  # that forces npm to use token auth and blocks the OIDC
+                  # trusted-publisher exchange. npm defaults to
+                  # registry.npmjs.org, which is what we want.
 
             # The npm shipped with recent Node 22.x tool-cache images has a
             # broken dependency tree (missing `promise-retry`), which breaks


### PR DESCRIPTION
## Summary
The last Publish NPM run still hit `404 Not Found` on `npm publish`. Log shows:

\`\`\`
env:
  NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX
  NPM_CONFIG_USERCONFIG: /home/runner/work/_temp/.npmrc
\`\`\`

Root cause: `actions/setup-node@v4` with `registry-url` writes a `.npmrc` containing \`_authToken=\${NODE_AUTH_TOKEN}\` and exports a placeholder `NODE_AUTH_TOKEN` into the job env. npm sees a token configured, attempts token auth against that placeholder, and fails — it never falls back to the OIDC trusted-publisher exchange.

Fix: drop `registry-url` from the `setup-node` step. With no `.npmrc` interference, npm defaults to `registry.npmjs.org` and auto-detects the GitHub Actions OIDC environment. npm ≥ 11.5.1 (installed via corepack) then performs the OIDC token exchange automatically and publishes with provenance — no `--provenance` flag needed.

References:
- [npm Trusted Publishing docs](https://docs.npmjs.com/trusted-publishers/)
- [Community thread documenting the same setup-node / OIDC conflict](https://github.com/orgs/community/discussions/176761)

## Test plan
- [ ] Re-run the Publish NPM workflow via `workflow_dispatch` on main; publish succeeds and produces a provenance attestation on npmjs.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)