### PR TITLE
Drop addon version from rule fault codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Changed
 
 - `bill`: removed the default exchange-rate / regime-currency conversion check; addons now enforce currency convertibility where required.
+- `addons`: **breaking**: rule fault codes no longer include the addon version segment. `GOBL-AR-ARCA-V4-BILL-INVOICE-24` is now `GOBL-AR-ARCA-BILL-INVOICE-24`. Generated rule files in `data/rules/` are likewise unversioned (`ar-arca.json`, not `ar-arca-v4.json`). Each addon package now exposes a `Key` constant for the unversioned family; version constants such as `V4` are derived from it. Assertion IDs are now guaranteed stable across versions of an addon family — preserved rules keep their numeric IDs on version bumps, and an ID must never be reassigned to a different rule. Consumers pinning fault-code strings should drop the version segment.
 
 ### Added
 

--- a/addons/ar/arca/arca.go
+++ b/addons/ar/arca/arca.go
@@ -11,8 +11,13 @@ import (
 )
 
 const (
+	// Key identifies the ARCA addon family. Individual versions append a
+	// suffix; the family key is used as the fault-code namespace so that
+	// rules that carry across versions keep stable codes.
+	Key cbc.Key = "ar-arca"
+
 	// V4 for ARCA version 4
-	V4 cbc.Key = "ar-arca-v4"
+	V4 cbc.Key = Key + "-v4"
 )
 
 // ARCA Official Codes to include in stamps
