### PR TITLE
Removing default FX requirement, now set by addon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Changed
+
+- `bill`: removed default calculation check for currency, this is now enforced by addons.
+
+### Added
+
+- `currency`: new `CanConvertTo` test that will ensure a document has or can convert to the provided currency.
+
 ### Fixed
 
 - `rules`: Anonymous embedded struct fields are now also checked from the parent.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Changed
 
-- `bill`: removed default calculation check for currency, this is now enforced by addons.
+- `bill`: removed the default exchange-rate / regime-currency conversion check; addons now enforce currency convertibility where required.
 
 ### Added
 

--- a/addons/ar/arca/bill_invoice.go
+++ b/addons/ar/arca/bill_invoice.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/currency"
 	"github.com/invopop/gobl/i18n"
 	"github.com/invopop/gobl/l10n"
 	"github.com/invopop/gobl/org"
@@ -199,6 +200,7 @@ func normalizeBillInvoiceTaxConcept(inv *bill.Invoice) {
 
 func billInvoiceRules() *rules.Set {
 	return rules.For(new(bill.Invoice),
+		rules.Assert("24", "invoice must be in ARS or provide exchange rate for conversion", currency.CanConvertTo(currency.ARS)),
 		rules.Field("series",
 			rules.Assert("01", "series is required", is.Present),
 			rules.Assert("02", "series must be a valid number between 1 and 99998",

--- a/addons/ar/arca/bill_invoice_test.go
+++ b/addons/ar/arca/bill_invoice_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cal"
 	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/currency"
 	"github.com/invopop/gobl/num"
 	"github.com/invopop/gobl/org"
 	"github.com/invopop/gobl/pay"
@@ -1427,6 +1428,31 @@ func TestTypeCInvoiceLineTaxesValidation(t *testing.T) {
 			},
 		})
 		assertValidationError(t, inv, "type C invoices (simplified tax scheme) must not have taxes on lines")
+	})
+}
+
+func TestInvoiceCurrencyValidation(t *testing.T) {
+	t.Run("non-ARS currency without exchange rates", func(t *testing.T) {
+		inv := testInvoiceWithGoods(t)
+		inv.Currency = "USD"
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "[GOBL-AR-ARCA-V4-BILL-INVOICE-24] invoice must be in ARS or provide exchange rate for conversion")
+	})
+
+	t.Run("non-ARS currency with exchange rates", func(t *testing.T) {
+		inv := testInvoiceWithGoods(t)
+		inv.Currency = "USD"
+		inv.ExchangeRates = []*currency.ExchangeRate{
+			{
+				From:   "USD",
+				To:     "ARS",
+				Amount: num.MakeAmount(1050, 0),
+			},
+		}
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.NoError(t, err)
 	})
 }
 

--- a/addons/br/nfe/bill_invoices.go
+++ b/addons/br/nfe/bill_invoices.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/currency"
 	"github.com/invopop/gobl/num"
 	"github.com/invopop/gobl/org"
 	"github.com/invopop/gobl/regimes/br"
