### PR TITLE
Fix payment line amount check when advances fully cover payable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - `cbc.CodeMap`: added `Lookup` method that returns the code matching a given key, falling back hierarchically to less specific keys.
 - `pay`: added `MeansKeyCredit` and `MeansKeyDebit` qualifiers, enabling the `card+credit` and `card+debit` payment means. Adapted all addons mapping payment means to extensions to use the two new qualified means.
 
+### Fixed
+
+- `bill`: payment line validation now correctly rejects an `amount` greater than `payable - advances` when advances fully cover the payable, instead of falling through to a misleading "due must be zero or positive" error on the calculated `due` field.
+
 ## [v0.402.0] - 2026-04-30
 
 ### Changed

--- a/bill/payment_line.go
+++ b/bill/payment_line.go
@@ -119,7 +119,7 @@ func paymentLineAmountWithinLimit(val any) bool {
 	if pl.Advances != nil {
 		mx = mx.Subtract(*pl.Advances)
 	}
-	if !mx.IsPositive() {
+	if mx.IsNegative() {
 		return true
 	}
 	return pl.Amount.Compare(mx) <= 0

--- a/bill/payment_line_test.go
+++ b/bill/payment_line_test.go
@@ -383,4 +383,15 @@ func TestPaymentLineValidation(t *testing.T) {
 		err := rules.Validate(pl)
 		assert.ErrorContains(t, err, "amount must not exceed payable less advances")
 	})
+
+	t.Run("amount with fully advanced payable", func(t *testing.T) {
+		pl := &PaymentLine{
+			Index:    1,
+			Payable:  num.NewAmount(2300, 2),
+			Advances: num.NewAmount(2300, 2),
+			Amount:   num.MakeAmount(12000, 2),
+		}
+		err := rules.Validate(pl)
+		assert.ErrorContains(t, err, "amount must not exceed payable less advances")
+	})
 }


### PR DESCRIPTION
## Summary

- When `payable - advances == 0`, the amount-within-limit rule (`PAYMENTLINE-12`) was being skipped, letting a non-zero `amount` slip past it and only fail later on the calculated `due` field with a misleading `due must be zero or positive` error.
- Tightened the guard in `paymentLineAmountWithinLimit` from `!mx.IsPositive()` to `mx.IsNegative()` so we only short-circuit when advances exceed payable (already covered by rule 11). The zero case now flows into the comparison and fires the proper "amount must not exceed payable less advances" error.
- Added a regression test mirroring the reported example (`payable=23, advances=23, amount=120`).

## Pre-Review Checklist

- [x] Opened this PR as a draft
- [x] Read the CONTRIBUTING.md guide.
- [x] Performed a self-review of my code.
- [x] Added thorough tests with at **least** 90% code coverage.
- [x] Modified or created example GOBL documents to show my changes in use, if appropriate.
- [x] Added links to the source of the changes in tax regimes or addons, either structured or in the comments.
- [x] Run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [x] Reviewed and fixed all linter warnings.
- [x] Been obsessive with pointer nil checks to avoid panics.
- [x] Updated the CHANGELOG.md with an overview of my changes.
- [x] Marked this PR as ready for review.

And if you are part of the org:
- [x] Requested a review from Copilot and fixed or dismissed (with a reason) all the feedback raised.
- [ ] Requested a review from @samlown.