@@ -28,8 +33,8 @@ const (
 func init() {
 	tax.RegisterAddonDef(newAddon())
 	rules.RegisterWithGuard(
-		V4.String(),
-		rules.GOBL.Add("AR-ARCA-V4"),
+		Key.String(),
+		rules.GOBL.Add("AR-ARCA"),
 		is.InContext(tax.AddonIn(V4)),
 		billInvoiceRules(),
 		billChargeRules(),

--- a/addons/ar/arca/bill_invoice_test.go
+++ b/addons/ar/arca/bill_invoice_test.go
@@ -1437,7 +1437,7 @@ func TestInvoiceCurrencyValidation(t *testing.T) {
 		inv.Currency = "USD"
 		require.NoError(t, inv.Calculate())
 		err := rules.Validate(inv)
-		assert.ErrorContains(t, err, "[GOBL-AR-ARCA-V4-BILL-INVOICE-24] invoice must be in ARS or provide exchange rate for conversion")
+		assert.ErrorContains(t, err, "[GOBL-AR-ARCA-BILL-INVOICE-24] invoice must be in ARS or provide exchange rate for conversion")
 	})
 
 	t.Run("non-ARS currency with exchange rates", func(t *testing.T) {

--- a/addons/br/nfe/bill_invoices_test.go
+++ b/addons/br/nfe/bill_invoices_test.go
@@ -435,7 +435,7 @@ func TestInvoiceCurrencyValidation(t *testing.T) {
 		inv.Currency = "USD"
 		require.NoError(t, inv.Calculate())
 		err := rules.Validate(inv)
-		assert.ErrorContains(t, err, "[GOBL-BR-NFE-V4-BILL-INVOICE-34] invoice must be in BRL or provide exchange rate for conversion")
+		assert.ErrorContains(t, err, "[GOBL-BR-NFE-BILL-INVOICE-34] invoice must be in BRL or provide exchange rate for conversion")
 	})
 
 	t.Run("non-BRL currency with exchange rates", func(t *testing.T) {

--- a/addons/br/nfe/nfe.go
+++ b/addons/br/nfe/nfe.go
@@ -12,15 +12,20 @@ import (
 )
 
 const (
+	// Key identifies the NF-e addon family. Individual versions append a
+	// suffix; the family key is used as the fault-code namespace so that
+	// rules that carry across versions keep stable codes.
+	Key cbc.Key = "br-nfe"
+
 	// V4 is the key for the NF-e 4.00 layout
-	V4 cbc.Key = "br-nfe-v4"
+	V4 cbc.Key = Key + "-v4"
 )
 
 func init() {
 	tax.RegisterAddonDef(newAddon())
 	rules.RegisterWithGuard(
-		V4.String(),
-		rules.GOBL.Add("BR-NFE-V4"),
+		Key.String(),
+		rules.GOBL.Add("BR-NFE"),
 		is.InContext(tax.AddonIn(V4)),
 		billInvoiceRules(),
 		billLineRules(),

--- a/addons/br/nfse/bill_invoices_test.go
+++ b/addons/br/nfse/bill_invoices_test.go
@@ -110,7 +110,7 @@ func TestInvoiceCurrencyValidation(t *testing.T) {
 			Currency: "USD",
 		}
 		err := rules.Validate(inv, withAddonContext())
-		assert.ErrorContains(t, err, "[GOBL-BR-NFSE-V1-BILL-INVOICE-17] invoice must be in BRL or provide exchange rate for conversion")
+		assert.ErrorContains(t, err, "[GOBL-BR-NFSE-BILL-INVOICE-17] invoice must be in BRL or provide exchange rate for conversion")
 	})
 
 	t.Run("non-BRL currency with exchange rates", func(t *testing.T) {

--- a/addons/br/nfse/nfse.go
+++ b/addons/br/nfse/nfse.go
@@ -12,15 +12,20 @@ import (
 )
 
 const (
+	// Key identifies the NFS-e addon family. Individual versions append a
+	// suffix; the family key is used as the fault-code namespace so that
+	// rules that carry across versions keep stable codes.
+	Key cbc.Key = "br-nfse"
+
 	// V1 identifies the NFS-e addon version
-	V1 cbc.Key = "br-nfse-v1"
+	V1 cbc.Key = Key + "-v1"
 )
 
 func init() {
 	tax.RegisterAddonDef(newAddon())
 	rules.RegisterWithGuard(
-		V1.String(),
-		rules.GOBL.Add("BR-NFSE-V1"),
+		Key.String(),
+		rules.GOBL.Add("BR-NFSE"),
 		is.InContext(tax.AddonIn(V1)),
 		billInvoiceRules(),
 		billLineRules(),

--- a/addons/co/dian/bill_invoices_test.go
+++ b/addons/co/dian/bill_invoices_test.go
@@ -177,7 +177,7 @@ func TestInvoiceCurrencyValidation(t *testing.T) {
 		inv.Currency = "USD"
 		require.NoError(t, inv.Calculate())
 		err := rules.Validate(inv)
-		assert.ErrorContains(t, err, "[GOBL-CO-DIAN-V2-BILL-INVOICE-14] invoice must be in COP or provide exchange rate for conversion")
+		assert.ErrorContains(t, err, "[GOBL-CO-DIAN-BILL-INVOICE-14] invoice must be in COP or provide exchange rate for conversion")
 	})
 
 	t.Run("non-COP currency with exchange rates", func(t *testing.T) {

--- a/addons/co/dian/dian.go
+++ b/addons/co/dian/dian.go
@@ -12,8 +12,13 @@ import (
 )
 
 const (
+	// Key identifies the DIAN addon family. Individual versions append a
+	// suffix; the family key is used as the fault-code namespace so that
+	// rules that carry across versions keep stable codes.
+	Key cbc.Key = "co-dian"
+
 	// V2 for DIAN UBL 2.1 in Colombia
-	V2 cbc.Key = "co-dian-v2"
+	V2 cbc.Key = Key + "-v2"
 )
 
 // DIAN official codes to include in stamps.
@@ -25,8 +30,8 @@ const (
 func init() {
 	tax.RegisterAddonDef(newAddon())
 	rules.RegisterWithGuard(
-		V2.String(),
-		rules.GOBL.Add("CO-DIAN-V2"),
+		Key.String(),
+		rules.GOBL.Add("CO-DIAN"),
 		is.InContext(tax.AddonIn(V2)),
 		billInvoiceRules(),
 	)

--- a/addons/de/xrechnung/xrechnung.go
+++ b/addons/de/xrechnung/xrechnung.go
@@ -21,15 +21,20 @@ import (
 // BR-DE-28 - handled by gobl validation of email address. BT-43
 
 const (
+	// Key identifies the XRechnung addon family. Individual versions append a
+	// suffix; the family key is used as the fault-code namespace so that
+	// rules that carry across versions keep stable codes.
+	Key cbc.Key = "de-xrechnung"
+
 	// V3 is the key for the XRechnung version 3.x
-	V3 cbc.Key = "de-xrechnung-v3"
+	V3 cbc.Key = Key + "-v3"
 )
 
 func init() {
 	tax.RegisterAddonDef(newAddon())
 	rules.RegisterWithGuard(
-		V3.String(),
-		rules.GOBL.Add("DE-XRECHNUNG-V3"),
+		Key.String(),
+		rules.GOBL.Add("DE-XRECHNUNG"),
 		is.InContext(tax.AddonIn(V3)),
 		billInvoiceRules(),
 	)

--- a/addons/es/facturae/bill_invoice_test.go
+++ b/addons/es/facturae/bill_invoice_test.go
@@ -43,7 +43,7 @@ func TestInvoiceValidation(t *testing.T) {
 		require.NoError(t, inv.Calculate())
 		delete(inv.Tax.Ext, facturae.ExtKeyDocType)
 		err := rules.Validate(inv)
-		assert.ErrorContains(t, err, "[GOBL-ES-FACTURAE-V3-BILL-INVOICE-03] ($.tax.ext) tax ext require 'es-facturae-doc-type' and 'es-facturae-invoice-class' extensions")
+		assert.ErrorContains(t, err, "[GOBL-ES-FACTURAE-BILL-INVOICE-03] ($.tax.ext) tax ext require 'es-facturae-doc-type' and 'es-facturae-invoice-class' extensions")
 	})
 
 	t.Run("non-EUR currency without exchange rates", func(t *testing.T) {
@@ -52,7 +52,7 @@ func TestInvoiceValidation(t *testing.T) {
 		inv.Currency = "USD"
 		require.NoError(t, inv.Calculate())
 		err := rules.Validate(inv)
-		assert.ErrorContains(t, err, "[GOBL-ES-FACTURAE-V3-BILL-INVOICE-07] invoice must be in EUR or provide exchange rate for conversion")
+		assert.ErrorContains(t, err, "[GOBL-ES-FACTURAE-BILL-INVOICE-07] invoice must be in EUR or provide exchange rate for conversion")
 	})
 
 	t.Run("non-EUR currency with exchange rates", func(t *testing.T) {
@@ -78,7 +78,7 @@ func TestInvoicePrecedingValidation(t *testing.T) {
 
 	require.NoError(t, inv.Calculate())
 	err := rules.Validate(inv)
-	assert.ErrorContains(t, err, "[GOBL-ES-FACTURAE-V3-BILL-INVOICE-04] ($.preceding) preceding document reference is required for credit-note, corrective, debit-note invoices")
+	assert.ErrorContains(t, err, "[GOBL-ES-FACTURAE-BILL-INVOICE-04] ($.preceding) preceding document reference is required for credit-note, corrective, debit-note invoices")
 
 	inv.Preceding = []*org.DocumentRef{
 		{
@@ -87,7 +87,7 @@ func TestInvoicePrecedingValidation(t *testing.T) {
 	}
 	require.NoError(t, inv.Calculate())
 	err = rules.Validate(inv)
-	assert.ErrorContains(t, err, "[GOBL-ES-FACTURAE-V3-BILL-INVOICE-05] ($.preceding[0].issue_date) preceding document issue date is required; [GOBL-ES-FACTURAE-V3-BILL-INVOICE-06] ($.preceding[0].ext) preceding document ext require 'es-facturae-correction' extension")
+	assert.ErrorContains(t, err, "[GOBL-ES-FACTURAE-BILL-INVOICE-05] ($.preceding[0].issue_date) preceding document issue date is required; [GOBL-ES-FACTURAE-BILL-INVOICE-06] ($.preceding[0].ext) preceding document ext require 'es-facturae-correction' extension")
 
 	inv.Preceding[0].Ext = tax.Extensions{
 		facturae.ExtKeyCorrection: "01",

--- a/addons/es/facturae/facturae.go
+++ b/addons/es/facturae/facturae.go
@@ -11,15 +11,20 @@ import (
 )
 
 const (
+	// Key identifies the FacturaE addon family. Individual versions append a
+	// suffix; the family key is used as the fault-code namespace so that
+	// rules that carry across versions keep stable codes.
+	Key cbc.Key = "es-facturae"
+
 	// V3 for FacturaE versions 3.x
-	V3 cbc.Key = "es-facturae-v3"
+	V3 cbc.Key = Key + "-v3"
 )
 
 func init() {
 	tax.RegisterAddonDef(newAddon())
 	rules.RegisterWithGuard(
-		V3.String(),
-		rules.GOBL.Add("ES-FACTURAE-V3"),
+		Key.String(),
+		rules.GOBL.Add("ES-FACTURAE"),
 		is.InContext(tax.AddonIn(V3)),
 		billInvoiceRules(),
 	)

--- a/addons/es/sii/bill_test.go
+++ b/addons/es/sii/bill_test.go
@@ -459,7 +459,7 @@ func TestInvoiceValidation(t *testing.T) {
 		inv.Currency = "USD"
 		require.NoError(t, inv.Calculate())
 		err := rules.Validate(inv)
-		assert.ErrorContains(t, err, "[GOBL-ES-SII-V1-BILL-INVOICE-15] invoice must be in EUR or provide exchange rate for conversion")
+		assert.ErrorContains(t, err, "[GOBL-ES-SII-BILL-INVOICE-15] invoice must be in EUR or provide exchange rate for conversion")
 	})
 
 	t.Run("non-EUR currency with exchange rates", func(t *testing.T) {

--- a/addons/es/sii/sii.go
+++ b/addons/es/sii/sii.go
@@ -12,15 +12,20 @@ import (
 )
 
 const (
+	// Key identifies the SII addon family. Individual versions append a
+	// suffix; the family key is used as the fault-code namespace so that
+	// rules that carry across versions keep stable codes.
+	Key cbc.Key = "es-sii"
+
 	// V1 for SII versions 1.x
-	V1 cbc.Key = "es-sii-v1"
+	V1 cbc.Key = Key + "-v1"
 )
 
 func init() {
 	tax.RegisterAddonDef(newAddon())
 	rules.RegisterWithGuard(
-		V1.String(),
-		rules.GOBL.Add("ES-SII-V1"),
+		Key.String(),
+		rules.GOBL.Add("ES-SII"),
 		is.InContext(tax.AddonIn(V1)),
 		billInvoiceRules(),
 		taxComboRules(),

--- a/addons/es/tbai/tbai.go
+++ b/addons/es/tbai/tbai.go
@@ -11,8 +11,13 @@ import (
 )
 
 const (
+	// Key identifies the TicketBAI addon family. Individual versions append a
+	// suffix; the family key is used as the fault-code namespace so that
+	// rules that carry across versions keep stable codes.
+	Key cbc.Key = "es-tbai"
+
 	// V1 for TicketBAI versions 1.x
-	V1 cbc.Key = "es-tbai-v1"
+	V1 cbc.Key = Key + "-v1"
 )
 
 // Official stamps or codes validated by government agencies
@@ -27,8 +32,8 @@ const (
 func init() {
 	tax.RegisterAddonDef(newAddon())
 	rules.RegisterWithGuard(
-		V1.String(),
-		rules.GOBL.Add("ES-TBAI-V1"),
+		Key.String(),
+		rules.GOBL.Add("ES-TBAI"),
 		is.InContext(tax.AddonIn(V1)),
 		billInvoiceRules(),
 		taxComboRules(),

--- a/addons/es/verifactu/bill.go
+++ b/addons/es/verifactu/bill.go
@@ -169,7 +169,7 @@ func billInvoiceRules() *rules.Set {
 			is.Func("not simplified", isNotSimplifiedInvoice),
 			rules.Field("customer",
 				rules.Assert("06", "customer is required", is.Present),
-				rules.Assert("07", "must have a tax_id or an identity with ext 'es-verifactu-v1-identity-type'",
+				rules.Assert("07", "must have a tax_id or an identity with ext 'es-verifactu-identity-type'",
 					is.Func("has tax_id or identity", customerHasTaxIDOrIdentity),
 				),
 				rules.Field("tax_id",

--- a/addons/es/verifactu/bill_test.go
+++ b/addons/es/verifactu/bill_test.go
@@ -322,8 +322,8 @@ func TestInvoiceValidation(t *testing.T) {
 		}
 		require.NoError(t, inv.Calculate())
 		err := rules.Validate(inv)
-		require.ErrorContains(t, err, "[GOBL-ES-VERIFACTU-V1-BILL-INVOICE-02] ($.preceding[0].issue_date) issue date is required")
-		require.ErrorContains(t, err, "[GOBL-ES-VERIFACTU-V1-BILL-INVOICE-03] ($.preceding[0].tax) preceding invoice tax data is required")
+		require.ErrorContains(t, err, "[GOBL-ES-VERIFACTU-BILL-INVOICE-02] ($.preceding[0].issue_date) issue date is required")
+		require.ErrorContains(t, err, "[GOBL-ES-VERIFACTU-BILL-INVOICE-03] ($.preceding[0].tax) preceding invoice tax data is required")
 	})
 
 	t.Run("customer nil", func(t *testing.T) {
@@ -344,7 +344,7 @@ func TestInvoiceValidation(t *testing.T) {
 		inv := testInvoiceStandard(t)
 		inv.Customer.TaxID.Code = ""
 		require.NoError(t, inv.Calculate())
-		assert.ErrorContains(t, rules.Validate(inv), "[GOBL-ES-VERIFACTU-V1-BILL-INVOICE-08] ($.customer.tax_id.code) tax ID must have a code")
+		assert.ErrorContains(t, rules.Validate(inv), "[GOBL-ES-VERIFACTU-BILL-INVOICE-08] ($.customer.tax_id.code) tax ID must have a code")
 	})
 	t.Run("customer with identity", func(t *testing.T) {
 		inv := testInvoiceStandard(t)
@@ -485,7 +485,7 @@ func TestInvoiceValidation(t *testing.T) {
 		inv.Currency = "USD"
 		require.NoError(t, inv.Calculate())
 		err := rules.Validate(inv)
-		assert.ErrorContains(t, err, "[GOBL-ES-VERIFACTU-V1-BILL-INVOICE-16] invoice must be in EUR or provide exchange rate for conversion")
+		assert.ErrorContains(t, err, "[GOBL-ES-VERIFACTU-BILL-INVOICE-16] invoice must be in EUR or provide exchange rate for conversion")
 	})
 
 	t.Run("non-EUR currency with exchange rates", func(t *testing.T) {

--- a/addons/es/verifactu/bill_test.go
+++ b/addons/es/verifactu/bill_test.go
@@ -337,7 +337,7 @@ func TestInvoiceValidation(t *testing.T) {
 		inv := testInvoiceStandard(t)
 		inv.Customer.TaxID = nil
 		require.NoError(t, inv.Calculate())
-		assert.ErrorContains(t, rules.Validate(inv), "($.customer) must have a tax_id or an identity with ext 'es-verifactu-v1-identity-type'")
+		assert.ErrorContains(t, rules.Validate(inv), "($.customer) must have a tax_id or an identity with ext 'es-verifactu-identity-type'")
 	})
 	t.Run("customer with missing Tax ID code", func(t *testing.T) {
 		// VERI*FACTU has no way to handle just a country without an actual code.

--- a/addons/es/verifactu/verifactu.go
+++ b/addons/es/verifactu/verifactu.go
@@ -12,8 +12,13 @@ import (
 )
 
 const (
+	// Key identifies the Verifactu addon family. Individual versions append a
+	// suffix; the family key is used as the fault-code namespace so that
+	// rules that carry across versions keep stable codes.
+	Key cbc.Key = "es-verifactu"
+
 	// V1 for Verifactu versions 1.x
-	V1 cbc.Key = "es-verifactu-v1"
+	V1 cbc.Key = Key + "-v1"
 )
 
 // Official stamps or codes validated by government agencies
@@ -25,8 +30,8 @@ const (
 func init() {
 	tax.RegisterAddonDef(newAddon())
 	rules.RegisterWithGuard(
-		V1.String(),
-		rules.GOBL.Add("ES-VERIFACTU-V1"),
+		Key.String(),
+		rules.GOBL.Add("ES-VERIFACTU"),
 		is.InContext(tax.AddonIn(V1)),
 		billInvoiceRules(),
 		taxComboRules(),

--- a/addons/eu/en16931/en16931.go
+++ b/addons/eu/en16931/en16931.go
@@ -15,15 +15,20 @@ import (
 )
 
 const (
+	// Key identifies the EN16931 addon family. Individual versions append a
+	// suffix; the family key is used as the fault-code namespace so that
+	// rules that carry across versions keep stable codes.
+	Key cbc.Key = "eu-en16931"
+
 	// V2017 is the key for the EN16931-1:2017 specification.
-	V2017 cbc.Key = "eu-en16931-v2017"
+	V2017 cbc.Key = Key + "-v2017"
 )
 
 func init() {
 	tax.RegisterAddonDef(newAddon())
 	rules.RegisterWithGuard(
-		V2017.String(),
-		rules.GOBL.Add("EU-EN16931-V2017"),
+		Key.String(),
+		rules.GOBL.Add("EU-EN16931"),
 		is.InContext(tax.AddonIn(V2017)),
 		billInvoiceRules(),
 		billDiscountRules(),

--- a/addons/fr/choruspro/bill_test.go
+++ b/addons/fr/choruspro/bill_test.go
@@ -183,7 +183,7 @@ func TestInvoiceCurrencyValidation(t *testing.T) {
 		inv.Currency = "USD"
 		require.NoError(t, inv.Calculate())
 		err := rules.Validate(inv)
-		assert.ErrorContains(t, err, "[GOBL-FR-CHORUSPRO-V1-BILL-INVOICE-07] invoice must be in EUR or provide exchange rate for conversion")
+		assert.ErrorContains(t, err, "[GOBL-FR-CHORUSPRO-BILL-INVOICE-07] invoice must be in EUR or provide exchange rate for conversion")
 	})
 
 	t.Run("non-EUR currency with exchange rates", func(t *testing.T) {

--- a/addons/fr/choruspro/choruspro.go
+++ b/addons/fr/choruspro/choruspro.go
@@ -14,15 +14,20 @@ import (
 )
 
 const (
+	// Key identifies the Chorus Pro addon family. Individual versions append
+	// a suffix; the family key is used as the fault-code namespace so that
+	// rules that carry across versions keep stable codes.
+	Key cbc.Key = "fr-choruspro"
+
 	// V1 is the key for the Chorus Pro standard
-	V1 cbc.Key = "fr-choruspro-v1"
+	V1 cbc.Key = Key + "-v1"
 )
 
 func init() {
 	tax.RegisterAddonDef(newAddon())
 	rules.RegisterWithGuard(
-		V1.String(),
-		rules.GOBL.Add("FR-CHORUSPRO-V1"),
+		Key.String(),
+		rules.GOBL.Add("FR-CHORUSPRO"),
 		is.InContext(tax.AddonIn(V1)),
 		billInvoiceRules(),
 		orgPartyRules(),

--- a/addons/fr/ctc/bill_test.go
+++ b/addons/fr/ctc/bill_test.go
@@ -169,7 +169,7 @@ func TestInvoiceValidation(t *testing.T) {
 		inv.Currency = "USD"
 		require.NoError(t, inv.Calculate())
 		err := rules.Validate(inv)
-		assert.ErrorContains(t, err, "[GOBL-FR-CTC-FLOW2-V1-BILL-INVOICE-42] invoice must be in EUR or provide exchange rate for conversion")
+		assert.ErrorContains(t, err, "[GOBL-FR-CTC-FLOW2-BILL-INVOICE-42] invoice must be in EUR or provide exchange rate for conversion")
 	})
 
 	t.Run("non-EUR currency with exchange rates", func(t *testing.T) {

--- a/addons/fr/ctc/ctc.go
+++ b/addons/fr/ctc/ctc.go
@@ -15,15 +15,21 @@ import (
 )
 
 const (
+	// Flow2Key identifies the French CTC Flow 2 addon family. Individual
+	// versions append a suffix; the family key is used as the fault-code
+	// namespace so that rules that carry across versions keep stable codes.
+	// Flow 1 is a separate rule family, not a prior version of Flow 2.
+	Flow2Key cbc.Key = "fr-ctc-flow2"
+
 	// Flow2V1 is the key for the French CTC addon
-	Flow2V1 cbc.Key = "fr-ctc-flow2-v1"
+	Flow2V1 cbc.Key = Flow2Key + "-v1"
 )
 
 func init() {
 	tax.RegisterAddonDef(newAddon())
 	rules.RegisterWithGuard(
-		Flow2V1.String(),
-		rules.GOBL.Add("FR-CTC-FLOW2-V1"),
+		Flow2Key.String(),
+		rules.GOBL.Add("FR-CTC-FLOW2"),
 		is.InContext(tax.AddonIn(Flow2V1)),
 		billInvoiceRules(),
 		orgPartyRules(),

--- a/addons/gr/mydata/bill_invoices_test.go
+++ b/addons/gr/mydata/bill_invoices_test.go
@@ -100,7 +100,7 @@ func TestInvoiceCurrencyValidation(t *testing.T) {
 		inv.Currency = "USD"
 		require.NoError(t, inv.Calculate())
 		err := rules.Validate(inv)
-		assert.ErrorContains(t, err, "[GOBL-GR-MYDATA-V1-BILL-INVOICE-19] invoice must be in EUR or provide exchange rate for conversion")
+		assert.ErrorContains(t, err, "[GOBL-GR-MYDATA-BILL-INVOICE-19] invoice must be in EUR or provide exchange rate for conversion")
 	})
 
 	t.Run("non-EUR currency with exchange rates", func(t *testing.T) {

--- a/addons/gr/mydata/mydata.go
+++ b/addons/gr/mydata/mydata.go
@@ -14,15 +14,20 @@ import (
 )
 
 const (
+	// Key identifies the MyData addon family. Individual versions append a
+	// suffix; the family key is used as the fault-code namespace so that
+	// rules that carry across versions keep stable codes.
+	Key cbc.Key = "gr-mydata"
+
 	// V1 for Greece MyData XML v1.x
-	V1 cbc.Key = "gr-mydata-v1"
+	V1 cbc.Key = Key + "-v1"
 )
 
 func init() {
 	tax.RegisterAddonDef(newAddon())
 	rules.RegisterWithGuard(
-		V1.String(),
-		rules.GOBL.Add("GR-MYDATA-V1"),
+		Key.String(),
+		rules.GOBL.Add("GR-MYDATA"),
 		is.InContext(tax.AddonIn(V1)),
 		billInvoiceRules(),
 		billChargeRules(),

--- a/addons/it/sdi/bill_test.go
+++ b/addons/it/sdi/bill_test.go
@@ -117,7 +117,7 @@ func TestInvoiceValidation(t *testing.T) {
 		inv.Currency = "USD"
 		require.NoError(t, inv.Calculate())
 		err := rules.Validate(inv)
-		assert.ErrorContains(t, err, "[GOBL-IT-SDI-V1-BILL-INVOICE-22] invoice must be in EUR or provide exchange rate for conversion")
+		assert.ErrorContains(t, err, "[GOBL-IT-SDI-BILL-INVOICE-22] invoice must be in EUR or provide exchange rate for conversion")
 	})
 
 	t.Run("non-EUR currency with exchange rates", func(t *testing.T) {

--- a/addons/it/sdi/sdi.go
+++ b/addons/it/sdi/sdi.go
@@ -16,8 +16,13 @@ import (
 )
 
 const (
+	// Key identifies the SDI addon family. Individual versions append a
+	// suffix; the family key is used as the fault-code namespace so that
+	// rules that carry across versions keep stable codes.
+	Key cbc.Key = "it-sdi"
+
 	// V1 for SDI's FatturaPA verions 1.x
-	V1 cbc.Key = "it-sdi-v1"
+	V1 cbc.Key = Key + "-v1"
 
 	// KeyFundContribution is the key for the Fund Contribution charge
 	KeyFundContribution cbc.Key = "fund-contribution"
@@ -26,8 +31,8 @@ const (
 func init() {
 	tax.RegisterAddonDef(newAddon())
 	rules.RegisterWithGuard(
-		V1.String(),
-		rules.GOBL.Add("IT-SDI-V1"),
+		Key.String(),
+		rules.GOBL.Add("IT-SDI"),
 		is.InContext(tax.AddonIn(V1)),
 		billInvoiceRules(),
 		billChargeRules(),

--- a/addons/it/sdi/sdi.go
+++ b/addons/it/sdi/sdi.go
@@ -21,7 +21,7 @@ const (
 	// rules that carry across versions keep stable codes.
 	Key cbc.Key = "it-sdi"
 
-	// V1 for SDI's FatturaPA verions 1.x
+	// V1 for SDI's FatturaPA versions 1.x
 	V1 cbc.Key = Key + "-v1"
 
 	// KeyFundContribution is the key for the Fund Contribution charge

--- a/addons/it/ticket/bill_invoices_test.go
+++ b/addons/it/ticket/bill_invoices_test.go
@@ -123,7 +123,7 @@ func TestInvoiceCurrencyValidation(t *testing.T) {
 		inv.Currency = "USD"
 		require.NoError(t, inv.Calculate())
 		err := rules.Validate(inv)
-		assert.ErrorContains(t, err, "[GOBL-IT-TICKET-V1-BILL-INVOICE-08] invoice must be in EUR or provide exchange rate for conversion")
+		assert.ErrorContains(t, err, "[GOBL-IT-TICKET-BILL-INVOICE-08] invoice must be in EUR or provide exchange rate for conversion")
 	})
 
 	t.Run("non-EUR currency with exchange rates", func(t *testing.T) {
@@ -336,8 +336,8 @@ func TestInvoiceTax(t *testing.T) {
 		require.NoError(t, inv.Calculate())
 		inv.Tax.PricesInclude = ""
 		err := rules.Validate(inv)
-		require.ErrorContains(t, err, "GOBL-IT-TICKET-V1-BILL-INVOICE-02")
-		require.ErrorContains(t, err, "GOBL-IT-TICKET-V1-BILL-INVOICE-03")
+		require.ErrorContains(t, err, "GOBL-IT-TICKET-BILL-INVOICE-02")
+		require.ErrorContains(t, err, "GOBL-IT-TICKET-BILL-INVOICE-03")
 	})
 
 	t.Run("missing Tax will be normalized", func(t *testing.T) {
@@ -351,7 +351,7 @@ func TestInvoiceTax(t *testing.T) {
 		inv := exampleStandardInvoice(t)
 		require.NoError(t, inv.Calculate())
 		inv.Tax = nil
-		require.ErrorContains(t, rules.Validate(inv), "GOBL-IT-TICKET-V1-BILL-INVOICE-01")
+		require.ErrorContains(t, rules.Validate(inv), "GOBL-IT-TICKET-BILL-INVOICE-01")
 	})
 
 	t.Run("lottery code length", func(t *testing.T) {

--- a/addons/it/ticket/ticket.go
+++ b/addons/it/ticket/ticket.go
@@ -14,8 +14,13 @@ import (
 
 // Key to identify the AdE ticket addon
 const (
+	// Key identifies the AdE ticket addon family. Individual versions append
+	// a suffix; the family key is used as the fault-code namespace so that
+	// rules that carry across versions keep stable codes.
+	Key cbc.Key = "it-ticket"
+
 	// V1 for AdE format
-	V1 cbc.Key = "it-ticket-v1"
+	V1 cbc.Key = Key + "-v1"
 )
 
 // Official stamps or codes validated by government agencies
@@ -31,8 +36,8 @@ const (
 func init() {
 	tax.RegisterAddonDef(newAddon())
 	rules.RegisterWithGuard(
-		V1.String(),
-		rules.GOBL.Add("IT-TICKET-V1"),
+		Key.String(),
+		rules.GOBL.Add("IT-TICKET"),
 		is.InContext(tax.AddonIn(V1)),
 		billInvoiceRules(),
 		taxComboRules(),

--- a/addons/mx/cfdi/bill_invoice_test.go
+++ b/addons/mx/cfdi/bill_invoice_test.go
@@ -163,7 +163,7 @@ func TestInvoiceCurrencyValidation(t *testing.T) {
 		inv.Currency = "USD"
 		require.NoError(t, inv.Calculate())
 		err := rules.Validate(inv)
-		assert.ErrorContains(t, err, "[GOBL-MX-CFDI-V4-BILL-INVOICE-27] invoice must be in MXN or provide exchange rate for conversion")
+		assert.ErrorContains(t, err, "[GOBL-MX-CFDI-BILL-INVOICE-27] invoice must be in MXN or provide exchange rate for conversion")
 	})
 
 	t.Run("non-MXN currency with exchange rates", func(t *testing.T) {

--- a/addons/mx/cfdi/cfdi.go
+++ b/addons/mx/cfdi/cfdi.go
@@ -17,7 +17,13 @@ import (
 
 // Key to identify the CFDI addon.
 const (
-	V4 cbc.Key = "mx-cfdi-v4"
+	// Key identifies the CFDI addon family. Individual versions append a
+	// suffix; the family key is used as the fault-code namespace so that
+	// rules that carry across versions keep stable codes.
+	Key cbc.Key = "mx-cfdi"
+
+	// V4 for CFDI version 4
+	V4 cbc.Key = Key + "-v4"
 )
 
 // Official CFDI codes to include in stamps.
@@ -41,8 +47,8 @@ func init() {
 	)
 
 	rules.RegisterWithGuard(
-		V4.String(),
-		rules.GOBL.Add("MX-CFDI-V4"),
+		Key.String(),
+		rules.GOBL.Add("MX-CFDI"),
 		is.InContext(tax.AddonIn(V4)),
 		billInvoiceRules(),
 		payInstructionsRules(),

--- a/addons/pl/favat/bill_test.go
+++ b/addons/pl/favat/bill_test.go
@@ -143,7 +143,7 @@ func TestInvoiceCurrencyValidation(t *testing.T) {
 		inv.Currency = "USD"
 		require.NoError(t, inv.Calculate())
 		err := rules.Validate(inv)
-		assert.ErrorContains(t, err, "[GOBL-PL-FAVAT-V3-BILL-INVOICE-15] invoice must be in PLN or provide exchange rate for conversion")
+		assert.ErrorContains(t, err, "[GOBL-PL-FAVAT-BILL-INVOICE-15] invoice must be in PLN or provide exchange rate for conversion")
 	})
 
 	t.Run("non-PLN currency with exchange rates", func(t *testing.T) {

--- a/addons/pl/favat/favat.go
+++ b/addons/pl/favat/favat.go
@@ -13,7 +13,13 @@ import (
 
 // Polish FA_VAT versions.
 const (
-	V3 cbc.Key = "pl-favat-v3"
+	// Key identifies the FA_VAT addon family. Individual versions append a
+	// suffix; the family key is used as the fault-code namespace so that
+	// rules that carry across versions keep stable codes.
+	Key cbc.Key = "pl-favat"
+
+	// V3 for FA_VAT version 3 (FA(3)).
+	V3 cbc.Key = Key + "-v3"
 )
 
 // KSeF official codes to include.
@@ -26,8 +32,8 @@ const (
 func init() {
 	tax.RegisterAddonDef(newAddonV3())
 	rules.RegisterWithGuard(
-		V3.String(),
-		rules.GOBL.Add("PL-FAVAT-V3"),
+		Key.String(),
+		rules.GOBL.Add("PL-FAVAT"),
 		is.InContext(tax.AddonIn(V3)),
 		billInvoiceRules(),
 		taxComboRules(),

--- a/addons/pt/saft/invoices_test.go
+++ b/addons/pt/saft/invoices_test.go
@@ -126,7 +126,7 @@ func TestInvoiceValidation(t *testing.T) {
 	t.Run("non-EUR currency without exchange rates", func(t *testing.T) {
 		inv := calculatedInvoice(t)
 		inv.Currency = "USD"
-		assert.ErrorContains(t, rules.Validate(inv), "[GOBL-PT-SAFT-V1-BILL-INVOICE-15] invoice must be in EUR or provide exchange rate for conversion")
+		assert.ErrorContains(t, rules.Validate(inv), "[GOBL-PT-SAFT-BILL-INVOICE-15] invoice must be in EUR or provide exchange rate for conversion")
 	})
 
 	t.Run("non-EUR currency with exchange rates", func(t *testing.T) {

--- a/addons/pt/saft/saft.go
+++ b/addons/pt/saft/saft.go
@@ -14,15 +14,20 @@ import (
 )
 
 const (
+	// Key identifies the SAF-T (PT) addon family. Individual versions append
+	// a suffix; the family key is used as the fault-code namespace so that
+	// rules that carry across versions keep stable codes.
+	Key cbc.Key = "pt-saft"
+
 	// V1 for SAF-T (PT) versions 1.x
-	V1 cbc.Key = "pt-saft-v1"
+	V1 cbc.Key = Key + "-v1"
 )
 
 func init() {
 	tax.RegisterAddonDef(newAddon())
 	rules.RegisterWithGuard(
-		V1.String(),
-		rules.GOBL.Add("PT-SAFT-V1"),
+		Key.String(),
+		rules.GOBL.Add("PT-SAFT"),
 		is.InContext(tax.AddonIn(V1)),
 		billInvoiceRules(),
 		billPaymentRules(),

--- a/cal/time_test.go
+++ b/cal/time_test.go
@@ -30,23 +30,47 @@ func TestTimeNew(t *testing.T) {
 }
 
 func TestTimeNow(t *testing.T) {
-	t.Run("valid time", func(t *testing.T) {
+	t.Run("matches current UTC wall clock", func(t *testing.T) {
+		before := time.Now().UTC()
 		tm := cal.TimeNow()
-		assert.NotZero(t, tm.Hour)
-		assert.NotZero(t, tm.Minute)
-		assert.NotZero(t, tm.Second)
+		after := time.Now().UTC()
+		assertTimeWithin(t, tm, before, after)
 	})
 }
 
 func TestTimeNowIn(t *testing.T) {
-	t.Run("valid time", func(t *testing.T) {
+	t.Run("matches current wall clock in location", func(t *testing.T) {
 		loc, err := time.LoadLocation("America/New_York")
 		require.NoError(t, err)
+		before := time.Now().In(loc)
 		tm := cal.TimeNowIn(loc)
-		assert.NotZero(t, tm.Hour)
-		assert.NotZero(t, tm.Minute)
-		assert.NotZero(t, tm.Second)
+		after := time.Now().In(loc)
+		assertTimeWithin(t, tm, before, after)
 	})
+}
+
+// assertTimeWithin checks that tm is a valid time-of-day falling between the
+// wall-clock samples taken immediately before and after the call, tolerating
+// a midnight rollover.
+func assertTimeWithin(t *testing.T, tm cal.Time, before, after time.Time) {
+	t.Helper()
+	assert.GreaterOrEqual(t, tm.Hour, 0)
+	assert.Less(t, tm.Hour, 24)
+	assert.GreaterOrEqual(t, tm.Minute, 0)
+	assert.Less(t, tm.Minute, 60)
+	assert.GreaterOrEqual(t, tm.Second, 0)
+	assert.Less(t, tm.Second, 60)
+	assert.Zero(t, tm.Nanosecond, "nanoseconds should be stripped")
+
+	secOfDay := func(h, m, s int) int { return h*3600 + m*60 + s }
+	got := secOfDay(tm.Hour, tm.Minute, tm.Second)
+	lo := secOfDay(before.Hour(), before.Minute(), before.Second())
+	hi := secOfDay(after.Hour(), after.Minute(), after.Second())
+	if hi < lo {
+		assert.True(t, got >= lo || got <= hi, "time %v outside window %v..%v across midnight", tm, before, after)
+	} else {
+		assert.True(t, got >= lo && got <= hi, "time %v outside window %v..%v", tm, before, after)
+	}
 }
 
 func TestTimeString(t *testing.T) {

--- a/data/rules/ar-arca.json
+++ b/data/rules/ar-arca.json
@@ -1,44 +1,49 @@
 {
-  "id": "GOBL-AR-ARCA-V4",
-  "package": "ar-arca-v4",
+  "id": "GOBL-AR-ARCA",
+  "package": "ar-arca",
   "guard": "context: addon in [ar-arca-v4]",
   "subsets": [
     {
-      "id": "GOBL-AR-ARCA-V4-BILL-INVOICE",
+      "id": "GOBL-AR-ARCA-BILL-INVOICE",
       "object": "bill.Invoice",
       "assert": [
         {
-          "id": "GOBL-AR-ARCA-V4-BILL-INVOICE-05",
+          "id": "GOBL-AR-ARCA-BILL-INVOICE-24",
+          "desc": "invoice must be in ARS or provide exchange rate for conversion",
+          "tests": "can convert to [ARS]"
+        },
+        {
+          "id": "GOBL-AR-ARCA-BILL-INVOICE-05",
           "desc": "invoice type is credit-note but ar-arca-doc-type is not a credit note",
           "tests": "type matches doc type credit note"
         },
         {
-          "id": "GOBL-AR-ARCA-V4-BILL-INVOICE-06",
+          "id": "GOBL-AR-ARCA-BILL-INVOICE-06",
           "desc": "invoice type is debit-note but ar-arca-doc-type is not a debit note",
           "tests": "type matches doc type debit note"
         },
         {
-          "id": "GOBL-AR-ARCA-V4-BILL-INVOICE-07",
+          "id": "GOBL-AR-ARCA-BILL-INVOICE-07",
           "desc": "ar-arca-doc-type is a credit note but invoice type is not credit-note",
           "tests": "doc type credit note matches type"
         },
         {
-          "id": "GOBL-AR-ARCA-V4-BILL-INVOICE-08",
+          "id": "GOBL-AR-ARCA-BILL-INVOICE-08",
           "desc": "doc type is a debit note but invoice type is not debit-note",
           "tests": "doc type debit note matches type"
         },
         {
-          "id": "GOBL-AR-ARCA-V4-BILL-INVOICE-12",
+          "id": "GOBL-AR-ARCA-BILL-INVOICE-12",
           "desc": "document type 49 (Used Goods Purchase Invoice) requires customer VAT status to be 5 (Final Consumer)",
           "tests": "doc type 49 vat status"
         },
         {
-          "id": "GOBL-AR-ARCA-V4-BILL-INVOICE-13",
+          "id": "GOBL-AR-ARCA-BILL-INVOICE-13",
           "desc": "document type A requires customer VAT status to be one of [1 6 13 16]",
           "tests": "doc type A vat status"
         },
         {
-          "id": "GOBL-AR-ARCA-V4-BILL-INVOICE-14",
+          "id": "GOBL-AR-ARCA-BILL-INVOICE-14",
           "desc": "document type B cannot have customer VAT status [1 6 13 16]",
           "tests": "doc type B vat status"
         }
@@ -48,12 +53,12 @@
           "field": "series",
           "assert": [
             {
-              "id": "GOBL-AR-ARCA-V4-BILL-INVOICE-01",
+              "id": "GOBL-AR-ARCA-BILL-INVOICE-01",
               "desc": "series is required",
               "tests": "present"
             },
             {
-              "id": "GOBL-AR-ARCA-V4-BILL-INVOICE-02",
+              "id": "GOBL-AR-ARCA-BILL-INVOICE-02",
               "desc": "series must be a valid number between 1 and 99998",
               "tests": "valid series"
             }
@@ -63,7 +68,7 @@
           "field": "tax",
           "assert": [
             {
-              "id": "GOBL-AR-ARCA-V4-BILL-INVOICE-03",
+              "id": "GOBL-AR-ARCA-BILL-INVOICE-03",
               "desc": "tax is required",
               "tests": "present"
             }
@@ -73,7 +78,7 @@
               "field": "ext",
               "assert": [
                 {
-                  "id": "GOBL-AR-ARCA-V4-BILL-INVOICE-04",
+                  "id": "GOBL-AR-ARCA-BILL-INVOICE-04",
                   "desc": "tax requires 'ar-arca-doc-type' extension",
                   "tests": "ext require [ar-arca-doc-type]"
                 }
@@ -88,7 +93,7 @@
               "field": "customer",
               "assert": [
                 {
-                  "id": "GOBL-AR-ARCA-V4-BILL-INVOICE-09",
+                  "id": "GOBL-AR-ARCA-BILL-INVOICE-09",
                   "desc": "customer is required",
                   "tests": "present"
                 }
@@ -100,7 +105,7 @@
           "field": "customer",
           "assert": [
             {
-              "id": "GOBL-AR-ARCA-V4-BILL-INVOICE-10",
+              "id": "GOBL-AR-ARCA-BILL-INVOICE-10",
               "desc": "must have a tax_id, or an identity with ext 'ar-arca-identity-type'",
               "tests": "has tax ID or identity"
             }
@@ -110,7 +115,7 @@
               "field": "ext",
               "assert": [
                 {
-                  "id": "GOBL-AR-ARCA-V4-BILL-INVOICE-11",
+                  "id": "GOBL-AR-ARCA-BILL-INVOICE-11",
                   "desc": "customer requires 'ar-arca-vat-status' extension",
                   "tests": "ext require [ar-arca-vat-status]"
                 }
@@ -125,7 +130,7 @@
               "field": "ordering",
               "assert": [
                 {
-                  "id": "GOBL-AR-ARCA-V4-BILL-INVOICE-15",
+                  "id": "GOBL-AR-ARCA-BILL-INVOICE-15",
                   "desc": "ordering is required for services",
                   "tests": "present"
                 }
@@ -135,7 +140,7 @@
                   "field": "period",
                   "assert": [
                     {
-                      "id": "GOBL-AR-ARCA-V4-BILL-INVOICE-16",
+                      "id": "GOBL-AR-ARCA-BILL-INVOICE-16",
                       "desc": "ordering period is required for services",
                       "tests": "present"
                     }
@@ -147,7 +152,7 @@
               "field": "payment",
               "assert": [
                 {
-                  "id": "GOBL-AR-ARCA-V4-BILL-INVOICE-17",
+                  "id": "GOBL-AR-ARCA-BILL-INVOICE-17",
                   "desc": "payment is required for services",
                   "tests": "present"
                 }
@@ -157,7 +162,7 @@
                   "field": "terms",
                   "assert": [
                     {
-                      "id": "GOBL-AR-ARCA-V4-BILL-INVOICE-18",
+                      "id": "GOBL-AR-ARCA-BILL-INVOICE-18",
                       "desc": "payment terms are required for services",
                       "tests": "present"
                     }
@@ -167,7 +172,7 @@
                       "field": "due_dates",
                       "assert": [
                         {
-                          "id": "GOBL-AR-ARCA-V4-BILL-INVOICE-19",
+                          "id": "GOBL-AR-ARCA-BILL-INVOICE-19",
                           "desc": "payment due dates are required for services",
                           "tests": "present"
                         }
@@ -192,7 +197,7 @@
                       "field": "due_dates",
                       "assert": [
                         {
-                          "id": "GOBL-AR-ARCA-V4-BILL-INVOICE-20",
+                          "id": "GOBL-AR-ARCA-BILL-INVOICE-20",
                           "desc": "payment due dates must not be set for goods",
                           "tests": "empty"
                         }
@@ -211,7 +216,7 @@
               "field": "preceding",
               "assert": [
                 {
-                  "id": "GOBL-AR-ARCA-V4-BILL-INVOICE-21",
+                  "id": "GOBL-AR-ARCA-BILL-INVOICE-21",
                   "desc": "preceding documents are required for credit/debit notes",
                   "tests": "present"
                 }
@@ -229,7 +234,7 @@
                   "field": "ext",
                   "assert": [
                     {
-                      "id": "GOBL-AR-ARCA-V4-BILL-INVOICE-22",
+                      "id": "GOBL-AR-ARCA-BILL-INVOICE-22",
                       "desc": "preceding document requires 'ar-arca-doc-type' extension",
                       "tests": "ext require [ar-arca-doc-type]"
                     }
@@ -252,7 +257,7 @@
                       "field": "taxes",
                       "assert": [
                         {
-                          "id": "GOBL-AR-ARCA-V4-BILL-INVOICE-23",
+                          "id": "GOBL-AR-ARCA-BILL-INVOICE-23",
                           "desc": "type C invoices (simplified tax scheme) must not have taxes on lines",
                           "tests": "empty"
                         }
@@ -267,7 +272,7 @@
       ]
     },
     {
-      "id": "GOBL-AR-ARCA-V4-BILL-CHARGE",
+      "id": "GOBL-AR-ARCA-BILL-CHARGE",
       "object": "bill.Charge",
       "subsets": [
         {
@@ -277,7 +282,7 @@
               "field": "ext",
               "assert": [
                 {
-                  "id": "GOBL-AR-ARCA-V4-BILL-CHARGE-01",
+                  "id": "GOBL-AR-ARCA-BILL-CHARGE-01",
                   "desc": "tax charge requires 'ar-arca-tax-type' extension",
                   "tests": "ext require [ar-arca-tax-type]"
                 }
@@ -292,7 +297,7 @@
               "field": "percent",
               "assert": [
                 {
-                  "id": "GOBL-AR-ARCA-V4-BILL-CHARGE-02",
+                  "id": "GOBL-AR-ARCA-BILL-CHARGE-02",
                   "desc": "percent is required when tax type is set",
                   "tests": "present"
                 }
@@ -307,7 +312,7 @@
               "field": "reason",
               "assert": [
                 {
-                  "id": "GOBL-AR-ARCA-V4-BILL-CHARGE-03",
+                  "id": "GOBL-AR-ARCA-BILL-CHARGE-03",
                   "desc": "reason is required when tax type is 'other'",
                   "tests": "present"
                 }
@@ -318,7 +323,7 @@
       ]
     },
     {
-      "id": "GOBL-AR-ARCA-V4-TAX-COMBO",
+      "id": "GOBL-AR-ARCA-TAX-COMBO",
       "object": "tax.Combo",
       "subsets": [
         {
@@ -328,7 +333,7 @@
               "field": "ext",
               "assert": [
                 {
-                  "id": "GOBL-AR-ARCA-V4-TAX-COMBO-01",
+                  "id": "GOBL-AR-ARCA-TAX-COMBO-01",
                   "desc": "VAT combo requires 'ar-arca-vat-rate' extension",
                   "tests": "ext require [ar-arca-vat-rate]"
                 }

--- a/data/rules/br-nfe.json
+++ b/data/rules/br-nfe.json
@@ -1,14 +1,19 @@
 {
-  "id": "GOBL-BR-NFE-V4",
-  "package": "br-nfe-v4",
+  "id": "GOBL-BR-NFE",
+  "package": "br-nfe",
   "guard": "context: addon in [br-nfe-v4]",
   "subsets": [
     {
-      "id": "GOBL-BR-NFE-V4-BILL-INVOICE",
+      "id": "GOBL-BR-NFE-BILL-INVOICE",
       "object": "bill.Invoice",
       "assert": [
         {
-          "id": "GOBL-BR-NFE-V4-BILL-INVOICE-30",
+          "id": "GOBL-BR-NFE-BILL-INVOICE-34",
+          "desc": "invoice must be in BRL or provide exchange rate for conversion",
+          "tests": "can convert to [BRL]"
+        },
+        {
+          "id": "GOBL-BR-NFE-BILL-INVOICE-30",
           "desc": "a note with key 'reason' is required to describe the nature of the operation (natOp)",
           "tests": "has reason note"
         }
@@ -21,7 +26,7 @@
               "field": "tax_id",
               "assert": [
                 {
-                  "id": "GOBL-BR-NFE-V4-BILL-INVOICE-01",
+                  "id": "GOBL-BR-NFE-BILL-INVOICE-01",
                   "desc": "supplier tax ID is required",
                   "tests": "present"
                 }
@@ -31,7 +36,7 @@
                   "field": "code",
                   "assert": [
                     {
-                      "id": "GOBL-BR-NFE-V4-BILL-INVOICE-02",
+                      "id": "GOBL-BR-NFE-BILL-INVOICE-02",
                       "desc": "supplier tax ID code is required",
                       "tests": "present"
                     }
@@ -46,7 +51,7 @@
                   "each": true,
                   "assert": [
                     {
-                      "id": "GOBL-BR-NFE-V4-BILL-INVOICE-03",
+                      "id": "GOBL-BR-NFE-BILL-INVOICE-03",
                       "desc": "supplier address must not be empty",
                       "tests": "present"
                     }
@@ -56,7 +61,7 @@
                       "field": "street",
                       "assert": [
                         {
-                          "id": "GOBL-BR-NFE-V4-BILL-INVOICE-04",
+                          "id": "GOBL-BR-NFE-BILL-INVOICE-04",
                           "desc": "supplier address requires a street",
                           "tests": "present"
                         }
@@ -66,7 +71,7 @@
                       "field": "num",
                       "assert": [
                         {
-                          "id": "GOBL-BR-NFE-V4-BILL-INVOICE-05",
+                          "id": "GOBL-BR-NFE-BILL-INVOICE-05",
                           "desc": "supplier address requires a number",
                           "tests": "present"
                         }
@@ -76,7 +81,7 @@
                       "field": "locality",
                       "assert": [
                         {
-                          "id": "GOBL-BR-NFE-V4-BILL-INVOICE-06",
+                          "id": "GOBL-BR-NFE-BILL-INVOICE-06",
                           "desc": "supplier address requires a locality",
                           "tests": "present"
                         }
@@ -86,7 +91,7 @@
                       "field": "state",
                       "assert": [
                         {
-                          "id": "GOBL-BR-NFE-V4-BILL-INVOICE-07",
+                          "id": "GOBL-BR-NFE-BILL-INVOICE-07",
                           "desc": "supplier address requires a state",
                           "tests": "present"
                         }
@@ -96,7 +101,7 @@
                       "field": "code",
                       "assert": [
                         {
-                          "id": "GOBL-BR-NFE-V4-BILL-INVOICE-08",
+                          "id": "GOBL-BR-NFE-BILL-INVOICE-08",
                           "desc": "supplier address requires a postal code",
                           "tests": "present"
                         }
@@ -113,7 +118,7 @@
                   "field": "ext",
                   "assert": [
                     {
-                      "id": "GOBL-BR-NFE-V4-BILL-INVOICE-09",
+                      "id": "GOBL-BR-NFE-BILL-INVOICE-09",
                       "desc": "supplier requires 'br-ibge-municipality' extension when addresses are present",
                       "tests": "ext require [br-ibge-municipality]"
                     }
@@ -125,7 +130,7 @@
               "field": "name",
               "assert": [
                 {
-                  "id": "GOBL-BR-NFE-V4-BILL-INVOICE-10",
+                  "id": "GOBL-BR-NFE-BILL-INVOICE-10",
                   "desc": "supplier name is required",
                   "tests": "present"
                 }
@@ -135,7 +140,7 @@
               "field": "addresses",
               "assert": [
                 {
-                  "id": "GOBL-BR-NFE-V4-BILL-INVOICE-11",
+                  "id": "GOBL-BR-NFE-BILL-INVOICE-11",
                   "desc": "supplier must have at least one address",
                   "tests": "present"
                 }
@@ -150,7 +155,7 @@
               "field": "customer",
               "assert": [
                 {
-                  "id": "GOBL-BR-NFE-V4-BILL-INVOICE-12",
+                  "id": "GOBL-BR-NFE-BILL-INVOICE-12",
                   "desc": "customer is required for NF-e invoices",
                   "tests": "present"
                 }
@@ -160,7 +165,7 @@
                   "field": "addresses",
                   "assert": [
                     {
-                      "id": "GOBL-BR-NFE-V4-BILL-INVOICE-13",
+                      "id": "GOBL-BR-NFE-BILL-INVOICE-13",
                       "desc": "customer must have at least one address for NF-e invoices",
                       "tests": "present"
                     }
@@ -177,7 +182,7 @@
               "field": "tax_id",
               "assert": [
                 {
-                  "id": "GOBL-BR-NFE-V4-BILL-INVOICE-14",
+                  "id": "GOBL-BR-NFE-BILL-INVOICE-14",
                   "desc": "customer tax ID is required",
                   "tests": "present"
                 }
@@ -187,7 +192,7 @@
                   "field": "code",
                   "assert": [
                     {
-                      "id": "GOBL-BR-NFE-V4-BILL-INVOICE-15",
+                      "id": "GOBL-BR-NFE-BILL-INVOICE-15",
                       "desc": "customer tax ID code is required",
                       "tests": "present"
                     }
@@ -202,7 +207,7 @@
                   "each": true,
                   "assert": [
                     {
-                      "id": "GOBL-BR-NFE-V4-BILL-INVOICE-16",
+                      "id": "GOBL-BR-NFE-BILL-INVOICE-16",
                       "desc": "customer address must not be empty",
                       "tests": "present"
                     }
@@ -212,7 +217,7 @@
                       "field": "street",
                       "assert": [
                         {
-                          "id": "GOBL-BR-NFE-V4-BILL-INVOICE-17",
+                          "id": "GOBL-BR-NFE-BILL-INVOICE-17",
                           "desc": "customer address requires a street",
                           "tests": "present"
                         }
@@ -222,7 +227,7 @@
                       "field": "num",
                       "assert": [
                         {
-                          "id": "GOBL-BR-NFE-V4-BILL-INVOICE-18",
+                          "id": "GOBL-BR-NFE-BILL-INVOICE-18",
                           "desc": "customer address requires a number",
                           "tests": "present"
                         }
@@ -232,7 +237,7 @@
                       "field": "locality",
                       "assert": [
                         {
-                          "id": "GOBL-BR-NFE-V4-BILL-INVOICE-19",
+                          "id": "GOBL-BR-NFE-BILL-INVOICE-19",
                           "desc": "customer address requires a locality",
                           "tests": "present"
                         }
@@ -242,7 +247,7 @@
                       "field": "state",
                       "assert": [
                         {
-                          "id": "GOBL-BR-NFE-V4-BILL-INVOICE-20",
+                          "id": "GOBL-BR-NFE-BILL-INVOICE-20",
                           "desc": "customer address requires a state",
                           "tests": "present"
                         }
@@ -252,7 +257,7 @@
                       "field": "code",
                       "assert": [
                         {
-                          "id": "GOBL-BR-NFE-V4-BILL-INVOICE-21",
+                          "id": "GOBL-BR-NFE-BILL-INVOICE-21",
                           "desc": "customer address requires a postal code",
                           "tests": "present"
                         }
@@ -269,7 +274,7 @@
                   "field": "ext",
                   "assert": [
                     {
-                      "id": "GOBL-BR-NFE-V4-BILL-INVOICE-22",
+                      "id": "GOBL-BR-NFE-BILL-INVOICE-22",
                       "desc": "customer requires 'br-ibge-municipality' extension when addresses are present",
                       "tests": "ext require [br-ibge-municipality]"
                     }
@@ -283,12 +288,12 @@
           "field": "series",
           "assert": [
             {
-              "id": "GOBL-BR-NFE-V4-BILL-INVOICE-23",
+              "id": "GOBL-BR-NFE-BILL-INVOICE-23",
               "desc": "series is required",
               "tests": "present"
             },
             {
-              "id": "GOBL-BR-NFE-V4-BILL-INVOICE-24",
+              "id": "GOBL-BR-NFE-BILL-INVOICE-24",
               "desc": "series format is invalid; must be 0 or 1-999",
               "tests": "matches ^(?:0|[1-9]{1}[0-9]{0,2})$"
             }
@@ -298,7 +303,7 @@
           "field": "tax",
           "assert": [
             {
-              "id": "GOBL-BR-NFE-V4-BILL-INVOICE-25",
+              "id": "GOBL-BR-NFE-BILL-INVOICE-25",
               "desc": "tax is required",
               "tests": "present"
             }
@@ -308,7 +313,7 @@
               "field": "ext",
               "assert": [
                 {
-                  "id": "GOBL-BR-NFE-V4-BILL-INVOICE-26",
+                  "id": "GOBL-BR-NFE-BILL-INVOICE-26",
                   "desc": "tax requires 'br-nfe-model' and 'br-nfe-presence' extensions",
                   "tests": "ext require [br-nfe-model, br-nfe-presence]"
                 }
@@ -318,7 +323,7 @@
                   "guard": "NFe model",
                   "assert": [
                     {
-                      "id": "GOBL-BR-NFE-V4-BILL-INVOICE-27",
+                      "id": "GOBL-BR-NFE-BILL-INVOICE-27",
                       "desc": "NF-e invoices do not support '4' for 'br-nfe-presence'",
                       "tests": "ext 'br-nfe-presence' not in [4]"
                     }
@@ -328,7 +333,7 @@
                   "guard": "NFCe model",
                   "assert": [
                     {
-                      "id": "GOBL-BR-NFE-V4-BILL-INVOICE-28",
+                      "id": "GOBL-BR-NFE-BILL-INVOICE-28",
                       "desc": "NFC-e invoices require in-person or delivery for 'br-nfe-presence'",
                       "tests": "ext 'br-nfe-presence' in [1, 4]"
                     }
@@ -351,7 +356,7 @@
                       "field": "text",
                       "assert": [
                         {
-                          "id": "GOBL-BR-NFE-V4-BILL-INVOICE-29",
+                          "id": "GOBL-BR-NFE-BILL-INVOICE-29",
                           "desc": "reason note text must be between 1 and 60 characters",
                           "tests": "length between 1 and 60"
                         }
@@ -370,7 +375,7 @@
               "field": "payment",
               "assert": [
                 {
-                  "id": "GOBL-BR-NFE-V4-BILL-INVOICE-31",
+                  "id": "GOBL-BR-NFE-BILL-INVOICE-31",
                   "desc": "payment is required when invoice is unpaid",
                   "tests": "present"
                 }
@@ -380,7 +385,7 @@
                   "field": "instructions",
                   "assert": [
                     {
-                      "id": "GOBL-BR-NFE-V4-BILL-INVOICE-32",
+                      "id": "GOBL-BR-NFE-BILL-INVOICE-32",
                       "desc": "payment instructions are required when invoice is unpaid",
                       "tests": "present"
                     }
@@ -397,7 +402,7 @@
               "field": "due",
               "assert": [
                 {
-                  "id": "GOBL-BR-NFE-V4-BILL-INVOICE-33",
+                  "id": "GOBL-BR-NFE-BILL-INVOICE-33",
                   "desc": "due amount must not be negative",
                   "tests": "zero or positive"
                 }
@@ -408,35 +413,35 @@
       ]
     },
     {
-      "id": "GOBL-BR-NFE-V4-BILL-LINE",
+      "id": "GOBL-BR-NFE-BILL-LINE",
       "object": "bill.Line",
       "assert": [
         {
-          "id": "GOBL-BR-NFE-V4-BILL-LINE-01",
+          "id": "GOBL-BR-NFE-BILL-LINE-01",
           "desc": "line taxes must include the ICMS category",
           "tests": "line has tax category ICMS"
         },
         {
-          "id": "GOBL-BR-NFE-V4-BILL-LINE-02",
+          "id": "GOBL-BR-NFE-BILL-LINE-02",
           "desc": "line taxes must include the PIS category",
           "tests": "line has tax category PIS"
         },
         {
-          "id": "GOBL-BR-NFE-V4-BILL-LINE-03",
+          "id": "GOBL-BR-NFE-BILL-LINE-03",
           "desc": "line taxes must include the COFINS category",
           "tests": "line has tax category COFINS"
         }
       ]
     },
     {
-      "id": "GOBL-BR-NFE-V4-PAY-INSTRUCTIONS",
+      "id": "GOBL-BR-NFE-PAY-INSTRUCTIONS",
       "object": "pay.Instructions",
       "subsets": [
         {
           "field": "ext",
           "assert": [
             {
-              "id": "GOBL-BR-NFE-V4-PAY-INSTRUCTIONS-01",
+              "id": "GOBL-BR-NFE-PAY-INSTRUCTIONS-01",
               "desc": "payment instructions require 'br-nfe-payment-means' extension",
               "tests": "ext require [br-nfe-payment-means]"
             }
@@ -445,14 +450,14 @@
       ]
     },
     {
-      "id": "GOBL-BR-NFE-V4-PAY-ADVANCE",
+      "id": "GOBL-BR-NFE-PAY-ADVANCE",
       "object": "pay.Advance",
       "subsets": [
         {
           "field": "ext",
           "assert": [
             {
-              "id": "GOBL-BR-NFE-V4-PAY-ADVANCE-01",
+              "id": "GOBL-BR-NFE-PAY-ADVANCE-01",
               "desc": "payment advance requires 'br-nfe-payment-means' extension",
               "tests": "ext require [br-nfe-payment-means]"
             }

--- a/data/rules/br-nfse.json
+++ b/data/rules/br-nfse.json
@@ -1,17 +1,24 @@
 {
-  "id": "GOBL-BR-NFSE-V1",
-  "package": "br-nfse-v1",
+  "id": "GOBL-BR-NFSE",
+  "package": "br-nfse",
   "guard": "context: addon in [br-nfse-v1]",
   "subsets": [
     {
-      "id": "GOBL-BR-NFSE-V1-BILL-INVOICE",
+      "id": "GOBL-BR-NFSE-BILL-INVOICE",
       "object": "bill.Invoice",
+      "assert": [
+        {
+          "id": "GOBL-BR-NFSE-BILL-INVOICE-17",
+          "desc": "invoice must be in BRL or provide exchange rate for conversion",
+          "tests": "can convert to [BRL]"
+        }
+      ],
       "subsets": [
         {
           "field": "series",
           "assert": [
             {
-              "id": "GOBL-BR-NFSE-V1-BILL-INVOICE-01",
+              "id": "GOBL-BR-NFSE-BILL-INVOICE-01",
               "desc": "series is required",
               "tests": "present"
             }
@@ -21,7 +28,7 @@
           "field": "code",
           "assert": [
             {
-              "id": "GOBL-BR-NFSE-V1-BILL-INVOICE-02",
+              "id": "GOBL-BR-NFSE-BILL-INVOICE-02",
               "desc": "code must be a positive integer",
               "tests": "matches ^[1-9][0-9]*$"
             }
@@ -31,7 +38,7 @@
           "field": "supplier",
           "assert": [
             {
-              "id": "GOBL-BR-NFSE-V1-BILL-INVOICE-03",
+              "id": "GOBL-BR-NFSE-BILL-INVOICE-03",
               "desc": "supplier is required",
               "tests": "present"
             }
@@ -41,7 +48,7 @@
               "field": "tax_id",
               "assert": [
                 {
-                  "id": "GOBL-BR-NFSE-V1-BILL-INVOICE-04",
+                  "id": "GOBL-BR-NFSE-BILL-INVOICE-04",
                   "desc": "supplier tax ID is required",
                   "tests": "present"
                 }
@@ -51,7 +58,7 @@
                   "field": "code",
                   "assert": [
                     {
-                      "id": "GOBL-BR-NFSE-V1-BILL-INVOICE-05",
+                      "id": "GOBL-BR-NFSE-BILL-INVOICE-05",
                       "desc": "supplier tax ID code is required",
                       "tests": "present"
                     }
@@ -63,7 +70,7 @@
               "field": "name",
               "assert": [
                 {
-                  "id": "GOBL-BR-NFSE-V1-BILL-INVOICE-06",
+                  "id": "GOBL-BR-NFSE-BILL-INVOICE-06",
                   "desc": "supplier name is required",
                   "tests": "present"
                 }
@@ -73,7 +80,7 @@
               "field": "addresses",
               "assert": [
                 {
-                  "id": "GOBL-BR-NFSE-V1-BILL-INVOICE-07",
+                  "id": "GOBL-BR-NFSE-BILL-INVOICE-07",
                   "desc": "supplier must have at least one address",
                   "tests": "present"
                 }
@@ -83,7 +90,7 @@
                   "each": true,
                   "assert": [
                     {
-                      "id": "GOBL-BR-NFSE-V1-BILL-INVOICE-08",
+                      "id": "GOBL-BR-NFSE-BILL-INVOICE-08",
                       "desc": "supplier address must not be empty",
                       "tests": "present"
                     }
@@ -93,7 +100,7 @@
                       "field": "street",
                       "assert": [
                         {
-                          "id": "GOBL-BR-NFSE-V1-BILL-INVOICE-09",
+                          "id": "GOBL-BR-NFSE-BILL-INVOICE-09",
                           "desc": "supplier address requires a street",
                           "tests": "present"
                         }
@@ -103,7 +110,7 @@
                       "field": "num",
                       "assert": [
                         {
-                          "id": "GOBL-BR-NFSE-V1-BILL-INVOICE-10",
+                          "id": "GOBL-BR-NFSE-BILL-INVOICE-10",
                           "desc": "supplier address requires a number",
                           "tests": "present"
                         }
@@ -113,7 +120,7 @@
                       "field": "locality",
                       "assert": [
                         {
-                          "id": "GOBL-BR-NFSE-V1-BILL-INVOICE-11",
+                          "id": "GOBL-BR-NFSE-BILL-INVOICE-11",
                           "desc": "supplier address requires a locality",
                           "tests": "present"
                         }
@@ -123,7 +130,7 @@
                       "field": "state",
                       "assert": [
                         {
-                          "id": "GOBL-BR-NFSE-V1-BILL-INVOICE-12",
+                          "id": "GOBL-BR-NFSE-BILL-INVOICE-12",
                           "desc": "supplier address requires a state",
                           "tests": "present"
                         }
@@ -133,7 +140,7 @@
                       "field": "code",
                       "assert": [
                         {
-                          "id": "GOBL-BR-NFSE-V1-BILL-INVOICE-13",
+                          "id": "GOBL-BR-NFSE-BILL-INVOICE-13",
                           "desc": "supplier address requires a postal code",
                           "tests": "present"
                         }
@@ -147,7 +154,7 @@
               "field": "ext",
               "assert": [
                 {
-                  "id": "GOBL-BR-NFSE-V1-BILL-INVOICE-14",
+                  "id": "GOBL-BR-NFSE-BILL-INVOICE-14",
                   "desc": "supplier requires 'br-ibge-municipality', 'br-nfse-simples', and 'br-nfse-fiscal-incentive' extensions",
                   "tests": "ext require [br-ibge-municipality, br-nfse-simples, br-nfse-fiscal-incentive]"
                 }
@@ -159,7 +166,7 @@
           "field": "charges",
           "assert": [
             {
-              "id": "GOBL-BR-NFSE-V1-BILL-INVOICE-15",
+              "id": "GOBL-BR-NFSE-BILL-INVOICE-15",
               "desc": "charges are not supported by NFS-e",
               "tests": "empty"
             }
@@ -169,7 +176,7 @@
           "field": "discounts",
           "assert": [
             {
-              "id": "GOBL-BR-NFSE-V1-BILL-INVOICE-16",
+              "id": "GOBL-BR-NFSE-BILL-INVOICE-16",
               "desc": "discounts are not supported by NFS-e",
               "tests": "empty"
             }
@@ -178,30 +185,30 @@
       ]
     },
     {
-      "id": "GOBL-BR-NFSE-V1-BILL-LINE",
+      "id": "GOBL-BR-NFSE-BILL-LINE",
       "object": "bill.Line",
       "assert": [
         {
-          "id": "GOBL-BR-NFSE-V1-BILL-LINE-01",
+          "id": "GOBL-BR-NFSE-BILL-LINE-01",
           "desc": "line taxes must include the ISS category",
           "tests": "line has tax category ISS"
         }
       ]
     },
     {
-      "id": "GOBL-BR-NFSE-V1-ORG-ITEM",
+      "id": "GOBL-BR-NFSE-ORG-ITEM",
       "object": "org.Item",
       "subsets": [
         {
           "field": "ext",
           "assert": [
             {
-              "id": "GOBL-BR-NFSE-V1-ORG-ITEM-01",
+              "id": "GOBL-BR-NFSE-ORG-ITEM-01",
               "desc": "item requires 'br-nfse-service' extension",
               "tests": "ext require [br-nfse-service]"
             },
             {
-              "id": "GOBL-BR-NFSE-V1-ORG-ITEM-02",
+              "id": "GOBL-BR-NFSE-ORG-ITEM-02",
               "desc": "item extensions 'br-nfse-operation', 'br-nfse-tax-status', and 'br-nfse-tax-class' must all be present or all absent",
               "tests": "ext require all or none of [br-nfse-operation, br-nfse-tax-status, br-nfse-tax-class]"
             }
@@ -210,7 +217,7 @@
       ]
     },
     {
-      "id": "GOBL-BR-NFSE-V1-TAX-COMBO",
+      "id": "GOBL-BR-NFSE-TAX-COMBO",
       "object": "tax.Combo",
       "subsets": [
         {
@@ -220,7 +227,7 @@
               "field": "ext",
               "assert": [
                 {
-                  "id": "GOBL-BR-NFSE-V1-TAX-COMBO-01",
+                  "id": "GOBL-BR-NFSE-TAX-COMBO-01",
                   "desc": "ISS tax combo requires 'br-nfse-iss-liability' extension",
                   "tests": "ext require [br-nfse-iss-liability]"
                 }

--- a/data/rules/co-dian.json
+++ b/data/rules/co-dian.json
@@ -1,14 +1,19 @@
 {
-  "id": "GOBL-CO-DIAN-V2",
-  "package": "co-dian-v2",
+  "id": "GOBL-CO-DIAN",
+  "package": "co-dian",
   "guard": "context: addon in [co-dian-v2]",
   "subsets": [
     {
-      "id": "GOBL-CO-DIAN-V2-BILL-INVOICE",
+      "id": "GOBL-CO-DIAN-BILL-INVOICE",
       "object": "bill.Invoice",
       "assert": [
         {
-          "id": "GOBL-CO-DIAN-V2-BILL-INVOICE-01",
+          "id": "GOBL-CO-DIAN-BILL-INVOICE-14",
+          "desc": "invoice must be in COP or provide exchange rate for conversion",
+          "tests": "can convert to [COP]"
+        },
+        {
+          "id": "GOBL-CO-DIAN-BILL-INVOICE-01",
           "desc": "invoice type must be one of standard, credit-note, debit-note, or proforma",
           "tests": "invoice type in [standard, credit-note, debit-note, proforma]"
         }
@@ -24,7 +29,7 @@
                   "field": "addresses",
                   "assert": [
                     {
-                      "id": "GOBL-CO-DIAN-V2-BILL-INVOICE-02",
+                      "id": "GOBL-CO-DIAN-BILL-INVOICE-02",
                       "desc": "at least one address is required for Colombian suppliers",
                       "tests": "length between 1 and 0"
                     }
@@ -39,7 +44,7 @@
                   "field": "ext",
                   "assert": [
                     {
-                      "id": "GOBL-CO-DIAN-V2-BILL-INVOICE-03",
+                      "id": "GOBL-CO-DIAN-BILL-INVOICE-03",
                       "desc": "extension 'co-dian-municipality' is required",
                       "tests": "ext require [co-dian-municipality]"
                     }
@@ -54,7 +59,7 @@
                   "field": "ext",
                   "assert": [
                     {
-                      "id": "GOBL-CO-DIAN-V2-BILL-INVOICE-04",
+                      "id": "GOBL-CO-DIAN-BILL-INVOICE-04",
                       "desc": "extension 'co-dian-fiscal-responsibility' is required",
                       "tests": "ext require [co-dian-fiscal-responsibility]"
                     }
@@ -74,7 +79,7 @@
                   "field": "tax_id",
                   "assert": [
                     {
-                      "id": "GOBL-CO-DIAN-V2-BILL-INVOICE-05",
+                      "id": "GOBL-CO-DIAN-BILL-INVOICE-05",
                       "desc": "customer tax ID is required",
                       "tests": "present"
                     }
@@ -94,7 +99,7 @@
                   "field": "addresses",
                   "assert": [
                     {
-                      "id": "GOBL-CO-DIAN-V2-BILL-INVOICE-06",
+                      "id": "GOBL-CO-DIAN-BILL-INVOICE-06",
                       "desc": "at least one address is required for Colombian customers",
                       "tests": "length between 1 and 0"
                     }
@@ -109,7 +114,7 @@
                   "field": "ext",
                   "assert": [
                     {
-                      "id": "GOBL-CO-DIAN-V2-BILL-INVOICE-07",
+                      "id": "GOBL-CO-DIAN-BILL-INVOICE-07",
                       "desc": "extension 'co-dian-municipality' is required",
                       "tests": "ext require [co-dian-municipality]"
                     }
@@ -124,7 +129,7 @@
                   "field": "ext",
                   "assert": [
                     {
-                      "id": "GOBL-CO-DIAN-V2-BILL-INVOICE-08",
+                      "id": "GOBL-CO-DIAN-BILL-INVOICE-08",
                       "desc": "extension 'co-dian-fiscal-responsibility' is required",
                       "tests": "ext require [co-dian-fiscal-responsibility]"
                     }
@@ -141,7 +146,7 @@
               "field": "preceding",
               "assert": [
                 {
-                  "id": "GOBL-CO-DIAN-V2-BILL-INVOICE-09",
+                  "id": "GOBL-CO-DIAN-BILL-INVOICE-09",
                   "desc": "preceding documents are required for credit and debit notes",
                   "tests": "present"
                 }
@@ -162,7 +167,7 @@
                       "field": "ext",
                       "assert": [
                         {
-                          "id": "GOBL-CO-DIAN-V2-BILL-INVOICE-10",
+                          "id": "GOBL-CO-DIAN-BILL-INVOICE-10",
                           "desc": "extension 'co-dian-credit-code' is required for credit notes",
                           "tests": "ext require [co-dian-credit-code]"
                         }
@@ -172,7 +177,7 @@
                       "field": "reason",
                       "assert": [
                         {
-                          "id": "GOBL-CO-DIAN-V2-BILL-INVOICE-12",
+                          "id": "GOBL-CO-DIAN-BILL-INVOICE-12",
                           "desc": "preceding reason is required",
                           "tests": "present"
                         }
@@ -197,7 +202,7 @@
                       "field": "ext",
                       "assert": [
                         {
-                          "id": "GOBL-CO-DIAN-V2-BILL-INVOICE-11",
+                          "id": "GOBL-CO-DIAN-BILL-INVOICE-11",
                           "desc": "extension 'co-dian-debit-code' is required for debit notes",
                           "tests": "ext require [co-dian-debit-code]"
                         }
@@ -207,7 +212,7 @@
                       "field": "reason",
                       "assert": [
                         {
-                          "id": "GOBL-CO-DIAN-V2-BILL-INVOICE-13",
+                          "id": "GOBL-CO-DIAN-BILL-INVOICE-13",
                           "desc": "preceding reason is required",
                           "tests": "present"
                         }

--- a/data/rules/currency.json
+++ b/data/rules/currency.json
@@ -3,6 +3,22 @@
   "package": "currency",
   "subsets": [
     {
+      "id": "GOBL-CURRENCY-CODE",
+      "object": "currency.Code",
+      "subsets": [
+        {
+          "guard": "present",
+          "assert": [
+            {
+              "id": "GOBL-CURRENCY-CODE-01",
+              "desc": "currency code must be defined in GOBL",
+              "tests": "valid currency code"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "id": "GOBL-CURRENCY-AMOUNT",
       "object": "currency.Amount",
       "subsets": [

--- a/data/rules/de-xrechnung.json
+++ b/data/rules/de-xrechnung.json
@@ -1,10 +1,10 @@
 {
-  "id": "GOBL-DE-XRECHNUNG-V3",
-  "package": "de-xrechnung-v3",
+  "id": "GOBL-DE-XRECHNUNG",
+  "package": "de-xrechnung",
   "guard": "context: addon in [de-xrechnung-v3]",
   "subsets": [
     {
-      "id": "GOBL-DE-XRECHNUNG-V3-BILL-INVOICE",
+      "id": "GOBL-DE-XRECHNUNG-BILL-INVOICE",
       "object": "bill.Invoice",
       "subsets": [
         {
@@ -14,7 +14,7 @@
               "field": "ext",
               "assert": [
                 {
-                  "id": "GOBL-DE-XRECHNUNG-V3-BILL-INVOICE-01",
+                  "id": "GOBL-DE-XRECHNUNG-BILL-INVOICE-01",
                   "desc": "tax ext must have a valid UNTDID document type code (BR-DE-17)",
                   "tests": "ext 'untdid-tax-category' in [326, 380, 384, 389, 381, 875, 876, 877]"
                 }
@@ -29,7 +29,7 @@
               "field": "preceding",
               "assert": [
                 {
-                  "id": "GOBL-DE-XRECHNUNG-V3-BILL-INVOICE-02",
+                  "id": "GOBL-DE-XRECHNUNG-BILL-INVOICE-02",
                   "desc": "preceding documents are required for corrective and credit note invoices (BR-DE-26)",
                   "tests": "present"
                 }
@@ -41,17 +41,17 @@
           "field": "supplier",
           "assert": [
             {
-              "id": "GOBL-DE-XRECHNUNG-V3-BILL-INVOICE-03",
+              "id": "GOBL-DE-XRECHNUNG-BILL-INVOICE-03",
               "desc": "supplier is required",
               "tests": "present"
             },
             {
-              "id": "GOBL-DE-XRECHNUNG-V3-BILL-INVOICE-09",
+              "id": "GOBL-DE-XRECHNUNG-BILL-INVOICE-09",
               "desc": "either party.telephones or party.people[0].telephones is required (BR-DE-6)",
               "tests": "has telephones"
             },
             {
-              "id": "GOBL-DE-XRECHNUNG-V3-BILL-INVOICE-10",
+              "id": "GOBL-DE-XRECHNUNG-BILL-INVOICE-10",
               "desc": "either party.emails or party.people[0].emails is required (BR-DE-7)",
               "tests": "has emails"
             }
@@ -61,7 +61,7 @@
               "field": "people",
               "assert": [
                 {
-                  "id": "GOBL-DE-XRECHNUNG-V3-BILL-INVOICE-04",
+                  "id": "GOBL-DE-XRECHNUNG-BILL-INVOICE-04",
                   "desc": "supplier people is required (BR-DE-5)",
                   "tests": "present"
                 }
@@ -71,17 +71,17 @@
               "field": "addresses",
               "assert": [
                 {
-                  "id": "GOBL-DE-XRECHNUNG-V3-BILL-INVOICE-05",
+                  "id": "GOBL-DE-XRECHNUNG-BILL-INVOICE-05",
                   "desc": "supplier addresses is required (BR-DE-2)",
                   "tests": "present"
                 },
                 {
-                  "id": "GOBL-DE-XRECHNUNG-V3-BILL-INVOICE-06",
+                  "id": "GOBL-DE-XRECHNUNG-BILL-INVOICE-06",
                   "desc": "supplier first address must have a locality (BR-DE-3)",
                   "tests": "has locality"
                 },
                 {
-                  "id": "GOBL-DE-XRECHNUNG-V3-BILL-INVOICE-07",
+                  "id": "GOBL-DE-XRECHNUNG-BILL-INVOICE-07",
                   "desc": "supplier first address must have a postal code (BR-DE-4)",
                   "tests": "has code"
                 }
@@ -91,7 +91,7 @@
               "field": "inboxes",
               "assert": [
                 {
-                  "id": "GOBL-DE-XRECHNUNG-V3-BILL-INVOICE-08",
+                  "id": "GOBL-DE-XRECHNUNG-BILL-INVOICE-08",
                   "desc": "supplier inboxes are required (PEPPOL-EN16931-R020)",
                   "tests": "present"
                 }
@@ -103,7 +103,7 @@
           "field": "customer",
           "assert": [
             {
-              "id": "GOBL-DE-XRECHNUNG-V3-BILL-INVOICE-11",
+              "id": "GOBL-DE-XRECHNUNG-BILL-INVOICE-11",
               "desc": "customer is required",
               "tests": "present"
             }
@@ -113,17 +113,17 @@
               "field": "addresses",
               "assert": [
                 {
-                  "id": "GOBL-DE-XRECHNUNG-V3-BILL-INVOICE-12",
+                  "id": "GOBL-DE-XRECHNUNG-BILL-INVOICE-12",
                   "desc": "customer addresses are required (BR-DE-8)",
                   "tests": "present"
                 },
                 {
-                  "id": "GOBL-DE-XRECHNUNG-V3-BILL-INVOICE-13",
+                  "id": "GOBL-DE-XRECHNUNG-BILL-INVOICE-13",
                   "desc": "customer first address must have a locality (BR-DE-9)",
                   "tests": "has locality"
                 },
                 {
-                  "id": "GOBL-DE-XRECHNUNG-V3-BILL-INVOICE-14",
+                  "id": "GOBL-DE-XRECHNUNG-BILL-INVOICE-14",
                   "desc": "customer first address must have a postal code (BR-DE-10)",
                   "tests": "has code"
                 }
@@ -133,7 +133,7 @@
               "field": "inboxes",
               "assert": [
                 {
-                  "id": "GOBL-DE-XRECHNUNG-V3-BILL-INVOICE-15",
+                  "id": "GOBL-DE-XRECHNUNG-BILL-INVOICE-15",
                   "desc": "customer inboxes are required (PEPPOL-EN16931-R010)",
                   "tests": "present"
                 }
@@ -145,7 +145,7 @@
           "field": "payment",
           "assert": [
             {
-              "id": "GOBL-DE-XRECHNUNG-V3-BILL-INVOICE-16",
+              "id": "GOBL-DE-XRECHNUNG-BILL-INVOICE-16",
               "desc": "payment is required (BR-DE-1)",
               "tests": "present"
             }
@@ -155,7 +155,7 @@
               "field": "instructions",
               "assert": [
                 {
-                  "id": "GOBL-DE-XRECHNUNG-V3-BILL-INVOICE-17",
+                  "id": "GOBL-DE-XRECHNUNG-BILL-INVOICE-17",
                   "desc": "payment instructions are required (BR-DE-1)",
                   "tests": "present"
                 }
@@ -168,7 +168,7 @@
                       "field": "credit_transfer",
                       "assert": [
                         {
-                          "id": "GOBL-DE-XRECHNUNG-V3-BILL-INVOICE-18",
+                          "id": "GOBL-DE-XRECHNUNG-BILL-INVOICE-18",
                           "desc": "credit transfer is required for credit-transfer payments (BR-DE-23)",
                           "tests": "present"
                         }
@@ -184,7 +184,7 @@
                                   "field": "number",
                                   "assert": [
                                     {
-                                      "id": "GOBL-DE-XRECHNUNG-V3-BILL-INVOICE-19",
+                                      "id": "GOBL-DE-XRECHNUNG-BILL-INVOICE-19",
                                       "desc": "account number is required when IBAN is not provided (BR-DE-19)",
                                       "tests": "present"
                                     }
@@ -205,7 +205,7 @@
                       "field": "card",
                       "assert": [
                         {
-                          "id": "GOBL-DE-XRECHNUNG-V3-BILL-INVOICE-20",
+                          "id": "GOBL-DE-XRECHNUNG-BILL-INVOICE-20",
                           "desc": "card details are required for card payments (BR-DE-24)",
                           "tests": "present"
                         }
@@ -220,7 +220,7 @@
                       "field": "direct_debit",
                       "assert": [
                         {
-                          "id": "GOBL-DE-XRECHNUNG-V3-BILL-INVOICE-21",
+                          "id": "GOBL-DE-XRECHNUNG-BILL-INVOICE-21",
                           "desc": "direct debit details are required for direct-debit payments (BR-DE-25)",
                           "tests": "present"
                         }
@@ -230,7 +230,7 @@
                           "field": "ref",
                           "assert": [
                             {
-                              "id": "GOBL-DE-XRECHNUNG-V3-BILL-INVOICE-22",
+                              "id": "GOBL-DE-XRECHNUNG-BILL-INVOICE-22",
                               "desc": "direct debit mandate reference is required (BR-DE-29)",
                               "tests": "present"
                             }
@@ -240,7 +240,7 @@
                           "field": "creditor",
                           "assert": [
                             {
-                              "id": "GOBL-DE-XRECHNUNG-V3-BILL-INVOICE-23",
+                              "id": "GOBL-DE-XRECHNUNG-BILL-INVOICE-23",
                               "desc": "direct debit creditor identifier is required (BR-DE-30)",
                               "tests": "present"
                             }
@@ -250,7 +250,7 @@
                           "field": "account",
                           "assert": [
                             {
-                              "id": "GOBL-DE-XRECHNUNG-V3-BILL-INVOICE-24",
+                              "id": "GOBL-DE-XRECHNUNG-BILL-INVOICE-24",
                               "desc": "direct debit account is required (BR-DE-31)",
                               "tests": "present"
                             }
@@ -271,7 +271,7 @@
               "field": "receiver",
               "assert": [
                 {
-                  "id": "GOBL-DE-XRECHNUNG-V3-BILL-INVOICE-25",
+                  "id": "GOBL-DE-XRECHNUNG-BILL-INVOICE-25",
                   "desc": "delivery receiver is required",
                   "tests": "present"
                 }
@@ -281,17 +281,17 @@
                   "field": "addresses",
                   "assert": [
                     {
-                      "id": "GOBL-DE-XRECHNUNG-V3-BILL-INVOICE-26",
+                      "id": "GOBL-DE-XRECHNUNG-BILL-INVOICE-26",
                       "desc": "delivery receiver addresses are required",
                       "tests": "present"
                     },
                     {
-                      "id": "GOBL-DE-XRECHNUNG-V3-BILL-INVOICE-27",
+                      "id": "GOBL-DE-XRECHNUNG-BILL-INVOICE-27",
                       "desc": "delivery receiver first address must have a locality (BR-DE-11)",
                       "tests": "has locality"
                     },
                     {
-                      "id": "GOBL-DE-XRECHNUNG-V3-BILL-INVOICE-28",
+                      "id": "GOBL-DE-XRECHNUNG-BILL-INVOICE-28",
                       "desc": "delivery receiver first address must have a postal code (BR-DE-12)",
                       "tests": "has code"
                     }
@@ -305,7 +305,7 @@
           "field": "ordering",
           "assert": [
             {
-              "id": "GOBL-DE-XRECHNUNG-V3-BILL-INVOICE-29",
+              "id": "GOBL-DE-XRECHNUNG-BILL-INVOICE-29",
               "desc": "ordering is required (BR-DE-15)",
               "tests": "present"
             }
@@ -315,7 +315,7 @@
               "field": "code",
               "assert": [
                 {
-                  "id": "GOBL-DE-XRECHNUNG-V3-BILL-INVOICE-30",
+                  "id": "GOBL-DE-XRECHNUNG-BILL-INVOICE-30",
                   "desc": "ordering code is required (BR-DE-15)",
                   "tests": "present"
                 }

--- a/data/rules/es-facturae.json
+++ b/data/rules/es-facturae.json
@@ -1,11 +1,18 @@
 {
-  "id": "GOBL-ES-FACTURAE-V3",
-  "package": "es-facturae-v3",
+  "id": "GOBL-ES-FACTURAE",
+  "package": "es-facturae",
   "guard": "context: addon in [es-facturae-v3]",
   "subsets": [
     {
-      "id": "GOBL-ES-FACTURAE-V3-BILL-INVOICE",
+      "id": "GOBL-ES-FACTURAE-BILL-INVOICE",
       "object": "bill.Invoice",
+      "assert": [
+        {
+          "id": "GOBL-ES-FACTURAE-BILL-INVOICE-07",
+          "desc": "invoice must be in EUR or provide exchange rate for conversion",
+          "tests": "can convert to [EUR]"
+        }
+      ],
       "subsets": [
         {
           "field": "customer",
@@ -20,7 +27,7 @@
                       "field": "code",
                       "assert": [
                         {
-                          "id": "GOBL-ES-FACTURAE-V3-BILL-INVOICE-01",
+                          "id": "GOBL-ES-FACTURAE-BILL-INVOICE-01",
                           "desc": "customer tax ID code is required for Spanish customers",
                           "tests": "present"
                         }
@@ -36,7 +43,7 @@
           "field": "tax",
           "assert": [
             {
-              "id": "GOBL-ES-FACTURAE-V3-BILL-INVOICE-02",
+              "id": "GOBL-ES-FACTURAE-BILL-INVOICE-02",
               "desc": "tax object is required with ext document type and invoice classes",
               "tests": "present"
             }
@@ -46,7 +53,7 @@
               "field": "ext",
               "assert": [
                 {
-                  "id": "GOBL-ES-FACTURAE-V3-BILL-INVOICE-03",
+                  "id": "GOBL-ES-FACTURAE-BILL-INVOICE-03",
                   "desc": "tax ext require 'es-facturae-doc-type' and 'es-facturae-invoice-class' extensions",
                   "tests": "ext require [es-facturae-doc-type, es-facturae-invoice-class]"
                 }
@@ -61,7 +68,7 @@
               "field": "preceding",
               "assert": [
                 {
-                  "id": "GOBL-ES-FACTURAE-V3-BILL-INVOICE-04",
+                  "id": "GOBL-ES-FACTURAE-BILL-INVOICE-04",
                   "desc": "preceding document reference is required for credit-note, corrective, debit-note invoices",
                   "tests": "present"
                 }
@@ -74,7 +81,7 @@
                       "field": "issue_date",
                       "assert": [
                         {
-                          "id": "GOBL-ES-FACTURAE-V3-BILL-INVOICE-05",
+                          "id": "GOBL-ES-FACTURAE-BILL-INVOICE-05",
                           "desc": "preceding document issue date is required",
                           "tests": "present"
                         }
@@ -84,7 +91,7 @@
                       "field": "ext",
                       "assert": [
                         {
-                          "id": "GOBL-ES-FACTURAE-V3-BILL-INVOICE-06",
+                          "id": "GOBL-ES-FACTURAE-BILL-INVOICE-06",
                           "desc": "preceding document ext require 'es-facturae-correction' extension",
                           "tests": "ext require [es-facturae-correction]"
                         }

--- a/data/rules/es-sii.json
+++ b/data/rules/es-sii.json
@@ -1,11 +1,18 @@
 {
-  "id": "GOBL-ES-SII-V1",
-  "package": "es-sii-v1",
+  "id": "GOBL-ES-SII",
+  "package": "es-sii",
   "guard": "context: addon in [es-sii-v1]",
   "subsets": [
     {
-      "id": "GOBL-ES-SII-V1-BILL-INVOICE",
+      "id": "GOBL-ES-SII-BILL-INVOICE",
       "object": "bill.Invoice",
+      "assert": [
+        {
+          "id": "GOBL-ES-SII-BILL-INVOICE-15",
+          "desc": "invoice must be in EUR or provide exchange rate for conversion",
+          "tests": "can convert to [EUR]"
+        }
+      ],
       "subsets": [
         {
           "guard": "invoice type in [corrective]",
@@ -14,7 +21,7 @@
               "field": "preceding",
               "assert": [
                 {
-                  "id": "GOBL-ES-SII-V1-BILL-INVOICE-01",
+                  "id": "GOBL-ES-SII-BILL-INVOICE-01",
                   "desc": "preceding documents are required for corrective invoices",
                   "tests": "present"
                 }
@@ -32,7 +39,7 @@
                   "field": "issue_date",
                   "assert": [
                     {
-                      "id": "GOBL-ES-SII-V1-BILL-INVOICE-02",
+                      "id": "GOBL-ES-SII-BILL-INVOICE-02",
                       "desc": "preceding issue date is required",
                       "tests": "present"
                     }
@@ -55,7 +62,7 @@
                       "field": "tax",
                       "assert": [
                         {
-                          "id": "GOBL-ES-SII-V1-BILL-INVOICE-03",
+                          "id": "GOBL-ES-SII-BILL-INVOICE-03",
                           "desc": "preceding invoice tax data is required for corrective invoices",
                           "tests": "present"
                         }
@@ -74,12 +81,12 @@
               "field": "customer",
               "assert": [
                 {
-                  "id": "GOBL-ES-SII-V1-BILL-INVOICE-04",
+                  "id": "GOBL-ES-SII-BILL-INVOICE-04",
                   "desc": "customer is required",
                   "tests": "present"
                 },
                 {
-                  "id": "GOBL-ES-SII-V1-BILL-INVOICE-05",
+                  "id": "GOBL-ES-SII-BILL-INVOICE-05",
                   "desc": "must have a tax_id, or an identity with ext 'es-sii-identity-type'",
                   "tests": "has tax_id or identity"
                 }
@@ -92,7 +99,7 @@
                       "field": "code",
                       "assert": [
                         {
-                          "id": "GOBL-ES-SII-V1-BILL-INVOICE-06",
+                          "id": "GOBL-ES-SII-BILL-INVOICE-06",
                           "desc": "customer tax ID must have a code",
                           "tests": "present"
                         }
@@ -108,7 +115,7 @@
           "field": "tax",
           "assert": [
             {
-              "id": "GOBL-ES-SII-V1-BILL-INVOICE-07",
+              "id": "GOBL-ES-SII-BILL-INVOICE-07",
               "desc": "tax object is required with extensions",
               "tests": "present"
             }
@@ -118,7 +125,7 @@
               "field": "ext",
               "assert": [
                 {
-                  "id": "GOBL-ES-SII-V1-BILL-INVOICE-08",
+                  "id": "GOBL-ES-SII-BILL-INVOICE-08",
                   "desc": "tax extension 'es-sii-doc-type' is required",
                   "tests": "ext require [es-sii-doc-type]"
                 }
@@ -128,7 +135,7 @@
                   "guard": "ext 'es-sii-doc-type' in [R1, R2, R3, R4, R5]",
                   "assert": [
                     {
-                      "id": "GOBL-ES-SII-V1-BILL-INVOICE-09",
+                      "id": "GOBL-ES-SII-BILL-INVOICE-09",
                       "desc": "tax extension 'es-sii-correction-type' is required",
                       "tests": "ext require [es-sii-correction-type]"
                     }
@@ -148,7 +155,7 @@
                   "field": "ext",
                   "assert": [
                     {
-                      "id": "GOBL-ES-SII-V1-BILL-INVOICE-10",
+                      "id": "GOBL-ES-SII-BILL-INVOICE-10",
                       "desc": "tax extension 'es-sii-doc-type' for standard invoices must be F1, F2, or F3",
                       "tests": "ext 'es-sii-doc-type' in [F1, F2, F3]"
                     }
@@ -168,7 +175,7 @@
                   "field": "ext",
                   "assert": [
                     {
-                      "id": "GOBL-ES-SII-V1-BILL-INVOICE-11",
+                      "id": "GOBL-ES-SII-BILL-INVOICE-11",
                       "desc": "doc type extension for corrective invoices must be R1, R2, R3, R4, or R5",
                       "tests": "ext 'es-sii-doc-type' in [R1, R2, R3, R4, R5]"
                     }
@@ -191,7 +198,7 @@
                       "field": "text",
                       "assert": [
                         {
-                          "id": "GOBL-ES-SII-V1-BILL-INVOICE-12",
+                          "id": "GOBL-ES-SII-BILL-INVOICE-12",
                           "desc": "general note text must be 500 characters or less",
                           "tests": "length between 0 and 500"
                         }
@@ -207,12 +214,12 @@
           "field": "lines",
           "assert": [
             {
-              "id": "GOBL-ES-SII-V1-BILL-INVOICE-13",
+              "id": "GOBL-ES-SII-BILL-INVOICE-13",
               "desc": "'es-sii-product' must be present in all tax combos or none",
               "tests": "consistent product"
             },
             {
-              "id": "GOBL-ES-SII-V1-BILL-INVOICE-14",
+              "id": "GOBL-ES-SII-BILL-INVOICE-14",
               "desc": "'es-sii-regime' must be the same in all tax combos",
               "tests": "same regime"
             }
@@ -221,7 +228,7 @@
       ]
     },
     {
-      "id": "GOBL-ES-SII-V1-TAX-COMBO",
+      "id": "GOBL-ES-SII-TAX-COMBO",
       "object": "tax.Combo",
       "subsets": [
         {
@@ -231,7 +238,7 @@
               "field": "ext",
               "assert": [
                 {
-                  "id": "GOBL-ES-SII-V1-TAX-COMBO-01",
+                  "id": "GOBL-ES-SII-TAX-COMBO-01",
                   "desc": "extension 'es-sii-regime' is required",
                   "tests": "ext require [es-sii-regime]"
                 }
@@ -241,7 +248,7 @@
                   "guard": "has outside scope",
                   "assert": [
                     {
-                      "id": "GOBL-ES-SII-V1-TAX-COMBO-03",
+                      "id": "GOBL-ES-SII-TAX-COMBO-03",
                       "desc": "extension 'es-sii-exempt' must not be set when 'es-sii-outside-scope' is set",
                       "tests": "ext exclude [es-sii-exempt]"
                     }
@@ -251,7 +258,7 @@
                   "guard": "ext 'es-sii-regime' in [01]",
                   "assert": [
                     {
-                      "id": "GOBL-ES-SII-V1-TAX-COMBO-04",
+                      "id": "GOBL-ES-SII-TAX-COMBO-04",
                       "desc": "exempt codes E2 and E3 not allowed with 'es-sii-regime' 01",
                       "tests": "ext 'es-sii-exempt' not in [E2, E3]"
                     }
@@ -266,7 +273,7 @@
                   "field": "ext",
                   "assert": [
                     {
-                      "id": "GOBL-ES-SII-V1-TAX-COMBO-02",
+                      "id": "GOBL-ES-SII-TAX-COMBO-02",
                       "desc": "extension 'es-sii-exempt' must not be set when percent is set",
                       "tests": "ext exclude [es-sii-exempt]"
                     }

--- a/data/rules/es-tbai.json
+++ b/data/rules/es-tbai.json
@@ -1,17 +1,24 @@
 {
-  "id": "GOBL-ES-TBAI-V1",
-  "package": "es-tbai-v1",
+  "id": "GOBL-ES-TBAI",
+  "package": "es-tbai",
   "guard": "context: addon in [es-tbai-v1]",
   "subsets": [
     {
-      "id": "GOBL-ES-TBAI-V1-BILL-INVOICE",
+      "id": "GOBL-ES-TBAI-BILL-INVOICE",
       "object": "bill.Invoice",
+      "assert": [
+        {
+          "id": "GOBL-ES-TBAI-BILL-INVOICE-09",
+          "desc": "invoice must be in EUR or provide exchange rate for conversion",
+          "tests": "can convert to [EUR]"
+        }
+      ],
       "subsets": [
         {
           "field": "tax",
           "assert": [
             {
-              "id": "GOBL-ES-TBAI-V1-BILL-INVOICE-01",
+              "id": "GOBL-ES-TBAI-BILL-INVOICE-01",
               "desc": "tax is required",
               "tests": "present"
             }
@@ -21,7 +28,7 @@
               "field": "ext",
               "assert": [
                 {
-                  "id": "GOBL-ES-TBAI-V1-BILL-INVOICE-02",
+                  "id": "GOBL-ES-TBAI-BILL-INVOICE-02",
                   "desc": "extension 'es-tbai-region' is required",
                   "tests": "ext require [es-tbai-region]"
                 }
@@ -36,7 +43,7 @@
               "field": "customer",
               "assert": [
                 {
-                  "id": "GOBL-ES-TBAI-V1-BILL-INVOICE-03",
+                  "id": "GOBL-ES-TBAI-BILL-INVOICE-03",
                   "desc": "customer is required for non-simplified invoices",
                   "tests": "present"
                 }
@@ -46,7 +53,7 @@
                   "field": "tax_id",
                   "assert": [
                     {
-                      "id": "GOBL-ES-TBAI-V1-BILL-INVOICE-08",
+                      "id": "GOBL-ES-TBAI-BILL-INVOICE-08",
                       "desc": "customer tax ID is required",
                       "tests": "present"
                     }
@@ -63,7 +70,7 @@
               "field": "preceding",
               "assert": [
                 {
-                  "id": "GOBL-ES-TBAI-V1-BILL-INVOICE-04",
+                  "id": "GOBL-ES-TBAI-BILL-INVOICE-04",
                   "desc": "preceding documents are required for credit-note, corrective, debit-note invoices",
                   "tests": "present"
                 }
@@ -81,7 +88,7 @@
                   "field": "issue_date",
                   "assert": [
                     {
-                      "id": "GOBL-ES-TBAI-V1-BILL-INVOICE-05",
+                      "id": "GOBL-ES-TBAI-BILL-INVOICE-05",
                       "desc": "preceding issue date is required",
                       "tests": "present"
                     }
@@ -91,7 +98,7 @@
                   "field": "ext",
                   "assert": [
                     {
-                      "id": "GOBL-ES-TBAI-V1-BILL-INVOICE-06",
+                      "id": "GOBL-ES-TBAI-BILL-INVOICE-06",
                       "desc": "preceding ext 'es-tbai-correction' is required",
                       "tests": "ext require [es-tbai-correction]"
                     }
@@ -105,7 +112,7 @@
           "field": "notes",
           "assert": [
             {
-              "id": "GOBL-ES-TBAI-V1-BILL-INVOICE-07",
+              "id": "GOBL-ES-TBAI-BILL-INVOICE-07",
               "desc": "with key 'general' missing",
               "tests": "has general note"
             }
@@ -114,7 +121,7 @@
       ]
     },
     {
-      "id": "GOBL-ES-TBAI-V1-TAX-COMBO",
+      "id": "GOBL-ES-TBAI-TAX-COMBO",
       "object": "tax.Combo",
       "subsets": [
         {
@@ -124,7 +131,7 @@
               "field": "ext",
               "assert": [
                 {
-                  "id": "GOBL-ES-TBAI-V1-TAX-COMBO-01",
+                  "id": "GOBL-ES-TBAI-TAX-COMBO-01",
                   "desc": "extension 'es-tbai-exemption' is required for exempt tax combos",
                   "tests": "ext require [es-tbai-exemption]"
                 }

--- a/data/rules/es-verifactu.json
+++ b/data/rules/es-verifactu.json
@@ -124,7 +124,7 @@
                 },
                 {
                   "id": "GOBL-ES-VERIFACTU-BILL-INVOICE-07",
-                  "desc": "must have a tax_id or an identity with ext 'es-verifactu-v1-identity-type'",
+                  "desc": "must have a tax_id or an identity with ext 'es-verifactu-identity-type'",
                   "tests": "has tax_id or identity"
                 }
               ],

--- a/data/rules/es-verifactu.json
+++ b/data/rules/es-verifactu.json
@@ -1,11 +1,18 @@
 {
-  "id": "GOBL-ES-VERIFACTU-V1",
-  "package": "es-verifactu-v1",
+  "id": "GOBL-ES-VERIFACTU",
+  "package": "es-verifactu",
   "guard": "context: addon in [es-verifactu-v1]",
   "subsets": [
     {
-      "id": "GOBL-ES-VERIFACTU-V1-BILL-INVOICE",
+      "id": "GOBL-ES-VERIFACTU-BILL-INVOICE",
       "object": "bill.Invoice",
+      "assert": [
+        {
+          "id": "GOBL-ES-VERIFACTU-BILL-INVOICE-16",
+          "desc": "invoice must be in EUR or provide exchange rate for conversion",
+          "tests": "can convert to [EUR]"
+        }
+      ],
       "subsets": [
         {
           "guard": "invoice type in [corrective]",
@@ -14,7 +21,7 @@
               "field": "preceding",
               "assert": [
                 {
-                  "id": "GOBL-ES-VERIFACTU-V1-BILL-INVOICE-01",
+                  "id": "GOBL-ES-VERIFACTU-BILL-INVOICE-01",
                   "desc": "preceding documents are required for corrective invoices",
                   "tests": "present"
                 }
@@ -35,7 +42,7 @@
                       "field": "issue_date",
                       "assert": [
                         {
-                          "id": "GOBL-ES-VERIFACTU-V1-BILL-INVOICE-02",
+                          "id": "GOBL-ES-VERIFACTU-BILL-INVOICE-02",
                           "desc": "issue date is required",
                           "tests": "present"
                         }
@@ -63,7 +70,7 @@
                           "field": "tax",
                           "assert": [
                             {
-                              "id": "GOBL-ES-VERIFACTU-V1-BILL-INVOICE-03",
+                              "id": "GOBL-ES-VERIFACTU-BILL-INVOICE-03",
                               "desc": "preceding invoice tax data is required for corrective invoices",
                               "tests": "present"
                             }
@@ -84,7 +91,7 @@
               "field": "customer",
               "assert": [
                 {
-                  "id": "GOBL-ES-VERIFACTU-V1-BILL-INVOICE-05",
+                  "id": "GOBL-ES-VERIFACTU-BILL-INVOICE-05",
                   "desc": "customer identity type extension not allowed for simplified invoices",
                   "tests": "no identity type ext"
                 }
@@ -94,7 +101,7 @@
                   "field": "tax_id",
                   "assert": [
                     {
-                      "id": "GOBL-ES-VERIFACTU-V1-BILL-INVOICE-04",
+                      "id": "GOBL-ES-VERIFACTU-BILL-INVOICE-04",
                       "desc": "customer tax ID must not be set for simplified invoices",
                       "tests": "nil"
                     }
@@ -111,12 +118,12 @@
               "field": "customer",
               "assert": [
                 {
-                  "id": "GOBL-ES-VERIFACTU-V1-BILL-INVOICE-06",
+                  "id": "GOBL-ES-VERIFACTU-BILL-INVOICE-06",
                   "desc": "customer is required",
                   "tests": "present"
                 },
                 {
-                  "id": "GOBL-ES-VERIFACTU-V1-BILL-INVOICE-07",
+                  "id": "GOBL-ES-VERIFACTU-BILL-INVOICE-07",
                   "desc": "must have a tax_id or an identity with ext 'es-verifactu-v1-identity-type'",
                   "tests": "has tax_id or identity"
                 }
@@ -129,7 +136,7 @@
                       "field": "code",
                       "assert": [
                         {
-                          "id": "GOBL-ES-VERIFACTU-V1-BILL-INVOICE-08",
+                          "id": "GOBL-ES-VERIFACTU-BILL-INVOICE-08",
                           "desc": "tax ID must have a code",
                           "tests": "present"
                         }
@@ -145,7 +152,7 @@
           "field": "tax",
           "assert": [
             {
-              "id": "GOBL-ES-VERIFACTU-V1-BILL-INVOICE-09",
+              "id": "GOBL-ES-VERIFACTU-BILL-INVOICE-09",
               "desc": "tax is required",
               "tests": "present"
             }
@@ -155,7 +162,7 @@
               "field": "ext",
               "assert": [
                 {
-                  "id": "GOBL-ES-VERIFACTU-V1-BILL-INVOICE-10",
+                  "id": "GOBL-ES-VERIFACTU-BILL-INVOICE-10",
                   "desc": "doc type is required",
                   "tests": "ext require [es-verifactu-doc-type]"
                 }
@@ -165,7 +172,7 @@
                   "guard": "ext 'es-verifactu-doc-type' in [R1, R2, R3, R4, R5]",
                   "assert": [
                     {
-                      "id": "GOBL-ES-VERIFACTU-V1-BILL-INVOICE-13",
+                      "id": "GOBL-ES-VERIFACTU-BILL-INVOICE-13",
                       "desc": "correction type extension is required",
                       "tests": "ext require [es-verifactu-correction-type]"
                     }
@@ -185,7 +192,7 @@
                   "field": "ext",
                   "assert": [
                     {
-                      "id": "GOBL-ES-VERIFACTU-V1-BILL-INVOICE-11",
+                      "id": "GOBL-ES-VERIFACTU-BILL-INVOICE-11",
                       "desc": "doc type extension for standard invoices must be F1, F2, or F3",
                       "tests": "ext 'es-verifactu-doc-type' in [F1, F2, F3]"
                     }
@@ -205,7 +212,7 @@
                   "field": "ext",
                   "assert": [
                     {
-                      "id": "GOBL-ES-VERIFACTU-V1-BILL-INVOICE-12",
+                      "id": "GOBL-ES-VERIFACTU-BILL-INVOICE-12",
                       "desc": "doc type extension for corrective invoices must be R1, R2, R3, R4, or R5",
                       "tests": "ext 'es-verifactu-doc-type' in [R1, R2, R3, R4, R5]"
                     }
@@ -228,7 +235,7 @@
                       "field": "text",
                       "assert": [
                         {
-                          "id": "GOBL-ES-VERIFACTU-V1-BILL-INVOICE-14",
+                          "id": "GOBL-ES-VERIFACTU-BILL-INVOICE-14",
                           "desc": "general note text must be 500 characters or less",
                           "tests": "length between 0 and 500"
                         }
@@ -250,7 +257,7 @@
                   "field": "taxes",
                   "assert": [
                     {
-                      "id": "GOBL-ES-VERIFACTU-V1-BILL-INVOICE-15",
+                      "id": "GOBL-ES-VERIFACTU-BILL-INVOICE-15",
                       "desc": "must include at least one of VAT, IGIC, or IPSI",
                       "tests": "one of [VAT, IGIC, IPSI]"
                     }
@@ -263,7 +270,7 @@
       ]
     },
     {
-      "id": "GOBL-ES-VERIFACTU-V1-TAX-COMBO",
+      "id": "GOBL-ES-VERIFACTU-TAX-COMBO",
       "object": "tax.Combo",
       "subsets": [
         {
@@ -273,12 +280,12 @@
               "field": "ext",
               "assert": [
                 {
-                  "id": "GOBL-ES-VERIFACTU-V1-TAX-COMBO-01",
+                  "id": "GOBL-ES-VERIFACTU-TAX-COMBO-01",
                   "desc": "extension 'es-verifactu-regime' is required",
                   "tests": "ext require [es-verifactu-regime]"
                 },
                 {
-                  "id": "GOBL-ES-VERIFACTU-V1-TAX-COMBO-03",
+                  "id": "GOBL-ES-VERIFACTU-TAX-COMBO-03",
                   "desc": "cannot use both 'es-verifactu-op-class' and 'es-verifactu-exempt' at the same time",
                   "tests": "ext allow one of [es-verifactu-op-class, es-verifactu-exempt]"
                 }
@@ -288,7 +295,7 @@
                   "guard": "ext 'es-verifactu-regime' in [01]",
                   "assert": [
                     {
-                      "id": "GOBL-ES-VERIFACTU-V1-TAX-COMBO-02",
+                      "id": "GOBL-ES-VERIFACTU-TAX-COMBO-02",
                       "desc": "exempt codes E2 and E3 not allowed with 'es-verifactu-regime' 01",
                       "tests": "ext 'es-verifactu-exempt' not in [E2, E3]"
                     }
@@ -303,7 +310,7 @@
                   "field": "ext",
                   "assert": [
                     {
-                      "id": "GOBL-ES-VERIFACTU-V1-TAX-COMBO-04",
+                      "id": "GOBL-ES-VERIFACTU-TAX-COMBO-04",
                       "desc": "extension 'es-verifactu-op-class' is required for taxed operations",
                       "tests": "ext require [es-verifactu-op-class]"
                     }

--- a/data/rules/eu-en16931.json
+++ b/data/rules/eu-en16931.json
@@ -1,14 +1,14 @@
 {
-  "id": "GOBL-EU-EN16931-V2017",
-  "package": "eu-en16931-v2017",
+  "id": "GOBL-EU-EN16931",
+  "package": "eu-en16931",
   "guard": "context: addon in [eu-en16931-v2017]",
   "subsets": [
     {
-      "id": "GOBL-EU-EN16931-V2017-BILL-INVOICE",
+      "id": "GOBL-EU-EN16931-BILL-INVOICE",
       "object": "bill.Invoice",
       "assert": [
         {
-          "id": "GOBL-EU-EN16931-V2017-BILL-INVOICE-08",
+          "id": "GOBL-EU-EN16931-BILL-INVOICE-08",
           "desc": "exempt tax categories require either a VATEX code or an exemption note",
           "tests": "exemption notes"
         }
@@ -18,7 +18,7 @@
           "field": "tax",
           "assert": [
             {
-              "id": "GOBL-EU-EN16931-V2017-BILL-INVOICE-01",
+              "id": "GOBL-EU-EN16931-BILL-INVOICE-01",
               "desc": "tax details are required with ext and UNTDID document type",
               "tests": "present"
             }
@@ -28,7 +28,7 @@
               "field": "ext",
               "assert": [
                 {
-                  "id": "GOBL-EU-EN16931-V2017-BILL-INVOICE-02",
+                  "id": "GOBL-EU-EN16931-BILL-INVOICE-02",
                   "desc": "document type extension is required",
                   "tests": "ext require [untdid-document-type]"
                 }
@@ -40,7 +40,7 @@
           "field": "lines",
           "assert": [
             {
-              "id": "GOBL-EU-EN16931-V2017-BILL-INVOICE-03",
+              "id": "GOBL-EU-EN16931-BILL-INVOICE-03",
               "desc": "at least one line is required (BR-16)",
               "tests": "present"
             }
@@ -53,7 +53,7 @@
               "field": "addresses",
               "assert": [
                 {
-                  "id": "GOBL-EU-EN16931-V2017-BILL-INVOICE-04",
+                  "id": "GOBL-EU-EN16931-BILL-INVOICE-04",
                   "desc": "supplier addresses are required (BR-8)",
                   "tests": "present"
                 }
@@ -68,7 +68,7 @@
               "field": "addresses",
               "assert": [
                 {
-                  "id": "GOBL-EU-EN16931-V2017-BILL-INVOICE-05",
+                  "id": "GOBL-EU-EN16931-BILL-INVOICE-05",
                   "desc": "customer addresses are required (BR-10)",
                   "tests": "present"
                 }
@@ -83,7 +83,7 @@
               "field": "payment",
               "assert": [
                 {
-                  "id": "GOBL-EU-EN16931-V2017-BILL-INVOICE-06",
+                  "id": "GOBL-EU-EN16931-BILL-INVOICE-06",
                   "desc": "payment details are required when amount is due (BR-CO-25)",
                   "tests": "present"
                 }
@@ -93,7 +93,7 @@
                   "field": "terms",
                   "assert": [
                     {
-                      "id": "GOBL-EU-EN16931-V2017-BILL-INVOICE-07",
+                      "id": "GOBL-EU-EN16931-BILL-INVOICE-07",
                       "desc": "payment terms are required when amount is due (BR-CO-25)",
                       "tests": "present"
                     }
@@ -106,11 +106,11 @@
       ]
     },
     {
-      "id": "GOBL-EU-EN16931-V2017-BILL-DISCOUNT",
+      "id": "GOBL-EU-EN16931-BILL-DISCOUNT",
       "object": "bill.Discount",
       "assert": [
         {
-          "id": "GOBL-EU-EN16931-V2017-BILL-DISCOUNT-02",
+          "id": "GOBL-EU-EN16931-BILL-DISCOUNT-02",
           "desc": "either a reason or an allowance type extension is required (BR-33)",
           "tests": "reason or allowance"
         }
@@ -120,7 +120,7 @@
           "field": "taxes",
           "assert": [
             {
-              "id": "GOBL-EU-EN16931-V2017-BILL-DISCOUNT-01",
+              "id": "GOBL-EU-EN16931-BILL-DISCOUNT-01",
               "desc": "taxes are required (BR-32)",
               "tests": "present"
             }
@@ -129,47 +129,47 @@
       ]
     },
     {
-      "id": "GOBL-EU-EN16931-V2017-BILL-LINEDISCOUNT",
+      "id": "GOBL-EU-EN16931-BILL-LINEDISCOUNT",
       "object": "bill.LineDiscount",
       "assert": [
         {
-          "id": "GOBL-EU-EN16931-V2017-BILL-LINEDISCOUNT-01",
+          "id": "GOBL-EU-EN16931-BILL-LINEDISCOUNT-01",
           "desc": "either a reason or an allowance type extension is required (BR-41)",
           "tests": "reason or allowance"
         }
       ]
     },
     {
-      "id": "GOBL-EU-EN16931-V2017-BILL-CHARGE",
+      "id": "GOBL-EU-EN16931-BILL-CHARGE",
       "object": "bill.Charge",
       "assert": [
         {
-          "id": "GOBL-EU-EN16931-V2017-BILL-CHARGE-01",
+          "id": "GOBL-EU-EN16931-BILL-CHARGE-01",
           "desc": "either a reason or a charge type extension is required (BR-36)",
           "tests": "reason or charge"
         }
       ]
     },
     {
-      "id": "GOBL-EU-EN16931-V2017-BILL-LINECHARGE",
+      "id": "GOBL-EU-EN16931-BILL-LINECHARGE",
       "object": "bill.LineCharge",
       "assert": [
         {
-          "id": "GOBL-EU-EN16931-V2017-BILL-LINECHARGE-01",
+          "id": "GOBL-EU-EN16931-BILL-LINECHARGE-01",
           "desc": "either a reason or a charge type extension is required (BR-44)",
           "tests": "reason or charge"
         }
       ]
     },
     {
-      "id": "GOBL-EU-EN16931-V2017-PAY-INSTRUCTIONS",
+      "id": "GOBL-EU-EN16931-PAY-INSTRUCTIONS",
       "object": "pay.Instructions",
       "subsets": [
         {
           "field": "ext",
           "assert": [
             {
-              "id": "GOBL-EU-EN16931-V2017-PAY-INSTRUCTIONS-01",
+              "id": "GOBL-EU-EN16931-PAY-INSTRUCTIONS-01",
               "desc": "payment means extension is required (BR-49)",
               "tests": "ext require [untdid-payment-means]"
             }
@@ -178,25 +178,25 @@
       ]
     },
     {
-      "id": "GOBL-EU-EN16931-V2017-PAY-TERMS",
+      "id": "GOBL-EU-EN16931-PAY-TERMS",
       "object": "pay.Terms",
       "assert": [
         {
-          "id": "GOBL-EU-EN16931-V2017-PAY-TERMS-01",
+          "id": "GOBL-EU-EN16931-PAY-TERMS-01",
           "desc": "either due_dates or notes must be provided (BR-CO-25)",
           "tests": "has due dates or notes"
         }
       ]
     },
     {
-      "id": "GOBL-EU-EN16931-V2017-ORG-ITEM",
+      "id": "GOBL-EU-EN16931-ORG-ITEM",
       "object": "org.Item",
       "subsets": [
         {
           "field": "unit",
           "assert": [
             {
-              "id": "GOBL-EU-EN16931-V2017-ORG-ITEM-01",
+              "id": "GOBL-EU-EN16931-ORG-ITEM-01",
               "desc": "unit is required (BR-23)",
               "tests": "present"
             }
@@ -205,14 +205,14 @@
       ]
     },
     {
-      "id": "GOBL-EU-EN16931-V2017-ORG-ATTACHMENT",
+      "id": "GOBL-EU-EN16931-ORG-ATTACHMENT",
       "object": "org.Attachment",
       "subsets": [
         {
           "field": "code",
           "assert": [
             {
-              "id": "GOBL-EU-EN16931-V2017-ORG-ATTACHMENT-01",
+              "id": "GOBL-EU-EN16931-ORG-ATTACHMENT-01",
               "desc": "code is required",
               "tests": "present"
             }
@@ -221,14 +221,14 @@
       ]
     },
     {
-      "id": "GOBL-EU-EN16931-V2017-ORG-PARTY",
+      "id": "GOBL-EU-EN16931-ORG-PARTY",
       "object": "org.Party",
       "subsets": [
         {
           "field": "inboxes",
           "assert": [
             {
-              "id": "GOBL-EU-EN16931-V2017-ORG-PARTY-01",
+              "id": "GOBL-EU-EN16931-ORG-PARTY-01",
               "desc": "cannot have more than one inbox (BT-34, BT-49)",
               "tests": "length between 0 and 1"
             }
@@ -237,30 +237,30 @@
       ]
     },
     {
-      "id": "GOBL-EU-EN16931-V2017-ORG-INBOX",
+      "id": "GOBL-EU-EN16931-ORG-INBOX",
       "object": "org.Inbox",
       "assert": [
         {
-          "id": "GOBL-EU-EN16931-V2017-ORG-INBOX-01",
+          "id": "GOBL-EU-EN16931-ORG-INBOX-01",
           "desc": "scheme cannot be blank when code is set (BR-62, BR-63)",
           "tests": "scheme required with code"
         },
         {
-          "id": "GOBL-EU-EN16931-V2017-ORG-INBOX-02",
+          "id": "GOBL-EU-EN16931-ORG-INBOX-02",
           "desc": "code cannot be blank when scheme is set",
           "tests": "code required with scheme"
         }
       ]
     },
     {
-      "id": "GOBL-EU-EN16931-V2017-ORG-ADDRESS",
+      "id": "GOBL-EU-EN16931-ORG-ADDRESS",
       "object": "org.Address",
       "subsets": [
         {
           "field": "country",
           "assert": [
             {
-              "id": "GOBL-EU-EN16931-V2017-ORG-ADDRESS-01",
+              "id": "GOBL-EU-EN16931-ORG-ADDRESS-01",
               "desc": "country is required (BR-9, BR-11, BR-20, BR-57)",
               "tests": "present"
             }
@@ -269,14 +269,14 @@
       ]
     },
     {
-      "id": "GOBL-EU-EN16931-V2017-TAX-COMBO",
+      "id": "GOBL-EU-EN16931-TAX-COMBO",
       "object": "tax.Combo",
       "subsets": [
         {
           "field": "ext",
           "assert": [
             {
-              "id": "GOBL-EU-EN16931-V2017-TAX-COMBO-01",
+              "id": "GOBL-EU-EN16931-TAX-COMBO-01",
               "desc": "tax category extension is required",
               "tests": "ext require [untdid-tax-category]"
             }
@@ -289,7 +289,7 @@
               "field": "ext",
               "assert": [
                 {
-                  "id": "GOBL-EU-EN16931-V2017-TAX-COMBO-02",
+                  "id": "GOBL-EU-EN16931-TAX-COMBO-02",
                   "desc": "VAT category code must be valid",
                   "tests": "ext 'untdid-tax-category' in [AE, E, G, K, O, S, Z]"
                 }
@@ -304,7 +304,7 @@
               "field": "ext",
               "assert": [
                 {
-                  "id": "GOBL-EU-EN16931-V2017-TAX-COMBO-03",
+                  "id": "GOBL-EU-EN16931-TAX-COMBO-03",
                   "desc": "must use IGIC category code",
                   "tests": "ext 'untdid-tax-category' in [L]"
                 }
@@ -319,7 +319,7 @@
               "field": "ext",
               "assert": [
                 {
-                  "id": "GOBL-EU-EN16931-V2017-TAX-COMBO-04",
+                  "id": "GOBL-EU-EN16931-TAX-COMBO-04",
                   "desc": "must use IPSI category code",
                   "tests": "ext 'untdid-tax-category' in [M]"
                 }
@@ -334,7 +334,7 @@
               "field": "ext",
               "assert": [
                 {
-                  "id": "GOBL-EU-EN16931-V2017-TAX-COMBO-05",
+                  "id": "GOBL-EU-EN16931-TAX-COMBO-05",
                   "desc": "must use outside scope category code",
                   "tests": "ext 'untdid-tax-category' in [O]"
                 }
@@ -349,7 +349,7 @@
               "field": "ext",
               "assert": [
                 {
-                  "id": "GOBL-EU-EN16931-V2017-TAX-COMBO-06",
+                  "id": "GOBL-EU-EN16931-TAX-COMBO-06",
                   "desc": "VATEX extension is required for exempt tax (BR-E-10)",
                   "tests": "ext require [cef-vatex]"
                 }
@@ -364,7 +364,7 @@
               "field": "ext",
               "assert": [
                 {
-                  "id": "GOBL-EU-EN16931-V2017-TAX-COMBO-07",
+                  "id": "GOBL-EU-EN16931-TAX-COMBO-07",
                   "desc": "VATEX extension must not be set for standard, zero, IGIC, or IPSI categories (BR-S-10, BR-Z-10)",
                   "tests": "ext exclude [cef-vatex]"
                 }

--- a/data/rules/fr-choruspro.json
+++ b/data/rules/fr-choruspro.json
@@ -1,11 +1,18 @@
 {
-  "id": "GOBL-FR-CHORUSPRO-V1",
-  "package": "fr-choruspro-v1",
+  "id": "GOBL-FR-CHORUSPRO",
+  "package": "fr-choruspro",
   "guard": "context: addon in [fr-choruspro-v1]",
   "subsets": [
     {
-      "id": "GOBL-FR-CHORUSPRO-V1-BILL-INVOICE",
+      "id": "GOBL-FR-CHORUSPRO-BILL-INVOICE",
       "object": "bill.Invoice",
+      "assert": [
+        {
+          "id": "GOBL-FR-CHORUSPRO-BILL-INVOICE-07",
+          "desc": "invoice must be in EUR or provide exchange rate for conversion",
+          "tests": "can convert to [EUR]"
+        }
+      ],
       "subsets": [
         {
           "field": "customer",
@@ -14,7 +21,7 @@
               "field": "ext",
               "assert": [
                 {
-                  "id": "GOBL-FR-CHORUSPRO-V1-BILL-INVOICE-01",
+                  "id": "GOBL-FR-CHORUSPRO-BILL-INVOICE-01",
                   "desc": "customer scheme extension must be '1'",
                   "tests": "ext 'fr-choruspro-scheme' in [1]"
                 }
@@ -24,7 +31,7 @@
               "field": "identities",
               "assert": [
                 {
-                  "id": "GOBL-FR-CHORUSPRO-V1-BILL-INVOICE-02",
+                  "id": "GOBL-FR-CHORUSPRO-BILL-INVOICE-02",
                   "desc": "customer identities are required",
                   "tests": "present"
                 }
@@ -36,7 +43,7 @@
           "field": "tax",
           "assert": [
             {
-              "id": "GOBL-FR-CHORUSPRO-V1-BILL-INVOICE-03",
+              "id": "GOBL-FR-CHORUSPRO-BILL-INVOICE-03",
               "desc": "tax object is required with extensions",
               "tests": "present"
             }
@@ -46,12 +53,12 @@
               "field": "ext",
               "assert": [
                 {
-                  "id": "GOBL-FR-CHORUSPRO-V1-BILL-INVOICE-04",
+                  "id": "GOBL-FR-CHORUSPRO-BILL-INVOICE-04",
                   "desc": "tax extensions are required",
                   "tests": "present"
                 },
                 {
-                  "id": "GOBL-FR-CHORUSPRO-V1-BILL-INVOICE-05",
+                  "id": "GOBL-FR-CHORUSPRO-BILL-INVOICE-05",
                   "desc": "framework extension is required",
                   "tests": "ext require [fr-choruspro-framework]"
                 }
@@ -66,7 +73,7 @@
               "field": "totals",
               "assert": [
                 {
-                  "id": "GOBL-FR-CHORUSPRO-V1-BILL-INVOICE-06",
+                  "id": "GOBL-FR-CHORUSPRO-BILL-INVOICE-06",
                   "desc": "must be paid in full for framework 'A2'",
                   "tests": "paid"
                 }
@@ -77,14 +84,14 @@
       ]
     },
     {
-      "id": "GOBL-FR-CHORUSPRO-V1-ORG-PARTY",
+      "id": "GOBL-FR-CHORUSPRO-ORG-PARTY",
       "object": "org.Party",
       "subsets": [
         {
           "field": "ext",
           "assert": [
             {
-              "id": "GOBL-FR-CHORUSPRO-V1-ORG-PARTY-01",
+              "id": "GOBL-FR-CHORUSPRO-ORG-PARTY-01",
               "desc": "scheme extension is required",
               "tests": "ext require [fr-choruspro-scheme]"
             }
@@ -97,7 +104,7 @@
               "field": "identities",
               "assert": [
                 {
-                  "id": "GOBL-FR-CHORUSPRO-V1-ORG-PARTY-02",
+                  "id": "GOBL-FR-CHORUSPRO-ORG-PARTY-02",
                   "desc": "identities must have a SIRET entry for scheme '1'",
                   "tests": "has SIRET"
                 }
@@ -110,7 +117,7 @@
                   "field": "country",
                   "assert": [
                     {
-                      "id": "GOBL-FR-CHORUSPRO-V1-ORG-PARTY-03",
+                      "id": "GOBL-FR-CHORUSPRO-ORG-PARTY-03",
                       "desc": "tax ID must be 'FR' for scheme '1'",
                       "tests": "one of [FR]"
                     }
@@ -127,7 +134,7 @@
               "field": "identities",
               "assert": [
                 {
-                  "id": "GOBL-FR-CHORUSPRO-V1-ORG-PARTY-04",
+                  "id": "GOBL-FR-CHORUSPRO-ORG-PARTY-04",
                   "desc": "identities cannot have a SIRET entry when not '1' scheme",
                   "tests": "no SIRET"
                 }
@@ -145,12 +152,12 @@
                   "field": "country",
                   "assert": [
                     {
-                      "id": "GOBL-FR-CHORUSPRO-V1-ORG-PARTY-05",
+                      "id": "GOBL-FR-CHORUSPRO-ORG-PARTY-05",
                       "desc": "tax ID country must be a non-French, EU company with scheme '2'",
                       "tests": "not one of [FR]"
                     },
                     {
-                      "id": "GOBL-FR-CHORUSPRO-V1-ORG-PARTY-06",
+                      "id": "GOBL-FR-CHORUSPRO-ORG-PARTY-06",
                       "desc": "tax ID country must be a member of the EU with scheme '2'",
                       "tests": "EU member"
                     }
@@ -170,7 +177,7 @@
                   "field": "country",
                   "assert": [
                     {
-                      "id": "GOBL-FR-CHORUSPRO-V1-ORG-PARTY-07",
+                      "id": "GOBL-FR-CHORUSPRO-ORG-PARTY-07",
                       "desc": "tax ID country must be a non-EU company with scheme '3'",
                       "tests": "non-EU"
                     }

--- a/data/rules/fr-ctc-flow2.json
+++ b/data/rules/fr-ctc-flow2.json
@@ -1,14 +1,19 @@
 {
-  "id": "GOBL-FR-CTC-FLOW2-V1",
-  "package": "fr-ctc-flow2-v1",
+  "id": "GOBL-FR-CTC-FLOW2",
+  "package": "fr-ctc-flow2",
   "guard": "context: addon in [fr-ctc-flow2-v1]",
   "subsets": [
     {
-      "id": "GOBL-FR-CTC-FLOW2-V1-BILL-INVOICE",
+      "id": "GOBL-FR-CTC-FLOW2-BILL-INVOICE",
       "object": "bill.Invoice",
       "assert": [
         {
-          "id": "GOBL-FR-CTC-FLOW2-V1-BILL-INVOICE-01",
+          "id": "GOBL-FR-CTC-FLOW2-BILL-INVOICE-42",
+          "desc": "invoice must be in EUR or provide exchange rate for conversion",
+          "tests": "can convert to [EUR]"
+        },
+        {
+          "id": "GOBL-FR-CTC-FLOW2-BILL-INVOICE-01",
           "desc": "must be 1-35 characters, alphanumeric plus -+_/ (BR-FR-01/02), including the series",
           "tests": "valid invoice code"
         }
@@ -21,7 +26,7 @@
               "each": true,
               "assert": [
                 {
-                  "id": "GOBL-FR-CTC-FLOW2-V1-BILL-INVOICE-02",
+                  "id": "GOBL-FR-CTC-FLOW2-BILL-INVOICE-02",
                   "desc": "preceding code must be 1-35 characters, alphanumeric plus -+_/ (BR-FR-01/02), including the series",
                   "tests": "valid preceding code"
                 }
@@ -36,12 +41,12 @@
               "field": "preceding",
               "assert": [
                 {
-                  "id": "GOBL-FR-CTC-FLOW2-V1-BILL-INVOICE-03",
+                  "id": "GOBL-FR-CTC-FLOW2-BILL-INVOICE-03",
                   "desc": "corrective invoices must have exactly one preceding invoice reference (BR-FR-CO-04)",
                   "tests": "present"
                 },
                 {
-                  "id": "GOBL-FR-CTC-FLOW2-V1-BILL-INVOICE-04",
+                  "id": "GOBL-FR-CTC-FLOW2-BILL-INVOICE-04",
                   "desc": "corrective invoices must have exactly one preceding invoice reference (BR-FR-CO-04)",
                   "tests": "length between 1 and 1"
                 }
@@ -56,7 +61,7 @@
               "field": "preceding",
               "assert": [
                 {
-                  "id": "GOBL-FR-CTC-FLOW2-V1-BILL-INVOICE-05",
+                  "id": "GOBL-FR-CTC-FLOW2-BILL-INVOICE-05",
                   "desc": "credit notes must have at least one preceding invoice reference (BR-FR-CO-05)",
                   "tests": "present"
                 }
@@ -68,7 +73,7 @@
           "field": "tax",
           "assert": [
             {
-              "id": "GOBL-FR-CTC-FLOW2-V1-BILL-INVOICE-06",
+              "id": "GOBL-FR-CTC-FLOW2-BILL-INVOICE-06",
               "desc": "tax is required",
               "tests": "present"
             }
@@ -78,12 +83,12 @@
               "field": "ext",
               "assert": [
                 {
-                  "id": "GOBL-FR-CTC-FLOW2-V1-BILL-INVOICE-07",
+                  "id": "GOBL-FR-CTC-FLOW2-BILL-INVOICE-07",
                   "desc": "UNTDID document type must be valid (BR-FR-04)",
                   "tests": "ext 'untdid-document-type' in [380, 389, 393, 501, 386, 500, 384, 471, 472, 473, 261, 262, 381, 396, 502, 503]"
                 },
                 {
-                  "id": "GOBL-FR-CTC-FLOW2-V1-BILL-INVOICE-08",
+                  "id": "GOBL-FR-CTC-FLOW2-BILL-INVOICE-08",
                   "desc": "billing mode extension is required",
                   "tests": "ext require [fr-ctc-billing-mode]"
                 }
@@ -101,7 +106,7 @@
                   "field": "ext",
                   "assert": [
                     {
-                      "id": "GOBL-FR-CTC-FLOW2-V1-BILL-INVOICE-09",
+                      "id": "GOBL-FR-CTC-FLOW2-BILL-INVOICE-09",
                       "desc": "advance payment document types not allowed for factoring billing modes (BR-FR-CO-08)",
                       "tests": "ext 'untdid-document-type' not in [386, 500, 503]"
                     }
@@ -118,7 +123,7 @@
               "field": "inboxes",
               "assert": [
                 {
-                  "id": "GOBL-FR-CTC-FLOW2-V1-BILL-INVOICE-10",
+                  "id": "GOBL-FR-CTC-FLOW2-BILL-INVOICE-10",
                   "desc": "seller electronic address required for French B2B invoices (BR-FR-13)",
                   "tests": "present"
                 }
@@ -128,7 +133,7 @@
               "field": "identities",
               "assert": [
                 {
-                  "id": "GOBL-FR-CTC-FLOW2-V1-BILL-INVOICE-11",
+                  "id": "GOBL-FR-CTC-FLOW2-BILL-INVOICE-11",
                   "desc": "SIREN identity required for French parties with scheme 0002 and scope legal (BR-FR-10/11)",
                   "tests": "has SIREN"
                 }
@@ -143,7 +148,7 @@
               "field": "supplier",
               "assert": [
                 {
-                  "id": "GOBL-FR-CTC-FLOW2-V1-BILL-INVOICE-12",
+                  "id": "GOBL-FR-CTC-FLOW2-BILL-INVOICE-12",
                   "desc": "party must have endpoint ID with scheme 0225 (SIREN) (BR-FR-21/22)",
                   "tests": "has SIREN inbox"
                 }
@@ -158,7 +163,7 @@
               "field": "inboxes",
               "assert": [
                 {
-                  "id": "GOBL-FR-CTC-FLOW2-V1-BILL-INVOICE-13",
+                  "id": "GOBL-FR-CTC-FLOW2-BILL-INVOICE-13",
                   "desc": "buyer electronic address required for French B2B invoices (BR-FR-13)",
                   "tests": "present"
                 }
@@ -176,7 +181,7 @@
                   "field": "identities",
                   "assert": [
                     {
-                      "id": "GOBL-FR-CTC-FLOW2-V1-BILL-INVOICE-14",
+                      "id": "GOBL-FR-CTC-FLOW2-BILL-INVOICE-14",
                       "desc": "SIREN identity required for French parties with scheme 0002 and scope legal (BR-FR-10/11)",
                       "tests": "has SIREN"
                     }
@@ -193,7 +198,7 @@
               "field": "customer",
               "assert": [
                 {
-                  "id": "GOBL-FR-CTC-FLOW2-V1-BILL-INVOICE-15",
+                  "id": "GOBL-FR-CTC-FLOW2-BILL-INVOICE-15",
                   "desc": "party must have endpoint ID with scheme 0225 (SIREN) (BR-FR-21/22)",
                   "tests": "has SIREN inbox"
                 }
@@ -208,12 +213,12 @@
               "field": "identities",
               "assert": [
                 {
-                  "id": "GOBL-FR-CTC-FLOW2-V1-BILL-INVOICE-16",
+                  "id": "GOBL-FR-CTC-FLOW2-BILL-INVOICE-16",
                   "desc": "only one ordering identity with UNTDID reference 'AFL' is allowed (BR-FR-30)",
                   "tests": "no dup AFL"
                 },
                 {
-                  "id": "GOBL-FR-CTC-FLOW2-V1-BILL-INVOICE-17",
+                  "id": "GOBL-FR-CTC-FLOW2-BILL-INVOICE-17",
                   "desc": "only one ordering identity with UNTDID reference 'AWW' is allowed (BR-FR-30)",
                   "tests": "no dup AWW"
                 }
@@ -228,7 +233,7 @@
               "field": "ordering",
               "assert": [
                 {
-                  "id": "GOBL-FR-CTC-FLOW2-V1-BILL-INVOICE-18",
+                  "id": "GOBL-FR-CTC-FLOW2-BILL-INVOICE-18",
                   "desc": "ordering with seller is required when supplier is under STC scheme (BR-FR-CO-15)",
                   "tests": "present"
                 }
@@ -238,7 +243,7 @@
                   "field": "seller",
                   "assert": [
                     {
-                      "id": "GOBL-FR-CTC-FLOW2-V1-BILL-INVOICE-19",
+                      "id": "GOBL-FR-CTC-FLOW2-BILL-INVOICE-19",
                       "desc": "seller is required when supplier is under STC scheme (BR-FR-CO-15)",
                       "tests": "present"
                     }
@@ -248,7 +253,7 @@
                       "field": "tax_id",
                       "assert": [
                         {
-                          "id": "GOBL-FR-CTC-FLOW2-V1-BILL-INVOICE-20",
+                          "id": "GOBL-FR-CTC-FLOW2-BILL-INVOICE-20",
                           "desc": "tax ID is required when supplier is under STC scheme (BR-FR-CO-15)",
                           "tests": "present"
                         }
@@ -258,7 +263,7 @@
                           "field": "code",
                           "assert": [
                             {
-                              "id": "GOBL-FR-CTC-FLOW2-V1-BILL-INVOICE-21",
+                              "id": "GOBL-FR-CTC-FLOW2-BILL-INVOICE-21",
                               "desc": "code is required when supplier is under STC scheme (BR-FR-CO-15)",
                               "tests": "present"
                             }
@@ -274,7 +279,7 @@
               "field": "notes",
               "assert": [
                 {
-                  "id": "GOBL-FR-CTC-FLOW2-V1-BILL-INVOICE-22",
+                  "id": "GOBL-FR-CTC-FLOW2-BILL-INVOICE-22",
                   "desc": "for sellers with STC scheme (0231), a note with code 'TXD' and text 'MEMBRE_ASSUJETTI_UNIQUE' is required (BR-FR-CO-14)",
                   "tests": "has TXD note"
                 }
@@ -289,7 +294,7 @@
               "field": "ordering",
               "assert": [
                 {
-                  "id": "GOBL-FR-CTC-FLOW2-V1-BILL-INVOICE-23",
+                  "id": "GOBL-FR-CTC-FLOW2-BILL-INVOICE-23",
                   "desc": "ordering with contracts is required for consolidated credit notes (BR-FR-CO-03)",
                   "tests": "present"
                 }
@@ -299,12 +304,12 @@
                   "field": "contracts",
                   "assert": [
                     {
-                      "id": "GOBL-FR-CTC-FLOW2-V1-BILL-INVOICE-24",
+                      "id": "GOBL-FR-CTC-FLOW2-BILL-INVOICE-24",
                       "desc": "at least one contract reference is required in ordering details for consolidated credit notes (BR-FR-CO-03)",
                       "tests": "present"
                     },
                     {
-                      "id": "GOBL-FR-CTC-FLOW2-V1-BILL-INVOICE-25",
+                      "id": "GOBL-FR-CTC-FLOW2-BILL-INVOICE-25",
                       "desc": "at least one contract reference is required in ordering details for consolidated credit notes (BR-FR-CO-03)",
                       "tests": "length between 1 and 0"
                     }
@@ -316,7 +321,7 @@
               "field": "delivery",
               "assert": [
                 {
-                  "id": "GOBL-FR-CTC-FLOW2-V1-BILL-INVOICE-26",
+                  "id": "GOBL-FR-CTC-FLOW2-BILL-INVOICE-26",
                   "desc": "delivery details are required for consolidated credit notes (BR-FR-CO-03)",
                   "tests": "present"
                 }
@@ -326,7 +331,7 @@
                   "field": "period",
                   "assert": [
                     {
-                      "id": "GOBL-FR-CTC-FLOW2-V1-BILL-INVOICE-27",
+                      "id": "GOBL-FR-CTC-FLOW2-BILL-INVOICE-27",
                       "desc": "delivery period is required for consolidated credit notes (BR-FR-CO-03)",
                       "tests": "present"
                     }
@@ -340,7 +345,7 @@
           "guard": "not advance or final",
           "assert": [
             {
-              "id": "GOBL-FR-CTC-FLOW2-V1-BILL-INVOICE-28",
+              "id": "GOBL-FR-CTC-FLOW2-BILL-INVOICE-28",
               "desc": "due dates must not be before invoice issue date (BR-FR-CO-07)",
               "tests": "due dates valid"
             }
@@ -353,7 +358,7 @@
               "field": "payment",
               "assert": [
                 {
-                  "id": "GOBL-FR-CTC-FLOW2-V1-BILL-INVOICE-29",
+                  "id": "GOBL-FR-CTC-FLOW2-BILL-INVOICE-29",
                   "desc": "payment details are required for final invoices (BR-FR-CO-09)",
                   "tests": "present"
                 }
@@ -363,7 +368,7 @@
                   "field": "terms",
                   "assert": [
                     {
-                      "id": "GOBL-FR-CTC-FLOW2-V1-BILL-INVOICE-30",
+                      "id": "GOBL-FR-CTC-FLOW2-BILL-INVOICE-30",
                       "desc": "payment terms required for final invoices (BR-FR-CO-09)",
                       "tests": "present"
                     }
@@ -373,7 +378,7 @@
                       "field": "due_dates",
                       "assert": [
                         {
-                          "id": "GOBL-FR-CTC-FLOW2-V1-BILL-INVOICE-31",
+                          "id": "GOBL-FR-CTC-FLOW2-BILL-INVOICE-31",
                           "desc": "at least one due date required for final invoices (BR-FR-CO-09)",
                           "tests": "present"
                         }
@@ -387,12 +392,12 @@
               "field": "totals",
               "assert": [
                 {
-                  "id": "GOBL-FR-CTC-FLOW2-V1-BILL-INVOICE-33",
+                  "id": "GOBL-FR-CTC-FLOW2-BILL-INVOICE-33",
                   "desc": "advance amount must equal total with tax for final invoices (BR-FR-CO-09)",
                   "tests": "advances match"
                 },
                 {
-                  "id": "GOBL-FR-CTC-FLOW2-V1-BILL-INVOICE-34",
+                  "id": "GOBL-FR-CTC-FLOW2-BILL-INVOICE-34",
                   "desc": "payable amount must be zero for final invoices (BR-FR-CO-09)",
                   "tests": "payable zero"
                 }
@@ -402,7 +407,7 @@
                   "field": "advance",
                   "assert": [
                     {
-                      "id": "GOBL-FR-CTC-FLOW2-V1-BILL-INVOICE-32",
+                      "id": "GOBL-FR-CTC-FLOW2-BILL-INVOICE-32",
                       "desc": "advance amount is required for already-paid invoices (BR-FR-CO-09)",
                       "tests": "present"
                     }
@@ -416,22 +421,22 @@
           "field": "notes",
           "assert": [
             {
-              "id": "GOBL-FR-CTC-FLOW2-V1-BILL-INVOICE-35",
+              "id": "GOBL-FR-CTC-FLOW2-BILL-INVOICE-35",
               "desc": "notes are required for French CTC invoices (BR-FR-05)",
               "tests": "present"
             },
             {
-              "id": "GOBL-FR-CTC-FLOW2-V1-BILL-INVOICE-36",
+              "id": "GOBL-FR-CTC-FLOW2-BILL-INVOICE-36",
               "desc": "missing required note codes (BR-FR-05)",
               "tests": "has required notes"
             },
             {
-              "id": "GOBL-FR-CTC-FLOW2-V1-BILL-INVOICE-37",
+              "id": "GOBL-FR-CTC-FLOW2-BILL-INVOICE-37",
               "desc": "duplicate note codes found (BR-FR-06/BR-FR-30)",
               "tests": "no duplicate notes"
             },
             {
-              "id": "GOBL-FR-CTC-FLOW2-V1-BILL-INVOICE-38",
+              "id": "GOBL-FR-CTC-FLOW2-BILL-INVOICE-38",
               "desc": "BAR note text must be one of: B2B, B2BINT, B2C, OUTOFSCOPE, ARCHIVEONLY",
               "tests": "valid BAR text"
             }
@@ -441,7 +446,7 @@
           "field": "attachments",
           "assert": [
             {
-              "id": "GOBL-FR-CTC-FLOW2-V1-BILL-INVOICE-41",
+              "id": "GOBL-FR-CTC-FLOW2-BILL-INVOICE-41",
               "desc": "only one attachment with description 'LISIBLE' is allowed per invoice (BR-FR-18)",
               "tests": "unique LISIBLE"
             }
@@ -454,12 +459,12 @@
                   "field": "description",
                   "assert": [
                     {
-                      "id": "GOBL-FR-CTC-FLOW2-V1-BILL-INVOICE-39",
+                      "id": "GOBL-FR-CTC-FLOW2-BILL-INVOICE-39",
                       "desc": "must be one of the allowed attachment descriptions (BR-FR-17)",
                       "tests": "present"
                     },
                     {
-                      "id": "GOBL-FR-CTC-FLOW2-V1-BILL-INVOICE-40",
+                      "id": "GOBL-FR-CTC-FLOW2-BILL-INVOICE-40",
                       "desc": "must be one of the allowed attachment descriptions (BR-FR-17)",
                       "tests": "one of [RIB, LISIBLE, FEUILLE_DE_STYLE, PJA, BON_LIVRAISON, BON_COMMANDE, DOCUMENT_ANNEXE, BORDEREAU_SUIVI, BORDEREAU_SUIVI_VALIDATION, ETAT_ACOMPTE, FACTURE_PAIEMENT_DIRECT, RECAPITULATIF_COTRAITANCE]"
                     }
@@ -472,19 +477,19 @@
       ]
     },
     {
-      "id": "GOBL-FR-CTC-FLOW2-V1-ORG-PARTY",
+      "id": "GOBL-FR-CTC-FLOW2-ORG-PARTY",
       "object": "org.Party",
       "subsets": [
         {
           "field": "identities",
           "assert": [
             {
-              "id": "GOBL-FR-CTC-FLOW2-V1-ORG-PARTY-01",
+              "id": "GOBL-FR-CTC-FLOW2-ORG-PARTY-01",
               "desc": "SIRET and SIREN must be coherent (BR-FR-09/10)",
               "tests": "SIRET/SIREN coherent"
             },
             {
-              "id": "GOBL-FR-CTC-FLOW2-V1-ORG-PARTY-02",
+              "id": "GOBL-FR-CTC-FLOW2-ORG-PARTY-02",
               "desc": "identity scheme format invalid (BR-FR-CO-10)",
               "tests": "valid scheme format"
             }
@@ -497,7 +502,7 @@
               "each": true,
               "assert": [
                 {
-                  "id": "GOBL-FR-CTC-FLOW2-V1-ORG-PARTY-03",
+                  "id": "GOBL-FR-CTC-FLOW2-ORG-PARTY-03",
                   "desc": "inbox code format invalid",
                   "tests": "valid inbox"
                 }
@@ -508,7 +513,7 @@
       ]
     },
     {
-      "id": "GOBL-FR-CTC-FLOW2-V1-ORG-IDENTITY",
+      "id": "GOBL-FR-CTC-FLOW2-ORG-IDENTITY",
       "object": "org.Identity",
       "subsets": [
         {
@@ -518,12 +523,12 @@
               "field": "code",
               "assert": [
                 {
-                  "id": "GOBL-FR-CTC-FLOW2-V1-ORG-IDENTITY-01",
+                  "id": "GOBL-FR-CTC-FLOW2-ORG-IDENTITY-01",
                   "desc": "must be no more than 100 characters long",
                   "tests": "length between 0 and 100"
                 },
                 {
-                  "id": "GOBL-FR-CTC-FLOW2-V1-ORG-IDENTITY-02",
+                  "id": "GOBL-FR-CTC-FLOW2-ORG-IDENTITY-02",
                   "desc": "must be in a valid format",
                   "tests": "matches ^[A-Za-z0-9\\-\\+_/]+$"
                 }
@@ -534,7 +539,7 @@
       ]
     },
     {
-      "id": "GOBL-FR-CTC-FLOW2-V1-ORG-INBOX",
+      "id": "GOBL-FR-CTC-FLOW2-ORG-INBOX",
       "object": "org.Inbox",
       "subsets": [
         {
@@ -544,12 +549,12 @@
               "field": "code",
               "assert": [
                 {
-                  "id": "GOBL-FR-CTC-FLOW2-V1-ORG-INBOX-01",
+                  "id": "GOBL-FR-CTC-FLOW2-ORG-INBOX-01",
                   "desc": "the length must be between 0 and 125",
                   "tests": "length between 0 and 125"
                 },
                 {
-                  "id": "GOBL-FR-CTC-FLOW2-V1-ORG-INBOX-02",
+                  "id": "GOBL-FR-CTC-FLOW2-ORG-INBOX-02",
                   "desc": "must be in a valid format",
                   "tests": "matches ^[A-Za-z0-9\\-\\+_/]+$"
                 }
@@ -560,14 +565,14 @@
       ]
     },
     {
-      "id": "GOBL-FR-CTC-FLOW2-V1-ORG-ITEM",
+      "id": "GOBL-FR-CTC-FLOW2-ORG-ITEM",
       "object": "org.Item",
       "subsets": [
         {
           "field": "meta",
           "assert": [
             {
-              "id": "GOBL-FR-CTC-FLOW2-V1-ORG-ITEM-01",
+              "id": "GOBL-FR-CTC-FLOW2-ORG-ITEM-01",
               "desc": "meta values cannot be blank (BR-FR-28)",
               "tests": "no blank meta"
             }

--- a/data/rules/gr-mydata.json
+++ b/data/rules/gr-mydata.json
@@ -1,17 +1,24 @@
 {
-  "id": "GOBL-GR-MYDATA-V1",
-  "package": "gr-mydata-v1",
+  "id": "GOBL-GR-MYDATA",
+  "package": "gr-mydata",
   "guard": "context: addon in [gr-mydata-v1]",
   "subsets": [
     {
-      "id": "GOBL-GR-MYDATA-V1-BILL-INVOICE",
+      "id": "GOBL-GR-MYDATA-BILL-INVOICE",
       "object": "bill.Invoice",
+      "assert": [
+        {
+          "id": "GOBL-GR-MYDATA-BILL-INVOICE-19",
+          "desc": "invoice must be in EUR or provide exchange rate for conversion",
+          "tests": "can convert to [EUR]"
+        }
+      ],
       "subsets": [
         {
           "field": "series",
           "assert": [
             {
-              "id": "GOBL-GR-MYDATA-V1-BILL-INVOICE-01",
+              "id": "GOBL-GR-MYDATA-BILL-INVOICE-01",
               "desc": "series is required",
               "tests": "present"
             }
@@ -21,7 +28,7 @@
           "field": "tax",
           "assert": [
             {
-              "id": "GOBL-GR-MYDATA-V1-BILL-INVOICE-02",
+              "id": "GOBL-GR-MYDATA-BILL-INVOICE-02",
               "desc": "tax is required",
               "tests": "present"
             }
@@ -31,7 +38,7 @@
               "field": "ext",
               "assert": [
                 {
-                  "id": "GOBL-GR-MYDATA-V1-BILL-INVOICE-03",
+                  "id": "GOBL-GR-MYDATA-BILL-INVOICE-03",
                   "desc": "tax requires 'gr-mydata-invoice-type' extension",
                   "tests": "ext require [gr-mydata-invoice-type]"
                 }
@@ -46,7 +53,7 @@
               "field": "tax_id",
               "assert": [
                 {
-                  "id": "GOBL-GR-MYDATA-V1-BILL-INVOICE-04",
+                  "id": "GOBL-GR-MYDATA-BILL-INVOICE-04",
                   "desc": "supplier tax ID is required",
                   "tests": "present"
                 }
@@ -56,7 +63,7 @@
                   "field": "code",
                   "assert": [
                     {
-                      "id": "GOBL-GR-MYDATA-V1-BILL-INVOICE-18",
+                      "id": "GOBL-GR-MYDATA-BILL-INVOICE-18",
                       "desc": "supplier tax ID code is required",
                       "tests": "present"
                     }
@@ -73,7 +80,7 @@
               "field": "customer",
               "assert": [
                 {
-                  "id": "GOBL-GR-MYDATA-V1-BILL-INVOICE-05",
+                  "id": "GOBL-GR-MYDATA-BILL-INVOICE-05",
                   "desc": "customer is required",
                   "tests": "present"
                 }
@@ -83,7 +90,7 @@
                   "field": "tax_id",
                   "assert": [
                     {
-                      "id": "GOBL-GR-MYDATA-V1-BILL-INVOICE-06",
+                      "id": "GOBL-GR-MYDATA-BILL-INVOICE-06",
                       "desc": "customer tax ID is required",
                       "tests": "present"
                     }
@@ -93,7 +100,7 @@
                   "field": "addresses",
                   "assert": [
                     {
-                      "id": "GOBL-GR-MYDATA-V1-BILL-INVOICE-07",
+                      "id": "GOBL-GR-MYDATA-BILL-INVOICE-07",
                       "desc": "customer addresses are required",
                       "tests": "present"
                     }
@@ -106,7 +113,7 @@
                           "field": "locality",
                           "assert": [
                             {
-                              "id": "GOBL-GR-MYDATA-V1-BILL-INVOICE-08",
+                              "id": "GOBL-GR-MYDATA-BILL-INVOICE-08",
                               "desc": "customer address locality is required",
                               "tests": "present"
                             }
@@ -116,7 +123,7 @@
                           "field": "code",
                           "assert": [
                             {
-                              "id": "GOBL-GR-MYDATA-V1-BILL-INVOICE-09",
+                              "id": "GOBL-GR-MYDATA-BILL-INVOICE-09",
                               "desc": "customer address code is required",
                               "tests": "present"
                             }
@@ -140,12 +147,12 @@
                   "field": "total",
                   "assert": [
                     {
-                      "id": "GOBL-GR-MYDATA-V1-BILL-INVOICE-10",
+                      "id": "GOBL-GR-MYDATA-BILL-INVOICE-10",
                       "desc": "line total must be positive",
                       "tests": "min 0"
                     },
                     {
-                      "id": "GOBL-GR-MYDATA-V1-BILL-INVOICE-11",
+                      "id": "GOBL-GR-MYDATA-BILL-INVOICE-11",
                       "desc": "line total must not be zero",
                       "tests": "not zero"
                     }
@@ -158,7 +165,7 @@
                       "field": "ext",
                       "assert": [
                         {
-                          "id": "GOBL-GR-MYDATA-V1-BILL-INVOICE-12",
+                          "id": "GOBL-GR-MYDATA-BILL-INVOICE-12",
                           "desc": "item income extensions 'gr-mydata-income-cat' and 'gr-mydata-income-type' must both be present",
                           "tests": "income ext pair"
                         }
@@ -174,7 +181,7 @@
           "field": "discounts",
           "assert": [
             {
-              "id": "GOBL-GR-MYDATA-V1-BILL-INVOICE-13",
+              "id": "GOBL-GR-MYDATA-BILL-INVOICE-13",
               "desc": "discounts are not supported by mydata",
               "tests": "empty"
             }
@@ -184,12 +191,12 @@
           "field": "payment",
           "assert": [
             {
-              "id": "GOBL-GR-MYDATA-V1-BILL-INVOICE-14",
+              "id": "GOBL-GR-MYDATA-BILL-INVOICE-14",
               "desc": "payment is required",
               "tests": "present"
             },
             {
-              "id": "GOBL-GR-MYDATA-V1-BILL-INVOICE-15",
+              "id": "GOBL-GR-MYDATA-BILL-INVOICE-15",
               "desc": "payment instructions are required when no advances",
               "tests": "has instructions or advances"
             }
@@ -202,7 +209,7 @@
               "field": "preceding",
               "assert": [
                 {
-                  "id": "GOBL-GR-MYDATA-V1-BILL-INVOICE-16",
+                  "id": "GOBL-GR-MYDATA-BILL-INVOICE-16",
                   "desc": "preceding documents are required for credit notes",
                   "tests": "present"
                 }
@@ -220,7 +227,7 @@
                   "field": "stamps",
                   "assert": [
                     {
-                      "id": "GOBL-GR-MYDATA-V1-BILL-INVOICE-17",
+                      "id": "GOBL-GR-MYDATA-BILL-INVOICE-17",
                       "desc": "preceding document requires 'iapr-mark' stamp",
                       "tests": "stamps have iapr-mark"
                     }
@@ -233,14 +240,14 @@
       ]
     },
     {
-      "id": "GOBL-GR-MYDATA-V1-BILL-CHARGE",
+      "id": "GOBL-GR-MYDATA-BILL-CHARGE",
       "object": "bill.Charge",
       "subsets": [
         {
           "field": "ext",
           "assert": [
             {
-              "id": "GOBL-GR-MYDATA-V1-BILL-CHARGE-01",
+              "id": "GOBL-GR-MYDATA-BILL-CHARGE-01",
               "desc": "only one of fee, other-tax, or stamp-duty allowed",
               "tests": "ext allow one of [gr-mydata-fee, gr-mydata-other-tax, gr-mydata-stamp-duty]"
             }
@@ -253,7 +260,7 @@
               "field": "ext",
               "assert": [
                 {
-                  "id": "GOBL-GR-MYDATA-V1-BILL-CHARGE-02",
+                  "id": "GOBL-GR-MYDATA-BILL-CHARGE-02",
                   "desc": "charge with fee tax type requires 'gr-mydata-fee' extension",
                   "tests": "ext require [gr-mydata-fee]"
                 }
@@ -268,7 +275,7 @@
               "field": "ext",
               "assert": [
                 {
-                  "id": "GOBL-GR-MYDATA-V1-BILL-CHARGE-03",
+                  "id": "GOBL-GR-MYDATA-BILL-CHARGE-03",
                   "desc": "charge with other-tax type requires 'gr-mydata-other-tax' extension",
                   "tests": "ext require [gr-mydata-other-tax]"
                 }
@@ -283,7 +290,7 @@
               "field": "ext",
               "assert": [
                 {
-                  "id": "GOBL-GR-MYDATA-V1-BILL-CHARGE-04",
+                  "id": "GOBL-GR-MYDATA-BILL-CHARGE-04",
                   "desc": "charge with stamp-duty type requires 'gr-mydata-stamp-duty' extension",
                   "tests": "ext require [gr-mydata-stamp-duty]"
                 }
@@ -294,7 +301,7 @@
       ]
     },
     {
-      "id": "GOBL-GR-MYDATA-V1-TAX-COMBO",
+      "id": "GOBL-GR-MYDATA-TAX-COMBO",
       "object": "tax.Combo",
       "subsets": [
         {
@@ -304,7 +311,7 @@
               "field": "ext",
               "assert": [
                 {
-                  "id": "GOBL-GR-MYDATA-V1-TAX-COMBO-01",
+                  "id": "GOBL-GR-MYDATA-TAX-COMBO-01",
                   "desc": "VAT combo requires 'gr-mydata-vat-rate' extension",
                   "tests": "ext require [gr-mydata-vat-rate]"
                 }
@@ -319,7 +326,7 @@
               "field": "ext",
               "assert": [
                 {
-                  "id": "GOBL-GR-MYDATA-V1-TAX-COMBO-02",
+                  "id": "GOBL-GR-MYDATA-TAX-COMBO-02",
                   "desc": "exempt VAT combo requires 'gr-mydata-exemption' extension",
                   "tests": "ext require [gr-mydata-exemption]"
                 }
@@ -334,7 +341,7 @@
               "field": "ext",
               "assert": [
                 {
-                  "id": "GOBL-GR-MYDATA-V1-TAX-COMBO-03",
+                  "id": "GOBL-GR-MYDATA-TAX-COMBO-03",
                   "desc": "income extensions 'gr-mydata-income-cat' and 'gr-mydata-income-type' must both be present",
                   "tests": "ext require [gr-mydata-income-cat, gr-mydata-income-type]"
                 }
@@ -345,14 +352,14 @@
       ]
     },
     {
-      "id": "GOBL-GR-MYDATA-V1-PAY-INSTRUCTIONS",
+      "id": "GOBL-GR-MYDATA-PAY-INSTRUCTIONS",
       "object": "pay.Instructions",
       "subsets": [
         {
           "field": "key",
           "assert": [
             {
-              "id": "GOBL-GR-MYDATA-V1-PAY-INSTRUCTIONS-01",
+              "id": "GOBL-GR-MYDATA-PAY-INSTRUCTIONS-01",
               "desc": "payment instructions key is required",
               "tests": "present"
             }
@@ -362,7 +369,7 @@
           "field": "ext",
           "assert": [
             {
-              "id": "GOBL-GR-MYDATA-V1-PAY-INSTRUCTIONS-02",
+              "id": "GOBL-GR-MYDATA-PAY-INSTRUCTIONS-02",
               "desc": "payment instructions require 'gr-mydata-payment-means' extension",
               "tests": "ext require [gr-mydata-payment-means]"
             }
@@ -371,14 +378,14 @@
       ]
     },
     {
-      "id": "GOBL-GR-MYDATA-V1-PAY-ADVANCE",
+      "id": "GOBL-GR-MYDATA-PAY-ADVANCE",
       "object": "pay.Advance",
       "subsets": [
         {
           "field": "key",
           "assert": [
             {
-              "id": "GOBL-GR-MYDATA-V1-PAY-ADVANCE-01",
+              "id": "GOBL-GR-MYDATA-PAY-ADVANCE-01",
               "desc": "payment advance key is required",
               "tests": "present"
             }
@@ -388,7 +395,7 @@
           "field": "ext",
           "assert": [
             {
-              "id": "GOBL-GR-MYDATA-V1-PAY-ADVANCE-02",
+              "id": "GOBL-GR-MYDATA-PAY-ADVANCE-02",
               "desc": "payment advance requires 'gr-mydata-payment-means' extension",
               "tests": "ext require [gr-mydata-payment-means]"
             }

--- a/data/rules/it-sdi.json
+++ b/data/rules/it-sdi.json
@@ -1,24 +1,29 @@
 {
-  "id": "GOBL-IT-SDI-V1",
-  "package": "it-sdi-v1",
+  "id": "GOBL-IT-SDI",
+  "package": "it-sdi",
   "guard": "context: addon in [it-sdi-v1]",
   "subsets": [
     {
-      "id": "GOBL-IT-SDI-V1-BILL-INVOICE",
+      "id": "GOBL-IT-SDI-BILL-INVOICE",
       "object": "bill.Invoice",
       "assert": [
         {
-          "id": "GOBL-IT-SDI-V1-BILL-INVOICE-13",
+          "id": "GOBL-IT-SDI-BILL-INVOICE-22",
+          "desc": "invoice must be in EUR or provide exchange rate for conversion",
+          "tests": "can convert to [EUR]"
+        },
+        {
+          "id": "GOBL-IT-SDI-BILL-INVOICE-13",
           "desc": "customer name is required",
           "tests": "customer name check"
         },
         {
-          "id": "GOBL-IT-SDI-V1-BILL-INVOICE-14",
+          "id": "GOBL-IT-SDI-BILL-INVOICE-14",
           "desc": "customer people are required when name is empty",
           "tests": "customer people check"
         },
         {
-          "id": "GOBL-IT-SDI-V1-BILL-INVOICE-21",
+          "id": "GOBL-IT-SDI-BILL-INVOICE-21",
           "desc": "payment instructions are required when terms with due dates are present",
           "tests": "payment instructions check"
         }
@@ -28,7 +33,7 @@
           "field": "tax",
           "assert": [
             {
-              "id": "GOBL-IT-SDI-V1-BILL-INVOICE-01",
+              "id": "GOBL-IT-SDI-BILL-INVOICE-01",
               "desc": "tax is required",
               "tests": "present"
             }
@@ -38,7 +43,7 @@
               "field": "ext",
               "assert": [
                 {
-                  "id": "GOBL-IT-SDI-V1-BILL-INVOICE-02",
+                  "id": "GOBL-IT-SDI-BILL-INVOICE-02",
                   "desc": "tax requires 'it-sdi-document-type' and 'it-sdi-format' extensions",
                   "tests": "ext require [it-sdi-format, it-sdi-document-type]"
                 }
@@ -53,7 +58,7 @@
               "field": "name",
               "assert": [
                 {
-                  "id": "GOBL-IT-SDI-V1-BILL-INVOICE-03",
+                  "id": "GOBL-IT-SDI-BILL-INVOICE-03",
                   "desc": "supplier name must use Latin-1 characters",
                   "tests": "latin1"
                 }
@@ -63,7 +68,7 @@
               "field": "addresses",
               "assert": [
                 {
-                  "id": "GOBL-IT-SDI-V1-BILL-INVOICE-04",
+                  "id": "GOBL-IT-SDI-BILL-INVOICE-04",
                   "desc": "supplier addresses are required",
                   "tests": "present"
                 }
@@ -73,7 +78,7 @@
               "field": "ext",
               "assert": [
                 {
-                  "id": "GOBL-IT-SDI-V1-BILL-INVOICE-05",
+                  "id": "GOBL-IT-SDI-BILL-INVOICE-05",
                   "desc": "supplier requires 'it-sdi-fiscal-regime' extension",
                   "tests": "ext require [it-sdi-fiscal-regime]"
                 }
@@ -86,7 +91,7 @@
                   "field": "entry",
                   "assert": [
                     {
-                      "id": "GOBL-IT-SDI-V1-BILL-INVOICE-06",
+                      "id": "GOBL-IT-SDI-BILL-INVOICE-06",
                       "desc": "supplier registration entry is required when registration is present",
                       "tests": "present"
                     }
@@ -96,7 +101,7 @@
                   "field": "office",
                   "assert": [
                     {
-                      "id": "GOBL-IT-SDI-V1-BILL-INVOICE-07",
+                      "id": "GOBL-IT-SDI-BILL-INVOICE-07",
                       "desc": "supplier registration office is required when registration is present",
                       "tests": "present"
                     }
@@ -122,7 +127,7 @@
                           "field": "num",
                           "assert": [
                             {
-                              "id": "GOBL-IT-SDI-V1-BILL-INVOICE-08",
+                              "id": "GOBL-IT-SDI-BILL-INVOICE-08",
                               "desc": "Italian telephone number length must be between 5 and 12",
                               "tests": "length between 5 and 12"
                             }
@@ -140,7 +145,7 @@
           "field": "customer",
           "assert": [
             {
-              "id": "GOBL-IT-SDI-V1-BILL-INVOICE-09",
+              "id": "GOBL-IT-SDI-BILL-INVOICE-09",
               "desc": "customer is required",
               "tests": "present"
             }
@@ -150,7 +155,7 @@
               "field": "name",
               "assert": [
                 {
-                  "id": "GOBL-IT-SDI-V1-BILL-INVOICE-10",
+                  "id": "GOBL-IT-SDI-BILL-INVOICE-10",
                   "desc": "customer name must use Latin-1 characters",
                   "tests": "latin1"
                 }
@@ -160,7 +165,7 @@
               "field": "tax_id",
               "assert": [
                 {
-                  "id": "GOBL-IT-SDI-V1-BILL-INVOICE-11",
+                  "id": "GOBL-IT-SDI-BILL-INVOICE-11",
                   "desc": "customer tax ID is required",
                   "tests": "present"
                 }
@@ -170,7 +175,7 @@
               "field": "addresses",
               "assert": [
                 {
-                  "id": "GOBL-IT-SDI-V1-BILL-INVOICE-12",
+                  "id": "GOBL-IT-SDI-BILL-INVOICE-12",
                   "desc": "customer addresses are required",
                   "tests": "present"
                 }
@@ -191,7 +196,7 @@
                       "field": "code",
                       "assert": [
                         {
-                          "id": "GOBL-IT-SDI-V1-BILL-INVOICE-15",
+                          "id": "GOBL-IT-SDI-BILL-INVOICE-15",
                           "desc": "customer tax ID code is required for Italian parties without fiscal code",
                           "tests": "present"
                         }
@@ -213,7 +218,7 @@
                   "field": "identities",
                   "assert": [
                     {
-                      "id": "GOBL-IT-SDI-V1-BILL-INVOICE-16",
+                      "id": "GOBL-IT-SDI-BILL-INVOICE-16",
                       "desc": "customer requires identity with key 'it-fiscal-code'",
                       "tests": "has fiscal code"
                     }
@@ -230,7 +235,7 @@
               "each": true,
               "assert": [
                 {
-                  "id": "GOBL-IT-SDI-V1-BILL-INVOICE-17",
+                  "id": "GOBL-IT-SDI-BILL-INVOICE-17",
                   "desc": "line must have VAT tax category",
                   "tests": "line has tax category VAT"
                 }
@@ -243,7 +248,7 @@
                       "field": "name",
                       "assert": [
                         {
-                          "id": "GOBL-IT-SDI-V1-BILL-INVOICE-18",
+                          "id": "GOBL-IT-SDI-BILL-INVOICE-18",
                           "desc": "item name must use Latin-1 characters",
                           "tests": "latin1"
                         }
@@ -271,7 +276,7 @@
                           "field": "issue_date",
                           "assert": [
                             {
-                              "id": "GOBL-IT-SDI-V1-BILL-INVOICE-19",
+                              "id": "GOBL-IT-SDI-BILL-INVOICE-19",
                               "desc": "despatch issue date is required",
                               "tests": "present"
                             }
@@ -295,7 +300,7 @@
                   "field": "despatch",
                   "assert": [
                     {
-                      "id": "GOBL-IT-SDI-V1-BILL-INVOICE-20",
+                      "id": "GOBL-IT-SDI-BILL-INVOICE-20",
                       "desc": "despatch can only be set when invoice has deferred tag",
                       "tests": "empty"
                     }
@@ -308,7 +313,7 @@
       ]
     },
     {
-      "id": "GOBL-IT-SDI-V1-BILL-CHARGE",
+      "id": "GOBL-IT-SDI-BILL-CHARGE",
       "object": "bill.Charge",
       "subsets": [
         {
@@ -318,7 +323,7 @@
               "field": "percent",
               "assert": [
                 {
-                  "id": "GOBL-IT-SDI-V1-BILL-CHARGE-01",
+                  "id": "GOBL-IT-SDI-BILL-CHARGE-01",
                   "desc": "fund contribution charge requires a percentage",
                   "tests": "present"
                 }
@@ -328,7 +333,7 @@
               "field": "ext",
               "assert": [
                 {
-                  "id": "GOBL-IT-SDI-V1-BILL-CHARGE-02",
+                  "id": "GOBL-IT-SDI-BILL-CHARGE-02",
                   "desc": "fund contribution charge requires 'it-sdi-fund-type' extension",
                   "tests": "ext require [it-sdi-fund-type]"
                 }
@@ -338,7 +343,7 @@
               "field": "taxes",
               "assert": [
                 {
-                  "id": "GOBL-IT-SDI-V1-BILL-CHARGE-03",
+                  "id": "GOBL-IT-SDI-BILL-CHARGE-03",
                   "desc": "fund contribution charge must have VAT tax category",
                   "tests": "all of [VAT]"
                 }
@@ -349,11 +354,11 @@
       ]
     },
     {
-      "id": "GOBL-IT-SDI-V1-ORG-ADDRESS",
+      "id": "GOBL-IT-SDI-ORG-ADDRESS",
       "object": "org.Address",
       "assert": [
         {
-          "id": "GOBL-IT-SDI-V1-ORG-ADDRESS-01",
+          "id": "GOBL-IT-SDI-ORG-ADDRESS-01",
           "desc": "address either street or post office box must be set",
           "tests": "street or postbox"
         }
@@ -363,7 +368,7 @@
           "field": "street",
           "assert": [
             {
-              "id": "GOBL-IT-SDI-V1-ORG-ADDRESS-02",
+              "id": "GOBL-IT-SDI-ORG-ADDRESS-02",
               "desc": "address street must use Latin-1 characters",
               "tests": "latin1"
             }
@@ -373,7 +378,7 @@
           "field": "po_box",
           "assert": [
             {
-              "id": "GOBL-IT-SDI-V1-ORG-ADDRESS-03",
+              "id": "GOBL-IT-SDI-ORG-ADDRESS-03",
               "desc": "address post office box must use Latin-1 characters",
               "tests": "latin1"
             }
@@ -383,7 +388,7 @@
           "field": "country",
           "assert": [
             {
-              "id": "GOBL-IT-SDI-V1-ORG-ADDRESS-04",
+              "id": "GOBL-IT-SDI-ORG-ADDRESS-04",
               "desc": "address country is required",
               "tests": "present"
             }
@@ -393,12 +398,12 @@
           "field": "locality",
           "assert": [
             {
-              "id": "GOBL-IT-SDI-V1-ORG-ADDRESS-05",
+              "id": "GOBL-IT-SDI-ORG-ADDRESS-05",
               "desc": "address locality is required",
               "tests": "present"
             },
             {
-              "id": "GOBL-IT-SDI-V1-ORG-ADDRESS-06",
+              "id": "GOBL-IT-SDI-ORG-ADDRESS-06",
               "desc": "address locality must use Latin-1 characters",
               "tests": "latin1"
             }
@@ -411,12 +416,12 @@
               "field": "code",
               "assert": [
                 {
-                  "id": "GOBL-IT-SDI-V1-ORG-ADDRESS-07",
+                  "id": "GOBL-IT-SDI-ORG-ADDRESS-07",
                   "desc": "Italian address code is required",
                   "tests": "present"
                 },
                 {
-                  "id": "GOBL-IT-SDI-V1-ORG-ADDRESS-08",
+                  "id": "GOBL-IT-SDI-ORG-ADDRESS-08",
                   "desc": "Italian address code must be 5 digits",
                   "tests": "matches ^\\d{5}$"
                 }
@@ -427,7 +432,7 @@
       ]
     },
     {
-      "id": "GOBL-IT-SDI-V1-TAX-COMBO",
+      "id": "GOBL-IT-SDI-TAX-COMBO",
       "object": "tax.Combo",
       "subsets": [
         {
@@ -437,7 +442,7 @@
               "field": "ext",
               "assert": [
                 {
-                  "id": "GOBL-IT-SDI-V1-TAX-COMBO-01",
+                  "id": "GOBL-IT-SDI-TAX-COMBO-01",
                   "desc": "VAT tax combo without percent requires 'it-sdi-exempt' extension",
                   "tests": "ext require [it-sdi-exempt]"
                 }
@@ -452,7 +457,7 @@
               "field": "ext",
               "assert": [
                 {
-                  "id": "GOBL-IT-SDI-V1-TAX-COMBO-02",
+                  "id": "GOBL-IT-SDI-TAX-COMBO-02",
                   "desc": "retained tax combo requires 'it-sdi-retained' extension",
                   "tests": "ext require [it-sdi-retained]"
                 }
@@ -463,14 +468,14 @@
       ]
     },
     {
-      "id": "GOBL-IT-SDI-V1-PAY-INSTRUCTIONS",
+      "id": "GOBL-IT-SDI-PAY-INSTRUCTIONS",
       "object": "pay.Instructions",
       "subsets": [
         {
           "field": "ext",
           "assert": [
             {
-              "id": "GOBL-IT-SDI-V1-PAY-INSTRUCTIONS-01",
+              "id": "GOBL-IT-SDI-PAY-INSTRUCTIONS-01",
               "desc": "payment instructions require 'it-sdi-payment-means' extension",
               "tests": "ext require [it-sdi-payment-means]"
             }
@@ -479,14 +484,14 @@
       ]
     },
     {
-      "id": "GOBL-IT-SDI-V1-PAY-ADVANCE",
+      "id": "GOBL-IT-SDI-PAY-ADVANCE",
       "object": "pay.Advance",
       "subsets": [
         {
           "field": "ext",
           "assert": [
             {
-              "id": "GOBL-IT-SDI-V1-PAY-ADVANCE-01",
+              "id": "GOBL-IT-SDI-PAY-ADVANCE-01",
               "desc": "payment advance requires 'it-sdi-payment-means' extension",
               "tests": "ext require [it-sdi-payment-means]"
             }

--- a/data/rules/it-ticket.json
+++ b/data/rules/it-ticket.json
@@ -1,17 +1,24 @@
 {
-  "id": "GOBL-IT-TICKET-V1",
-  "package": "it-ticket-v1",
+  "id": "GOBL-IT-TICKET",
+  "package": "it-ticket",
   "guard": "context: addon in [it-ticket-v1]",
   "subsets": [
     {
-      "id": "GOBL-IT-TICKET-V1-BILL-INVOICE",
+      "id": "GOBL-IT-TICKET-BILL-INVOICE",
       "object": "bill.Invoice",
+      "assert": [
+        {
+          "id": "GOBL-IT-TICKET-BILL-INVOICE-08",
+          "desc": "invoice must be in EUR or provide exchange rate for conversion",
+          "tests": "can convert to [EUR]"
+        }
+      ],
       "subsets": [
         {
           "field": "tax",
           "assert": [
             {
-              "id": "GOBL-IT-TICKET-V1-BILL-INVOICE-01",
+              "id": "GOBL-IT-TICKET-BILL-INVOICE-01",
               "desc": "tax is required",
               "tests": "present"
             }
@@ -21,12 +28,12 @@
               "field": "prices_include",
               "assert": [
                 {
-                  "id": "GOBL-IT-TICKET-V1-BILL-INVOICE-02",
+                  "id": "GOBL-IT-TICKET-BILL-INVOICE-02",
                   "desc": "prices_include is required",
                   "tests": "present"
                 },
                 {
-                  "id": "GOBL-IT-TICKET-V1-BILL-INVOICE-03",
+                  "id": "GOBL-IT-TICKET-BILL-INVOICE-03",
                   "desc": "prices_include must be VAT",
                   "tests": "one of [VAT]"
                 }
@@ -41,7 +48,7 @@
               "field": "tax_id",
               "assert": [
                 {
-                  "id": "GOBL-IT-TICKET-V1-BILL-INVOICE-04",
+                  "id": "GOBL-IT-TICKET-BILL-INVOICE-04",
                   "desc": "supplier tax ID is required",
                   "tests": "present"
                 }
@@ -56,7 +63,7 @@
               "field": "preceding",
               "assert": [
                 {
-                  "id": "GOBL-IT-TICKET-V1-BILL-INVOICE-05",
+                  "id": "GOBL-IT-TICKET-BILL-INVOICE-05",
                   "desc": "preceding documents are required for corrective invoices",
                   "tests": "present"
                 }
@@ -71,7 +78,7 @@
               "each": true,
               "assert": [
                 {
-                  "id": "GOBL-IT-TICKET-V1-BILL-INVOICE-06",
+                  "id": "GOBL-IT-TICKET-BILL-INVOICE-06",
                   "desc": "line taxes must include VAT category",
                   "tests": "line has tax category VAT"
                 }
@@ -92,7 +99,7 @@
                       "field": "ext",
                       "assert": [
                         {
-                          "id": "GOBL-IT-TICKET-V1-BILL-INVOICE-07",
+                          "id": "GOBL-IT-TICKET-BILL-INVOICE-07",
                           "desc": "corrective invoice lines require 'it-ticket-line-ref' extension",
                           "tests": "ext require [it-ticket-line-ref]"
                         }
@@ -107,7 +114,7 @@
       ]
     },
     {
-      "id": "GOBL-IT-TICKET-V1-TAX-COMBO",
+      "id": "GOBL-IT-TICKET-TAX-COMBO",
       "object": "tax.Combo",
       "subsets": [
         {
@@ -117,7 +124,7 @@
               "field": "ext",
               "assert": [
                 {
-                  "id": "GOBL-IT-TICKET-V1-TAX-COMBO-01",
+                  "id": "GOBL-IT-TICKET-TAX-COMBO-01",
                   "desc": "exempt VAT combo requires 'it-ticket-exempt' extension",
                   "tests": "ext require [it-ticket-exempt]"
                 }
@@ -132,7 +139,7 @@
               "field": "percent",
               "assert": [
                 {
-                  "id": "GOBL-IT-TICKET-V1-TAX-COMBO-02",
+                  "id": "GOBL-IT-TICKET-TAX-COMBO-02",
                   "desc": "must be a valid value",
                   "tests": "valid percentage"
                 }

--- a/data/rules/mx-cfdi.json
+++ b/data/rules/mx-cfdi.json
@@ -1,11 +1,18 @@
 {
-  "id": "GOBL-MX-CFDI-V4",
-  "package": "mx-cfdi-v4",
+  "id": "GOBL-MX-CFDI",
+  "package": "mx-cfdi",
   "guard": "context: addon in [mx-cfdi-v4]",
   "subsets": [
     {
-      "id": "GOBL-MX-CFDI-V4-BILL-INVOICE",
+      "id": "GOBL-MX-CFDI-BILL-INVOICE",
       "object": "bill.Invoice",
+      "assert": [
+        {
+          "id": "GOBL-MX-CFDI-BILL-INVOICE-27",
+          "desc": "invoice must be in MXN or provide exchange rate for conversion",
+          "tests": "can convert to [MXN]"
+        }
+      ],
       "subsets": [
         {
           "field": "tax",
@@ -14,7 +21,7 @@
               "field": "ext",
               "assert": [
                 {
-                  "id": "GOBL-MX-CFDI-V4-BILL-INVOICE-01",
+                  "id": "GOBL-MX-CFDI-BILL-INVOICE-01",
                   "desc": "tax requires 'mx-cfdi-doc-type', 'mx-cfdi-issue-place', and 'mx-cfdi-payment-method' extensions",
                   "tests": "ext require [mx-cfdi-doc-type, mx-cfdi-issue-place, mx-cfdi-payment-method]"
                 }
@@ -32,7 +39,7 @@
                   "field": "ext",
                   "assert": [
                     {
-                      "id": "GOBL-MX-CFDI-V4-BILL-INVOICE-02",
+                      "id": "GOBL-MX-CFDI-BILL-INVOICE-02",
                       "desc": "global invoices require 'mx-cfdi-global-period', 'mx-cfdi-global-month', and 'mx-cfdi-global-year' extensions",
                       "tests": "ext require [mx-cfdi-global-period, mx-cfdi-global-month, mx-cfdi-global-year]"
                     }
@@ -44,7 +51,7 @@
               "field": "customer",
               "assert": [
                 {
-                  "id": "GOBL-MX-CFDI-V4-BILL-INVOICE-03",
+                  "id": "GOBL-MX-CFDI-BILL-INVOICE-03",
                   "desc": "cannot be set with global tag",
                   "tests": "empty"
                 }
@@ -54,7 +61,7 @@
               "field": "payment",
               "assert": [
                 {
-                  "id": "GOBL-MX-CFDI-V4-BILL-INVOICE-04",
+                  "id": "GOBL-MX-CFDI-BILL-INVOICE-04",
                   "desc": "payment is required for global invoices",
                   "tests": "present"
                 }
@@ -64,7 +71,7 @@
                   "field": "advances",
                   "assert": [
                     {
-                      "id": "GOBL-MX-CFDI-V4-BILL-INVOICE-05",
+                      "id": "GOBL-MX-CFDI-BILL-INVOICE-05",
                       "desc": "advances must be set with global tag",
                       "tests": "present"
                     }
@@ -85,7 +92,7 @@
                           "field": "ref",
                           "assert": [
                             {
-                              "id": "GOBL-MX-CFDI-V4-BILL-INVOICE-06",
+                              "id": "GOBL-MX-CFDI-BILL-INVOICE-06",
                               "desc": "must be set with global tag",
                               "tests": "present"
                             }
@@ -109,7 +116,7 @@
                   "field": "ext",
                   "assert": [
                     {
-                      "id": "GOBL-MX-CFDI-V4-BILL-INVOICE-07",
+                      "id": "GOBL-MX-CFDI-BILL-INVOICE-07",
                       "desc": "'mx-cfdi-global-period', 'mx-cfdi-global-month', and 'mx-cfdi-global-year' extensions must all be present or all absent",
                       "tests": "ext require all or none of [mx-cfdi-global-period, mx-cfdi-global-month, mx-cfdi-global-year]"
                     }
@@ -124,7 +131,7 @@
                   "field": "tax_id",
                   "assert": [
                     {
-                      "id": "GOBL-MX-CFDI-V4-BILL-INVOICE-08",
+                      "id": "GOBL-MX-CFDI-BILL-INVOICE-08",
                       "desc": "customer tax ID is required",
                       "tests": "present"
                     }
@@ -134,7 +141,7 @@
                       "field": "code",
                       "assert": [
                         {
-                          "id": "GOBL-MX-CFDI-V4-BILL-INVOICE-09",
+                          "id": "GOBL-MX-CFDI-BILL-INVOICE-09",
                           "desc": "customer tax ID code is required",
                           "tests": "present"
                         }
@@ -149,7 +156,7 @@
                       "field": "ext",
                       "assert": [
                         {
-                          "id": "GOBL-MX-CFDI-V4-BILL-INVOICE-10",
+                          "id": "GOBL-MX-CFDI-BILL-INVOICE-10",
                           "desc": "Mexican customer requires 'mx-cfdi-fiscal-regime' and 'mx-cfdi-use' extensions",
                           "tests": "ext require [mx-cfdi-fiscal-regime, mx-cfdi-use]"
                         }
@@ -159,7 +166,7 @@
                       "field": "addresses",
                       "assert": [
                         {
-                          "id": "GOBL-MX-CFDI-V4-BILL-INVOICE-11",
+                          "id": "GOBL-MX-CFDI-BILL-INVOICE-11",
                           "desc": "Mexican customer must have at least one address",
                           "tests": "present"
                         }
@@ -172,12 +179,12 @@
                               "field": "code",
                               "assert": [
                                 {
-                                  "id": "GOBL-MX-CFDI-V4-BILL-INVOICE-12",
+                                  "id": "GOBL-MX-CFDI-BILL-INVOICE-12",
                                   "desc": "customer address postal code is required",
                                   "tests": "present"
                                 },
                                 {
-                                  "id": "GOBL-MX-CFDI-V4-BILL-INVOICE-13",
+                                  "id": "GOBL-MX-CFDI-BILL-INVOICE-13",
                                   "desc": "customer address postal code format is invalid",
                                   "tests": "matches ^[0-9]{5}$"
                                 }
@@ -204,12 +211,12 @@
                           "field": "ext",
                           "assert": [
                             {
-                              "id": "GOBL-MX-CFDI-V4-BILL-INVOICE-14",
+                              "id": "GOBL-MX-CFDI-BILL-INVOICE-14",
                               "desc": "item requires 'mx-cfdi-prod-serv' extension",
                               "tests": "ext require [mx-cfdi-prod-serv]"
                             },
                             {
-                              "id": "GOBL-MX-CFDI-V4-BILL-INVOICE-15",
+                              "id": "GOBL-MX-CFDI-BILL-INVOICE-15",
                               "desc": "product/service code must have 8 digits",
                               "tests": "valid prod-serv"
                             }
@@ -233,7 +240,7 @@
                   "field": "ext",
                   "assert": [
                     {
-                      "id": "GOBL-MX-CFDI-V4-BILL-INVOICE-16",
+                      "id": "GOBL-MX-CFDI-BILL-INVOICE-16",
                       "desc": "tax requires 'mx-cfdi-rel-type' extension when preceding documents are present",
                       "tests": "ext require [mx-cfdi-rel-type]"
                     }
@@ -253,7 +260,7 @@
                   "field": "stamps",
                   "assert": [
                     {
-                      "id": "GOBL-MX-CFDI-V4-BILL-INVOICE-17",
+                      "id": "GOBL-MX-CFDI-BILL-INVOICE-17",
                       "desc": "preceding row is missing 'sat-uuid' stamp",
                       "tests": "stamps have sat-uuid"
                     }
@@ -270,7 +277,7 @@
               "field": "tax_id",
               "assert": [
                 {
-                  "id": "GOBL-MX-CFDI-V4-BILL-INVOICE-18",
+                  "id": "GOBL-MX-CFDI-BILL-INVOICE-18",
                   "desc": "supplier tax ID is required",
                   "tests": "present"
                 }
@@ -280,7 +287,7 @@
                   "field": "code",
                   "assert": [
                     {
-                      "id": "GOBL-MX-CFDI-V4-BILL-INVOICE-19",
+                      "id": "GOBL-MX-CFDI-BILL-INVOICE-19",
                       "desc": "supplier tax ID code is required",
                       "tests": "present"
                     }
@@ -292,7 +299,7 @@
               "field": "ext",
               "assert": [
                 {
-                  "id": "GOBL-MX-CFDI-V4-BILL-INVOICE-20",
+                  "id": "GOBL-MX-CFDI-BILL-INVOICE-20",
                   "desc": "supplier requires 'mx-cfdi-fiscal-regime' extension",
                   "tests": "ext require [mx-cfdi-fiscal-regime]"
                 }
@@ -310,7 +317,7 @@
                   "field": "quantity",
                   "assert": [
                     {
-                      "id": "GOBL-MX-CFDI-V4-BILL-INVOICE-21",
+                      "id": "GOBL-MX-CFDI-BILL-INVOICE-21",
                       "desc": "line quantity must be greater than 0",
                       "tests": "min 0"
                     }
@@ -323,12 +330,12 @@
                       "field": "price",
                       "assert": [
                         {
-                          "id": "GOBL-MX-CFDI-V4-BILL-INVOICE-22",
+                          "id": "GOBL-MX-CFDI-BILL-INVOICE-22",
                           "desc": "line item price is required",
                           "tests": "present"
                         },
                         {
-                          "id": "GOBL-MX-CFDI-V4-BILL-INVOICE-23",
+                          "id": "GOBL-MX-CFDI-BILL-INVOICE-23",
                           "desc": "line item price must be greater than 0",
                           "tests": "min 0"
                         }
@@ -340,7 +347,7 @@
                   "field": "total",
                   "assert": [
                     {
-                      "id": "GOBL-MX-CFDI-V4-BILL-INVOICE-24",
+                      "id": "GOBL-MX-CFDI-BILL-INVOICE-24",
                       "desc": "line total must not be negative",
                       "tests": "min 0"
                     }
@@ -354,7 +361,7 @@
           "field": "discounts",
           "assert": [
             {
-              "id": "GOBL-MX-CFDI-V4-BILL-INVOICE-25",
+              "id": "GOBL-MX-CFDI-BILL-INVOICE-25",
               "desc": "document level discounts are not supported, use line discounts instead",
               "tests": "empty"
             }
@@ -364,7 +371,7 @@
           "field": "charges",
           "assert": [
             {
-              "id": "GOBL-MX-CFDI-V4-BILL-INVOICE-26",
+              "id": "GOBL-MX-CFDI-BILL-INVOICE-26",
               "desc": "document level charges are not supported",
               "tests": "empty"
             }
@@ -373,14 +380,14 @@
       ]
     },
     {
-      "id": "GOBL-MX-CFDI-V4-PAY-INSTRUCTIONS",
+      "id": "GOBL-MX-CFDI-PAY-INSTRUCTIONS",
       "object": "pay.Instructions",
       "subsets": [
         {
           "field": "ext",
           "assert": [
             {
-              "id": "GOBL-MX-CFDI-V4-PAY-INSTRUCTIONS-01",
+              "id": "GOBL-MX-CFDI-PAY-INSTRUCTIONS-01",
               "desc": "payment instructions require 'mx-cfdi-payment-means' extension",
               "tests": "ext require [mx-cfdi-payment-means]"
             }
@@ -389,14 +396,14 @@
       ]
     },
     {
-      "id": "GOBL-MX-CFDI-V4-PAY-ADVANCE",
+      "id": "GOBL-MX-CFDI-PAY-ADVANCE",
       "object": "pay.Advance",
       "subsets": [
         {
           "field": "ext",
           "assert": [
             {
-              "id": "GOBL-MX-CFDI-V4-PAY-ADVANCE-01",
+              "id": "GOBL-MX-CFDI-PAY-ADVANCE-01",
               "desc": "payment advance requires 'mx-cfdi-payment-means' extension",
               "tests": "ext require [mx-cfdi-payment-means]"
             }
@@ -405,14 +412,14 @@
       ]
     },
     {
-      "id": "GOBL-MX-CFDI-V4-PAY-TERMS",
+      "id": "GOBL-MX-CFDI-PAY-TERMS",
       "object": "pay.Terms",
       "subsets": [
         {
           "field": "notes",
           "assert": [
             {
-              "id": "GOBL-MX-CFDI-V4-PAY-TERMS-01",
+              "id": "GOBL-MX-CFDI-PAY-TERMS-01",
               "desc": "notes length must be no more than 1000",
               "tests": "length between 0 and 1000"
             }
@@ -421,14 +428,14 @@
       ]
     },
     {
-      "id": "GOBL-MX-CFDI-V4-FOODVOUCHERS",
+      "id": "GOBL-MX-CFDI-FOODVOUCHERS",
       "object": "cfdi.FoodVouchers",
       "subsets": [
         {
           "field": "employer_registration",
           "assert": [
             {
-              "id": "GOBL-MX-CFDI-V4-FOODVOUCHERS-01",
+              "id": "GOBL-MX-CFDI-FOODVOUCHERS-01",
               "desc": "employer registration must be no more than 20 characters",
               "tests": "length between 0 and 20"
             }
@@ -438,12 +445,12 @@
           "field": "account_number",
           "assert": [
             {
-              "id": "GOBL-MX-CFDI-V4-FOODVOUCHERS-02",
+              "id": "GOBL-MX-CFDI-FOODVOUCHERS-02",
               "desc": "account number is required",
               "tests": "present"
             },
             {
-              "id": "GOBL-MX-CFDI-V4-FOODVOUCHERS-03",
+              "id": "GOBL-MX-CFDI-FOODVOUCHERS-03",
               "desc": "account number must be no more than 20 characters",
               "tests": "length between 0 and 20"
             }
@@ -453,7 +460,7 @@
           "field": "total",
           "assert": [
             {
-              "id": "GOBL-MX-CFDI-V4-FOODVOUCHERS-04",
+              "id": "GOBL-MX-CFDI-FOODVOUCHERS-04",
               "desc": "total is required",
               "tests": "present"
             }
@@ -463,7 +470,7 @@
           "field": "lines",
           "assert": [
             {
-              "id": "GOBL-MX-CFDI-V4-FOODVOUCHERS-05",
+              "id": "GOBL-MX-CFDI-FOODVOUCHERS-05",
               "desc": "lines are required",
               "tests": "present"
             }
@@ -476,12 +483,12 @@
                   "field": "e_wallet_id",
                   "assert": [
                     {
-                      "id": "GOBL-MX-CFDI-V4-FOODVOUCHERS-06",
+                      "id": "GOBL-MX-CFDI-FOODVOUCHERS-06",
                       "desc": "line e-wallet ID is required",
                       "tests": "present"
                     },
                     {
-                      "id": "GOBL-MX-CFDI-V4-FOODVOUCHERS-07",
+                      "id": "GOBL-MX-CFDI-FOODVOUCHERS-07",
                       "desc": "line e-wallet ID must be no more than 20 characters",
                       "tests": "length between 0 and 20"
                     }
@@ -491,7 +498,7 @@
                   "field": "issue_date_time",
                   "assert": [
                     {
-                      "id": "GOBL-MX-CFDI-V4-FOODVOUCHERS-08",
+                      "id": "GOBL-MX-CFDI-FOODVOUCHERS-08",
                       "desc": "line issue date and time is required",
                       "tests": "not zero"
                     }
@@ -501,7 +508,7 @@
                   "field": "employee",
                   "assert": [
                     {
-                      "id": "GOBL-MX-CFDI-V4-FOODVOUCHERS-09",
+                      "id": "GOBL-MX-CFDI-FOODVOUCHERS-09",
                       "desc": "line employee is required",
                       "tests": "present"
                     }
@@ -511,12 +518,12 @@
                       "field": "tax_code",
                       "assert": [
                         {
-                          "id": "GOBL-MX-CFDI-V4-FOODVOUCHERS-10",
+                          "id": "GOBL-MX-CFDI-FOODVOUCHERS-10",
                           "desc": "employee tax code (RFC) is required",
                           "tests": "present"
                         },
                         {
-                          "id": "GOBL-MX-CFDI-V4-FOODVOUCHERS-11",
+                          "id": "GOBL-MX-CFDI-FOODVOUCHERS-11",
                           "desc": "employee tax code (RFC) must be valid",
                           "tests": "valid RFC"
                         }
@@ -526,12 +533,12 @@
                       "field": "curp",
                       "assert": [
                         {
-                          "id": "GOBL-MX-CFDI-V4-FOODVOUCHERS-12",
+                          "id": "GOBL-MX-CFDI-FOODVOUCHERS-12",
                           "desc": "employee CURP is required",
                           "tests": "present"
                         },
                         {
-                          "id": "GOBL-MX-CFDI-V4-FOODVOUCHERS-13",
+                          "id": "GOBL-MX-CFDI-FOODVOUCHERS-13",
                           "desc": "employee CURP format must be valid",
                           "tests": "matches ^[A-Z][A,E,I,O,U,X][A-Z]{2}[0-9]{2}[0-1][0-9][0-3][0-9][M,H][A-Z]{2}[B,C,D,F,G,H,J,K,L,M,N,Ñ,P,Q,R,S,T,V,W,X,Y,Z]{3}[0-9,A-Z][0-9]$"
                         }
@@ -541,12 +548,12 @@
                       "field": "name",
                       "assert": [
                         {
-                          "id": "GOBL-MX-CFDI-V4-FOODVOUCHERS-14",
+                          "id": "GOBL-MX-CFDI-FOODVOUCHERS-14",
                           "desc": "employee name is required",
                           "tests": "present"
                         },
                         {
-                          "id": "GOBL-MX-CFDI-V4-FOODVOUCHERS-15",
+                          "id": "GOBL-MX-CFDI-FOODVOUCHERS-15",
                           "desc": "employee name must be no more than 100 characters",
                           "tests": "length between 0 and 100"
                         }
@@ -556,7 +563,7 @@
                       "field": "social_security",
                       "assert": [
                         {
-                          "id": "GOBL-MX-CFDI-V4-FOODVOUCHERS-16",
+                          "id": "GOBL-MX-CFDI-FOODVOUCHERS-16",
                           "desc": "employee social security number format is invalid",
                           "tests": "matches ^[0-9]{11}$"
                         }
@@ -568,7 +575,7 @@
                   "field": "amount",
                   "assert": [
                     {
-                      "id": "GOBL-MX-CFDI-V4-FOODVOUCHERS-17",
+                      "id": "GOBL-MX-CFDI-FOODVOUCHERS-17",
                       "desc": "line amount is required",
                       "tests": "present"
                     }
@@ -581,19 +588,19 @@
       ]
     },
     {
-      "id": "GOBL-MX-CFDI-V4-FUELACCOUNTBALANCE",
+      "id": "GOBL-MX-CFDI-FUELACCOUNTBALANCE",
       "object": "cfdi.FuelAccountBalance",
       "subsets": [
         {
           "field": "account_number",
           "assert": [
             {
-              "id": "GOBL-MX-CFDI-V4-FUELACCOUNTBALANCE-01",
+              "id": "GOBL-MX-CFDI-FUELACCOUNTBALANCE-01",
               "desc": "account number is required",
               "tests": "present"
             },
             {
-              "id": "GOBL-MX-CFDI-V4-FUELACCOUNTBALANCE-02",
+              "id": "GOBL-MX-CFDI-FUELACCOUNTBALANCE-02",
               "desc": "account number must be between 1 and 50 characters",
               "tests": "length between 1 and 50"
             }
@@ -603,7 +610,7 @@
           "field": "subtotal",
           "assert": [
             {
-              "id": "GOBL-MX-CFDI-V4-FUELACCOUNTBALANCE-03",
+              "id": "GOBL-MX-CFDI-FUELACCOUNTBALANCE-03",
               "desc": "subtotal is required",
               "tests": "present"
             }
@@ -613,7 +620,7 @@
           "field": "total",
           "assert": [
             {
-              "id": "GOBL-MX-CFDI-V4-FUELACCOUNTBALANCE-04",
+              "id": "GOBL-MX-CFDI-FUELACCOUNTBALANCE-04",
               "desc": "total is required",
               "tests": "present"
             }
@@ -623,7 +630,7 @@
           "field": "lines",
           "assert": [
             {
-              "id": "GOBL-MX-CFDI-V4-FUELACCOUNTBALANCE-05",
+              "id": "GOBL-MX-CFDI-FUELACCOUNTBALANCE-05",
               "desc": "lines are required",
               "tests": "present"
             }
@@ -633,7 +640,7 @@
               "each": true,
               "assert": [
                 {
-                  "id": "GOBL-MX-CFDI-V4-FUELACCOUNTBALANCE-20",
+                  "id": "GOBL-MX-CFDI-FUELACCOUNTBALANCE-20",
                   "desc": "line total must be quantity x unit_price",
                   "tests": "valid line total"
                 }
@@ -643,7 +650,7 @@
                   "field": "e_wallet_id",
                   "assert": [
                     {
-                      "id": "GOBL-MX-CFDI-V4-FUELACCOUNTBALANCE-06",
+                      "id": "GOBL-MX-CFDI-FUELACCOUNTBALANCE-06",
                       "desc": "line e-wallet ID is required",
                       "tests": "present"
                     }
@@ -653,7 +660,7 @@
                   "field": "purchase_date_time",
                   "assert": [
                     {
-                      "id": "GOBL-MX-CFDI-V4-FUELACCOUNTBALANCE-07",
+                      "id": "GOBL-MX-CFDI-FUELACCOUNTBALANCE-07",
                       "desc": "line purchase date and time is required",
                       "tests": "not zero"
                     }
@@ -663,12 +670,12 @@
                   "field": "vendor_tax_code",
                   "assert": [
                     {
-                      "id": "GOBL-MX-CFDI-V4-FUELACCOUNTBALANCE-08",
+                      "id": "GOBL-MX-CFDI-FUELACCOUNTBALANCE-08",
                       "desc": "line vendor tax code is required",
                       "tests": "present"
                     },
                     {
-                      "id": "GOBL-MX-CFDI-V4-FUELACCOUNTBALANCE-09",
+                      "id": "GOBL-MX-CFDI-FUELACCOUNTBALANCE-09",
                       "desc": "line vendor tax identity code is invalid",
                       "tests": "valid RFC"
                     }
@@ -678,12 +685,12 @@
                   "field": "service_station_code",
                   "assert": [
                     {
-                      "id": "GOBL-MX-CFDI-V4-FUELACCOUNTBALANCE-10",
+                      "id": "GOBL-MX-CFDI-FUELACCOUNTBALANCE-10",
                       "desc": "line service station code is required",
                       "tests": "present"
                     },
                     {
-                      "id": "GOBL-MX-CFDI-V4-FUELACCOUNTBALANCE-11",
+                      "id": "GOBL-MX-CFDI-FUELACCOUNTBALANCE-11",
                       "desc": "line service station code must be between 1 and 20 characters",
                       "tests": "length between 1 and 20"
                     }
@@ -693,7 +700,7 @@
                   "field": "quantity",
                   "assert": [
                     {
-                      "id": "GOBL-MX-CFDI-V4-FUELACCOUNTBALANCE-12",
+                      "id": "GOBL-MX-CFDI-FUELACCOUNTBALANCE-12",
                       "desc": "line quantity must be greater than 0",
                       "tests": "min 0"
                     }
@@ -703,7 +710,7 @@
                   "field": "item",
                   "assert": [
                     {
-                      "id": "GOBL-MX-CFDI-V4-FUELACCOUNTBALANCE-13",
+                      "id": "GOBL-MX-CFDI-FUELACCOUNTBALANCE-13",
                       "desc": "line item is required",
                       "tests": "present"
                     }
@@ -713,7 +720,7 @@
                       "field": "type",
                       "assert": [
                         {
-                          "id": "GOBL-MX-CFDI-V4-FUELACCOUNTBALANCE-14",
+                          "id": "GOBL-MX-CFDI-FUELACCOUNTBALANCE-14",
                           "desc": "line item type is required",
                           "tests": "present"
                         }
@@ -723,12 +730,12 @@
                       "field": "name",
                       "assert": [
                         {
-                          "id": "GOBL-MX-CFDI-V4-FUELACCOUNTBALANCE-15",
+                          "id": "GOBL-MX-CFDI-FUELACCOUNTBALANCE-15",
                           "desc": "line item name is required",
                           "tests": "present"
                         },
                         {
-                          "id": "GOBL-MX-CFDI-V4-FUELACCOUNTBALANCE-16",
+                          "id": "GOBL-MX-CFDI-FUELACCOUNTBALANCE-16",
                           "desc": "line item name must be between 1 and 300 characters",
                           "tests": "length between 1 and 300"
                         }
@@ -738,7 +745,7 @@
                       "field": "price",
                       "assert": [
                         {
-                          "id": "GOBL-MX-CFDI-V4-FUELACCOUNTBALANCE-17",
+                          "id": "GOBL-MX-CFDI-FUELACCOUNTBALANCE-17",
                           "desc": "line item price must be greater than 0",
                           "tests": "min 0"
                         }
@@ -750,12 +757,12 @@
                   "field": "purchase_code",
                   "assert": [
                     {
-                      "id": "GOBL-MX-CFDI-V4-FUELACCOUNTBALANCE-18",
+                      "id": "GOBL-MX-CFDI-FUELACCOUNTBALANCE-18",
                       "desc": "line purchase code is required",
                       "tests": "present"
                     },
                     {
-                      "id": "GOBL-MX-CFDI-V4-FUELACCOUNTBALANCE-19",
+                      "id": "GOBL-MX-CFDI-FUELACCOUNTBALANCE-19",
                       "desc": "line purchase code must be between 1 and 50 characters",
                       "tests": "length between 1 and 50"
                     }
@@ -765,7 +772,7 @@
                   "field": "taxes",
                   "assert": [
                     {
-                      "id": "GOBL-MX-CFDI-V4-FUELACCOUNTBALANCE-21",
+                      "id": "GOBL-MX-CFDI-FUELACCOUNTBALANCE-21",
                       "desc": "line taxes are required",
                       "tests": "present"
                     }
@@ -778,12 +785,12 @@
                           "field": "cat",
                           "assert": [
                             {
-                              "id": "GOBL-MX-CFDI-V4-FUELACCOUNTBALANCE-22",
+                              "id": "GOBL-MX-CFDI-FUELACCOUNTBALANCE-22",
                               "desc": "line tax category is required",
                               "tests": "present"
                             },
                             {
-                              "id": "GOBL-MX-CFDI-V4-FUELACCOUNTBALANCE-23",
+                              "id": "GOBL-MX-CFDI-FUELACCOUNTBALANCE-23",
                               "desc": "line tax category must be a valid value",
                               "tests": "one of [VAT, IEPS]"
                             }
@@ -796,7 +803,7 @@
                               "field": "rate",
                               "assert": [
                                 {
-                                  "id": "GOBL-MX-CFDI-V4-FUELACCOUNTBALANCE-24",
+                                  "id": "GOBL-MX-CFDI-FUELACCOUNTBALANCE-24",
                                   "desc": "line tax rate is required when percent is not set",
                                   "tests": "present"
                                 }
@@ -811,7 +818,7 @@
                               "guard": "present",
                               "assert": [
                                 {
-                                  "id": "GOBL-MX-CFDI-V4-FUELACCOUNTBALANCE-25",
+                                  "id": "GOBL-MX-CFDI-FUELACCOUNTBALANCE-25",
                                   "desc": "line tax rate must be greater than 0",
                                   "tests": "min 0"
                                 }
@@ -823,7 +830,7 @@
                           "field": "amount",
                           "assert": [
                             {
-                              "id": "GOBL-MX-CFDI-V4-FUELACCOUNTBALANCE-26",
+                              "id": "GOBL-MX-CFDI-FUELACCOUNTBALANCE-26",
                               "desc": "line tax amount must be greater than 0",
                               "tests": "min 0"
                             }

--- a/data/rules/pl-favat.json
+++ b/data/rules/pl-favat.json
@@ -1,29 +1,34 @@
 {
-  "id": "GOBL-PL-FAVAT-V3",
-  "package": "pl-favat-v3",
+  "id": "GOBL-PL-FAVAT",
+  "package": "pl-favat",
   "guard": "context: addon in [pl-favat-v3]",
   "subsets": [
     {
-      "id": "GOBL-PL-FAVAT-V3-BILL-INVOICE",
+      "id": "GOBL-PL-FAVAT-BILL-INVOICE",
       "object": "bill.Invoice",
       "assert": [
         {
-          "id": "GOBL-PL-FAVAT-V3-BILL-INVOICE-11",
+          "id": "GOBL-PL-FAVAT-BILL-INVOICE-15",
+          "desc": "invoice must be in PLN or provide exchange rate for conversion",
+          "tests": "can convert to [PLN]"
+        },
+        {
+          "id": "GOBL-PL-FAVAT-BILL-INVOICE-11",
           "desc": "customer requires identity with role '8' and code for JST",
           "tests": "JST identity"
         },
         {
-          "id": "GOBL-PL-FAVAT-V3-BILL-INVOICE-12",
+          "id": "GOBL-PL-FAVAT-BILL-INVOICE-12",
           "desc": "customer requires identity with role '10' and code for GroupVAT",
           "tests": "GroupVAT identity"
         },
         {
-          "id": "GOBL-PL-FAVAT-V3-BILL-INVOICE-13",
+          "id": "GOBL-PL-FAVAT-BILL-INVOICE-13",
           "desc": "missing exemption note",
           "tests": "exemption note present"
         },
         {
-          "id": "GOBL-PL-FAVAT-V3-BILL-INVOICE-14",
+          "id": "GOBL-PL-FAVAT-BILL-INVOICE-14",
           "desc": "too many exemption notes",
           "tests": "single exemption note"
         }
@@ -33,7 +38,7 @@
           "field": "type",
           "assert": [
             {
-              "id": "GOBL-PL-FAVAT-V3-BILL-INVOICE-01",
+              "id": "GOBL-PL-FAVAT-BILL-INVOICE-01",
               "desc": "invoice type must be standard or credit-note",
               "tests": "one of [standard, credit-note]"
             }
@@ -49,7 +54,7 @@
                   "field": "issue_date",
                   "assert": [
                     {
-                      "id": "GOBL-PL-FAVAT-V3-BILL-INVOICE-02",
+                      "id": "GOBL-PL-FAVAT-BILL-INVOICE-02",
                       "desc": "preceding issue date is required",
                       "tests": "present"
                     }
@@ -59,7 +64,7 @@
                   "field": "code",
                   "assert": [
                     {
-                      "id": "GOBL-PL-FAVAT-V3-BILL-INVOICE-03",
+                      "id": "GOBL-PL-FAVAT-BILL-INVOICE-03",
                       "desc": "preceding code is required",
                       "tests": "present"
                     }
@@ -73,7 +78,7 @@
           "field": "supplier",
           "assert": [
             {
-              "id": "GOBL-PL-FAVAT-V3-BILL-INVOICE-04",
+              "id": "GOBL-PL-FAVAT-BILL-INVOICE-04",
               "desc": "supplier is required",
               "tests": "present"
             }
@@ -83,7 +88,7 @@
               "field": "name",
               "assert": [
                 {
-                  "id": "GOBL-PL-FAVAT-V3-BILL-INVOICE-05",
+                  "id": "GOBL-PL-FAVAT-BILL-INVOICE-05",
                   "desc": "supplier name is required",
                   "tests": "present"
                 }
@@ -93,17 +98,17 @@
               "field": "addresses",
               "assert": [
                 {
-                  "id": "GOBL-PL-FAVAT-V3-BILL-INVOICE-06",
+                  "id": "GOBL-PL-FAVAT-BILL-INVOICE-06",
                   "desc": "supplier addresses are required",
                   "tests": "present"
                 },
                 {
-                  "id": "GOBL-PL-FAVAT-V3-BILL-INVOICE-07",
+                  "id": "GOBL-PL-FAVAT-BILL-INVOICE-07",
                   "desc": "supplier first address must have a country",
                   "tests": "first address country"
                 },
                 {
-                  "id": "GOBL-PL-FAVAT-V3-BILL-INVOICE-08",
+                  "id": "GOBL-PL-FAVAT-BILL-INVOICE-08",
                   "desc": "supplier first address must have a street",
                   "tests": "first address street"
                 }
@@ -118,7 +123,7 @@
               "field": "customer",
               "assert": [
                 {
-                  "id": "GOBL-PL-FAVAT-V3-BILL-INVOICE-09",
+                  "id": "GOBL-PL-FAVAT-BILL-INVOICE-09",
                   "desc": "customer is required",
                   "tests": "present"
                 }
@@ -139,7 +144,7 @@
                       "field": "code",
                       "assert": [
                         {
-                          "id": "GOBL-PL-FAVAT-V3-BILL-INVOICE-10",
+                          "id": "GOBL-PL-FAVAT-BILL-INVOICE-10",
                           "desc": "customer Polish tax ID code is required",
                           "tests": "present"
                         }
@@ -154,14 +159,14 @@
       ]
     },
     {
-      "id": "GOBL-PL-FAVAT-V3-TAX-COMBO",
+      "id": "GOBL-PL-FAVAT-TAX-COMBO",
       "object": "tax.Combo",
       "subsets": [
         {
           "field": "ext",
           "assert": [
             {
-              "id": "GOBL-PL-FAVAT-V3-TAX-COMBO-01",
+              "id": "GOBL-PL-FAVAT-TAX-COMBO-01",
               "desc": "tax combo requires 'pl-favat-tax-category' extension",
               "tests": "ext require [pl-favat-tax-category]"
             }
@@ -170,14 +175,14 @@
       ]
     },
     {
-      "id": "GOBL-PL-FAVAT-V3-PAY-ADVANCE",
+      "id": "GOBL-PL-FAVAT-PAY-ADVANCE",
       "object": "pay.Advance",
       "subsets": [
         {
           "field": "date",
           "assert": [
             {
-              "id": "GOBL-PL-FAVAT-V3-PAY-ADVANCE-01",
+              "id": "GOBL-PL-FAVAT-PAY-ADVANCE-01",
               "desc": "advance payment date is required",
               "tests": "present"
             }

--- a/data/rules/pt-saft.json
+++ b/data/rules/pt-saft.json
@@ -1,44 +1,49 @@
 {
-  "id": "GOBL-PT-SAFT-V1",
-  "package": "pt-saft-v1",
+  "id": "GOBL-PT-SAFT",
+  "package": "pt-saft",
   "guard": "context: addon in [pt-saft-v1]",
   "subsets": [
     {
-      "id": "GOBL-PT-SAFT-V1-BILL-INVOICE",
+      "id": "GOBL-PT-SAFT-BILL-INVOICE",
       "object": "bill.Invoice",
       "assert": [
         {
-          "id": "GOBL-PT-SAFT-V1-BILL-INVOICE-01",
+          "id": "GOBL-PT-SAFT-BILL-INVOICE-15",
+          "desc": "invoice must be in EUR or provide exchange rate for conversion",
+          "tests": "can convert to [EUR]"
+        },
+        {
+          "id": "GOBL-PT-SAFT-BILL-INVOICE-01",
           "desc": "either 'pt-saft-work-type' or 'pt-saft-invoice-type' must be set",
           "tests": "has doc type"
         },
         {
-          "id": "GOBL-PT-SAFT-V1-BILL-INVOICE-02",
+          "id": "GOBL-PT-SAFT-BILL-INVOICE-02",
           "desc": "either 'pt-saft-work-type' or 'pt-saft-invoice-type' must be set, but not both",
           "tests": "not both doc types"
         },
         {
-          "id": "GOBL-PT-SAFT-V1-BILL-INVOICE-03",
+          "id": "GOBL-PT-SAFT-BILL-INVOICE-03",
           "desc": "invoice work type is not valid",
           "tests": "valid invoice work type"
         },
         {
-          "id": "GOBL-PT-SAFT-V1-BILL-INVOICE-04",
+          "id": "GOBL-PT-SAFT-BILL-INVOICE-04",
           "desc": "series format must be valid",
           "tests": "series format"
         },
         {
-          "id": "GOBL-PT-SAFT-V1-BILL-INVOICE-05",
+          "id": "GOBL-PT-SAFT-BILL-INVOICE-05",
           "desc": "code format must be valid",
           "tests": "code format"
         },
         {
-          "id": "GOBL-PT-SAFT-V1-BILL-INVOICE-12",
+          "id": "GOBL-PT-SAFT-BILL-INVOICE-12",
           "desc": "tax requires 'pt-saft-source' extension",
           "tests": "tax has source"
         },
         {
-          "id": "GOBL-PT-SAFT-V1-BILL-INVOICE-14",
+          "id": "GOBL-PT-SAFT-BILL-INVOICE-14",
           "desc": "source ref format is invalid",
           "tests": "source ref format"
         }
@@ -48,7 +53,7 @@
           "field": "value_date",
           "assert": [
             {
-              "id": "GOBL-PT-SAFT-V1-BILL-INVOICE-06",
+              "id": "GOBL-PT-SAFT-BILL-INVOICE-06",
               "desc": "cannot be blank",
               "tests": "present"
             }
@@ -61,7 +66,7 @@
               "each": true,
               "assert": [
                 {
-                  "id": "GOBL-PT-SAFT-V1-BILL-INVOICE-07",
+                  "id": "GOBL-PT-SAFT-BILL-INVOICE-07",
                   "desc": "line taxes must include VAT category",
                   "tests": "line has tax category VAT"
                 }
@@ -82,7 +87,7 @@
                       "field": "date",
                       "assert": [
                         {
-                          "id": "GOBL-PT-SAFT-V1-BILL-INVOICE-08",
+                          "id": "GOBL-PT-SAFT-BILL-INVOICE-08",
                           "desc": "cannot be blank",
                           "tests": "present"
                         }
@@ -101,7 +106,7 @@
               "field": "payable",
               "assert": [
                 {
-                  "id": "GOBL-PT-SAFT-V1-BILL-INVOICE-09",
+                  "id": "GOBL-PT-SAFT-BILL-INVOICE-09",
                   "desc": "must be no less than 0",
                   "tests": "min 0"
                 }
@@ -119,7 +124,7 @@
                   "field": "due",
                   "assert": [
                     {
-                      "id": "GOBL-PT-SAFT-V1-BILL-INVOICE-10",
+                      "id": "GOBL-PT-SAFT-BILL-INVOICE-10",
                       "desc": "must be equal to 0",
                       "tests": "equals 0"
                     }
@@ -133,7 +138,7 @@
           "field": "preceding",
           "assert": [
             {
-              "id": "GOBL-PT-SAFT-V1-BILL-INVOICE-11",
+              "id": "GOBL-PT-SAFT-BILL-INVOICE-11",
               "desc": "the length must be no more than 1",
               "tests": "length between 0 and 1"
             }
@@ -143,7 +148,7 @@
           "guard": "source not produced",
           "assert": [
             {
-              "id": "GOBL-PT-SAFT-V1-BILL-INVOICE-13",
+              "id": "GOBL-PT-SAFT-BILL-INVOICE-13",
               "desc": "tax requires 'pt-saft-source-ref' extension when source is not produced",
               "tests": "tax has source ref"
             }
@@ -152,26 +157,26 @@
       ]
     },
     {
-      "id": "GOBL-PT-SAFT-V1-BILL-PAYMENT",
+      "id": "GOBL-PT-SAFT-BILL-PAYMENT",
       "object": "bill.Payment",
       "assert": [
         {
-          "id": "GOBL-PT-SAFT-V1-BILL-PAYMENT-01",
+          "id": "GOBL-PT-SAFT-BILL-PAYMENT-01",
           "desc": "series format must be valid",
           "tests": "series format"
         },
         {
-          "id": "GOBL-PT-SAFT-V1-BILL-PAYMENT-02",
+          "id": "GOBL-PT-SAFT-BILL-PAYMENT-02",
           "desc": "code format must be valid",
           "tests": "code format"
         },
         {
-          "id": "GOBL-PT-SAFT-V1-BILL-PAYMENT-06",
+          "id": "GOBL-PT-SAFT-BILL-PAYMENT-06",
           "desc": "source ref format is invalid",
           "tests": "source ref format"
         },
         {
-          "id": "GOBL-PT-SAFT-V1-BILL-PAYMENT-09",
+          "id": "GOBL-PT-SAFT-BILL-PAYMENT-09",
           "desc": "customer name is required when customer has tax ID code",
           "tests": "customer name present"
         }
@@ -181,12 +186,12 @@
           "field": "ext",
           "assert": [
             {
-              "id": "GOBL-PT-SAFT-V1-BILL-PAYMENT-03",
+              "id": "GOBL-PT-SAFT-BILL-PAYMENT-03",
               "desc": "'pt-saft-payment-type' extension is required",
               "tests": "ext require [pt-saft-payment-type]"
             },
             {
-              "id": "GOBL-PT-SAFT-V1-BILL-PAYMENT-04",
+              "id": "GOBL-PT-SAFT-BILL-PAYMENT-04",
               "desc": "'pt-saft-source' extension is required",
               "tests": "ext require [pt-saft-source]"
             }
@@ -199,7 +204,7 @@
               "field": "ext",
               "assert": [
                 {
-                  "id": "GOBL-PT-SAFT-V1-BILL-PAYMENT-05",
+                  "id": "GOBL-PT-SAFT-BILL-PAYMENT-05",
                   "desc": "'pt-saft-source-ref' extension is required when source is not produced",
                   "tests": "ext require [pt-saft-source-ref]"
                 }
@@ -214,7 +219,7 @@
               "field": "tax_id",
               "assert": [
                 {
-                  "id": "GOBL-PT-SAFT-V1-BILL-PAYMENT-07",
+                  "id": "GOBL-PT-SAFT-BILL-PAYMENT-07",
                   "desc": "supplier tax ID is required",
                   "tests": "present"
                 }
@@ -224,7 +229,7 @@
                   "field": "code",
                   "assert": [
                     {
-                      "id": "GOBL-PT-SAFT-V1-BILL-PAYMENT-08",
+                      "id": "GOBL-PT-SAFT-BILL-PAYMENT-08",
                       "desc": "supplier tax ID code is required",
                       "tests": "present"
                     }
@@ -238,7 +243,7 @@
           "field": "total",
           "assert": [
             {
-              "id": "GOBL-PT-SAFT-V1-BILL-PAYMENT-10",
+              "id": "GOBL-PT-SAFT-BILL-PAYMENT-10",
               "desc": "must be no less than 0",
               "tests": "min 0"
             }
@@ -247,21 +252,21 @@
       ]
     },
     {
-      "id": "GOBL-PT-SAFT-V1-BILL-DELIVERY",
+      "id": "GOBL-PT-SAFT-BILL-DELIVERY",
       "object": "bill.Delivery",
       "assert": [
         {
-          "id": "GOBL-PT-SAFT-V1-BILL-DELIVERY-01",
+          "id": "GOBL-PT-SAFT-BILL-DELIVERY-01",
           "desc": "tax requires 'pt-saft-movement-type' extension",
           "tests": "has movement type"
         },
         {
-          "id": "GOBL-PT-SAFT-V1-BILL-DELIVERY-02",
+          "id": "GOBL-PT-SAFT-BILL-DELIVERY-02",
           "desc": "series format must be valid",
           "tests": "series format"
         },
         {
-          "id": "GOBL-PT-SAFT-V1-BILL-DELIVERY-03",
+          "id": "GOBL-PT-SAFT-BILL-DELIVERY-03",
           "desc": "code format must be valid",
           "tests": "code format"
         }
@@ -274,7 +279,7 @@
               "field": "tax_id",
               "assert": [
                 {
-                  "id": "GOBL-PT-SAFT-V1-BILL-DELIVERY-04",
+                  "id": "GOBL-PT-SAFT-BILL-DELIVERY-04",
                   "desc": "supplier tax ID is required",
                   "tests": "present"
                 }
@@ -284,7 +289,7 @@
                   "field": "code",
                   "assert": [
                     {
-                      "id": "GOBL-PT-SAFT-V1-BILL-DELIVERY-05",
+                      "id": "GOBL-PT-SAFT-BILL-DELIVERY-05",
                       "desc": "supplier tax ID code is required",
                       "tests": "present"
                     }
@@ -298,7 +303,7 @@
           "field": "despatch_date",
           "assert": [
             {
-              "id": "GOBL-PT-SAFT-V1-BILL-DELIVERY-06",
+              "id": "GOBL-PT-SAFT-BILL-DELIVERY-06",
               "desc": "cannot be blank",
               "tests": "present"
             }
@@ -307,26 +312,26 @@
       ]
     },
     {
-      "id": "GOBL-PT-SAFT-V1-BILL-ORDER",
+      "id": "GOBL-PT-SAFT-BILL-ORDER",
       "object": "bill.Order",
       "assert": [
         {
-          "id": "GOBL-PT-SAFT-V1-BILL-ORDER-01",
+          "id": "GOBL-PT-SAFT-BILL-ORDER-01",
           "desc": "tax requires 'pt-saft-work-type' extension",
           "tests": "has work type"
         },
         {
-          "id": "GOBL-PT-SAFT-V1-BILL-ORDER-02",
+          "id": "GOBL-PT-SAFT-BILL-ORDER-02",
           "desc": "work type must not be an invoice work type",
           "tests": "order work type valid"
         },
         {
-          "id": "GOBL-PT-SAFT-V1-BILL-ORDER-03",
+          "id": "GOBL-PT-SAFT-BILL-ORDER-03",
           "desc": "series format must be valid",
           "tests": "series format"
         },
         {
-          "id": "GOBL-PT-SAFT-V1-BILL-ORDER-04",
+          "id": "GOBL-PT-SAFT-BILL-ORDER-04",
           "desc": "code format must be valid",
           "tests": "code format"
         }
@@ -336,7 +341,7 @@
           "field": "value_date",
           "assert": [
             {
-              "id": "GOBL-PT-SAFT-V1-BILL-ORDER-05",
+              "id": "GOBL-PT-SAFT-BILL-ORDER-05",
               "desc": "cannot be blank",
               "tests": "present"
             }
@@ -349,7 +354,7 @@
               "each": true,
               "assert": [
                 {
-                  "id": "GOBL-PT-SAFT-V1-BILL-ORDER-06",
+                  "id": "GOBL-PT-SAFT-BILL-ORDER-06",
                   "desc": "line taxes must include VAT category",
                   "tests": "line has tax category VAT"
                 }
@@ -360,7 +365,7 @@
       ]
     },
     {
-      "id": "GOBL-PT-SAFT-V1-TAX-COMBO",
+      "id": "GOBL-PT-SAFT-TAX-COMBO",
       "object": "tax.Combo",
       "subsets": [
         {
@@ -370,12 +375,12 @@
               "field": "ext",
               "assert": [
                 {
-                  "id": "GOBL-PT-SAFT-V1-TAX-COMBO-01",
+                  "id": "GOBL-PT-SAFT-TAX-COMBO-01",
                   "desc": "region and tax rate are required",
                   "tests": "ext require [pt-region, pt-saft-tax-rate]"
                 },
                 {
-                  "id": "GOBL-PT-SAFT-V1-TAX-COMBO-02",
+                  "id": "GOBL-PT-SAFT-TAX-COMBO-02",
                   "desc": "exemption is required when tax rate is exempt",
                   "tests": "exempt requires exemption"
                 }
@@ -386,19 +391,19 @@
       ]
     },
     {
-      "id": "GOBL-PT-SAFT-V1-TAX-RATETOTAL",
+      "id": "GOBL-PT-SAFT-TAX-RATETOTAL",
       "object": "tax.RateTotal",
       "subsets": [
         {
           "field": "ext",
           "assert": [
             {
-              "id": "GOBL-PT-SAFT-V1-TAX-RATETOTAL-01",
+              "id": "GOBL-PT-SAFT-TAX-RATETOTAL-01",
               "desc": "region and tax rate are required",
               "tests": "ext require [pt-region, pt-saft-tax-rate]"
             },
             {
-              "id": "GOBL-PT-SAFT-V1-TAX-RATETOTAL-02",
+              "id": "GOBL-PT-SAFT-TAX-RATETOTAL-02",
               "desc": "exemption is required when tax rate is exempt",
               "tests": "exempt requires exemption"
             }
@@ -407,14 +412,14 @@
       ]
     },
     {
-      "id": "GOBL-PT-SAFT-V1-ORG-ITEM",
+      "id": "GOBL-PT-SAFT-ORG-ITEM",
       "object": "org.Item",
       "subsets": [
         {
           "field": "unit",
           "assert": [
             {
-              "id": "GOBL-PT-SAFT-V1-ORG-ITEM-01",
+              "id": "GOBL-PT-SAFT-ORG-ITEM-01",
               "desc": "cannot be blank",
               "tests": "present"
             }
@@ -424,7 +429,7 @@
           "field": "ext",
           "assert": [
             {
-              "id": "GOBL-PT-SAFT-V1-ORG-ITEM-02",
+              "id": "GOBL-PT-SAFT-ORG-ITEM-02",
               "desc": "product type is required",
               "tests": "ext require [pt-saft-product-type]"
             }
@@ -433,7 +438,7 @@
       ]
     },
     {
-      "id": "GOBL-PT-SAFT-V1-ORG-NOTE",
+      "id": "GOBL-PT-SAFT-ORG-NOTE",
       "object": "org.Note",
       "subsets": [
         {
@@ -443,7 +448,7 @@
               "field": "text",
               "assert": [
                 {
-                  "id": "GOBL-PT-SAFT-V1-ORG-NOTE-01",
+                  "id": "GOBL-PT-SAFT-ORG-NOTE-01",
                   "desc": "the length must be between 6 and 60",
                   "tests": "length between 6 and 60"
                 }
@@ -454,11 +459,11 @@
       ]
     },
     {
-      "id": "GOBL-PT-SAFT-V1-BILL-LINE",
+      "id": "GOBL-PT-SAFT-BILL-LINE",
       "object": "bill.Line",
       "assert": [
         {
-          "id": "GOBL-PT-SAFT-V1-BILL-LINE-05",
+          "id": "GOBL-PT-SAFT-BILL-LINE-05",
           "desc": "exemption notes invalid",
           "tests": "exemption notes"
         }
@@ -468,7 +473,7 @@
           "field": "quantity",
           "assert": [
             {
-              "id": "GOBL-PT-SAFT-V1-BILL-LINE-01",
+              "id": "GOBL-PT-SAFT-BILL-LINE-01",
               "desc": "must be greater than 0",
               "tests": "min 0"
             }
@@ -478,7 +483,7 @@
           "field": "sum",
           "assert": [
             {
-              "id": "GOBL-PT-SAFT-V1-BILL-LINE-02",
+              "id": "GOBL-PT-SAFT-BILL-LINE-02",
               "desc": "must be no less than 0",
               "tests": "min 0"
             }
@@ -488,7 +493,7 @@
           "field": "total",
           "assert": [
             {
-              "id": "GOBL-PT-SAFT-V1-BILL-LINE-03",
+              "id": "GOBL-PT-SAFT-BILL-LINE-03",
               "desc": "must be no less than 0",
               "tests": "min 0"
             }
@@ -504,7 +509,7 @@
                   "field": "amount",
                   "assert": [
                     {
-                      "id": "GOBL-PT-SAFT-V1-BILL-LINE-04",
+                      "id": "GOBL-PT-SAFT-BILL-LINE-04",
                       "desc": "must be no less than 0",
                       "tests": "min 0"
                     }
@@ -517,11 +522,11 @@
       ]
     },
     {
-      "id": "GOBL-PT-SAFT-V1-BILL-PAYMENTLINE",
+      "id": "GOBL-PT-SAFT-BILL-PAYMENTLINE",
       "object": "bill.PaymentLine",
       "assert": [
         {
-          "id": "GOBL-PT-SAFT-V1-BILL-PAYMENTLINE-06",
+          "id": "GOBL-PT-SAFT-BILL-PAYMENTLINE-06",
           "desc": "exemption notes invalid",
           "tests": "exemption notes"
         }
@@ -531,7 +536,7 @@
           "field": "document",
           "assert": [
             {
-              "id": "GOBL-PT-SAFT-V1-BILL-PAYMENTLINE-01",
+              "id": "GOBL-PT-SAFT-BILL-PAYMENTLINE-01",
               "desc": "cannot be blank",
               "tests": "present"
             }
@@ -541,7 +546,7 @@
               "field": "issue_date",
               "assert": [
                 {
-                  "id": "GOBL-PT-SAFT-V1-BILL-PAYMENTLINE-02",
+                  "id": "GOBL-PT-SAFT-BILL-PAYMENTLINE-02",
                   "desc": "cannot be blank",
                   "tests": "present"
                 }
@@ -553,12 +558,12 @@
           "field": "tax",
           "assert": [
             {
-              "id": "GOBL-PT-SAFT-V1-BILL-PAYMENTLINE-03",
+              "id": "GOBL-PT-SAFT-BILL-PAYMENTLINE-03",
               "desc": "cannot be blank",
               "tests": "present"
             },
             {
-              "id": "GOBL-PT-SAFT-V1-BILL-PAYMENTLINE-04",
+              "id": "GOBL-PT-SAFT-BILL-PAYMENTLINE-04",
               "desc": "missing category VAT",
               "tests": "has VAT category"
             }
@@ -574,7 +579,7 @@
                       "field": "rates",
                       "assert": [
                         {
-                          "id": "GOBL-PT-SAFT-V1-BILL-PAYMENTLINE-05",
+                          "id": "GOBL-PT-SAFT-BILL-PAYMENTLINE-05",
                           "desc": "only one rate allowed per line",
                           "tests": "length between 0 and 1"
                         }

--- a/rules/rules.go
+++ b/rules/rules.go
@@ -61,12 +61,22 @@ func Registry() []*Set {
 }
 
 // Register is used to register a set of rules for a given namespace.
+//
+// For addon rules, pkg and code should identify the addon *family* rather
+// than a specific version (e.g. "ar-arca" and "AR-ARCA", not "ar-arca-v4"
+// and "AR-ARCA-V4"). The addon version is expressed through the guard.
+// Assertion IDs are a public contract that customers pin for error handling,
+// so they must be stable across versions of an addon family: when introducing
+// a new version, preserved rules must keep their existing numeric IDs. An ID
+// may be retired, but it must never be reassigned to a semantically different
+// rule.
 func Register(pkg string, code Code, sets ...*Set) {
 	RegisterWithGuard(pkg, code, nil, sets...)
 }
 
 // RegisterWithGuard is used to register a set of rules for a given namespace
 // with an optional guard condition that determines when the rules should be applied.
+// See [Register] for guidance on choosing pkg and code for addon families.
 func RegisterWithGuard(pkg string, code Code, guard Test, sets ...*Set) {
 	sets = cloneSets(sets)
 	set := &Set{


### PR DESCRIPTION
## Summary

- Fault codes for addon validation rules no longer embed the addon version. `GOBL-AR-ARCA-V4-BILL-INVOICE-24` is now `GOBL-AR-ARCA-BILL-INVOICE-24`. Generated files in `data/rules/` lose the version from their filenames too (`ar-arca.json`, not `ar-arca-v4.json`).
- Each addon package now exposes a `Key` constant for the unversioned family (e.g. `ar-arca`); versioned keys such as `V4` are derived via constant concatenation (`Key + "-v4"`). The `tax.AddonIn(...)` guard still uses the versioned key, so rules fire only when that specific addon version is enabled.
- Assertion IDs are now a cross-version contract: preserved rules must keep their existing numeric IDs on a version bump, and an ID must never be reassigned to a semantically different rule. Documented on `rules.Register`.

## Motivation

Most rules carry over unchanged when an addon bumps (v4 → v5, v3 → v4). Embedding the version in the fault code forced every customer error handler that pins a code to be rewritten on every bump, even when nothing about the rule actually changed. Dropping the version makes the fault-code namespace match the rule's actual lifetime.

## Breaking change

Consumers pinning fault-code strings should drop the version segment. A one-line regex handles the common case:

```
s/GOBL-([A-Z0-9]+-[A-Z0-9]+)-V[0-9]+(-)/GOBL-\1\2/
```

The published rule-doc pages in `gobl.docs` are regenerated from the JSON files in this repo, so they'll update on the next docs sync.

## Test plan

- [x] `go test ./...` passes (including `rules/codes_test.go` uniqueness/format checks).
- [x] `go run ./rules/generate.go` produces clean unversioned filenames and codes.
- [x] Spot-check one regenerated file to confirm codes inside lost the version segment.
- [ ] Verify downstream modules (`gobl.verifactu`, `gobl.ticketbai`, `gobl.cfdi`, etc.) — grep for pinned code strings and coordinate version bumps if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)