### PR TITLE
Add rules.NewSet for standalone use without global registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Added
+
+- `rules`: `NewSet` function for standalone use of rule sets with namespaced error codes, without requiring global registration.
+- `rules`: `Set.Validate` now accepts optional `WithContext` values for context-aware guards.
+
+### Changed
+
+- `rules`: `Set.Name` field replaced with `Set.Package` (set by `Register`) and `Set.Object` (set by `For`).
+- `rules`: `Register` and `RegisterWithGuard` first parameter renamed from `name` to `pkg` for clarity.
+- `rules`: Input sets are now cloned internally by `Register`, `RegisterWithGuard`, and `NewSet`, so the same `For` output can be safely reused.
+
 ## [v0.400.0-rc1] - 2026-04-13
 
 Major GOBL release: migrating from the old validation methods to the new "rules" package. This is a very significant change and solves one of the most frequently requested features in GOBL, the ability to know what validations and checks will be performed on the data before they are applied. Now every validation is assigned a specific unique reference code that allows them to be easily identified. The rules package is designed to be useable in any project, not just GOBL, so we're hoping to see in broader use through all the systems that depend on GOBL as an alternative to other validation packages.

--- a/data/rules/ae.json
+++ b/data/rules/ae.json
@@ -1,10 +1,10 @@
 {
   "id": "GOBL-AE",
-  "name": "ae",
+  "package": "ae",
   "subsets": [
     {
       "id": "GOBL-AE-TAX-IDENTITY",
-      "name": "tax.Identity",
+      "object": "tax.Identity",
       "subsets": [
         {
           "guard": "code in [AE]",

--- a/data/rules/ar-arca-v4.json
+++ b/data/rules/ar-arca-v4.json
@@ -1,11 +1,11 @@
 {
   "id": "GOBL-AR-ARCA-V4",
-  "name": "ar-arca-v4",
+  "package": "ar-arca-v4",
   "guard": "context: addon in [ar-arca-v4]",
   "subsets": [
     {
       "id": "GOBL-AR-ARCA-V4-BILL-INVOICE",
-      "name": "bill.Invoice",
+      "object": "bill.Invoice",
       "assert": [
         {
           "id": "GOBL-AR-ARCA-V4-BILL-INVOICE-05",
@@ -268,7 +268,7 @@
     },
     {
       "id": "GOBL-AR-ARCA-V4-BILL-CHARGE",
-      "name": "bill.Charge",
+      "object": "bill.Charge",
       "subsets": [
         {
           "guard": "key is tax",
@@ -319,7 +319,7 @@
     },
     {
       "id": "GOBL-AR-ARCA-V4-TAX-COMBO",
-      "name": "tax.Combo",
+      "object": "tax.Combo",
       "subsets": [
         {
           "guard": "category is VAT",

--- a/data/rules/ar.json
+++ b/data/rules/ar.json
@@ -1,10 +1,10 @@
 {
   "id": "GOBL-AR",
-  "name": "ar",
+  "package": "ar",
   "subsets": [
     {
       "id": "GOBL-AR-BILL-INVOICE",
-      "name": "bill.Invoice",
+      "object": "bill.Invoice",
       "subsets": [
         {
           "guard": "context: regime in [AR]",
@@ -30,7 +30,7 @@
     },
     {
       "id": "GOBL-AR-TAX-IDENTITY",
-      "name": "tax.Identity",
+      "object": "tax.Identity",
       "subsets": [
         {
           "guard": "code in [AR]",

--- a/data/rules/at.json
+++ b/data/rules/at.json
@@ -1,10 +1,10 @@
 {
   "id": "GOBL-AT",
-  "name": "at",
+  "package": "at",
   "subsets": [
     {
       "id": "GOBL-AT-TAX-IDENTITY",
-      "name": "tax.Identity",
+      "object": "tax.Identity",
       "subsets": [
         {
           "guard": "code in [AT]",

--- a/data/rules/be.json
+++ b/data/rules/be.json
@@ -1,10 +1,10 @@
 {
   "id": "GOBL-BE",
-  "name": "be",
+  "package": "be",
   "subsets": [
     {
       "id": "GOBL-BE-TAX-IDENTITY",
-      "name": "tax.Identity",
+      "object": "tax.Identity",
       "subsets": [
         {
           "guard": "code in [BE]",
@@ -30,7 +30,7 @@
     },
     {
       "id": "GOBL-BE-BILL-INVOICE",
-      "name": "bill.Invoice",
+      "object": "bill.Invoice",
       "subsets": [
         {
           "guard": "context: regime in [BE]",

--- a/data/rules/bill.json
+++ b/data/rules/bill.json
@@ -1,10 +1,10 @@
 {
   "id": "GOBL-BILL",
-  "name": "bill",
+  "package": "bill",
   "subsets": [
     {
       "id": "GOBL-BILL-INVOICE",
-      "name": "bill.Invoice",
+      "object": "bill.Invoice",
       "subsets": [
         {
           "field": "type",
@@ -152,7 +152,7 @@
     },
     {
       "id": "GOBL-BILL-DELIVERY",
-      "name": "bill.Delivery",
+      "object": "bill.Delivery",
       "subsets": [
         {
           "field": "type",
@@ -203,7 +203,7 @@
     },
     {
       "id": "GOBL-BILL-ORDER",
-      "name": "bill.Order",
+      "object": "bill.Order",
       "subsets": [
         {
           "field": "type",
@@ -264,7 +264,7 @@
     },
     {
       "id": "GOBL-BILL-PAYMENT",
-      "name": "bill.Payment",
+      "object": "bill.Payment",
       "subsets": [
         {
           "field": "type",
@@ -335,7 +335,7 @@
     },
     {
       "id": "GOBL-BILL-LINE",
-      "name": "bill.Line",
+      "object": "bill.Line",
       "subsets": [
         {
           "field": "i",
@@ -396,7 +396,7 @@
     },
     {
       "id": "GOBL-BILL-SUBLINE",
-      "name": "bill.SubLine",
+      "object": "bill.SubLine",
       "subsets": [
         {
           "field": "i",
@@ -457,7 +457,7 @@
     },
     {
       "id": "GOBL-BILL-LINEDISCOUNT",
-      "name": "bill.LineDiscount",
+      "object": "bill.LineDiscount",
       "subsets": [
         {
           "guard": "Base != nil",
@@ -478,7 +478,7 @@
     },
     {
       "id": "GOBL-BILL-LINECHARGE",
-      "name": "bill.LineCharge",
+      "object": "bill.LineCharge",
       "subsets": [
         {
           "guard": "Base != nil",
@@ -554,7 +554,7 @@
     },
     {
       "id": "GOBL-BILL-DISCOUNT",
-      "name": "bill.Discount",
+      "object": "bill.Discount",
       "subsets": [
         {
           "guard": "Base != nil",
@@ -575,7 +575,7 @@
     },
     {
       "id": "GOBL-BILL-CHARGE",
-      "name": "bill.Charge",
+      "object": "bill.Charge",
       "subsets": [
         {
           "guard": "Base != nil",
@@ -596,7 +596,7 @@
     },
     {
       "id": "GOBL-BILL-PAYMENTLINE",
-      "name": "bill.PaymentLine",
+      "object": "bill.PaymentLine",
       "assert": [
         {
           "id": "GOBL-BILL-PAYMENTLINE-11",
@@ -664,7 +664,7 @@
     },
     {
       "id": "GOBL-BILL-TAX",
-      "name": "bill.Tax",
+      "object": "bill.Tax",
       "subsets": [
         {
           "field": "rounding",
@@ -700,7 +700,7 @@
     },
     {
       "id": "GOBL-BILL-TOTALS",
-      "name": "bill.Totals"
+      "object": "bill.Totals"
     }
   ]
 }

--- a/data/rules/br-nfe-v4.json
+++ b/data/rules/br-nfe-v4.json
@@ -1,11 +1,11 @@
 {
   "id": "GOBL-BR-NFE-V4",
-  "name": "br-nfe-v4",
+  "package": "br-nfe-v4",
   "guard": "context: addon in [br-nfe-v4]",
   "subsets": [
     {
       "id": "GOBL-BR-NFE-V4-BILL-INVOICE",
-      "name": "bill.Invoice",
+      "object": "bill.Invoice",
       "assert": [
         {
           "id": "GOBL-BR-NFE-V4-BILL-INVOICE-30",
@@ -409,7 +409,7 @@
     },
     {
       "id": "GOBL-BR-NFE-V4-BILL-LINE",
-      "name": "bill.Line",
+      "object": "bill.Line",
       "assert": [
         {
           "id": "GOBL-BR-NFE-V4-BILL-LINE-01",
@@ -430,7 +430,7 @@
     },
     {
       "id": "GOBL-BR-NFE-V4-PAY-INSTRUCTIONS",
-      "name": "pay.Instructions",
+      "object": "pay.Instructions",
       "subsets": [
         {
           "field": "ext",
@@ -446,7 +446,7 @@
     },
     {
       "id": "GOBL-BR-NFE-V4-PAY-ADVANCE",
-      "name": "pay.Advance",
+      "object": "pay.Advance",
       "subsets": [
         {
           "field": "ext",

--- a/data/rules/br-nfse-v1.json
+++ b/data/rules/br-nfse-v1.json
@@ -1,11 +1,11 @@
 {
   "id": "GOBL-BR-NFSE-V1",
-  "name": "br-nfse-v1",
+  "package": "br-nfse-v1",
   "guard": "context: addon in [br-nfse-v1]",
   "subsets": [
     {
       "id": "GOBL-BR-NFSE-V1-BILL-INVOICE",
-      "name": "bill.Invoice",
+      "object": "bill.Invoice",
       "subsets": [
         {
           "field": "series",
@@ -179,7 +179,7 @@
     },
     {
       "id": "GOBL-BR-NFSE-V1-BILL-LINE",
-      "name": "bill.Line",
+      "object": "bill.Line",
       "assert": [
         {
           "id": "GOBL-BR-NFSE-V1-BILL-LINE-01",
@@ -190,7 +190,7 @@
     },
     {
       "id": "GOBL-BR-NFSE-V1-ORG-ITEM",
-      "name": "org.Item",
+      "object": "org.Item",
       "subsets": [
         {
           "field": "ext",
@@ -211,7 +211,7 @@
     },
     {
       "id": "GOBL-BR-NFSE-V1-TAX-COMBO",
-      "name": "tax.Combo",
+      "object": "tax.Combo",
       "subsets": [
         {
           "guard": "ISS category",

--- a/data/rules/br.json
+++ b/data/rules/br.json
@@ -1,10 +1,10 @@
 {
   "id": "GOBL-BR",
-  "name": "br",
+  "package": "br",
   "subsets": [
     {
       "id": "GOBL-BR-ORG-PARTY",
-      "name": "org.Party",
+      "object": "org.Party",
       "subsets": [
         {
           "guard": "context: regime in [BR]",
@@ -80,7 +80,7 @@
     },
     {
       "id": "GOBL-BR-TAX-IDENTITY",
-      "name": "tax.Identity",
+      "object": "tax.Identity",
       "subsets": [
         {
           "guard": "code in [BR]",

--- a/data/rules/cal.json
+++ b/data/rules/cal.json
@@ -1,10 +1,10 @@
 {
   "id": "GOBL-CAL",
-  "name": "cal",
+  "package": "cal",
   "subsets": [
     {
       "id": "GOBL-CAL-DATE",
-      "name": "cal.Date",
+      "object": "cal.Date",
       "assert": [
         {
           "id": "GOBL-CAL-DATE-01",
@@ -15,7 +15,7 @@
     },
     {
       "id": "GOBL-CAL-DATETIME",
-      "name": "cal.DateTime",
+      "object": "cal.DateTime",
       "assert": [
         {
           "id": "GOBL-CAL-DATETIME-01",
@@ -26,7 +26,7 @@
     },
     {
       "id": "GOBL-CAL-PERIOD",
-      "name": "cal.Period",
+      "object": "cal.Period",
       "assert": [
         {
           "id": "GOBL-CAL-PERIOD-10",

--- a/data/rules/cbc.json
+++ b/data/rules/cbc.json
@@ -1,10 +1,10 @@
 {
   "id": "GOBL-CBC",
-  "name": "cbc",
+  "package": "cbc",
   "subsets": [
     {
       "id": "GOBL-CBC-CODE",
-      "name": "cbc.Code",
+      "object": "cbc.Code",
       "assert": [
         {
           "id": "GOBL-CBC-CODE-01",
@@ -20,7 +20,7 @@
     },
     {
       "id": "GOBL-CBC-CODEMAP",
-      "name": "cbc.CodeMap",
+      "object": "cbc.CodeMap",
       "assert": [
         {
           "id": "GOBL-CBC-CODEMAP-01",
@@ -31,7 +31,7 @@
     },
     {
       "id": "GOBL-CBC-KEY",
-      "name": "cbc.Key",
+      "object": "cbc.Key",
       "assert": [
         {
           "id": "GOBL-CBC-KEY-01",
@@ -47,7 +47,7 @@
     },
     {
       "id": "GOBL-CBC-DEFINITION",
-      "name": "cbc.Definition",
+      "object": "cbc.Definition",
       "assert": [
         {
           "id": "GOBL-CBC-DEFINITION-02",
@@ -85,7 +85,7 @@
     },
     {
       "id": "GOBL-CBC-SOURCE",
-      "name": "cbc.Source",
+      "object": "cbc.Source",
       "subsets": [
         {
           "field": "url",

--- a/data/rules/ch.json
+++ b/data/rules/ch.json
@@ -1,10 +1,10 @@
 {
   "id": "GOBL-CH",
-  "name": "ch",
+  "package": "ch",
   "subsets": [
     {
       "id": "GOBL-CH-TAX-IDENTITY",
-      "name": "tax.Identity",
+      "object": "tax.Identity",
       "subsets": [
         {
           "guard": "code in [CH]",

--- a/data/rules/co-dian-v2.json
+++ b/data/rules/co-dian-v2.json
@@ -1,11 +1,11 @@
 {
   "id": "GOBL-CO-DIAN-V2",
-  "name": "co-dian-v2",
+  "package": "co-dian-v2",
   "guard": "context: addon in [co-dian-v2]",
   "subsets": [
     {
       "id": "GOBL-CO-DIAN-V2-BILL-INVOICE",
-      "name": "bill.Invoice",
+      "object": "bill.Invoice",
       "assert": [
         {
           "id": "GOBL-CO-DIAN-V2-BILL-INVOICE-01",

--- a/data/rules/co.json
+++ b/data/rules/co.json
@@ -1,10 +1,10 @@
 {
   "id": "GOBL-CO",
-  "name": "co",
+  "package": "co",
   "subsets": [
     {
       "id": "GOBL-CO-TAX-IDENTITY",
-      "name": "tax.Identity",
+      "object": "tax.Identity",
       "subsets": [
         {
           "guard": "code in [CO]",

--- a/data/rules/currency.json
+++ b/data/rules/currency.json
@@ -1,10 +1,10 @@
 {
   "id": "GOBL-CURRENCY",
-  "name": "currency",
+  "package": "currency",
   "subsets": [
     {
       "id": "GOBL-CURRENCY-AMOUNT",
-      "name": "currency.Amount",
+      "object": "currency.Amount",
       "subsets": [
         {
           "field": "currency",
@@ -20,7 +20,7 @@
     },
     {
       "id": "GOBL-CURRENCY-EXCHANGERATE",
-      "name": "currency.ExchangeRate",
+      "object": "currency.ExchangeRate",
       "subsets": [
         {
           "field": "from",

--- a/data/rules/de-xrechnung-v3.json
+++ b/data/rules/de-xrechnung-v3.json
@@ -1,11 +1,11 @@
 {
   "id": "GOBL-DE-XRECHNUNG-V3",
-  "name": "de-xrechnung-v3",
+  "package": "de-xrechnung-v3",
   "guard": "context: addon in [de-xrechnung-v3]",
   "subsets": [
     {
       "id": "GOBL-DE-XRECHNUNG-V3-BILL-INVOICE",
-      "name": "bill.Invoice",
+      "object": "bill.Invoice",
       "subsets": [
         {
           "field": "tax",

--- a/data/rules/de.json
+++ b/data/rules/de.json
@@ -1,10 +1,10 @@
 {
   "id": "GOBL-DE",
-  "name": "de",
+  "package": "de",
   "subsets": [
     {
       "id": "GOBL-DE-BILL-INVOICE",
-      "name": "bill.Invoice",
+      "object": "bill.Invoice",
       "subsets": [
         {
           "guard": "context: regime in [DE]",
@@ -25,7 +25,7 @@
     },
     {
       "id": "GOBL-DE-ORG-IDENTITY",
-      "name": "org.Identity",
+      "object": "org.Identity",
       "subsets": [
         {
           "guard": "context: regime in [DE]",
@@ -51,7 +51,7 @@
     },
     {
       "id": "GOBL-DE-TAX-IDENTITY",
-      "name": "tax.Identity",
+      "object": "tax.Identity",
       "subsets": [
         {
           "guard": "code in [DE]",

--- a/data/rules/dk.json
+++ b/data/rules/dk.json
@@ -1,10 +1,10 @@
 {
   "id": "GOBL-DK",
-  "name": "dk",
+  "package": "dk",
   "subsets": [
     {
       "id": "GOBL-DK-BILL-INVOICE",
-      "name": "bill.Invoice",
+      "object": "bill.Invoice",
       "subsets": [
         {
           "guard": "context: regime in [DK]",
@@ -25,7 +25,7 @@
     },
     {
       "id": "GOBL-DK-ORG-IDENTITY",
-      "name": "org.Identity",
+      "object": "org.Identity",
       "subsets": [
         {
           "guard": "is CVR",
@@ -51,7 +51,7 @@
     },
     {
       "id": "GOBL-DK-TAX-IDENTITY",
-      "name": "tax.Identity",
+      "object": "tax.Identity",
       "subsets": [
         {
           "guard": "code in [DK]",

--- a/data/rules/dsig.json
+++ b/data/rules/dsig.json
@@ -1,10 +1,10 @@
 {
   "id": "GOBL-DSIG",
-  "name": "dsig",
+  "package": "dsig",
   "subsets": [
     {
       "id": "GOBL-DSIG-DIGEST",
-      "name": "dsig.Digest",
+      "object": "dsig.Digest",
       "subsets": [
         {
           "field": "alg",

--- a/data/rules/es-facturae-v3.json
+++ b/data/rules/es-facturae-v3.json
@@ -1,11 +1,11 @@
 {
   "id": "GOBL-ES-FACTURAE-V3",
-  "name": "es-facturae-v3",
+  "package": "es-facturae-v3",
   "guard": "context: addon in [es-facturae-v3]",
   "subsets": [
     {
       "id": "GOBL-ES-FACTURAE-V3-BILL-INVOICE",
-      "name": "bill.Invoice",
+      "object": "bill.Invoice",
       "subsets": [
         {
           "field": "customer",

--- a/data/rules/es-sii-v1.json
+++ b/data/rules/es-sii-v1.json
@@ -1,11 +1,11 @@
 {
   "id": "GOBL-ES-SII-V1",
-  "name": "es-sii-v1",
+  "package": "es-sii-v1",
   "guard": "context: addon in [es-sii-v1]",
   "subsets": [
     {
       "id": "GOBL-ES-SII-V1-BILL-INVOICE",
-      "name": "bill.Invoice",
+      "object": "bill.Invoice",
       "subsets": [
         {
           "guard": "invoice type in [corrective]",
@@ -222,7 +222,7 @@
     },
     {
       "id": "GOBL-ES-SII-V1-TAX-COMBO",
-      "name": "tax.Combo",
+      "object": "tax.Combo",
       "subsets": [
         {
           "guard": "sii vat/igic",

--- a/data/rules/es-tbai-v1.json
+++ b/data/rules/es-tbai-v1.json
@@ -1,11 +1,11 @@
 {
   "id": "GOBL-ES-TBAI-V1",
-  "name": "es-tbai-v1",
+  "package": "es-tbai-v1",
   "guard": "context: addon in [es-tbai-v1]",
   "subsets": [
     {
       "id": "GOBL-ES-TBAI-V1-BILL-INVOICE",
-      "name": "bill.Invoice",
+      "object": "bill.Invoice",
       "subsets": [
         {
           "field": "tax",
@@ -115,7 +115,7 @@
     },
     {
       "id": "GOBL-ES-TBAI-V1-TAX-COMBO",
-      "name": "tax.Combo",
+      "object": "tax.Combo",
       "subsets": [
         {
           "guard": "exempt vat/igic",

--- a/data/rules/es-verifactu-v1.json
+++ b/data/rules/es-verifactu-v1.json
@@ -1,11 +1,11 @@
 {
   "id": "GOBL-ES-VERIFACTU-V1",
-  "name": "es-verifactu-v1",
+  "package": "es-verifactu-v1",
   "guard": "context: addon in [es-verifactu-v1]",
   "subsets": [
     {
       "id": "GOBL-ES-VERIFACTU-V1-BILL-INVOICE",
-      "name": "bill.Invoice",
+      "object": "bill.Invoice",
       "subsets": [
         {
           "guard": "invoice type in [corrective]",
@@ -264,7 +264,7 @@
     },
     {
       "id": "GOBL-ES-VERIFACTU-V1-TAX-COMBO",
-      "name": "tax.Combo",
+      "object": "tax.Combo",
       "subsets": [
         {
           "guard": "verifactu vat/igic",

--- a/data/rules/es.json
+++ b/data/rules/es.json
@@ -1,10 +1,10 @@
 {
   "id": "GOBL-ES",
-  "name": "es",
+  "package": "es",
   "subsets": [
     {
       "id": "GOBL-ES-BILL-INVOICE",
-      "name": "bill.Invoice",
+      "object": "bill.Invoice",
       "subsets": [
         {
           "guard": "context: regime in [ES]",
@@ -49,7 +49,7 @@
     },
     {
       "id": "GOBL-ES-TAX-IDENTITY",
-      "name": "tax.Identity",
+      "object": "tax.Identity",
       "subsets": [
         {
           "guard": "code in [ES]",

--- a/data/rules/eu-en16931-v2017.json
+++ b/data/rules/eu-en16931-v2017.json
@@ -1,11 +1,11 @@
 {
   "id": "GOBL-EU-EN16931-V2017",
-  "name": "eu-en16931-v2017",
+  "package": "eu-en16931-v2017",
   "guard": "context: addon in [eu-en16931-v2017]",
   "subsets": [
     {
       "id": "GOBL-EU-EN16931-V2017-BILL-INVOICE",
-      "name": "bill.Invoice",
+      "object": "bill.Invoice",
       "assert": [
         {
           "id": "GOBL-EU-EN16931-V2017-BILL-INVOICE-08",
@@ -107,7 +107,7 @@
     },
     {
       "id": "GOBL-EU-EN16931-V2017-BILL-DISCOUNT",
-      "name": "bill.Discount",
+      "object": "bill.Discount",
       "assert": [
         {
           "id": "GOBL-EU-EN16931-V2017-BILL-DISCOUNT-02",
@@ -130,7 +130,7 @@
     },
     {
       "id": "GOBL-EU-EN16931-V2017-BILL-LINEDISCOUNT",
-      "name": "bill.LineDiscount",
+      "object": "bill.LineDiscount",
       "assert": [
         {
           "id": "GOBL-EU-EN16931-V2017-BILL-LINEDISCOUNT-01",
@@ -141,7 +141,7 @@
     },
     {
       "id": "GOBL-EU-EN16931-V2017-BILL-CHARGE",
-      "name": "bill.Charge",
+      "object": "bill.Charge",
       "assert": [
         {
           "id": "GOBL-EU-EN16931-V2017-BILL-CHARGE-01",
@@ -152,7 +152,7 @@
     },
     {
       "id": "GOBL-EU-EN16931-V2017-BILL-LINECHARGE",
-      "name": "bill.LineCharge",
+      "object": "bill.LineCharge",
       "assert": [
         {
           "id": "GOBL-EU-EN16931-V2017-BILL-LINECHARGE-01",
@@ -163,7 +163,7 @@
     },
     {
       "id": "GOBL-EU-EN16931-V2017-PAY-INSTRUCTIONS",
-      "name": "pay.Instructions",
+      "object": "pay.Instructions",
       "subsets": [
         {
           "field": "ext",
@@ -179,7 +179,7 @@
     },
     {
       "id": "GOBL-EU-EN16931-V2017-PAY-TERMS",
-      "name": "pay.Terms",
+      "object": "pay.Terms",
       "assert": [
         {
           "id": "GOBL-EU-EN16931-V2017-PAY-TERMS-01",
@@ -190,7 +190,7 @@
     },
     {
       "id": "GOBL-EU-EN16931-V2017-ORG-ITEM",
-      "name": "org.Item",
+      "object": "org.Item",
       "subsets": [
         {
           "field": "unit",
@@ -206,7 +206,7 @@
     },
     {
       "id": "GOBL-EU-EN16931-V2017-ORG-ATTACHMENT",
-      "name": "org.Attachment",
+      "object": "org.Attachment",
       "subsets": [
         {
           "field": "code",
@@ -222,7 +222,7 @@
     },
     {
       "id": "GOBL-EU-EN16931-V2017-ORG-PARTY",
-      "name": "org.Party",
+      "object": "org.Party",
       "subsets": [
         {
           "field": "inboxes",
@@ -238,7 +238,7 @@
     },
     {
       "id": "GOBL-EU-EN16931-V2017-ORG-INBOX",
-      "name": "org.Inbox",
+      "object": "org.Inbox",
       "assert": [
         {
           "id": "GOBL-EU-EN16931-V2017-ORG-INBOX-01",
@@ -254,7 +254,7 @@
     },
     {
       "id": "GOBL-EU-EN16931-V2017-ORG-ADDRESS",
-      "name": "org.Address",
+      "object": "org.Address",
       "subsets": [
         {
           "field": "country",
@@ -270,7 +270,7 @@
     },
     {
       "id": "GOBL-EU-EN16931-V2017-TAX-COMBO",
-      "name": "tax.Combo",
+      "object": "tax.Combo",
       "subsets": [
         {
           "field": "ext",

--- a/data/rules/fr-choruspro-v1.json
+++ b/data/rules/fr-choruspro-v1.json
@@ -1,11 +1,11 @@
 {
   "id": "GOBL-FR-CHORUSPRO-V1",
-  "name": "fr-choruspro-v1",
+  "package": "fr-choruspro-v1",
   "guard": "context: addon in [fr-choruspro-v1]",
   "subsets": [
     {
       "id": "GOBL-FR-CHORUSPRO-V1-BILL-INVOICE",
-      "name": "bill.Invoice",
+      "object": "bill.Invoice",
       "subsets": [
         {
           "field": "customer",
@@ -78,7 +78,7 @@
     },
     {
       "id": "GOBL-FR-CHORUSPRO-V1-ORG-PARTY",
-      "name": "org.Party",
+      "object": "org.Party",
       "subsets": [
         {
           "field": "ext",

--- a/data/rules/fr-ctc-flow2-v1.json
+++ b/data/rules/fr-ctc-flow2-v1.json
@@ -1,11 +1,11 @@
 {
   "id": "GOBL-FR-CTC-FLOW2-V1",
-  "name": "fr-ctc-flow2-v1",
+  "package": "fr-ctc-flow2-v1",
   "guard": "context: addon in [fr-ctc-flow2-v1]",
   "subsets": [
     {
       "id": "GOBL-FR-CTC-FLOW2-V1-BILL-INVOICE",
-      "name": "bill.Invoice",
+      "object": "bill.Invoice",
       "assert": [
         {
           "id": "GOBL-FR-CTC-FLOW2-V1-BILL-INVOICE-01",
@@ -473,7 +473,7 @@
     },
     {
       "id": "GOBL-FR-CTC-FLOW2-V1-ORG-PARTY",
-      "name": "org.Party",
+      "object": "org.Party",
       "subsets": [
         {
           "field": "identities",
@@ -509,7 +509,7 @@
     },
     {
       "id": "GOBL-FR-CTC-FLOW2-V1-ORG-IDENTITY",
-      "name": "org.Identity",
+      "object": "org.Identity",
       "subsets": [
         {
           "guard": "scheme 0224",
@@ -535,7 +535,7 @@
     },
     {
       "id": "GOBL-FR-CTC-FLOW2-V1-ORG-INBOX",
-      "name": "org.Inbox",
+      "object": "org.Inbox",
       "subsets": [
         {
           "guard": "scheme 0225",
@@ -561,7 +561,7 @@
     },
     {
       "id": "GOBL-FR-CTC-FLOW2-V1-ORG-ITEM",
-      "name": "org.Item",
+      "object": "org.Item",
       "subsets": [
         {
           "field": "meta",

--- a/data/rules/fr.json
+++ b/data/rules/fr.json
@@ -1,10 +1,10 @@
 {
   "id": "GOBL-FR",
-  "name": "fr",
+  "package": "fr",
   "subsets": [
     {
       "id": "GOBL-FR-BILL-INVOICE",
-      "name": "bill.Invoice",
+      "object": "bill.Invoice",
       "subsets": [
         {
           "guard": "context: regime in [FR]",
@@ -25,7 +25,7 @@
     },
     {
       "id": "GOBL-FR-ORG-IDENTITY",
-      "name": "org.Identity",
+      "object": "org.Identity",
       "subsets": [
         {
           "guard": "context: regime in [FR]",
@@ -66,7 +66,7 @@
     },
     {
       "id": "GOBL-FR-TAX-IDENTITY",
-      "name": "tax.Identity",
+      "object": "tax.Identity",
       "subsets": [
         {
           "guard": "code in [FR]",

--- a/data/rules/gb.json
+++ b/data/rules/gb.json
@@ -1,10 +1,10 @@
 {
   "id": "GOBL-GB",
-  "name": "gb",
+  "package": "gb",
   "subsets": [
     {
       "id": "GOBL-GB-TAX-IDENTITY",
-      "name": "tax.Identity",
+      "object": "tax.Identity",
       "subsets": [
         {
           "guard": "code in [GB]",

--- a/data/rules/gobl.json
+++ b/data/rules/gobl.json
@@ -1,10 +1,10 @@
 {
   "id": "GOBL",
-  "name": "gobl",
+  "package": "gobl",
   "subsets": [
     {
       "id": "GOBL-ENVELOPE",
-      "name": "gobl.Envelope",
+      "object": "gobl.Envelope",
       "assert": [
         {
           "id": "GOBL-ENVELOPE-11",

--- a/data/rules/gr-mydata-v1.json
+++ b/data/rules/gr-mydata-v1.json
@@ -1,11 +1,11 @@
 {
   "id": "GOBL-GR-MYDATA-V1",
-  "name": "gr-mydata-v1",
+  "package": "gr-mydata-v1",
   "guard": "context: addon in [gr-mydata-v1]",
   "subsets": [
     {
       "id": "GOBL-GR-MYDATA-V1-BILL-INVOICE",
-      "name": "bill.Invoice",
+      "object": "bill.Invoice",
       "subsets": [
         {
           "field": "series",
@@ -234,7 +234,7 @@
     },
     {
       "id": "GOBL-GR-MYDATA-V1-BILL-CHARGE",
-      "name": "bill.Charge",
+      "object": "bill.Charge",
       "subsets": [
         {
           "field": "ext",
@@ -295,7 +295,7 @@
     },
     {
       "id": "GOBL-GR-MYDATA-V1-TAX-COMBO",
-      "name": "tax.Combo",
+      "object": "tax.Combo",
       "subsets": [
         {
           "guard": "category is VAT",
@@ -346,7 +346,7 @@
     },
     {
       "id": "GOBL-GR-MYDATA-V1-PAY-INSTRUCTIONS",
-      "name": "pay.Instructions",
+      "object": "pay.Instructions",
       "subsets": [
         {
           "field": "key",
@@ -372,7 +372,7 @@
     },
     {
       "id": "GOBL-GR-MYDATA-V1-PAY-ADVANCE",
-      "name": "pay.Advance",
+      "object": "pay.Advance",
       "subsets": [
         {
           "field": "key",

--- a/data/rules/gr.json
+++ b/data/rules/gr.json
@@ -1,10 +1,10 @@
 {
   "id": "GOBL-GR",
-  "name": "gr",
+  "package": "gr",
   "subsets": [
     {
       "id": "GOBL-GR-TAX-IDENTITY",
-      "name": "tax.Identity",
+      "object": "tax.Identity",
       "subsets": [
         {
           "guard": "code in [EL]",

--- a/data/rules/head.json
+++ b/data/rules/head.json
@@ -1,10 +1,10 @@
 {
   "id": "GOBL-HEAD",
-  "name": "head",
+  "package": "head",
   "subsets": [
     {
       "id": "GOBL-HEAD-HEADER",
-      "name": "head.Header",
+      "object": "head.Header",
       "subsets": [
         {
           "field": "uuid",
@@ -50,7 +50,7 @@
     },
     {
       "id": "GOBL-HEAD-STAMP",
-      "name": "head.Stamp",
+      "object": "head.Stamp",
       "subsets": [
         {
           "field": "prv",
@@ -76,7 +76,7 @@
     },
     {
       "id": "GOBL-HEAD-LINK",
-      "name": "head.Link",
+      "object": "head.Link",
       "assert": [
         {
           "id": "GOBL-HEAD-LINK-06",

--- a/data/rules/i18n.json
+++ b/data/rules/i18n.json
@@ -1,10 +1,10 @@
 {
   "id": "GOBL-I18N",
-  "name": "i18n",
+  "package": "i18n",
   "subsets": [
     {
       "id": "GOBL-I18N-LANG",
-      "name": "i18n.Lang",
+      "object": "i18n.Lang",
       "assert": [
         {
           "id": "GOBL-I18N-LANG-01",

--- a/data/rules/ie.json
+++ b/data/rules/ie.json
@@ -1,10 +1,10 @@
 {
   "id": "GOBL-IE",
-  "name": "ie",
+  "package": "ie",
   "subsets": [
     {
       "id": "GOBL-IE-TAX-IDENTITY",
-      "name": "tax.Identity",
+      "object": "tax.Identity",
       "subsets": [
         {
           "guard": "code in [IE]",

--- a/data/rules/in.json
+++ b/data/rules/in.json
@@ -1,10 +1,10 @@
 {
   "id": "GOBL-IN",
-  "name": "in",
+  "package": "in",
   "subsets": [
     {
       "id": "GOBL-IN-ORG-IDENTITY",
-      "name": "org.Identity",
+      "object": "org.Identity",
       "subsets": [
         {
           "guard": "context: regime in [IN]",
@@ -45,7 +45,7 @@
     },
     {
       "id": "GOBL-IN-ORG-ITEM",
-      "name": "org.Item",
+      "object": "org.Item",
       "subsets": [
         {
           "guard": "context: regime in [IN]",
@@ -66,7 +66,7 @@
     },
     {
       "id": "GOBL-IN-TAX-IDENTITY",
-      "name": "tax.Identity",
+      "object": "tax.Identity",
       "subsets": [
         {
           "guard": "code in [IN]",

--- a/data/rules/it-sdi-v1.json
+++ b/data/rules/it-sdi-v1.json
@@ -1,11 +1,11 @@
 {
   "id": "GOBL-IT-SDI-V1",
-  "name": "it-sdi-v1",
+  "package": "it-sdi-v1",
   "guard": "context: addon in [it-sdi-v1]",
   "subsets": [
     {
       "id": "GOBL-IT-SDI-V1-BILL-INVOICE",
-      "name": "bill.Invoice",
+      "object": "bill.Invoice",
       "assert": [
         {
           "id": "GOBL-IT-SDI-V1-BILL-INVOICE-13",
@@ -309,7 +309,7 @@
     },
     {
       "id": "GOBL-IT-SDI-V1-BILL-CHARGE",
-      "name": "bill.Charge",
+      "object": "bill.Charge",
       "subsets": [
         {
           "guard": "is fund contribution",
@@ -350,7 +350,7 @@
     },
     {
       "id": "GOBL-IT-SDI-V1-ORG-ADDRESS",
-      "name": "org.Address",
+      "object": "org.Address",
       "assert": [
         {
           "id": "GOBL-IT-SDI-V1-ORG-ADDRESS-01",
@@ -428,7 +428,7 @@
     },
     {
       "id": "GOBL-IT-SDI-V1-TAX-COMBO",
-      "name": "tax.Combo",
+      "object": "tax.Combo",
       "subsets": [
         {
           "guard": "VAT without percent",
@@ -464,7 +464,7 @@
     },
     {
       "id": "GOBL-IT-SDI-V1-PAY-INSTRUCTIONS",
-      "name": "pay.Instructions",
+      "object": "pay.Instructions",
       "subsets": [
         {
           "field": "ext",
@@ -480,7 +480,7 @@
     },
     {
       "id": "GOBL-IT-SDI-V1-PAY-ADVANCE",
-      "name": "pay.Advance",
+      "object": "pay.Advance",
       "subsets": [
         {
           "field": "ext",

--- a/data/rules/it-ticket-v1.json
+++ b/data/rules/it-ticket-v1.json
@@ -1,11 +1,11 @@
 {
   "id": "GOBL-IT-TICKET-V1",
-  "name": "it-ticket-v1",
+  "package": "it-ticket-v1",
   "guard": "context: addon in [it-ticket-v1]",
   "subsets": [
     {
       "id": "GOBL-IT-TICKET-V1-BILL-INVOICE",
-      "name": "bill.Invoice",
+      "object": "bill.Invoice",
       "subsets": [
         {
           "field": "tax",
@@ -108,7 +108,7 @@
     },
     {
       "id": "GOBL-IT-TICKET-V1-TAX-COMBO",
-      "name": "tax.Combo",
+      "object": "tax.Combo",
       "subsets": [
         {
           "guard": "VAT without percent",

--- a/data/rules/it.json
+++ b/data/rules/it.json
@@ -1,10 +1,10 @@
 {
   "id": "GOBL-IT",
-  "name": "it",
+  "package": "it",
   "subsets": [
     {
       "id": "GOBL-IT-TAX-IDENTITY",
-      "name": "tax.Identity",
+      "object": "tax.Identity",
       "subsets": [
         {
           "guard": "code in [IT]",
@@ -30,7 +30,7 @@
     },
     {
       "id": "GOBL-IT-ORG-IDENTITY",
-      "name": "org.Identity",
+      "object": "org.Identity",
       "subsets": [
         {
           "guard": "context: regime in [IT]",

--- a/data/rules/mx-cfdi-v4.json
+++ b/data/rules/mx-cfdi-v4.json
@@ -1,11 +1,11 @@
 {
   "id": "GOBL-MX-CFDI-V4",
-  "name": "mx-cfdi-v4",
+  "package": "mx-cfdi-v4",
   "guard": "context: addon in [mx-cfdi-v4]",
   "subsets": [
     {
       "id": "GOBL-MX-CFDI-V4-BILL-INVOICE",
-      "name": "bill.Invoice",
+      "object": "bill.Invoice",
       "subsets": [
         {
           "field": "tax",
@@ -374,7 +374,7 @@
     },
     {
       "id": "GOBL-MX-CFDI-V4-PAY-INSTRUCTIONS",
-      "name": "pay.Instructions",
+      "object": "pay.Instructions",
       "subsets": [
         {
           "field": "ext",
@@ -390,7 +390,7 @@
     },
     {
       "id": "GOBL-MX-CFDI-V4-PAY-ADVANCE",
-      "name": "pay.Advance",
+      "object": "pay.Advance",
       "subsets": [
         {
           "field": "ext",
@@ -406,7 +406,7 @@
     },
     {
       "id": "GOBL-MX-CFDI-V4-PAY-TERMS",
-      "name": "pay.Terms",
+      "object": "pay.Terms",
       "subsets": [
         {
           "field": "notes",
@@ -422,7 +422,7 @@
     },
     {
       "id": "GOBL-MX-CFDI-V4-FOODVOUCHERS",
-      "name": "cfdi.FoodVouchers",
+      "object": "cfdi.FoodVouchers",
       "subsets": [
         {
           "field": "employer_registration",
@@ -582,7 +582,7 @@
     },
     {
       "id": "GOBL-MX-CFDI-V4-FUELACCOUNTBALANCE",
-      "name": "cfdi.FuelAccountBalance",
+      "object": "cfdi.FuelAccountBalance",
       "subsets": [
         {
           "field": "account_number",

--- a/data/rules/mx.json
+++ b/data/rules/mx.json
@@ -1,10 +1,10 @@
 {
   "id": "GOBL-MX",
-  "name": "mx",
+  "package": "mx",
   "subsets": [
     {
       "id": "GOBL-MX-TAX-IDENTITY",
-      "name": "tax.Identity",
+      "object": "tax.Identity",
       "subsets": [
         {
           "guard": "code in [MX]",

--- a/data/rules/nl.json
+++ b/data/rules/nl.json
@@ -1,10 +1,10 @@
 {
   "id": "GOBL-NL",
-  "name": "nl",
+  "package": "nl",
   "subsets": [
     {
       "id": "GOBL-NL-BILL-INVOICE",
-      "name": "bill.Invoice",
+      "object": "bill.Invoice",
       "subsets": [
         {
           "guard": "context: regime in [NL]",
@@ -25,7 +25,7 @@
     },
     {
       "id": "GOBL-NL-ORG-IDENTITY",
-      "name": "org.Identity",
+      "object": "org.Identity",
       "subsets": [
         {
           "guard": "context: regime in [NL]",
@@ -66,7 +66,7 @@
     },
     {
       "id": "GOBL-NL-TAX-IDENTITY",
-      "name": "tax.Identity",
+      "object": "tax.Identity",
       "subsets": [
         {
           "guard": "code in [NL]",

--- a/data/rules/note.json
+++ b/data/rules/note.json
@@ -1,10 +1,10 @@
 {
   "id": "GOBL-NOTE",
-  "name": "note",
+  "package": "note",
   "subsets": [
     {
       "id": "GOBL-NOTE-MESSAGE",
-      "name": "note.Message",
+      "object": "note.Message",
       "subsets": [
         {
           "field": "content",

--- a/data/rules/org.json
+++ b/data/rules/org.json
@@ -1,10 +1,10 @@
 {
   "id": "GOBL-ORG",
-  "name": "org",
+  "package": "org",
   "subsets": [
     {
       "id": "GOBL-ORG-ATTACHMENT",
-      "name": "org.Attachment",
+      "object": "org.Attachment",
       "subsets": [
         {
           "field": "url",
@@ -35,7 +35,7 @@
     },
     {
       "id": "GOBL-ORG-COORDINATES",
-      "name": "org.Coordinates",
+      "object": "org.Coordinates",
       "subsets": [
         {
           "field": "lat",
@@ -86,7 +86,7 @@
     },
     {
       "id": "GOBL-ORG-DOCUMENTREF",
-      "name": "org.DocumentRef",
+      "object": "org.DocumentRef",
       "subsets": [
         {
           "field": "code",
@@ -132,7 +132,7 @@
     },
     {
       "id": "GOBL-ORG-EMAIL",
-      "name": "org.Email",
+      "object": "org.Email",
       "subsets": [
         {
           "field": "addr",
@@ -153,7 +153,7 @@
     },
     {
       "id": "GOBL-ORG-IDENTITY",
-      "name": "org.Identity",
+      "object": "org.Identity",
       "assert": [
         {
           "id": "GOBL-ORG-IDENTITY-03",
@@ -191,7 +191,7 @@
     },
     {
       "id": "GOBL-ORG-IMAGE",
-      "name": "org.Image",
+      "object": "org.Image",
       "subsets": [
         {
           "field": "url",
@@ -232,7 +232,7 @@
     },
     {
       "id": "GOBL-ORG-INBOX",
-      "name": "org.Inbox",
+      "object": "org.Inbox",
       "assert": [
         {
           "id": "GOBL-ORG-INBOX-01",
@@ -285,7 +285,7 @@
     },
     {
       "id": "GOBL-ORG-ITEM",
-      "name": "org.Item",
+      "object": "org.Item",
       "subsets": [
         {
           "field": "name",
@@ -316,7 +316,7 @@
     },
     {
       "id": "GOBL-ORG-NAME",
-      "name": "org.Name",
+      "object": "org.Name",
       "subsets": [
         {
           "guard": "Surname == \"\"",
@@ -352,7 +352,7 @@
     },
     {
       "id": "GOBL-ORG-NOTE",
-      "name": "org.Note",
+      "object": "org.Note",
       "subsets": [
         {
           "field": "text",
@@ -383,7 +383,7 @@
     },
     {
       "id": "GOBL-ORG-PERSON",
-      "name": "org.Person",
+      "object": "org.Person",
       "subsets": [
         {
           "field": "name",
@@ -399,7 +399,7 @@
     },
     {
       "id": "GOBL-ORG-REGISTRATION",
-      "name": "org.Registration",
+      "object": "org.Registration",
       "subsets": [
         {
           "field": "currency",
@@ -420,7 +420,7 @@
     },
     {
       "id": "GOBL-ORG-TELEPHONE",
-      "name": "org.Telephone",
+      "object": "org.Telephone",
       "subsets": [
         {
           "field": "num",
@@ -436,7 +436,7 @@
     },
     {
       "id": "GOBL-ORG-UNIT",
-      "name": "org.Unit",
+      "object": "org.Unit",
       "assert": [
         {
           "id": "GOBL-ORG-UNIT-01",
@@ -447,7 +447,7 @@
     },
     {
       "id": "GOBL-ORG-WEBSITE",
-      "name": "org.Website",
+      "object": "org.Website",
       "subsets": [
         {
           "field": "url",

--- a/data/rules/pay.json
+++ b/data/rules/pay.json
@@ -1,10 +1,10 @@
 {
   "id": "GOBL-PAY",
-  "name": "pay",
+  "package": "pay",
   "subsets": [
     {
       "id": "GOBL-PAY-ADVANCE",
-      "name": "pay.Advance",
+      "object": "pay.Advance",
       "subsets": [
         {
           "field": "description",
@@ -35,7 +35,7 @@
     },
     {
       "id": "GOBL-PAY-INSTRUCTIONS",
-      "name": "pay.Instructions",
+      "object": "pay.Instructions",
       "subsets": [
         {
           "field": "key",
@@ -63,7 +63,7 @@
     },
     {
       "id": "GOBL-PAY-ONLINE",
-      "name": "pay.Online",
+      "object": "pay.Online",
       "subsets": [
         {
           "field": "url",
@@ -79,7 +79,7 @@
     },
     {
       "id": "GOBL-PAY-TERMS",
-      "name": "pay.Terms",
+      "object": "pay.Terms",
       "subsets": [
         {
           "field": "key",
@@ -100,7 +100,7 @@
     },
     {
       "id": "GOBL-PAY-DUEDATE",
-      "name": "pay.DueDate",
+      "object": "pay.DueDate",
       "subsets": [
         {
           "field": "date",

--- a/data/rules/pl-favat-v3.json
+++ b/data/rules/pl-favat-v3.json
@@ -1,11 +1,11 @@
 {
   "id": "GOBL-PL-FAVAT-V3",
-  "name": "pl-favat-v3",
+  "package": "pl-favat-v3",
   "guard": "context: addon in [pl-favat-v3]",
   "subsets": [
     {
       "id": "GOBL-PL-FAVAT-V3-BILL-INVOICE",
-      "name": "bill.Invoice",
+      "object": "bill.Invoice",
       "assert": [
         {
           "id": "GOBL-PL-FAVAT-V3-BILL-INVOICE-11",
@@ -142,7 +142,7 @@
     },
     {
       "id": "GOBL-PL-FAVAT-V3-TAX-COMBO",
-      "name": "tax.Combo",
+      "object": "tax.Combo",
       "subsets": [
         {
           "field": "ext",
@@ -158,7 +158,7 @@
     },
     {
       "id": "GOBL-PL-FAVAT-V3-PAY-ADVANCE",
-      "name": "pay.Advance",
+      "object": "pay.Advance",
       "subsets": [
         {
           "field": "date",

--- a/data/rules/pl.json
+++ b/data/rules/pl.json
@@ -1,10 +1,10 @@
 {
   "id": "GOBL-PL",
-  "name": "pl",
+  "package": "pl",
   "subsets": [
     {
       "id": "GOBL-PL-BILL-INVOICE",
-      "name": "bill.Invoice",
+      "object": "bill.Invoice",
       "subsets": [
         {
           "guard": "context: regime in [PL]",
@@ -35,7 +35,7 @@
     },
     {
       "id": "GOBL-PL-TAX-IDENTITY",
-      "name": "tax.Identity",
+      "object": "tax.Identity",
       "subsets": [
         {
           "guard": "code in [PL]",

--- a/data/rules/pt-saft-v1.json
+++ b/data/rules/pt-saft-v1.json
@@ -1,11 +1,11 @@
 {
   "id": "GOBL-PT-SAFT-V1",
-  "name": "pt-saft-v1",
+  "package": "pt-saft-v1",
   "guard": "context: addon in [pt-saft-v1]",
   "subsets": [
     {
       "id": "GOBL-PT-SAFT-V1-BILL-INVOICE",
-      "name": "bill.Invoice",
+      "object": "bill.Invoice",
       "assert": [
         {
           "id": "GOBL-PT-SAFT-V1-BILL-INVOICE-01",
@@ -153,7 +153,7 @@
     },
     {
       "id": "GOBL-PT-SAFT-V1-BILL-PAYMENT",
-      "name": "bill.Payment",
+      "object": "bill.Payment",
       "assert": [
         {
           "id": "GOBL-PT-SAFT-V1-BILL-PAYMENT-01",
@@ -248,7 +248,7 @@
     },
     {
       "id": "GOBL-PT-SAFT-V1-BILL-DELIVERY",
-      "name": "bill.Delivery",
+      "object": "bill.Delivery",
       "assert": [
         {
           "id": "GOBL-PT-SAFT-V1-BILL-DELIVERY-01",
@@ -308,7 +308,7 @@
     },
     {
       "id": "GOBL-PT-SAFT-V1-BILL-ORDER",
-      "name": "bill.Order",
+      "object": "bill.Order",
       "assert": [
         {
           "id": "GOBL-PT-SAFT-V1-BILL-ORDER-01",
@@ -361,7 +361,7 @@
     },
     {
       "id": "GOBL-PT-SAFT-V1-TAX-COMBO",
-      "name": "tax.Combo",
+      "object": "tax.Combo",
       "subsets": [
         {
           "guard": "is VAT",
@@ -387,7 +387,7 @@
     },
     {
       "id": "GOBL-PT-SAFT-V1-TAX-RATETOTAL",
-      "name": "tax.RateTotal",
+      "object": "tax.RateTotal",
       "subsets": [
         {
           "field": "ext",
@@ -408,7 +408,7 @@
     },
     {
       "id": "GOBL-PT-SAFT-V1-ORG-ITEM",
-      "name": "org.Item",
+      "object": "org.Item",
       "subsets": [
         {
           "field": "unit",
@@ -434,7 +434,7 @@
     },
     {
       "id": "GOBL-PT-SAFT-V1-ORG-NOTE",
-      "name": "org.Note",
+      "object": "org.Note",
       "subsets": [
         {
           "guard": "legal exemption note",
@@ -455,7 +455,7 @@
     },
     {
       "id": "GOBL-PT-SAFT-V1-BILL-LINE",
-      "name": "bill.Line",
+      "object": "bill.Line",
       "assert": [
         {
           "id": "GOBL-PT-SAFT-V1-BILL-LINE-05",
@@ -518,7 +518,7 @@
     },
     {
       "id": "GOBL-PT-SAFT-V1-BILL-PAYMENTLINE",
-      "name": "bill.PaymentLine",
+      "object": "bill.PaymentLine",
       "assert": [
         {
           "id": "GOBL-PT-SAFT-V1-BILL-PAYMENTLINE-06",

--- a/data/rules/pt.json
+++ b/data/rules/pt.json
@@ -1,10 +1,10 @@
 {
   "id": "GOBL-PT",
-  "name": "pt",
+  "package": "pt",
   "subsets": [
     {
       "id": "GOBL-PT-BILL-INVOICE",
-      "name": "bill.Invoice",
+      "object": "bill.Invoice",
       "subsets": [
         {
           "guard": "context: regime in [PT]",
@@ -144,7 +144,7 @@
     },
     {
       "id": "GOBL-PT-TAX-COMBO",
-      "name": "tax.Combo",
+      "object": "tax.Combo",
       "subsets": [
         {
           "guard": "context: regime in [PT]",
@@ -170,7 +170,7 @@
     },
     {
       "id": "GOBL-PT-TAX-IDENTITY",
-      "name": "tax.Identity",
+      "object": "tax.Identity",
       "subsets": [
         {
           "guard": "code in [PT]",

--- a/data/rules/schema.json
+++ b/data/rules/schema.json
@@ -1,10 +1,10 @@
 {
   "id": "GOBL-SCHEMA",
-  "name": "schema",
+  "package": "schema",
   "subsets": [
     {
       "id": "GOBL-SCHEMA-ID",
-      "name": "schema.ID",
+      "object": "schema.ID",
       "subsets": [
         {
           "guard": "present",
@@ -20,7 +20,7 @@
     },
     {
       "id": "GOBL-SCHEMA-OBJECT",
-      "name": "schema.Object",
+      "object": "schema.Object",
       "subsets": [
         {
           "field": "$schema",

--- a/data/rules/se.json
+++ b/data/rules/se.json
@@ -1,10 +1,10 @@
 {
   "id": "GOBL-SE",
-  "name": "se",
+  "package": "se",
   "subsets": [
     {
       "id": "GOBL-SE-TAX-IDENTITY",
-      "name": "tax.Identity",
+      "object": "tax.Identity",
       "subsets": [
         {
           "guard": "code in [SE]",
@@ -30,7 +30,7 @@
     },
     {
       "id": "GOBL-SE-BILL-INVOICE",
-      "name": "bill.Invoice",
+      "object": "bill.Invoice",
       "subsets": [
         {
           "guard": "context: regime in [SE]",
@@ -51,7 +51,7 @@
     },
     {
       "id": "GOBL-SE-ORG-IDENTITY",
-      "name": "org.Identity",
+      "object": "org.Identity",
       "subsets": [
         {
           "guard": "context: regime in [SE]",

--- a/data/rules/sg.json
+++ b/data/rules/sg.json
@@ -1,10 +1,10 @@
 {
   "id": "GOBL-SG",
-  "name": "sg",
+  "package": "sg",
   "subsets": [
     {
       "id": "GOBL-SG-BILL-INVOICE",
-      "name": "bill.Invoice",
+      "object": "bill.Invoice",
       "subsets": [
         {
           "guard": "context: regime in [SG]",
@@ -25,7 +25,7 @@
     },
     {
       "id": "GOBL-SG-ORG-IDENTITY",
-      "name": "org.Identity",
+      "object": "org.Identity",
       "subsets": [
         {
           "guard": "context: regime in [SG]",
@@ -51,7 +51,7 @@
     },
     {
       "id": "GOBL-SG-TAX-IDENTITY",
-      "name": "tax.Identity",
+      "object": "tax.Identity",
       "subsets": [
         {
           "guard": "code in [SG]",

--- a/data/rules/tax.json
+++ b/data/rules/tax.json
@@ -1,10 +1,10 @@
 {
   "id": "GOBL-TAX",
-  "name": "tax",
+  "package": "tax",
   "subsets": [
     {
       "id": "GOBL-TAX-ADDONS",
-      "name": "tax.Addons",
+      "object": "tax.Addons",
       "subsets": [
         {
           "field": "$addons",
@@ -25,7 +25,7 @@
     },
     {
       "id": "GOBL-TAX-ADDONDEF",
-      "name": "tax.AddonDef",
+      "object": "tax.AddonDef",
       "subsets": [
         {
           "field": "key",
@@ -51,7 +51,7 @@
     },
     {
       "id": "GOBL-TAX-CATEGORYDEF",
-      "name": "tax.CategoryDef",
+      "object": "tax.CategoryDef",
       "assert": [
         {
           "id": "GOBL-TAX-CATEGORYDEF-04",
@@ -94,7 +94,7 @@
     },
     {
       "id": "GOBL-TAX-COMBO",
-      "name": "tax.Combo",
+      "object": "tax.Combo",
       "assert": [
         {
           "id": "GOBL-TAX-COMBO-01",
@@ -130,7 +130,7 @@
     },
     {
       "id": "GOBL-TAX-CORRECTIONDEFINITION",
-      "name": "tax.CorrectionDefinition",
+      "object": "tax.CorrectionDefinition",
       "subsets": [
         {
           "field": "schema",
@@ -146,7 +146,7 @@
     },
     {
       "id": "GOBL-TAX-IDENTITY",
-      "name": "tax.Identity",
+      "object": "tax.Identity",
       "subsets": [
         {
           "field": "country",
@@ -172,7 +172,7 @@
     },
     {
       "id": "GOBL-TAX-RATEDEF",
-      "name": "tax.RateDef",
+      "object": "tax.RateDef",
       "subsets": [
         {
           "field": "rate",
@@ -225,7 +225,7 @@
     },
     {
       "id": "GOBL-TAX-REGIMEDEF",
-      "name": "tax.RegimeDef",
+      "object": "tax.RegimeDef",
       "subsets": [
         {
           "field": "country",
@@ -283,7 +283,7 @@
     },
     {
       "id": "GOBL-TAX-SCENARIOSET",
-      "name": "tax.ScenarioSet",
+      "object": "tax.ScenarioSet",
       "subsets": [
         {
           "field": "schema",
@@ -309,7 +309,7 @@
     },
     {
       "id": "GOBL-TAX-SET",
-      "name": "tax.Set",
+      "object": "tax.Set",
       "assert": [
         {
           "id": "GOBL-TAX-SET-01",
@@ -320,7 +320,7 @@
     },
     {
       "id": "GOBL-TAX-NOTE",
-      "name": "tax.Note",
+      "object": "tax.Note",
       "subsets": [
         {
           "field": "text",

--- a/data/rules/uuid.json
+++ b/data/rules/uuid.json
@@ -1,10 +1,10 @@
 {
   "id": "GOBL-UUID",
-  "name": "uuid",
+  "package": "uuid",
   "subsets": [
     {
       "id": "GOBL-UUID-UUID",
-      "name": "uuid.UUID",
+      "object": "uuid.UUID",
       "subsets": [
         {
           "guard": "present",

--- a/rules/README.md
+++ b/rules/README.md
@@ -41,7 +41,7 @@ rules.Assert("01", "description", test1, test2, ...)
 
 All tests must pass. The first failure short-circuits the assertion and emits a
 fault with the given description. Assertion codes are prefixed automatically
-during `Register` to form globally unique codes like `GOBL-ORG-EMAIL-01`.
+by `Register` or `NewSet` to form globally unique codes like `GOBL-ORG-EMAIL-01`.
 
 Use `AssertIfPresent` when the assertion should be skipped for nil or empty values:
 
@@ -117,8 +117,49 @@ func init() {
 }
 ```
 
-Rules registered here are automatically applied by `rules.Validate(obj)` to
-any matching object type anywhere in the object graph.
+The first argument is the package name (used for generation), and the second is
+the namespace code prepended to all assertion IDs. Rules registered here are
+automatically applied by `rules.Validate(obj)` to any matching object type
+anywhere in the object graph.
+
+### `NewSet` — standalone namespace sets
+
+When using rule sets outside the GOBL global registry (e.g. in a separate
+application for validating request bodies), use `NewSet` to create a namespace
+set that can be validated directly:
+
+```go
+const MyApp rules.Code = "MYAPP"
+
+personSet := rules.For(new(Person),
+    rules.Assert("01", "name required", is.Present),
+)
+emailSet := rules.For(new(Email),
+    rules.Field("addr",
+        rules.Assert("01", "email required", is.Present),
+    ),
+)
+
+validator := rules.NewSet(MyApp, personSet, emailSet)
+faults := validator.Validate(person)
+// Codes: MYAPP-PERSON-01, MYAPP-EMAIL-01
+```
+
+Unlike `Register`, the returned set is NOT added to the global registry and
+will not be applied by `rules.Validate(obj)`. Like `Register`, the namespace
+code is prepended to all assertion and set IDs during construction.
+
+Input sets are cloned internally, so the same output of `For` can safely be
+reused across multiple `NewSet` or `Register` calls.
+
+`Set.Validate` also accepts optional `WithContext` values to inject context
+for context-aware guards:
+
+```go
+faults := validator.Validate(obj, func(rc *rules.Context) {
+    rc.Set("country", "ES")
+})
+```
 
 ## Available tests
 
@@ -250,9 +291,9 @@ context (e.g. "is signed?") must be derived from the object's own state.
 
 ### Nested struct fields
 
-Define rules for each type independently and register them all. `rules.Validate`
-recurses into every exported field automatically — no wiring is needed between
-parent and child.
+Define rules for each type independently and register them all (or group them
+with `NewSet`). Both `rules.Validate` and `Set.Validate` recurse into every
+exported field automatically — no wiring is needed between parent and child.
 
 When you need to add constraints on a nested type from the **parent's
 perspective** (e.g. regime-specific rules that don't belong on the child type),
@@ -303,11 +344,13 @@ rules.Assert("02", "code must not exceed 10 characters",
 
 ## Testing
 
-Call `rules.Validate(obj)` and assert on the returned `rules.Faults` value:
+Call `rules.Validate(obj)` (global registry) or `set.Validate(obj)` (standalone)
+and assert on the returned `rules.Faults` value:
 
 ```go
 import "github.com/invopop/gobl/rules"
 
+// Global registry validation:
 err := rules.Validate(obj)
 assert.NoError(t, err)
 
@@ -316,6 +359,11 @@ require.NotNil(t, faults)
 assert.True(t, faults.HasPath("field"))
 assert.True(t, faults.HasCode("GOBL-PKG-STRUCT-01"))
 assert.Equal(t, "assertion description", faults.First().Message())
+
+// Standalone set validation:
+faults = mySet.Validate(obj)
+require.NotNil(t, faults)
+assert.True(t, faults.HasCode("MYAPP-STRUCT-01"))
 ```
 
 `rules.Faults` implements `error`. A nil return means no faults. The full error
@@ -328,14 +376,15 @@ string format is:
 ## Assertion code conventions
 
 Codes within a set are short local identifiers (e.g. `"01"`, `"02"`). They are
-prefixed during `Register` to form globally unique codes. Follow this convention:
+prefixed by `Register` or `NewSet` to form globally unique codes. Follow this
+convention:
 
 - `01`–`09`: field-level assertions, in the order fields appear in the struct
 - `10`–`19`: object-level (cross-field) assertions
 - `20`+: reserved for `When` conditional subsets if needed
 
 The fully-qualified code is constructed as:
-`{REGISTER_PREFIX}-{PKG}-{STRUCT}-{LOCAL_CODE}`
+`{NAMESPACE}-{STRUCT}-{LOCAL_CODE}`
 
 For example, a `"03"` assertion on `head.Header` registered under `GOBL-HEAD`
 becomes `GOBL-HEAD-HEADER-03`.

--- a/rules/generate.go
+++ b/rules/generate.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	_ "github.com/invopop/gobl"
 	"github.com/invopop/gobl/rules"
@@ -29,7 +28,7 @@ func generate() error {
 		if err := enc.Encode(s); err != nil {
 			return err
 		}
-		n := strings.ToLower(string(s.Name))
+		n := s.Package
 		f := filepath.Join("data", "rules", n+".json")
 		if err := os.WriteFile(f, buf.Bytes(), 0644); err != nil {
 			return err

--- a/rules/rules.go
+++ b/rules/rules.go
@@ -40,8 +40,10 @@ type Def func(s *Set)
 type Set struct {
 	// ID is the namespace for this set of rules, typically a package-level code like "GOBL" or "GOBL-ORG".
 	ID Code `json:"id,omitempty"`
-	// Name is the name of the struct type this set of rules applies to. It is used for informational purposes and is not required to be unique.
-	Name string `json:"name,omitempty"`
+	// Package is the short package name used by Register to identify the rule set for generation purposes. It is only set by Register and RegisterWithGuard.
+	Package string `json:"package,omitempty"`
+	// Object is the fully-qualified Go type name (e.g. "bill.Invoice") that this set of rules applies to. It is set by For and is used for informational purposes.
+	Object string `json:"object,omitempty"`
 	// FieldName is the JSON tag name of the field this subset is scoped to. When non-empty, Validate extracts this field from the parent object and delegates to it.
 	FieldName string `json:"field,omitempty"`
 	// Each when true causes Validate to iterate over the slice elements of the field named by FieldName.
@@ -91,20 +93,21 @@ func Registry() []*Set {
 }
 
 // Register is used to register a set of rules for a given namespace.
-func Register(name string, pkg Code, sets ...*Set) {
-	RegisterWithGuard(name, pkg, nil, sets...)
+func Register(pkg string, code Code, sets ...*Set) {
+	RegisterWithGuard(pkg, code, nil, sets...)
 }
 
 // RegisterWithGuard is used to register a set of rules for a given namespace
 // with an optional guard condition that determines when the rules should be applied.
-func RegisterWithGuard(name string, pkg Code, guard Test, sets ...*Set) {
+func RegisterWithGuard(pkg string, code Code, guard Test, sets ...*Set) {
+	sets = cloneSets(sets)
 	set := &Set{
-		ID:      pkg,
-		Name:    name,
+		ID:      code,
+		Package: pkg,
 		Guard:   guard,
 		Subsets: sets,
 	}
-	prependToSets(pkg, sets)
+	prependToSets(code, sets)
 	buildTypeIndex(set)
 	if guard == nil {
 		coreRegistry = append(coreRegistry, set)
@@ -119,6 +122,26 @@ func RegisterWithGuard(name string, pkg Code, guard Test, sets ...*Set) {
 	} else {
 		unkeyedGuarded = append(unkeyedGuarded, set)
 	}
+}
+
+// NewSet creates a standalone namespace set from the given type-bound subsets.
+// It prepends the namespace code to all assertion and set IDs and builds
+// the type index for efficient lookup during validation.
+//
+// Unlike Register, the returned set is NOT added to the global registry.
+// Use Set.Validate to validate objects against it directly.
+//
+// The input sets are cloned internally, so the same output of For can safely
+// be passed to multiple NewSet or Register calls.
+func NewSet(ns Code, sets ...*Set) *Set {
+	sets = cloneSets(sets)
+	set := &Set{
+		ID:      ns,
+		Subsets: sets,
+	}
+	prependToSets(ns, sets)
+	buildTypeIndex(set)
+	return set
 }
 
 // buildTypeIndex populates the typeIndex map on a namespace set by grouping
@@ -174,13 +197,13 @@ func For(obj any, defs ...Def) *Set {
 	normPkg := func(p string) string { return strings.TrimSuffix(p, "_test") }
 	samePackage := callerPkg != "" && normPkg(callerPkg) == normPkg(t.PkgPath())
 	setID := typeSetID(t, samePackage)
-	name := t.Name()
+	objName := t.Name()
 	if pkg := pkgShortName(t); pkg != "" {
-		name = pkg + "." + name
+		objName = pkg + "." + objName
 	}
 	s := &Set{
 		ID:      setID,
-		Name:    name,
+		Object:  objName,
 		objType: t,
 	}
 	for _, def := range defs {
@@ -445,6 +468,33 @@ func pkgShortName(t reflect.Type) string {
 	return strings.TrimSuffix(name, "_test")
 }
 
+// cloneSets returns a deep-enough copy of each set so that prependToSets can
+// safely mutate IDs without affecting the originals. Only the fields modified
+// by prepending (Set.ID, Assertion.ID) and the slices that hold them are
+// copied; shared references like Guard, Tests, and objType are retained.
+func cloneSets(sets []*Set) []*Set {
+	out := make([]*Set, len(sets))
+	for i, s := range sets {
+		out[i] = cloneSet(s)
+	}
+	return out
+}
+
+func cloneSet(s *Set) *Set {
+	c := *s
+	if len(s.Assert) > 0 {
+		c.Assert = make([]*Assertion, len(s.Assert))
+		for i, a := range s.Assert {
+			ac := *a
+			c.Assert[i] = &ac
+		}
+	}
+	if len(s.Subsets) > 0 {
+		c.Subsets = cloneSets(s.Subsets)
+	}
+	return &c
+}
+
 func prependToSets(code Code, sets []*Set) {
 	for _, s := range sets {
 		if s.ID != "" {
@@ -538,8 +588,17 @@ func Validate(obj any, opts ...WithContext) Faults {
 // Validate validates an object against the set's rules. If the set has a test
 // condition (from When), it is evaluated first and the set is skipped when false.
 // Returns nil when no faults are found.
-func (s *Set) Validate(obj any) Faults {
-	return s.validate(nil, obj)
+//
+// Optional WithContext values inject additional context into the validation
+// session. Context is also collected automatically from the root object's
+// exported fields that implement ContextAdder (e.g. tax.Regime, tax.Addons).
+func (s *Set) Validate(obj any, opts ...WithContext) Faults {
+	rc := &Context{}
+	for _, opt := range opts {
+		opt(rc)
+	}
+	collectContext(rc, obj)
+	return s.validate(rc, obj)
 }
 
 // validate is the internal context-aware implementation of Validate.
@@ -847,7 +906,8 @@ func jsonFieldName(f reflect.StructField) string {
 func (s Set) MarshalJSON() ([]byte, error) {
 	type alias struct {
 		ID        Code         `json:"id,omitempty"`
-		Name      string       `json:"name,omitempty"`
+		Package   string       `json:"package,omitempty"`
+		Object    string       `json:"object,omitempty"`
 		FieldName string       `json:"field,omitempty"`
 		Each      bool         `json:"each,omitempty"`
 		Guard     string       `json:"guard,omitempty"`
@@ -856,7 +916,8 @@ func (s Set) MarshalJSON() ([]byte, error) {
 	}
 	a := alias{
 		ID:        s.ID,
-		Name:      s.Name,
+		Package:   s.Package,
+		Object:    s.Object,
 		FieldName: s.FieldName,
 		Each:      s.Each,
 		Assert:    s.Assert,

--- a/rules/rules_test.go
+++ b/rules/rules_test.go
@@ -56,9 +56,9 @@ func init() {
 }
 
 func TestFor(t *testing.T) {
-	t.Run("name includes go package name", func(t *testing.T) {
+	t.Run("object includes go package name", func(t *testing.T) {
 		set := emailRules()
-		assert.Equal(t, "rules.Email", set.Name)
+		assert.Equal(t, "rules.Email", set.Object)
 	})
 
 	t.Run("id omits package when For is called from the same package", func(t *testing.T) {
@@ -73,7 +73,7 @@ func TestFor(t *testing.T) {
 		var found *rules.Set
 		for _, ns := range rules.Registry() {
 			for _, sub := range ns.Subsets {
-				if sub.Name == "rules.Email" {
+				if sub.Object == "rules.Email" {
 					found = sub
 					break
 				}
@@ -939,4 +939,96 @@ func TestFieldWithDashJSONTag(t *testing.T) {
 	)
 	faults := set.Validate(&dashTag{Shown: ""})
 	require.Error(t, faults)
+}
+
+func TestNewSet(t *testing.T) {
+	t.Run("codes are namespaced", func(t *testing.T) {
+		// Use top-level helper so runtime.Caller(1) in For detects the
+		// correct package and omits the package prefix from the set ID.
+		set := rules.NewSet("MYAPP", emailRules())
+		faults := set.Validate(&Email{Addr: ""})
+		require.Error(t, faults)
+		assert.Equal(t, rules.Code("MYAPP-EMAIL-01"), faults.First().Code())
+		assert.True(t, faults.HasPath("$.addr"))
+	})
+
+	t.Run("multi-type validation", func(t *testing.T) {
+		set := rules.NewSet("NS", personRules(), emailRules())
+
+		// Validates Person with nested Email via type index traversal.
+		p := &Person{
+			Name:    "Alice",
+			Address: new(Address),
+			Emails: []Email{
+				{Addr: "ok@example.com"},
+				{Addr: ""},
+			},
+		}
+		faults := set.Validate(p)
+		require.Error(t, faults)
+		assert.True(t, faults.HasCode("NS-PERSON-01"))
+		assert.True(t, faults.HasCode("NS-EMAIL-01"))
+		assert.True(t, faults.HasPath("$.emails[1].addr"))
+	})
+
+	t.Run("does not pollute global registry", func(t *testing.T) {
+		before := len(rules.AllSets())
+		rules.NewSet("STANDALONE", emailRules())
+		after := len(rules.AllSets())
+		assert.Equal(t, before, after)
+	})
+
+	t.Run("passes when valid", func(t *testing.T) {
+		set := rules.NewSet("OK", emailRules())
+		faults := set.Validate(&Email{Addr: "test@example.com"})
+		assert.NoError(t, faults)
+	})
+
+	t.Run("same For output reused across multiple NewSet calls", func(t *testing.T) {
+		shared := emailRules()
+		a := rules.NewSet("AAA", shared)
+		b := rules.NewSet("BBB", shared)
+
+		fa := a.Validate(&Email{Addr: ""})
+		fb := b.Validate(&Email{Addr: ""})
+		require.Error(t, fa)
+		require.Error(t, fb)
+		assert.Equal(t, rules.Code("AAA-EMAIL-01"), fa.First().Code())
+		assert.Equal(t, rules.Code("BBB-EMAIL-01"), fb.First().Code())
+		// Original set is untouched.
+		assert.Equal(t, rules.Code("EMAIL"), shared.ID)
+	})
+}
+
+func docWithRegimeRules() *rules.Set {
+	return rules.For(new(docWithRegime),
+		rules.When(is.InContext(is.In("ES")),
+			rules.Field("name",
+				rules.Assert("01", "name required", is.Present),
+			),
+		),
+	)
+}
+
+func TestNewSetValidateWithContext(t *testing.T) {
+	set := rules.NewSet("CTX", docWithRegimeRules())
+
+	t.Run("context-aware guard fires with matching context", func(t *testing.T) {
+		doc := &docWithRegime{
+			Regime: testRegime{Code: "ES"},
+			Name:   "",
+		}
+		faults := set.Validate(doc)
+		require.Error(t, faults)
+		assert.True(t, faults.HasCode("CTX-DOCWITHREGIME-01"))
+	})
+
+	t.Run("context-aware guard skips with non-matching context", func(t *testing.T) {
+		doc := &docWithRegime{
+			Regime: testRegime{Code: "FR"},
+			Name:   "",
+		}
+		faults := set.Validate(doc)
+		assert.NoError(t, faults)
+	})
 }


### PR DESCRIPTION
## Summary

- Adds `rules.NewSet(ns Code, sets ...*Set) *Set` for creating namespace sets with properly prefixed error codes without touching the global registry. Enables use of the `rules` package in external Go projects (e.g., validating request bodies).
- Replaces `Set.Name` with `Set.Package` (set by `Register`, used by `generate.go`) and `Set.Object` (set by `For`, type reference like `"bill.Invoice"`).
- `Set.Validate` now accepts optional `...WithContext` values so standalone sets can use context-aware guards.
- Input sets are cloned internally by `NewSet`, `Register`, and `RegisterWithGuard`, so the same `For` output can be safely reused across multiple calls.

## Test plan

- [x] New `TestNewSet` tests: namespaced codes, multi-type validation with nested fields, no global registry pollution, valid passthrough, set reuse across multiple `NewSet` calls
- [x] New `TestNewSetValidateWithContext` tests: context-aware guards fire/skip correctly on standalone sets
- [x] All existing tests pass unchanged (`go test ./...`)
- [x] Regenerated `data/rules/*.json` files with updated `"package"` and `"object"` fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)