### PR TITLE
verifactu: validate country is present in identities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Added
 
 - `currency`: new `CanConvertTo` test that will ensure a document has or can convert to the provided currency.
+- `addons/es/verifactu`: Country is now required on customer identities when the identity type is not NIF-VAT (02).
 
 ### Fixed
 

--- a/addons/es/verifactu/bill.go
+++ b/addons/es/verifactu/bill.go
@@ -165,6 +165,7 @@ func billInvoiceRules() *rules.Set {
 		// Code 06: customer required
 		// Code 07: customer must have tax_id or identity
 		// Code 08: customer tax_id must have code
+		// Code 17: identity country required when identity type is not NIF-VAT
 		rules.When(
 			is.Func("not simplified", isNotSimplifiedInvoice),
 			rules.Field("customer",
@@ -175,6 +176,16 @@ func billInvoiceRules() *rules.Set {
 				rules.Field("tax_id",
 					rules.Field("code",
 						rules.Assert("08", "tax ID must have a code", is.Present),
+					),
+				),
+				rules.Field("identities",
+					rules.Each(
+						rules.When(
+							is.Func("has non-VAT identity type", identityHasNonVATType),
+							rules.Field("country",
+								rules.Assert("17", "country is required when ext 'es-verifactu-identity-type' is not 02 (NIF-VAT)", is.Present),
+							),
+						),
 					),
 				),
 			),
@@ -273,6 +284,11 @@ func customerHasTaxIDOrIdentity(val any) bool {
 		return true // nil customer handled by Required check
 	}
 	return p.TaxID != nil || org.IdentityForExtKey(p.Identities, ExtKeyIdentityType) != nil
+}
+
+func identityHasNonVATType(val any) bool {
+	id, ok := val.(*org.Identity)
+	return ok && id != nil && id.Ext.Has(ExtKeyIdentityType) && !id.Ext.Get(ExtKeyIdentityType).In(ExtCodeIdentityTypeVAT)
 }
 
 func isGeneralNote(val any) bool {

--- a/addons/es/verifactu/bill_test.go
+++ b/addons/es/verifactu/bill_test.go
@@ -351,8 +351,36 @@ func TestInvoiceValidation(t *testing.T) {
 		inv.Customer.TaxID = nil
 		inv.Customer.Identities = []*org.Identity{
 			{
+				Key:     org.IdentityKeyPassport,
+				Country: "GB",
+				Code:    "AA123456",
+			},
+		}
+		require.NoError(t, inv.Calculate())
+		require.NoError(t, rules.Validate(inv))
+	})
+	t.Run("customer with identity missing country", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Customer.TaxID = nil
+		inv.Customer.Identities = []*org.Identity{
+			{
 				Key:  org.IdentityKeyPassport,
 				Code: "AA123456",
+			},
+		}
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "country is required when ext 'es-verifactu-identity-type' is not 02 (NIF-VAT)")
+	})
+	t.Run("customer with NIF-VAT identity without country is valid", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Customer.TaxID = nil
+		inv.Customer.Identities = []*org.Identity{
+			{
+				Code: "B12345678",
+				Ext: tax.Extensions{
+					verifactu.ExtKeyIdentityType: "02",
+				},
 			},
 		}
 		require.NoError(t, inv.Calculate())

--- a/data/rules/es-verifactu.json
+++ b/data/rules/es-verifactu.json
@@ -143,6 +143,31 @@
                       ]
                     }
                   ]
+                },
+                {
+                  "field": "identities",
+                  "subsets": [
+                    {
+                      "each": true,
+                      "subsets": [
+                        {
+                          "guard": "has non-VAT identity type",
+                          "subsets": [
+                            {
+                              "field": "country",
+                              "assert": [
+                                {
+                                  "id": "GOBL-ES-VERIFACTU-BILL-INVOICE-17",
+                                  "desc": "country is required when 'es-verifactu-identity-type' is not NIF-VAT (02)",
+                                  "tests": "present"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
                 }
               ]
             }


### PR DESCRIPTION
- Mapping the verifactu validation error: El campo CodigoPais es obligatorio cuando IDType es distinto de NIF-IVA (02).

## Pre-Review Checklist

- [x] Opened this PR as a draft
- [x] Read the CONTRIBUTING.md guide.
- [x] Performed a self-review of my code.
- [x] Added thorough tests with at **least** 90% code coverage.
- [x] Modified or created example GOBL documents to show my changes in use, if appropriate.
- [x] Added links to the source of the changes in tax regimes or addons, either structured or in the comments.
- [x] Run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [x] Reviewed and fixed all linter warnings.
- [x] Been obsessive with pointer nil checks to avoid panics.
- [x] Updated the CHANGELOG.md with an overview of my changes.
- [x] Marked this PR as ready for review.

And if you are part of the org:
- [x] Requested a review from Copilot and fixed or dismissed (with a reason) all the feedback raised.
- [x] Requested a review from @samlown.
