### PR TITLE
fix(org): keep dotted inbox codes in code, not url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Fixed
+
+- `org`: `Inbox.Normalize()` no longer misclassifies a dotted `code` (e.g. the Peppol participant ID `BE0425.260.668`) as a `url`. A code is only routed into `url` when it carries an explicit scheme (`://`), keeping schemeless identifiers in `code`.
+
 ## [v0.403.0] - 2026-05-13
 
 ### Changed

--- a/org/inbox.go
+++ b/org/inbox.go
@@ -1,6 +1,8 @@
 package org
 
 import (
+	"strings"
+
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/rules"
 	"github.com/invopop/gobl/rules/is"
@@ -49,7 +51,10 @@ func (i *Inbox) Normalize() {
 	if is.EmailFormat.Check(code) {
 		i.Email = code
 		i.Code = ""
-	} else if is.URL.Check(code) {
+	} else if strings.Contains(code, "://") && is.URL.Check(code) {
+		// Only route a code into URL when it carries an explicit scheme.
+		// Otherwise permissive URL validation misclassifies dotted codes
+		// (e.g. the Peppol participant ID "BE0425.260.668") as URLs.
 		i.URL = code
 		i.Code = ""
 	}

--- a/org/inbox_test.go
+++ b/org/inbox_test.go
@@ -106,6 +106,27 @@ func TestInboxNormalize(t *testing.T) {
 		assert.Empty(t, id.Email)
 		assert.Equal(t, "https://inbox.example.com", id.URL)
 	})
+	t.Run("with dotted code in code", func(t *testing.T) {
+		id := &org.Inbox{
+			Code: "BE0425.260.668",
+		}
+		id.Normalize()
+		assert.Equal(t, "BE0425.260.668", id.Code.String())
+		assert.Empty(t, id.URL)
+		assert.Empty(t, id.Email)
+	})
+	t.Run("with peppol participant code with dots", func(t *testing.T) {
+		id := &org.Inbox{
+			Key:    org.InboxKeyPeppol,
+			Scheme: "9925",
+			Code:   "BE0425.260.668",
+		}
+		id.Normalize()
+		assert.Equal(t, "BE0425.260.668", id.Code.String())
+		assert.Equal(t, "9925", id.Scheme.String())
+		assert.Empty(t, id.URL)
+		assert.Equal(t, org.InboxKeyPeppol, id.Key)
+	})
 	t.Run("with peppol participant code", func(t *testing.T) {
 		id := &org.Inbox{
 			Key:  org.InboxKeyPeppol,


### PR DESCRIPTION
## Problem

A Peppol participant identifier whose code contains dots (e.g. `BE0425.260.668`) was being normalized into the inbox's `url` field instead of staying in `code`.

## Root cause

`org.Inbox.Normalize()` routed any code accepted by `is.URL` into `url`. `is.URL` is backed by the permissive `govalidator.IsURL`, which accepts bare domain-like strings with no scheme

## Fix

Only route a code into `url` when it carries an explicit scheme (`://`). This is consistent with the field's own doc ("URL of the inbox that includes the protocol, server, and path") and preserves the existing `https://inbox.example.com` behaviour, while leaving schemeless identifiers (dotted Peppol codes) in `code`.