### PR TITLE
Add IRNR tax category to Spain regime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - `pay`: added `MeansKeyCredit` and `MeansKeyDebit` qualifiers, enabling the `card+credit` and `card+debit` payment means. Adapted all addons mapping payment means to extensions to use the two new qualified means.
 - `es-tbai-v1`: added `es-tbai-bi-activity` extension for the Bizkaia activity code (epígrafe) required for individual suppliers.
 - `pt-saft-v1`: added rule to check that advance payment amounts on invoices are no less than 0 as required by the SAF-T spec.
+- `regimes/es`: added `IRNR` (Impuesto sobre la Renta de no Residentes) tax category for non-resident income tax withholdings. Rates depend on the type of income and recipient, so they are supplied per invoice rather than predefined.
 
 ### Fixed
 

--- a/data/regimes/es.json
+++ b/data/regimes/es.json
@@ -750,6 +750,27 @@
           ]
         }
       ]
+    },
+    {
+      "code": "IRNR",
+      "name": {
+        "ca": "IRNR",
+        "en": "IRNR",
+        "es": "IRNR",
+        "eu": "IRNR",
+        "gl": "IRNR"
+      },
+      "title": {
+        "ca": "Impost sobre la renda de no residents",
+        "en": "Non-residents income tax",
+        "es": "Impuesto sobre la renta de no residentes",
+        "eu": "Ez egoiliarren errentaren gaineko zerga",
+        "gl": "Imposto sobre a renda de non residentes"
+      },
+      "desc": {
+        "en": "Personal or corporate income tax levied on income obtained in Spanish\nterritory by individuals and entities that are not resident in Spain.\nRegulated by Real Decreto Legislativo 5/2004 (TRLIRNR).\n\nThis category covers income obtained without a permanent establishment\n(sin establecimiento permanente), where the Spanish payer is generally\nobliged to withhold the tax at source on each payment. Income obtained\nthrough a permanent establishment is taxed under the rules of the\nCorporate Income Tax (Impuesto sobre Sociedades) and is out of scope\nat the invoice level.\n\nApplicable rates depend on the type of income and on whether the\nrecipient is resident in another EU/EEA Member State with an effective\nexchange of tax information, in which case reduced rates apply."
+      },
+      "retained": true
     }
   ]
 }

--- a/regimes/es/es.go
+++ b/regimes/es/es.go
@@ -26,6 +26,7 @@ func init() {
 // Local tax category definitions which are not considered standard.
 const (
 	TaxCategoryIRPF cbc.Code = "IRPF"
+	TaxCategoryIRNR cbc.Code = "IRNR"
 	TaxCategoryIGIC cbc.Code = "IGIC"
 	TaxCategoryIPSI cbc.Code = "IPSI"
 )

--- a/regimes/es/tax_categories.go
+++ b/regimes/es/tax_categories.go
@@ -375,5 +375,45 @@ func taxCategories() []*tax.CategoryDef {
 				},
 			},
 		},
+
+		//
+		// IRNR
+		//
+		{
+			Code:     TaxCategoryIRNR,
+			Retained: true,
+			Name: i18n.String{
+				i18n.EN: "IRNR",
+				i18n.ES: "IRNR",
+				i18n.GL: "IRNR",
+				i18n.EU: "IRNR",
+				i18n.CA: "IRNR",
+			},
+			Title: i18n.String{
+				i18n.EN: "Non-residents income tax",
+				i18n.ES: "Impuesto sobre la renta de no residentes",
+				i18n.GL: "Imposto sobre a renda de non residentes",
+				i18n.EU: "Ez egoiliarren errentaren gaineko zerga",
+				i18n.CA: "Impost sobre la renda de no residents",
+			},
+			Description: &i18n.String{
+				i18n.EN: here.Doc(`
+					Personal or corporate income tax levied on income obtained in Spanish
+					territory by individuals and entities that are not resident in Spain.
+					Regulated by Real Decreto Legislativo 5/2004 (TRLIRNR).
+
+					This category covers income obtained without a permanent establishment
+					(sin establecimiento permanente), where the Spanish payer is generally
+					obliged to withhold the tax at source on each payment. Income obtained
+					through a permanent establishment is taxed under the rules of the
+					Corporate Income Tax (Impuesto sobre Sociedades) and is out of scope
+					at the invoice level.
+
+					Applicable rates depend on the type of income and on whether the
+					recipient is resident in another EU/EEA Member State with an effective
+					exchange of tax information, in which case reduced rates apply.
+				`),
+			},
+		},
 	}
 }


### PR DESCRIPTION
## Summary
- Adds the `IRNR` (Impuesto sobre la Renta de no Residentes) tax category to the Spanish regime as a retained tax with full i18n name/title and an English description covering scope and rate applicability.
- No fixed rates are defined — applicable percentages depend on income type and recipient residency, so they are supplied per invoice.
- Regenerated `data/regimes/es.json` and added a CHANGELOG entry.

## Test plan
- [x] `mage test`
- [x] `mage lint`
- [x] `mage generate` produces the expected IRNR block in `data/regimes/es.json`