### PR TITLE
ES TBAI: forbid customer tax_id on simplified invoices

### DIFF
--- a/addons/es/tbai/bill.go
+++ b/addons/es/tbai/bill.go
@@ -93,14 +93,20 @@ func billInvoiceRules() *rules.Set {
 		// Customer
 		// Code 03: customer required for non-simplified invoices
 		rules.When(
-			is.Func("non-simplified", func(val any) bool {
-				inv, ok := val.(*bill.Invoice)
-				return ok && inv != nil && !inv.HasTags(tax.TagSimplified)
-			}),
+			is.Func("non-simplified", isNotSimplifiedInvoice),
 			rules.Field("customer",
 				rules.Assert("03", "customer is required for non-simplified invoices", is.Present),
 				rules.Field("tax_id",
 					rules.Assert("08", "customer tax ID is required", is.Present),
+				),
+			),
+		),
+		// Code 09: customer tax_id must not be set on simplified invoices
+		rules.When(
+			is.Func("simplified", isSimplifiedInvoice),
+			rules.Field("customer",
+				rules.Field("tax_id",
+					rules.Assert("09", "customer tax ID must not be set for simplified invoices", is.Nil),
 				),
 			),
 		),
@@ -150,4 +156,13 @@ func notesHasGeneralKey(val any) bool {
 		}
 	}
 	return false
+}
+
+func isSimplifiedInvoice(val any) bool {
+	inv, ok := val.(*bill.Invoice)
+	return ok && inv != nil && inv.HasTags(tax.TagSimplified)
+}
+
+func isNotSimplifiedInvoice(val any) bool {
+	return !isSimplifiedInvoice(val)
 }

--- a/addons/es/tbai/bill_test.go
+++ b/addons/es/tbai/bill_test.go
@@ -146,7 +146,8 @@ func TestInvoiceValidation(t *testing.T) {
 		inv := testInvoiceStandard(t)
 		inv.SetTags(tax.TagSimplified)
 		require.NoError(t, inv.Calculate())
-		require.NoError(t, rules.Validate(inv))
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "customer tax ID must not be set for simplified invoices")
 	})
 
 	t.Run("with exemption reason", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Mirrors the Verifactu addon's strict rule for simplified invoices in the ticketbai addon: when `tax.tags` includes `simplified`, `customer.tax_id` must be `nil`. The current addon only required `customer` (and `customer.tax_id`) to be present on **non**-simplified invoices — there was no symmetric rule preventing `tax_id` from being set on a simplified one, so a downstream converter saw an inconsistent state.

Adds rule code **09** alongside the existing 03/08 (matches Verifactu code 04). Refactors the simplified predicate into reusable `isSimplifiedInvoice` / `isNotSimplifiedInvoice` helpers (matching Verifactu's pattern).

## Why

Spotted in the [gobl.ticketbai PR for B2C simplified invoices](https://github.com/invopop/gobl.ticketbai/pull/32). Reviewer asked that this validation live in the addon (early feedback, before the workflow runs the converter) rather than in the converter itself.

> Note: this branch is based on `v0.401.0`, not `main`, because gobl.ticketbai still depends on v0.401.0. Happy to rebase once the immutable-extensions refactor on main has settled.

## Test plan

- [x] `go test ./addons/es/tbai/...` — existing simplified test cases now exercise the new rule
- [x] No changes outside `addons/es/tbai/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)