### PR TITLE
Add IRNR (Impuesto sobre la Renta de no Residentes) to Spain's regime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Added
 
+- `es`: added `IRNR` (Impuesto sobre la Renta de no Residentes) retained tax category for income obtained without permanent establishment in Spain. Specific tax rates are not included.
 - `tax`: Added `CorrectionNormalize` callback type and `Normalize` field on `CorrectionDefinition` for addon-specific correction logic.
 - `bill`: Added `CorrectionOptionsValue()` accessor on `Invoice` for use by correction normalizers.
 - `cbc.CodeMap`: added `Lookup` method that returns the code matching a given key, falling back hierarchically to less specific keys.

--- a/data/regimes/es.json
+++ b/data/regimes/es.json
@@ -750,6 +750,27 @@
           ]
         }
       ]
+    },
+    {
+      "code": "IRNR",
+      "name": {
+        "ca": "IRNR",
+        "en": "IRNR",
+        "es": "IRNR",
+        "eu": "IRNR",
+        "gl": "IRNR"
+      },
+      "title": {
+        "ca": "Impost sobre la renda de no residents",
+        "en": "Non-residents income tax",
+        "es": "Impuesto sobre la renta de no residentes",
+        "eu": "Ez egoiliarren errentaren gaineko zerga",
+        "gl": "Imposto sobre a renda de non residentes"
+      },
+      "desc": {
+        "en": "Personal or corporate income tax levied on income obtained in Spanish\nterritory by individuals and entities that are not resident in Spain.\nRegulated by Real Decreto Legislativo 5/2004 (TRLIRNR).\n\nThis category covers income obtained without a permanent establishment\n(sin establecimiento permanente), where the Spanish payer is generally\nobliged to withhold the tax at source on each payment. Income obtained\nthrough a permanent establishment is taxed under the rules of the\nCorporate Income Tax (Impuesto sobre Sociedades) and is out of scope\nat the invoice level.\n\nApplicable rates depend on the type of income and on whether the\nrecipient is resident in another EU/EEA Member State with an effective\nexchange of tax information, in which case reduced rates apply."
+      },
+      "retained": true
     }
   ]
 }


### PR DESCRIPTION
`es`: added `IRNR` (Impuesto sobre la Renta de no Residentes) retained tax category for income obtained without permanent establishment in Spain. Specific tax rates are not included.

## Pre-Review Checklist

- [-] Opened this PR as a draft
- [x] Read the CONTRIBUTING.md guide.
- [x] Performed a self-review of my code.
- [-] Added thorough tests with at **least** 90% code coverage.
- [-] Modified or created example GOBL documents to show my changes in use, if appropriate.
- [-] Added links to the source of the changes in tax regimes or addons, either structured or in the comments.
- [x] Run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [x] Reviewed and fixed all linter warnings.
- [-] Been obsessive with pointer nil checks to avoid panics.
- [x] Updated the CHANGELOG.md with an overview of my changes.
- [x] Marked this PR as ready for review.

And if you are part of the org:
- [x] Requested a review from Copilot and fixed or dismissed (with a reason) all the feedback raised.
- [x] Requested a review from @samlown.