@@ -19,6 +20,7 @@ const (
 
 func billInvoiceRules() *rules.Set {
 	return rules.For(new(bill.Invoice),
+		rules.Assert("34", "invoice must be in BRL or provide exchange rate for conversion", currency.CanConvertTo(currency.BRL)),
 		// Supplier validation
 		rules.Field("supplier",
 			rules.Field("tax_id",

--- a/addons/br/nfe/bill_invoices_test.go
+++ b/addons/br/nfe/bill_invoices_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/invopop/gobl/addons/br/nfe"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/currency"
 	"github.com/invopop/gobl/num"
 	"github.com/invopop/gobl/org"
 	"github.com/invopop/gobl/pay"
@@ -425,6 +426,31 @@ func TestCustomerValidation(t *testing.T) {
 		inv.Customer.Addresses[0].Code = ""
 		err = rules.Validate(inv)
 		assert.ErrorContains(t, err, "customer address requires a postal code")
+	})
+}
+
+func TestInvoiceCurrencyValidation(t *testing.T) {
+	t.Run("non-BRL currency without exchange rates", func(t *testing.T) {
+		inv := validCalculatedInvoice(t)
+		inv.Currency = "USD"
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "[GOBL-BR-NFE-V4-BILL-INVOICE-34] invoice must be in BRL or provide exchange rate for conversion")
+	})
+
+	t.Run("non-BRL currency with exchange rates", func(t *testing.T) {
+		inv := validCalculatedInvoice(t)
+		inv.Currency = "USD"
+		inv.ExchangeRates = []*currency.ExchangeRate{
+			{
+				From:   "USD",
+				To:     "BRL",
+				Amount: num.MakeAmount(500, 2),
+			},
+		}
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.NoError(t, err)
 	})
 }
 

--- a/addons/br/nfse/bill_invoices.go
+++ b/addons/br/nfse/bill_invoices.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 
 	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/currency"
 	"github.com/invopop/gobl/org"
 	"github.com/invopop/gobl/regimes/br"
 	"github.com/invopop/gobl/rules"
@@ -24,6 +25,7 @@ var (
 
 func billInvoiceRules() *rules.Set {
 	return rules.For(new(bill.Invoice),
+		rules.Assert("17", "invoice must be in BRL or provide exchange rate for conversion", currency.CanConvertTo(currency.BRL)),
 		rules.Field("series",
 			rules.Assert("01", "series is required", is.Present),
 		),

--- a/addons/br/nfse/bill_invoices_test.go
+++ b/addons/br/nfse/bill_invoices_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/invopop/gobl/addons/br/nfse"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/currency"
 	"github.com/invopop/gobl/num"
 	"github.com/invopop/gobl/org"
 	"github.com/invopop/gobl/rules"
@@ -100,6 +101,35 @@ func TestInvoicesValidation(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestInvoiceCurrencyValidation(t *testing.T) {
+	t.Run("non-BRL currency without exchange rates", func(t *testing.T) {
+		inv := &bill.Invoice{
+			Series:   "SAMPLE",
+			Currency: "USD",
+		}
+		err := rules.Validate(inv, withAddonContext())
+		assert.ErrorContains(t, err, "[GOBL-BR-NFSE-V1-BILL-INVOICE-17] invoice must be in BRL or provide exchange rate for conversion")
+	})
+
+	t.Run("non-BRL currency with exchange rates", func(t *testing.T) {
+		inv := &bill.Invoice{
+			Series:   "SAMPLE",
+			Currency: "USD",
+			ExchangeRates: []*currency.ExchangeRate{
+				{
+					From:   "USD",
+					To:     "BRL",
+					Amount: num.MakeAmount(500, 2),
+				},
+			},
+		}
+		err := rules.Validate(inv, withAddonContext())
+		if err != nil {
+			assert.NotContains(t, err.Error(), "invoice must be in BRL or provide exchange rate for conversion")
+		}
+	})
 }
 
 func TestSuppliersValidation(t *testing.T) {

--- a/addons/co/dian/bill_invoices.go
+++ b/addons/co/dian/bill_invoices.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/currency"
 	"github.com/invopop/gobl/org"
 	"github.com/invopop/gobl/rules"
 	"github.com/invopop/gobl/rules/is"
@@ -47,6 +48,7 @@ func normalizeInvoiceParty(p *org.Party) {
 
 func billInvoiceRules() *rules.Set {
 	return rules.For(new(bill.Invoice),
+		rules.Assert("14", "invoice must be in COP or provide exchange rate for conversion", currency.CanConvertTo(currency.COP)),
 		// Code 01: invoice type restriction
 		rules.Assert("01", "invoice type must be one of standard, credit-note, debit-note, or proforma",
 			bill.InvoiceTypeIn(

--- a/addons/co/dian/bill_invoices_test.go
+++ b/addons/co/dian/bill_invoices_test.go
@@ -171,6 +171,31 @@ func TestBasicInvoiceValidation(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestInvoiceCurrencyValidation(t *testing.T) {
+	t.Run("non-COP currency without exchange rates", func(t *testing.T) {
+		inv := baseInvoice()
+		inv.Currency = "USD"
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "[GOBL-CO-DIAN-V2-BILL-INVOICE-14] invoice must be in COP or provide exchange rate for conversion")
+	})
+
+	t.Run("non-COP currency with exchange rates", func(t *testing.T) {
+		inv := baseInvoice()
+		inv.Currency = "USD"
+		inv.ExchangeRates = []*currency.ExchangeRate{
+			{
+				From:   "USD",
+				To:     "COP",
+				Amount: num.MakeAmount(4100, 0),
+			},
+		}
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.NoError(t, err)
+	})
+}
+
 func TestFiscalResponsibilityExtensionValidation(t *testing.T) {
 	// Colombian parties
 	inv := baseInvoice()

--- a/addons/es/facturae/bill_invoice.go
+++ b/addons/es/facturae/bill_invoice.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/currency"
 	"github.com/invopop/gobl/regimes/es"
 	"github.com/invopop/gobl/rules"
 	"github.com/invopop/gobl/rules/is"
@@ -23,6 +24,7 @@ var invoiceCorrectionDefinitions = tax.CorrectionSet{
 
 func billInvoiceRules() *rules.Set {
 	return rules.For(new(bill.Invoice),
+		rules.Assert("07", "invoice must be in EUR or provide exchange rate for conversion", currency.CanConvertTo(currency.EUR)),
 		rules.Field("customer",
 			rules.Field("tax_id",
 				rules.When(

--- a/addons/es/facturae/bill_invoice_test.go
+++ b/addons/es/facturae/bill_invoice_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/invopop/gobl/addons/es/facturae"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cal"
+	"github.com/invopop/gobl/currency"
 	"github.com/invopop/gobl/num"
 	"github.com/invopop/gobl/org"
 	"github.com/invopop/gobl/rules"
@@ -45,6 +46,30 @@ func TestInvoiceValidation(t *testing.T) {
 		assert.ErrorContains(t, err, "[GOBL-ES-FACTURAE-V3-BILL-INVOICE-03] ($.tax.ext) tax ext require 'es-facturae-doc-type' and 'es-facturae-invoice-class' extensions")
 	})
 
+	t.Run("non-EUR currency without exchange rates", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.SetRegime("ES")
+		inv.Currency = "USD"
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "[GOBL-ES-FACTURAE-V3-BILL-INVOICE-07] invoice must be in EUR or provide exchange rate for conversion")
+	})
+
+	t.Run("non-EUR currency with exchange rates", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.SetRegime("ES")
+		inv.Currency = "USD"
+		inv.ExchangeRates = []*currency.ExchangeRate{
+			{
+				From:   "USD",
+				To:     "EUR",
+				Amount: num.MakeAmount(875967, 6), // 0.875967
+			},
+		}
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.NoError(t, err)
+	})
 }
 
 func TestInvoicePrecedingValidation(t *testing.T) {

--- a/addons/es/sii/bill.go
+++ b/addons/es/sii/bill.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/currency"
 	"github.com/invopop/gobl/org"
 	"github.com/invopop/gobl/regimes/es"
 	"github.com/invopop/gobl/rules"
@@ -128,6 +129,7 @@ func normalizeBillLine(line *bill.Line) {
 
 func billInvoiceRules() *rules.Set {
 	return rules.For(new(bill.Invoice),
+		rules.Assert("15", "invoice must be in EUR or provide exchange rate for conversion", currency.CanConvertTo(currency.EUR)),
 		// Preceding documents
 		// Code 01: preceding required when corrective
 		rules.When(

--- a/addons/es/sii/bill_test.go
+++ b/addons/es/sii/bill_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cal"
 	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/currency"
 	"github.com/invopop/gobl/num"
 	"github.com/invopop/gobl/org"
 	"github.com/invopop/gobl/regimes/es"
@@ -450,6 +451,31 @@ func TestInvoiceValidation(t *testing.T) {
 		}
 		require.NoError(t, inv.Calculate())
 		require.NoError(t, rules.Validate(inv))
+	})
+
+	t.Run("non-EUR currency without exchange rates", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.SetRegime("ES")
+		inv.Currency = "USD"
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "[GOBL-ES-SII-V1-BILL-INVOICE-15] invoice must be in EUR or provide exchange rate for conversion")
+	})
+
+	t.Run("non-EUR currency with exchange rates", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.SetRegime("ES")
+		inv.Currency = "USD"
+		inv.ExchangeRates = []*currency.ExchangeRate{
+			{
+				From:   "USD",
+				To:     "EUR",
+				Amount: num.MakeAmount(875967, 6), // 0.875967
+			},
+		}
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.NoError(t, err)
 	})
 }
 

--- a/addons/es/tbai/bill.go
+++ b/addons/es/tbai/bill.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/currency"
 	"github.com/invopop/gobl/org"
 	"github.com/invopop/gobl/regimes/es"
 	"github.com/invopop/gobl/rules"
@@ -79,6 +80,7 @@ func normalizeBillLine(line *bill.Line) {
 
 func billInvoiceRules() *rules.Set {
 	return rules.For(new(bill.Invoice),
+		rules.Assert("09", "invoice must be in EUR or provide exchange rate for conversion", currency.CanConvertTo(currency.EUR)),
 		// Tax
 		// Code 01: tax required
 		// Code 02: region required in tax ext

--- a/addons/es/verifactu/bill.go
+++ b/addons/es/verifactu/bill.go
@@ -3,6 +3,7 @@ package verifactu
 import (
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/currency"
 	"github.com/invopop/gobl/org"
 	"github.com/invopop/gobl/regimes/es"
 	"github.com/invopop/gobl/rules"
@@ -110,6 +111,7 @@ func normalizeInvoicePartyIdentity(cus *org.Party) {
 
 func billInvoiceRules() *rules.Set {
 	return rules.For(new(bill.Invoice),
+		rules.Assert("16", "invoice must be in EUR or provide exchange rate for conversion", currency.CanConvertTo(currency.EUR)),
 		// Preceding documents
 		// Code 01: preceding required when corrective
 		rules.When(

--- a/addons/es/verifactu/bill_test.go
+++ b/addons/es/verifactu/bill_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/invopop/gobl/addons/es/verifactu"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cal"
+	"github.com/invopop/gobl/currency"
 	"github.com/invopop/gobl/num"
 	"github.com/invopop/gobl/org"
 	"github.com/invopop/gobl/rules"
@@ -476,6 +477,31 @@ func TestInvoiceValidation(t *testing.T) {
 		}
 		require.NoError(t, inv.Calculate())
 		require.NoError(t, rules.Validate(inv))
+	})
+
+	t.Run("non-EUR currency without exchange rates", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.SetRegime("ES")
+		inv.Currency = "USD"
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "[GOBL-ES-VERIFACTU-V1-BILL-INVOICE-16] invoice must be in EUR or provide exchange rate for conversion")
+	})
+
+	t.Run("non-EUR currency with exchange rates", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.SetRegime("ES")
+		inv.Currency = "USD"
+		inv.ExchangeRates = []*currency.ExchangeRate{
+			{
+				From:   "USD",
+				To:     "EUR",
+				Amount: num.MakeAmount(875967, 6), // 0.875967
+			},
+		}
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.NoError(t, err)
 	})
 
 }

--- a/addons/fr/choruspro/bill.go
+++ b/addons/fr/choruspro/bill.go
@@ -2,6 +2,7 @@ package choruspro
 
 import (
 	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/currency"
 	"github.com/invopop/gobl/rules"
 	"github.com/invopop/gobl/rules/is"
 	"github.com/invopop/gobl/tax"
@@ -44,6 +45,7 @@ func normalizeBillLine(line *bill.Line) {
 
 func billInvoiceRules() *rules.Set {
 	return rules.For(new(bill.Invoice),
+		rules.Assert("07", "invoice must be in EUR or provide exchange rate for conversion", currency.CanConvertTo(currency.EUR)),
 		// Customer validation (only when customer exists)
 		rules.Field("customer",
 			rules.Field("ext",

--- a/addons/fr/choruspro/bill_test.go
+++ b/addons/fr/choruspro/bill_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/invopop/gobl/addons/fr/choruspro"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/currency"
 	"github.com/invopop/gobl/num"
 	"github.com/invopop/gobl/org"
 	"github.com/invopop/gobl/pay"
@@ -174,6 +175,31 @@ func TestValidateInvoice(t *testing.T) {
 		assert.Equal(t, cbc.Code("A2"), inv.Tax.Ext.Get(choruspro.ExtKeyFramework))
 	})
 
+}
+
+func TestInvoiceCurrencyValidation(t *testing.T) {
+	t.Run("non-EUR currency without exchange rates", func(t *testing.T) {
+		inv := validInvoice()
+		inv.Currency = "USD"
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "[GOBL-FR-CHORUSPRO-V1-BILL-INVOICE-07] invoice must be in EUR or provide exchange rate for conversion")
+	})
+
+	t.Run("non-EUR currency with exchange rates", func(t *testing.T) {
+		inv := validInvoice()
+		inv.Currency = "USD"
+		inv.ExchangeRates = []*currency.ExchangeRate{
+			{
+				From:   "USD",
+				To:     "EUR",
+				Amount: num.MakeAmount(875967, 6),
+			},
+		}
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.NoError(t, err)
+	})
 }
 
 func TestNormalizeInvoice(t *testing.T) {

--- a/addons/fr/ctc/bill_invoices.go
+++ b/addons/fr/ctc/bill_invoices.go
@@ -8,6 +8,7 @@ import (
 	"github.com/invopop/gobl/catalogues/iso"
 	"github.com/invopop/gobl/catalogues/untdid"
 	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/currency"
 	"github.com/invopop/gobl/num"
 	"github.com/invopop/gobl/org"
 	"github.com/invopop/gobl/rules"
@@ -17,6 +18,7 @@ import (
 
 func billInvoiceRules() *rules.Set {
 	return rules.For(new(bill.Invoice),
+		rules.Assert("42", "invoice must be in EUR or provide exchange rate for conversion", currency.CanConvertTo(currency.EUR)),
 		// Invoice code validation (BR-FR-01/02) - cross-field: series + code
 		rules.Assert("01", "must be 1-35 characters, alphanumeric plus -+_/ (BR-FR-01/02), including the series",
 			is.Func("valid invoice code", invoiceCodeValid),

--- a/addons/fr/ctc/bill_test.go
+++ b/addons/fr/ctc/bill_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/invopop/gobl/catalogues/iso"
 	"github.com/invopop/gobl/catalogues/untdid"
 	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/currency"
 	"github.com/invopop/gobl/num"
 	"github.com/invopop/gobl/org"
 	"github.com/invopop/gobl/pay"
@@ -161,6 +162,29 @@ func TestInvoiceValidation(t *testing.T) {
 		inv := testInvoiceB2BStandard(t)
 		require.NoError(t, inv.Calculate())
 		require.NoError(t, rules.Validate(inv))
+	})
+
+	t.Run("non-EUR currency without exchange rates", func(t *testing.T) {
+		inv := testInvoiceB2BStandard(t)
+		inv.Currency = "USD"
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "[GOBL-FR-CTC-FLOW2-V1-BILL-INVOICE-42] invoice must be in EUR or provide exchange rate for conversion")
+	})
+
+	t.Run("non-EUR currency with exchange rates", func(t *testing.T) {
+		inv := testInvoiceB2BStandard(t)
+		inv.Currency = "USD"
+		inv.ExchangeRates = []*currency.ExchangeRate{
+			{
+				From:   "USD",
+				To:     "EUR",
+				Amount: num.MakeAmount(875967, 6),
+			},
+		}
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.NoError(t, err)
 	})
 
 	t.Run("invoice code too long", func(t *testing.T) {

--- a/addons/gr/mydata/bill_invoices.go
+++ b/addons/gr/mydata/bill_invoices.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/currency"
 	"github.com/invopop/gobl/head"
 	"github.com/invopop/gobl/num"
 	"github.com/invopop/gobl/regimes/gr"
@@ -15,6 +16,7 @@ import (
 
 func billInvoiceRules() *rules.Set {
 	return rules.For(new(bill.Invoice),
+		rules.Assert("19", "invoice must be in EUR or provide exchange rate for conversion", currency.CanConvertTo(currency.EUR)),
 		rules.Field("series",
 			rules.Assert("01", "series is required", is.Present),
 		),

--- a/addons/gr/mydata/bill_invoices_test.go
+++ b/addons/gr/mydata/bill_invoices_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/invopop/gobl/addons/gr/mydata"
 	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/currency"
 	"github.com/invopop/gobl/head"
 	"github.com/invopop/gobl/num"
 	"github.com/invopop/gobl/org"
@@ -91,6 +92,31 @@ func TestInvoiceValidation(t *testing.T) {
 	require.NoError(t, inv.Calculate())
 	err = rules.Validate(inv)
 	assert.ErrorContains(t, err, "payment instructions require 'gr-mydata-payment-means' extension")
+}
+
+func TestInvoiceCurrencyValidation(t *testing.T) {
+	t.Run("non-EUR currency without exchange rates", func(t *testing.T) {
+		inv := validInvoice()
+		inv.Currency = "USD"
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "[GOBL-GR-MYDATA-V1-BILL-INVOICE-19] invoice must be in EUR or provide exchange rate for conversion")
+	})
+
+	t.Run("non-EUR currency with exchange rates", func(t *testing.T) {
+		inv := validInvoice()
+		inv.Currency = "USD"
+		inv.ExchangeRates = []*currency.ExchangeRate{
+			{
+				From:   "USD",
+				To:     "EUR",
+				Amount: num.MakeAmount(875967, 6),
+			},
+		}
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.NoError(t, err)
+	})
 }
 
 func TestSimplifiedInvoiceValidation(t *testing.T) {

--- a/addons/it/sdi/bill.go
+++ b/addons/it/sdi/bill.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/currency"
 	"github.com/invopop/gobl/org"
 	"github.com/invopop/gobl/regimes/it"
 	"github.com/invopop/gobl/rules"
@@ -39,6 +40,7 @@ func normalizeSupplier(party *org.Party) {
 
 func billInvoiceRules() *rules.Set {
 	return rules.For(new(bill.Invoice),
+		rules.Assert("22", "invoice must be in EUR or provide exchange rate for conversion", currency.CanConvertTo(currency.EUR)),
 		rules.Field("tax",
 			rules.Assert("01", "tax is required", is.Present),
 			rules.Field("ext",

--- a/addons/it/sdi/bill_test.go
+++ b/addons/it/sdi/bill_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/invopop/gobl/addons/it/sdi"
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cal"
+	"github.com/invopop/gobl/currency"
 	"github.com/invopop/gobl/num"
 	"github.com/invopop/gobl/org"
 	"github.com/invopop/gobl/pay"
@@ -109,6 +110,29 @@ func TestInvoiceValidation(t *testing.T) {
 		inv.Tax.Ext = nil
 		err := rules.Validate(inv)
 		require.ErrorContains(t, err, "tax requires 'it-sdi-document-type' and 'it-sdi-format' extensions")
+	})
+
+	t.Run("non-EUR currency without exchange rates", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Currency = "USD"
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "[GOBL-IT-SDI-V1-BILL-INVOICE-22] invoice must be in EUR or provide exchange rate for conversion")
+	})
+
+	t.Run("non-EUR currency with exchange rates", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Currency = "USD"
+		inv.ExchangeRates = []*currency.ExchangeRate{
+			{
+				From:   "USD",
+				To:     "EUR",
+				Amount: num.MakeAmount(875967, 6),
+			},
+		}
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.NoError(t, err)
 	})
 }
 

--- a/addons/it/ticket/bill_invoices.go
+++ b/addons/it/ticket/bill_invoices.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/currency"
 	"github.com/invopop/gobl/rules"
 	"github.com/invopop/gobl/rules/is"
 	"github.com/invopop/gobl/tax"
@@ -34,6 +35,7 @@ func normalizeInvoice(inv *bill.Invoice) {
 
 func billInvoiceRules() *rules.Set {
 	return rules.For(new(bill.Invoice),
+		rules.Assert("08", "invoice must be in EUR or provide exchange rate for conversion", currency.CanConvertTo(currency.EUR)),
 		rules.Field("tax",
 			rules.Assert("01", "tax is required", is.Present),
 			rules.Field("prices_include",

--- a/addons/it/ticket/bill_invoices_test.go
+++ b/addons/it/ticket/bill_invoices_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cal"
 	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/currency"
 	"github.com/invopop/gobl/head"
 	"github.com/invopop/gobl/num"
 	"github.com/invopop/gobl/org"
@@ -113,6 +114,31 @@ func TestInvoiceValidation(t *testing.T) {
 		json, err := json.MarshalIndent(inv, "", "  ")
 		require.NoError(t, err)
 		t.Log(string(json))
+	})
+}
+
+func TestInvoiceCurrencyValidation(t *testing.T) {
+	t.Run("non-EUR currency without exchange rates", func(t *testing.T) {
+		inv := exampleStandardInvoice(t)
+		inv.Currency = "USD"
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "[GOBL-IT-TICKET-V1-BILL-INVOICE-08] invoice must be in EUR or provide exchange rate for conversion")
+	})
+
+	t.Run("non-EUR currency with exchange rates", func(t *testing.T) {
+		inv := exampleStandardInvoice(t)
+		inv.Currency = "USD"
+		inv.ExchangeRates = []*currency.ExchangeRate{
+			{
+				From:   "USD",
+				To:     "EUR",
+				Amount: num.MakeAmount(875967, 6),
+			},
+		}
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.NoError(t, err)
 	})
 }
 

--- a/addons/mx/cfdi/bill_invoice.go
+++ b/addons/mx/cfdi/bill_invoice.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cal"
+	"github.com/invopop/gobl/currency"
 	"github.com/invopop/gobl/head"
 	"github.com/invopop/gobl/num"
 	"github.com/invopop/gobl/org"
@@ -37,6 +38,7 @@ func normalizeInvoiceIssueDateAndTime(inv *bill.Invoice) {
 
 func billInvoiceRules() *rules.Set {
 	return rules.For(new(bill.Invoice),
+		rules.Assert("27", "invoice must be in MXN or provide exchange rate for conversion", currency.CanConvertTo(currency.MXN)),
 		// Tax extensions
 		rules.Field("tax",
 			rules.Field("ext",

--- a/addons/mx/cfdi/bill_invoice_test.go
+++ b/addons/mx/cfdi/bill_invoice_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cal"
 	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/currency"
 	"github.com/invopop/gobl/head"
 	"github.com/invopop/gobl/num"
 	"github.com/invopop/gobl/org"
@@ -153,6 +154,31 @@ func TestValidInvoice(t *testing.T) {
 		}
 		require.NoError(t, inv.Calculate())
 		require.ErrorContains(t, rules.Validate(inv), "extensions must all be present or all absent")
+	})
+}
+
+func TestInvoiceCurrencyValidation(t *testing.T) {
+	t.Run("non-MXN currency without exchange rates", func(t *testing.T) {
+		inv := validInvoice()
+		inv.Currency = "USD"
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "[GOBL-MX-CFDI-V4-BILL-INVOICE-27] invoice must be in MXN or provide exchange rate for conversion")
+	})
+
+	t.Run("non-MXN currency with exchange rates", func(t *testing.T) {
+		inv := validInvoice()
+		inv.Currency = "USD"
+		inv.ExchangeRates = []*currency.ExchangeRate{
+			{
+				From:   "USD",
+				To:     "MXN",
+				Amount: num.MakeAmount(1800, 2),
+			},
+		}
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.NoError(t, err)
 	})
 }
 

--- a/addons/pl/favat/bill.go
+++ b/addons/pl/favat/bill.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/currency"
 	"github.com/invopop/gobl/l10n"
 	"github.com/invopop/gobl/org"
 	"github.com/invopop/gobl/rules"
@@ -37,6 +38,7 @@ func isExemptionNote(n *org.Note) bool {
 
 func billInvoiceRules() *rules.Set {
 	return rules.For(new(bill.Invoice),
+		rules.Assert("15", "invoice must be in PLN or provide exchange rate for conversion", currency.CanConvertTo(currency.PLN)),
 		rules.Field("type",
 			rules.Assert("01", "invoice type must be standard or credit-note",
 				is.In(bill.InvoiceTypeStandard, bill.InvoiceTypeCreditNote),

--- a/addons/pl/favat/bill_test.go
+++ b/addons/pl/favat/bill_test.go
@@ -137,6 +137,31 @@ func TestBasicStandardInvoiceValidation(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestInvoiceCurrencyValidation(t *testing.T) {
+	t.Run("non-PLN currency without exchange rates", func(t *testing.T) {
+		inv := standardInvoice()
+		inv.Currency = "USD"
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "[GOBL-PL-FAVAT-V3-BILL-INVOICE-15] invoice must be in PLN or provide exchange rate for conversion")
+	})
+
+	t.Run("non-PLN currency with exchange rates", func(t *testing.T) {
+		inv := standardInvoice()
+		inv.Currency = "USD"
+		inv.ExchangeRates = []*currency.ExchangeRate{
+			{
+				From:   "USD",
+				To:     "PLN",
+				Amount: num.MakeAmount(400, 2),
+			},
+		}
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.NoError(t, err)
+	})
+}
+
 func TestExemptStandardInvoiceValidation(t *testing.T) {
 	inv := standardInvoice()
 	inv.Tax = &bill.Tax{

--- a/addons/pt/saft/invoices.go
+++ b/addons/pt/saft/invoices.go
@@ -10,6 +10,7 @@ import (
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cal"
 	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/currency"
 	"github.com/invopop/gobl/num"
 	"github.com/invopop/gobl/rules"
 	"github.com/invopop/gobl/rules/is"
@@ -96,6 +97,7 @@ func normalizeInvoiceValueDate(inv *bill.Invoice) {
 
 func billInvoiceRules() *rules.Set {
 	return rules.For(new(bill.Invoice),
+		rules.Assert("15", "invoice must be in EUR or provide exchange rate for conversion", currency.CanConvertTo(currency.EUR)),
 		// Tax ext must have either work type or invoice type
 		rules.Assert("01",
 			fmt.Sprintf("either '%s' or '%s' must be set", ExtKeyWorkType, ExtKeyInvoiceType),

--- a/addons/pt/saft/invoices_test.go
+++ b/addons/pt/saft/invoices_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/cal"
 	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/currency"
 	"github.com/invopop/gobl/num"
 	"github.com/invopop/gobl/org"
 	"github.com/invopop/gobl/pay"
@@ -120,6 +121,25 @@ func TestInvoiceValidation(t *testing.T) {
 		inv := calculatedInvoice(t)
 		inv.Lines[0].Taxes = nil
 		assert.ErrorContains(t, rules.Validate(inv), "line taxes must include VAT category")
+	})
+
+	t.Run("non-EUR currency without exchange rates", func(t *testing.T) {
+		inv := calculatedInvoice(t)
+		inv.Currency = "USD"
+		assert.ErrorContains(t, rules.Validate(inv), "[GOBL-PT-SAFT-V1-BILL-INVOICE-15] invoice must be in EUR or provide exchange rate for conversion")
+	})
+
+	t.Run("non-EUR currency with exchange rates", func(t *testing.T) {
+		inv := calculatedInvoice(t)
+		inv.Currency = "USD"
+		inv.ExchangeRates = []*currency.ExchangeRate{
+			{
+				From:   "USD",
+				To:     "EUR",
+				Amount: num.MakeAmount(875967, 6),
+			},
+		}
+		assert.NoError(t, rules.Validate(inv))
 	})
 
 	t.Run("missing source billing", func(t *testing.T) {

--- a/bill/calculator.go
+++ b/bill/calculator.go
@@ -22,14 +22,17 @@ type billable interface {
 	HasTags(tags ...cbc.Key) bool
 	GetTags() []cbc.Key
 
+	// Public methods
+	GetCurrency() currency.Code
+	GetExchangeRates() []*currency.ExchangeRate
+
+	// private methods
 	getIssueDate() cal.Date
 	getIssueTime() *cal.Time
 	getValueDate() *cal.Date
 	getTax() *Tax
 	getPreceding() []*org.DocumentRef
 	getCustomer() *org.Party
-	getCurrency() currency.Code
-	getExchangeRates() []*currency.ExchangeRate
 	getLines() []*Line
 	getDiscounts() []*Discount
 	getCharges() []*Charge
@@ -37,6 +40,7 @@ type billable interface {
 	getTotals() *Totals
 	getComplements() []*schema.Object
 
+	// private setters
 	setIssueDate(cal.Date)
 	setIssueTime(*cal.Time)
 	setCurrency(currency.Code)
@@ -48,22 +52,13 @@ func calculate(doc billable) error {
 	date := calculateIssueDateAndTime(r, doc)
 
 	// Convert empty or invalid currency to the regime's currency
-	if doc.getCurrency() == currency.CodeEmpty || doc.getCurrency().Def() == nil {
+	if doc.GetCurrency() == currency.CodeEmpty || doc.GetCurrency().Def() == nil {
 		if r == nil {
-			return fmt.Errorf("currency: missing")
+			return fmt.Errorf("currency: missing or invalid")
 		}
 		doc.setCurrency(r.Currency)
 	}
-	cur := doc.getCurrency()
-
-	// Check exchange rate is available if regime uses a different currency
-	if r != nil && r.Currency != currency.CodeEmpty && cur != r.Currency {
-		rates := doc.getExchangeRates()
-		if currency.MatchExchangeRate(rates, cur, r.Currency) == nil &&
-			currency.MatchExchangeRate(rates, r.Currency, cur) == nil {
-			return fmt.Errorf("currency: no exchange rate defined for '%v' to '%v'", cur, r.Currency)
-		}
-	}
+	cur := doc.GetCurrency()
 
 	if doc.HasTags(tax.TagBypass) {
 		// Stop all further calculations
@@ -107,7 +102,7 @@ func calculate(doc billable) error {
 	calculateOrgDocumentRefs(doc.getPreceding(), cur, rr)
 
 	// Lines
-	if err := calculateLines(doc.getLines(), cur, doc.getExchangeRates(), rr); err != nil {
+	if err := calculateLines(doc.getLines(), cur, doc.GetExchangeRates(), rr); err != nil {
 		return fmt.Errorf("lines: %w", err)
 	}
 	t.Sum = calculateLineSum(doc.getLines(), cur)
@@ -138,7 +133,7 @@ func calculate(doc billable) error {
 	// Now figure out the tax totals
 	t.Taxes = new(tax.Total)
 	tc := &tax.TotalCalculator{
-		Currency: doc.getCurrency(),
+		Currency: doc.GetCurrency(),
 		Rounding: rr,
 		Country:  r.GetCountry(),
 		Date:     *date,

--- a/bill/delivery.go
+++ b/bill/delivery.go
@@ -287,6 +287,16 @@ func (dlv *Delivery) ConvertInto(cur currency.Code) (*Delivery, error) {
 
 /** Calculation Interface Methods **/
 
+// GetCurrency provides the documents current currency code.
+func (dlv *Delivery) GetCurrency() currency.Code {
+	return dlv.Currency
+}
+
+// GetExchangeRates provides the documents exchange rates that can be used for currency conversion.
+func (dlv *Delivery) GetExchangeRates() []*currency.ExchangeRate {
+	return dlv.ExchangeRates
+}
+
 func (dlv *Delivery) getIssueDate() cal.Date {
 	return dlv.IssueDate
 }
@@ -304,12 +314,6 @@ func (dlv *Delivery) getPreceding() []*org.DocumentRef {
 }
 func (dlv *Delivery) getCustomer() *org.Party {
 	return dlv.Customer
-}
-func (dlv *Delivery) getCurrency() currency.Code {
-	return dlv.Currency
-}
-func (dlv *Delivery) getExchangeRates() []*currency.ExchangeRate {
-	return dlv.ExchangeRates
 }
 func (dlv *Delivery) getLines() []*Line {
 	return dlv.Lines

--- a/bill/invoice.go
+++ b/bill/invoice.go
@@ -339,6 +339,16 @@ func (inv *Invoice) RemoveIncludedTaxes() error {
 
 /** Calculation Interface Methods **/
 
+// GetCurrency provides the documents current currency code.
+func (inv *Invoice) GetCurrency() currency.Code {
+	return inv.Currency
+}
+
+// GetExchangeRates provides the documents exchange rates that can be used for currency conversion.
+func (inv *Invoice) GetExchangeRates() []*currency.ExchangeRate {
+	return inv.ExchangeRates
+}
+
 func (inv *Invoice) getIssueDate() cal.Date {
 	return inv.IssueDate
 }
@@ -356,12 +366,6 @@ func (inv *Invoice) getPreceding() []*org.DocumentRef {
 }
 func (inv *Invoice) getCustomer() *org.Party {
 	return inv.Customer
-}
-func (inv *Invoice) getCurrency() currency.Code {
-	return inv.Currency
-}
-func (inv *Invoice) getExchangeRates() []*currency.ExchangeRate {
-	return inv.ExchangeRates
 }
 func (inv *Invoice) getLines() []*Line {
 	return inv.Lines

--- a/bill/invoice_test.go
+++ b/bill/invoice_test.go
@@ -131,7 +131,9 @@ func TestInvoiceCurrencyValidation(t *testing.T) {
 	inv := baseInvoice(t, lines...)
 	inv.Currency = currency.USD
 
-	assert.ErrorContains(t, inv.Calculate(), "currency: no exchange rate defined for 'USD' to 'EUR'")
+	// Calculate no longer enforces the regime's currency; that is now handled
+	// by addon-level rules via currency.CanConvertTo.
+	assert.NoError(t, inv.Calculate())
 
 	inv.ExchangeRates = []*currency.ExchangeRate{
 		{

--- a/bill/order.go
+++ b/bill/order.go
@@ -272,6 +272,16 @@ func (ord *Order) ConvertInto(cur currency.Code) (*Order, error) {
 
 /** Calculation Interface Methods **/
 
+// GetCurrency provides the documents current currency code.
+func (ord *Order) GetCurrency() currency.Code {
+	return ord.Currency
+}
+
+// GetExchangeRates provides the documents exchange rates that can be used for currency conversion.
+func (ord *Order) GetExchangeRates() []*currency.ExchangeRate {
+	return ord.ExchangeRates
+}
+
 func (ord *Order) getIssueDate() cal.Date {
 	return ord.IssueDate
 }
@@ -289,12 +299,6 @@ func (ord *Order) getPreceding() []*org.DocumentRef {
 }
 func (ord *Order) getCustomer() *org.Party {
 	return ord.Customer
-}
-func (ord *Order) getCurrency() currency.Code {
-	return ord.Currency
-}
-func (ord *Order) getExchangeRates() []*currency.ExchangeRate {
-	return ord.ExchangeRates
 }
 func (ord *Order) getLines() []*Line {
 	return ord.Lines

--- a/currency/code.go
+++ b/currency/code.go
@@ -3,6 +3,7 @@ package currency
 import (
 	"fmt"
 
+	"github.com/invopop/gobl/rules/is"
 	"github.com/invopop/jsonschema"
 )
 
@@ -17,6 +18,15 @@ const CodeEmpty Code = ""
 func (c Code) Validate() error {
 	return inDefinitions(c)
 }
+
+// IsCodeDefined provides a rule validation that ensures the currency code is
+// defined in the GOBL source.
+var IsCodeDefined = is.Func("valid currency code", func(val any) bool {
+	if c, ok := val.(Code); ok {
+		return c == CodeEmpty || Get(c) != nil
+	}
+	return false
+})
 
 func inDefinitions(code Code) error {
 	if code == CodeEmpty {
@@ -36,6 +46,16 @@ func (c Code) Def() *Def {
 // String provides the currency code as a string.
 func (c Code) String() string {
 	return string(c)
+}
+
+// In checks if the code is in the provided list of codes.
+func (c Code) In(codes ...Code) bool {
+	for _, v := range codes {
+		if c == v {
+			return true
+		}
+	}
+	return false
 }
 
 // JSONSchema provides a representation of the struct for usage in Schema.

--- a/currency/code_test.go
+++ b/currency/code_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/invopop/gobl/currency"
+	"github.com/invopop/gobl/rules"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -24,6 +25,25 @@ func TestCode(t *testing.T) {
 	err := c.Validate()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "currency code FOOO not defined")
+}
+
+func TestCodeIn(t *testing.T) {
+	c := currency.USD
+	assert.True(t, c.In(currency.USD, currency.EUR))
+	assert.False(t, c.In(currency.EUR, currency.GBP))
+}
+
+func TestCodeRules(t *testing.T) {
+	r := currency.IsCodeDefined
+	assert.True(t, r.Check(currency.USD))
+	assert.False(t, r.Check("FOO"))
+
+	t.Run("rules registry check", func(t *testing.T) {
+		x := currency.USD
+		assert.NoError(t, rules.Validate(x))
+		x = "FOO"
+		assert.ErrorContains(t, rules.Validate(x), "[GOBL-CURRENCY-CODE-01] currency code must be defined in GOBL")
+	})
 }
 
 func TestCodeJSONSchema(t *testing.T) {

--- a/currency/currency.go
+++ b/currency/currency.go
@@ -23,8 +23,15 @@ func init() {
 	rules.Register(
 		"currency",
 		rules.GOBL.Add("CURRENCY"),
+		codeRules(),
 		amountRules(),
 		exchangeRateRules(),
+	)
+}
+
+func codeRules() *rules.Set {
+	return rules.For(Code(""),
+		rules.AssertIfPresent("01", "currency code must be defined in GOBL", IsCodeDefined),
 	)
 }
 

--- a/currency/exchange_rate.go
+++ b/currency/exchange_rate.go
@@ -1,9 +1,14 @@
 package currency
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/invopop/gobl/cal"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/num"
+	"github.com/invopop/gobl/rules"
+	"github.com/invopop/gobl/rules/is"
 )
 
 // ExchangeRate contains data on the rate to be used when converting amounts from
@@ -49,15 +54,44 @@ func (er *ExchangeRate) Convert(amount num.Amount) num.Amount {
 	return a.Rescale(z.Exp()) // ensure scale always matches destination currency
 }
 
+type exchangeableObject interface {
+	GetCurrency() Code
+	GetExchangeRates() []*ExchangeRate
+}
+
+// CanConvertTo provides a special rule test that can be used to ensure that the object
+// being tested has enough details to be able to convert from its base currency into
+// at least one of the provided codes.
+func CanConvertTo(to ...Code) rules.Test {
+	codes := make([]string, len(to))
+	for i, c := range to {
+		codes[i] = c.String()
+	}
+	return is.Func(fmt.Sprintf("can convert to [%s]", strings.Join(codes, ", ")), func(val any) bool {
+		o, ok := val.(exchangeableObject)
+		if !ok {
+			return false
+		}
+		if o.GetCurrency().In(to...) {
+			return true
+		}
+		if MatchExchangeRate(o.GetExchangeRates(), o.GetCurrency(), to...) != nil {
+			return true
+		}
+		return false
+	})
+}
+
 // MatchExchangeRate will attempt to find the matching exchange rate that
 // will convert from one currency into another. Will return nil if no
-// match is found or the currencies are the same.
-func MatchExchangeRate(rates []*ExchangeRate, from, to Code) *ExchangeRate {
-	if from == to {
+// match is found or the currencies are the same. When using exchange rates
+// any multiple potential target currencies, the first will be provided.
+func MatchExchangeRate(rates []*ExchangeRate, from Code, to ...Code) *ExchangeRate {
+	if from.In(to...) {
 		return nil
 	}
 	for _, rate := range rates {
-		if rate.From == from && rate.To == to {
+		if rate.From == from && rate.To.In(to...) {
 			return rate
 		}
 	}

--- a/currency/exchange_rate.go
+++ b/currency/exchange_rate.go
@@ -61,8 +61,11 @@ type exchangeableObject interface {
 
 // CanConvertTo provides a special rule test that can be used to ensure that the object
 // being tested has enough details to be able to convert from its base currency into
-// at least one of the provided codes.
+// at least one of the provided codes. Panics if called with no target currencies.
 func CanConvertTo(to ...Code) rules.Test {
+	if len(to) == 0 {
+		panic("currency.CanConvertTo requires at least one target currency")
+	}
 	codes := make([]string, len(to))
 	for i, c := range to {
 		codes[i] = c.String()
@@ -84,8 +87,9 @@ func CanConvertTo(to ...Code) rules.Test {
 
 // MatchExchangeRate will attempt to find the matching exchange rate that
 // will convert from one currency into another. Will return nil if no
-// match is found or the currencies are the same. When using exchange rates
-// any multiple potential target currencies, the first will be provided.
+// match is found or the "from" currency is itself one of the target
+// currencies. When multiple target currencies are provided, the first
+// rate in rates whose destination matches any of them is returned.
 func MatchExchangeRate(rates []*ExchangeRate, from Code, to ...Code) *ExchangeRate {
 	if from.In(to...) {
 		return nil

--- a/currency/exchange_rate_test.go
+++ b/currency/exchange_rate_test.go
@@ -91,6 +91,49 @@ func TestExchangeRateConvert(t *testing.T) {
 	assert.Equal(t, "100629", a.String())
 }
 
+type convertible struct {
+	cur   currency.Code
+	rates []*currency.ExchangeRate
+}
+
+func (c *convertible) GetCurrency() currency.Code                 { return c.cur }
+func (c *convertible) GetExchangeRates() []*currency.ExchangeRate { return c.rates }
+
+func TestCanConvertTo(t *testing.T) {
+	test := currency.CanConvertTo(currency.EUR)
+	assert.Equal(t, "can convert to [EUR]", test.String())
+
+	t.Run("same currency", func(t *testing.T) {
+		obj := &convertible{cur: currency.EUR}
+		assert.True(t, test.Check(obj))
+	})
+
+	t.Run("matching exchange rate", func(t *testing.T) {
+		obj := &convertible{cur: currency.USD, rates: sampleRates()}
+		assert.True(t, test.Check(obj))
+	})
+
+	t.Run("no matching exchange rate", func(t *testing.T) {
+		obj := &convertible{cur: currency.GBP, rates: sampleRates()}
+		assert.False(t, test.Check(obj))
+	})
+
+	t.Run("no exchange rates", func(t *testing.T) {
+		obj := &convertible{cur: currency.USD}
+		assert.False(t, test.Check(obj))
+	})
+
+	t.Run("multiple target currencies", func(t *testing.T) {
+		multi := currency.CanConvertTo(currency.EUR, currency.GBP)
+		obj := &convertible{cur: currency.USD, rates: sampleRates()}
+		assert.True(t, multi.Check(obj))
+	})
+
+	t.Run("non-exchangeable value", func(t *testing.T) {
+		assert.False(t, test.Check("not an object"))
+	})
+}
+
 func TestConvert(t *testing.T) {
 	rates := sampleRates()
 	a := num.MakeAmount(10000, 2)

--- a/examples/es/invoice-es-usd-no-fx.yaml
+++ b/examples/es/invoice-es-usd-no-fx.yaml
@@ -1,0 +1,46 @@
+$schema: "https://gobl.org/draft-0/bill/invoice"
+uuid: "3aea7b56-59d8-4beb-90bd-f8f280d852a0"
+currency: "USD"
+issue_date: "2024-05-09"
+series: "EXPORT"
+code: "001"
+
+supplier:
+  tax_id:
+    country: "ES"
+    code: "B98602642" # random
+  name: "Provide One S.L."
+  emails:
+    - addr: "billing@example.com"
+  addresses:
+    - num: "42"
+      street: "Calle Pradillo"
+      locality: "Madrid"
+      region: "Madrid"
+      code: "28002"
+      country: "ES"
+
+customer:
+  tax_id:
+    country: "US"
+  name: "Sample Consumer Inc."
+
+lines:
+  - quantity: 20
+    item:
+      name: "Development services from Spain"
+      price: "90.00"
+      unit: "h"
+    discounts:
+      - percent: "10%"
+        reason: "Special discount"
+    taxes:
+      - cat: VAT
+        rate: standard
+  - quantity: 1
+    item:
+      name: "Financial service"
+      price: "10.00"
+    taxes:
+      - cat: VAT
+        rate: zero

--- a/examples/es/out/invoice-es-usd-no-fx.json
+++ b/examples/es/out/invoice-es-usd-no-fx.json
@@ -1,0 +1,123 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
+		"dig": {
+			"alg": "sha256",
+			"val": "36d07f41c4e58fabb290c66f033f13eb9ae6d695638ca8d704e4668528451de2"
+		}
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"$regime": "ES",
+		"uuid": "3aea7b56-59d8-4beb-90bd-f8f280d852a0",
+		"type": "standard",
+		"series": "EXPORT",
+		"code": "001",
+		"issue_date": "2024-05-09",
+		"currency": "USD",
+		"supplier": {
+			"name": "Provide One S.L.",
+			"tax_id": {
+				"country": "ES",
+				"code": "B98602642"
+			},
+			"addresses": [
+				{
+					"num": "42",
+					"street": "Calle Pradillo",
+					"locality": "Madrid",
+					"region": "Madrid",
+					"code": "28002",
+					"country": "ES"
+				}
+			],
+			"emails": [
+				{
+					"addr": "billing@example.com"
+				}
+			]
+		},
+		"customer": {
+			"name": "Sample Consumer Inc.",
+			"tax_id": {
+				"country": "US"
+			}
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "20",
+				"item": {
+					"name": "Development services from Spain",
+					"price": "90.00",
+					"unit": "h"
+				},
+				"sum": "1800.00",
+				"discounts": [
+					{
+						"reason": "Special discount",
+						"percent": "10%",
+						"amount": "180.00"
+					}
+				],
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "general",
+						"percent": "21.0%"
+					}
+				],
+				"total": "1620.00"
+			},
+			{
+				"i": 2,
+				"quantity": "1",
+				"item": {
+					"name": "Financial service",
+					"price": "10.00"
+				},
+				"sum": "10.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "zero",
+						"percent": "0%"
+					}
+				],
+				"total": "10.00"
+			}
+		],
+		"totals": {
+			"sum": "1630.00",
+			"total": "1630.00",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"base": "1620.00",
+								"percent": "21.0%",
+								"amount": "340.20"
+							},
+							{
+								"key": "zero",
+								"base": "10.00",
+								"percent": "0%",
+								"amount": "0.00"
+							}
+						],
+						"amount": "340.20"
+					}
+				],
+				"sum": "340.20"
+			},
+			"tax": "340.20",
+			"total_with_tax": "1970.20",
+			"payable": "1970.20"
+		}
+	}
+}

--- a/regimes/es/bill_invoices_test.go
+++ b/regimes/es/bill_invoices_test.go
@@ -23,4 +23,5 @@ func TestInvoiceValidation(t *testing.T) {
 		err := rules.Validate(inv)
 		assert.ErrorContains(t, err, "[GOBL-ES-BILL-INVOICE-02]")
 	})
+
 }


### PR DESCRIPTION
- Removed the requirement for an exchange rate to be defined for the regime's currency.
- `currency` now provides a `CanConvertTo` tester method.
- Currency codes are now checked to ensure they have their own code.

## Pre-Review Checklist

- [ ] Read the CONTRIBUTING.md guide.
- [ ] Performed a self-review of my code.
- [ ] Added thorough tests with at **least** 90% code coverage.
- [ ] Modified or created example GOBL documents to show my changes in use, if appropriate.
- [ ] Added links to the source of the changes in tax regimes or addons, either structured or in the comments.
- [ ] Run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [ ] Reviewed and fixed all linter warnings.
- [ ] Been obsessive with pointer nil checks to avoid panics.
- [ ] Updated the CHANGELOG.md with an overview of my changes.

And if you are part of the org:
- [ ] Requested a review from Copilot and fixed or dismissed (with a reason) all the feedback raised.
- [ ] Requested a review from @samlown.
