### PR TITLE
Add New Zealand (NZ) GST regime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Added
+
+- `regimes/nz`: New Zealand (NZ) GST regime. Includes standard rate (15%, with historical 12.5% and 10% rates), accommodation reduced rate (9%), zero-rated and exempt supplies, IRD number validation with two-pass modulo-11 checksum, NZBN (New Zealand Business Number) as an optional organisation identity with GS1 Mod-10 checksum, and credit/debit note corrections.
+
 ## [v0.501.0] - 2026-06-16
 
 ### Added

--- a/data/regimes/nz.json
+++ b/data/regimes/nz.json
@@ -147,6 +147,24 @@
               "percent": "6%"
             }
           ]
+        },
+        {
+          "rate": "zero",
+          "keys": [
+            "standard"
+          ],
+          "name": {
+            "en": "Zero Rate"
+          },
+          "desc": {
+            "en": "Zero-rated supplies including exported goods, international transport, and certain land transactions between GST-registered parties."
+          },
+          "values": [
+            {
+              "since": "1986-10-01",
+              "percent": "0%"
+            }
+          ]
         }
       ],
       "sources": [

--- a/data/regimes/nz.json
+++ b/data/regimes/nz.json
@@ -37,13 +37,9 @@
           "tags": [
             "reverse-charge"
           ],
-          "cat": [
-            "VAT"
-          ],
           "note": {
-            "cat": "VAT",
             "key": "reverse-charge",
-            "text": "Reverse charge: Customer to account for VAT to the relevant tax authority."
+            "text": "Reverse charge: Recipient to account for GST to Inland Revenue."
           }
         }
       ]
@@ -79,6 +75,13 @@
           "name": {
             "en": "Zero"
           }
+        },
+        {
+          "key": "reverse-charge",
+          "name": {
+            "en": "Reverse charge"
+          },
+          "no_percent": true
         },
         {
           "key": "exempt",

--- a/data/regimes/nz.json
+++ b/data/regimes/nz.json
@@ -1,0 +1,162 @@
+{
+  "$schema": "https://gobl.org/draft-0/tax/regime-def",
+  "name": {
+    "en": "New Zealand"
+  },
+  "description": {
+    "en": "New Zealand's tax system is administered by Inland Revenue\n(Te Tari Taake). Goods and Services Tax (GST) applies at a standard\nrate of 15% to most goods and services. A reduced rate applies to\nlong-term accommodation of 28 or more consecutive days, equivalent\nto 60% of the full standard rate.\n\nZero-rated supplies include exported goods, international transport\nservices, and certain land transfers between GST-registered parties.\nExempt supplies include residential dwelling rent and most financial\nservices.\n\nBusinesses with annual turnover of NZD 60,000 or more must register\nfor GST. The GST registration number is the same as the IRD number\n(Inland Revenue Department number), an 8 or 9 digit identifier\nvalidated using a two-pass modulo-11 checksum algorithm.\n\nBusinesses are also identified by a New Zealand Business Number\n(NZBN), a 13-digit GS1 Global Location Number used for Peppol\ne-invoicing. E-invoicing via the Peppol network using the PINT A-NZ\nspecification is mandatory for government agencies and large suppliers\nto government.\n\nSupply Correction Information (credit and debit notes) may be issued\nto correct a previously issued invoice."
+  },
+  "sources": [
+    {
+      "title": {
+        "en": "Inland Revenue New Zealand"
+      },
+      "url": "https://www.ird.govt.nz"
+    }
+  ],
+  "time_zone": "Pacific/Auckland",
+  "country": "NZ",
+  "currency": "NZD",
+  "tax_scheme": "GST",
+  "identities": [
+    {
+      "code": "NZBN",
+      "name": {
+        "en": "New Zealand Business Number (NZBN)"
+      },
+      "desc": {
+        "en": "The New Zealand Business Number (NZBN) is a unique 13-digit identifier\nissued to all businesses registered in New Zealand. It is based on the\nGS1 Global Location Number (GLN) standard and is used as the Peppol\nparticipant identifier for e-invoicing. Mandatory for businesses with\nannual turnover of NZD 60,000 or more."
+      }
+    }
+  ],
+  "scenarios": [
+    {
+      "schema": "bill/invoice",
+      "list": [
+        {
+          "tags": [
+            "reverse-charge"
+          ],
+          "cat": [
+            "VAT"
+          ],
+          "note": {
+            "cat": "VAT",
+            "key": "reverse-charge",
+            "text": "Reverse charge: Customer to account for VAT to the relevant tax authority."
+          }
+        }
+      ]
+    }
+  ],
+  "corrections": [
+    {
+      "schema": "bill/invoice",
+      "types": [
+        "credit-note",
+        "debit-note"
+      ]
+    }
+  ],
+  "categories": [
+    {
+      "code": "GST",
+      "name": {
+        "en": "GST"
+      },
+      "title": {
+        "en": "Goods and Services Tax"
+      },
+      "keys": [
+        {
+          "key": "standard",
+          "name": {
+            "en": "Standard"
+          }
+        },
+        {
+          "key": "zero",
+          "name": {
+            "en": "Zero"
+          }
+        },
+        {
+          "key": "exempt",
+          "name": {
+            "en": "Exempt"
+          },
+          "no_percent": true
+        },
+        {
+          "key": "outside-scope",
+          "name": {
+            "en": "Outside scope"
+          },
+          "no_percent": true
+        }
+      ],
+      "rates": [
+        {
+          "rate": "general",
+          "keys": [
+            "standard"
+          ],
+          "name": {
+            "en": "Standard Rate"
+          },
+          "desc": {
+            "en": "Applies to most goods and services in New Zealand."
+          },
+          "values": [
+            {
+              "since": "2010-10-01",
+              "percent": "15%"
+            },
+            {
+              "since": "1989-07-01",
+              "percent": "12.5%"
+            },
+            {
+              "since": "1986-10-01",
+              "percent": "10%"
+            }
+          ]
+        },
+        {
+          "rate": "reduced",
+          "keys": [
+            "standard"
+          ],
+          "name": {
+            "en": "Accommodation Rate"
+          },
+          "desc": {
+            "en": "Applies to long-term accommodation of 28 or more consecutive days. Equivalent to 60% of the standard rate applied to the full charge."
+          },
+          "values": [
+            {
+              "since": "2010-10-01",
+              "percent": "9%"
+            },
+            {
+              "since": "1989-07-01",
+              "percent": "7.5%"
+            },
+            {
+              "since": "1986-10-01",
+              "percent": "6%"
+            }
+          ]
+        }
+      ],
+      "sources": [
+        {
+          "title": {
+            "en": "GST - Inland Revenue New Zealand"
+          },
+          "url": "https://www.ird.govt.nz/gst"
+        }
+      ]
+    }
+  ]
+}

--- a/data/rules/nz.json
+++ b/data/rules/nz.json
@@ -1,0 +1,83 @@
+{
+  "id": "GOBL-NZ",
+  "package": "nz",
+  "subsets": [
+    {
+      "id": "GOBL-NZ-TAX-IDENTITY",
+      "object": "tax.Identity",
+      "subsets": [
+        {
+          "guard": "code in [NZ]",
+          "subsets": [
+            {
+              "field": "code",
+              "subsets": [
+                {
+                  "guard": "present",
+                  "assert": [
+                    {
+                      "id": "GOBL-NZ-TAX-IDENTITY-01",
+                      "desc": "invalid NZ IRD number format",
+                      "tests": "matches ^\\d{8,9}$"
+                    }
+                  ]
+                },
+                {
+                  "guard": "present",
+                  "assert": [
+                    {
+                      "id": "GOBL-NZ-TAX-IDENTITY-02",
+                      "desc": "IRD number out of valid range",
+                      "tests": "range"
+                    }
+                  ]
+                },
+                {
+                  "guard": "present",
+                  "assert": [
+                    {
+                      "id": "GOBL-NZ-TAX-IDENTITY-03",
+                      "desc": "IRD number checksum mismatch",
+                      "tests": "checksum"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "GOBL-NZ-ORG-IDENTITY",
+      "object": "org.Identity",
+      "subsets": [
+        {
+          "guard": "context: regime in [NZ]",
+          "subsets": [
+            {
+              "guard": "type in [NZBN]",
+              "subsets": [
+                {
+                  "field": "code",
+                  "assert": [
+                    {
+                      "id": "GOBL-NZ-ORG-IDENTITY-01",
+                      "desc": "NZBN must be 13 digits",
+                      "tests": "matches ^\\d{13}$"
+                    },
+                    {
+                      "id": "GOBL-NZ-ORG-IDENTITY-02",
+                      "desc": "NZBN check digit mismatch",
+                      "tests": "checksum"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/data/schemas/tax/regime-code.json
+++ b/data/schemas/tax/regime-code.json
@@ -86,6 +86,10 @@
           "title": "Norway"
         },
         {
+          "const": "NZ",
+          "title": "New Zealand"
+        },
+        {
           "const": "PL",
           "title": "Poland"
         },

--- a/examples/nz/invoice-reverse-charge.yaml
+++ b/examples/nz/invoice-reverse-charge.yaml
@@ -1,0 +1,40 @@
+$schema: "https://gobl.org/draft-0/bill/invoice"
+uuid: "7f3a2b1c-8d4e-5f6a-9b0c-1d2e3f4a5b6c"
+issue_date: "2024-07-31"
+series: "INV"
+code: "002"
+tax:
+  tags:
+    - reverse-charge
+
+supplier:
+  tax_id:
+    country: "NZ"
+    code: "123456785"
+  name: "Kiwi Software Ltd."
+  addresses:
+    - street: "12 Lambton Quay"
+      locality: "Wellington"
+      code: "6011"
+      country: "NZ"
+
+customer:
+  tax_id:
+    country: "AU"
+    code: "12345678901"
+  name: "Sydney Enterprises Pty Ltd."
+  addresses:
+    - street: "100 George Street"
+      locality: "Sydney"
+      code: "2000"
+      country: "AU"
+
+lines:
+  - quantity: 5
+    item:
+      name: "Software consultancy services"
+      price: "200.00"
+      unit: "h"
+    taxes:
+      - cat: GST
+        key: reverse-charge

--- a/examples/nz/invoice-standard.yaml
+++ b/examples/nz/invoice-standard.yaml
@@ -42,4 +42,4 @@ lines:
       price: "500.00"
     taxes:
       - cat: GST
-        key: zero
+        rate: zero

--- a/examples/nz/invoice-standard.yaml
+++ b/examples/nz/invoice-standard.yaml
@@ -1,0 +1,45 @@
+$schema: "https://gobl.org/draft-0/bill/invoice"
+uuid: "3e8a1f2b-4c5d-6e7f-8a9b-0c1d2e3f4a5b"
+issue_date: "2024-07-31"
+series: "INV"
+code: "001"
+
+supplier:
+  tax_id:
+    country: "NZ"
+    code: "123456785"
+  name: "Kiwi Software Ltd."
+  addresses:
+    - street: "12 Lambton Quay"
+      locality: "Wellington"
+      code: "6011"
+      country: "NZ"
+
+customer:
+  tax_id:
+    country: "NZ"
+    code: "12345674"
+  name: "Auckland Enterprises Ltd."
+  addresses:
+    - street: "45 Queen Street"
+      locality: "Auckland"
+      code: "1010"
+      country: "NZ"
+
+lines:
+  - quantity: 10
+    item:
+      name: "Software development services"
+      price: "150.00"
+      unit: "h"
+    taxes:
+      - cat: GST
+        rate: general
+
+  - quantity: 1
+    item:
+      name: "Exported software licence"
+      price: "500.00"
+    taxes:
+      - cat: GST
+        key: zero

--- a/examples/nz/out/invoice-reverse-charge.json
+++ b/examples/nz/out/invoice-reverse-charge.json
@@ -1,0 +1,103 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
+		"dig": {
+			"alg": "sha256",
+			"val": "088f7c03c263b942cc841156477a38ac19538f2af5ddae7e819e782f5fd160aa"
+		}
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"$regime": "NZ",
+		"$tags": [
+			"reverse-charge"
+		],
+		"uuid": "7f3a2b1c-8d4e-5f6a-9b0c-1d2e3f4a5b6c",
+		"type": "standard",
+		"series": "INV",
+		"code": "002",
+		"issue_date": "2024-07-31",
+		"currency": "NZD",
+		"tax": {
+			"notes": [
+				{
+					"key": "reverse-charge",
+					"text": "Reverse charge: Recipient to account for GST to Inland Revenue."
+				}
+			]
+		},
+		"supplier": {
+			"name": "Kiwi Software Ltd.",
+			"tax_id": {
+				"country": "NZ",
+				"code": "123456785"
+			},
+			"addresses": [
+				{
+					"street": "12 Lambton Quay",
+					"locality": "Wellington",
+					"code": "6011",
+					"country": "NZ"
+				}
+			]
+		},
+		"customer": {
+			"name": "Sydney Enterprises Pty Ltd.",
+			"tax_id": {
+				"country": "AU",
+				"code": "12345678901"
+			},
+			"addresses": [
+				{
+					"street": "100 George Street",
+					"locality": "Sydney",
+					"code": "2000",
+					"country": "AU"
+				}
+			]
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "5",
+				"item": {
+					"name": "Software consultancy services",
+					"price": "200.00",
+					"unit": "h"
+				},
+				"sum": "1000.00",
+				"taxes": [
+					{
+						"cat": "GST",
+						"key": "reverse-charge"
+					}
+				],
+				"total": "1000.00"
+			}
+		],
+		"totals": {
+			"sum": "1000.00",
+			"total": "1000.00",
+			"taxes": {
+				"categories": [
+					{
+						"code": "GST",
+						"rates": [
+							{
+								"key": "reverse-charge",
+								"base": "1000.00",
+								"amount": "0.00"
+							}
+						],
+						"amount": "0.00"
+					}
+				],
+				"sum": "0.00"
+			},
+			"tax": "0.00",
+			"total_with_tax": "1000.00",
+			"payable": "1000.00"
+		}
+	}
+}

--- a/examples/nz/out/invoice-standard.json
+++ b/examples/nz/out/invoice-standard.json
@@ -1,0 +1,119 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
+		"dig": {
+			"alg": "sha256",
+			"val": "120e52f1dc16f52bd5c6b85ea2d64560db7133c0adbdfbf50ad08580bc143bbc"
+		}
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"$regime": "NZ",
+		"uuid": "3e8a1f2b-4c5d-6e7f-8a9b-0c1d2e3f4a5b",
+		"type": "standard",
+		"series": "INV",
+		"code": "001",
+		"issue_date": "2024-07-31",
+		"currency": "NZD",
+		"supplier": {
+			"name": "Kiwi Software Ltd.",
+			"tax_id": {
+				"country": "NZ",
+				"code": "123456785"
+			},
+			"addresses": [
+				{
+					"street": "12 Lambton Quay",
+					"locality": "Wellington",
+					"code": "6011",
+					"country": "NZ"
+				}
+			]
+		},
+		"customer": {
+			"name": "Auckland Enterprises Ltd.",
+			"tax_id": {
+				"country": "NZ",
+				"code": "12345674"
+			},
+			"addresses": [
+				{
+					"street": "45 Queen Street",
+					"locality": "Auckland",
+					"code": "1010",
+					"country": "NZ"
+				}
+			]
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "10",
+				"item": {
+					"name": "Software development services",
+					"price": "150.00",
+					"unit": "h"
+				},
+				"sum": "1500.00",
+				"taxes": [
+					{
+						"cat": "GST",
+						"key": "standard",
+						"rate": "general",
+						"percent": "15%"
+					}
+				],
+				"total": "1500.00"
+			},
+			{
+				"i": 2,
+				"quantity": "1",
+				"item": {
+					"name": "Exported software licence",
+					"price": "500.00"
+				},
+				"sum": "500.00",
+				"taxes": [
+					{
+						"cat": "GST",
+						"key": "standard",
+						"rate": "zero",
+						"percent": "0%"
+					}
+				],
+				"total": "500.00"
+			}
+		],
+		"totals": {
+			"sum": "2000.00",
+			"total": "2000.00",
+			"taxes": {
+				"categories": [
+					{
+						"code": "GST",
+						"rates": [
+							{
+								"key": "standard",
+								"base": "1500.00",
+								"percent": "15%",
+								"amount": "225.00"
+							},
+							{
+								"key": "standard",
+								"base": "500.00",
+								"percent": "0%",
+								"amount": "0.00"
+							}
+						],
+						"amount": "225.00"
+					}
+				],
+				"sum": "225.00"
+			},
+			"tax": "225.00",
+			"total_with_tax": "2225.00",
+			"payable": "2225.00"
+		}
+	}
+}

--- a/regimes/nz/nz.go
+++ b/regimes/nz/nz.go
@@ -1,0 +1,98 @@
+// Package nz provides the New Zealand tax regime.
+package nz
+
+import (
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/currency"
+	"github.com/invopop/gobl/i18n"
+	"github.com/invopop/gobl/org"
+	"github.com/invopop/gobl/pkg/here"
+	"github.com/invopop/gobl/rules"
+	"github.com/invopop/gobl/tax"
+)
+
+// CountryCode is the ISO 3166-1 alpha-2 code for New Zealand.
+const CountryCode = "NZ"
+
+func init() {
+	tax.RegisterRegimeDef(New())
+	rules.Register("nz", rules.GOBL.Add(CountryCode),
+		taxIdentityRules(),
+		orgIdentityRules(),
+	)
+}
+
+// New provides the tax region definition
+func New() *tax.RegimeDef {
+	return &tax.RegimeDef{
+		Country:   CountryCode,
+		Currency:  currency.NZD,
+		TaxScheme: tax.CategoryGST,
+		Name: i18n.String{
+			i18n.EN: "New Zealand",
+		},
+		Sources: []*cbc.Source{
+			{
+				Title: i18n.String{
+					i18n.EN: "Inland Revenue New Zealand",
+				},
+				URL: "https://www.ird.govt.nz",
+			},
+		},
+		Description: i18n.String{
+			i18n.EN: here.Doc(`
+				New Zealand's tax system is administered by Inland Revenue
+				(Te Tari Taake). Goods and Services Tax (GST) applies at a standard
+				rate of 15% to most goods and services. A reduced rate applies to
+				long-term accommodation of 28 or more consecutive days, equivalent
+				to 60% of the full standard rate.
+
+				Zero-rated supplies include exported goods, international transport
+				services, and certain land transfers between GST-registered parties.
+				Exempt supplies include residential dwelling rent and most financial
+				services.
+
+				Businesses with annual turnover of NZD 60,000 or more must register
+				for GST. The GST registration number is the same as the IRD number
+				(Inland Revenue Department number), an 8 or 9 digit identifier
+				validated using a two-pass modulo-11 checksum algorithm.
+
+				Businesses are also identified by a New Zealand Business Number
+				(NZBN), a 13-digit GS1 Global Location Number used for Peppol
+				e-invoicing. E-invoicing via the Peppol network using the PINT A-NZ
+				specification is mandatory for government agencies and large suppliers
+				to government.
+
+				Supply Correction Information (credit and debit notes) may be issued
+				to correct a previously issued invoice.
+			`),
+		},
+		TimeZone:   "Pacific/Auckland",
+		Normalizer: Normalize,
+		Identities: identityDefs,
+		Scenarios: []*tax.ScenarioSet{
+			bill.InvoiceScenarios(),
+		},
+		Categories: taxCategories(),
+		Corrections: []*tax.CorrectionDefinition{
+			{
+				Schema: bill.ShortSchemaInvoice,
+				Types: []cbc.Key{
+					bill.InvoiceTypeCreditNote,
+					bill.InvoiceTypeDebitNote,
+				},
+			},
+		},
+	}
+}
+
+// Normalize will attempt to clean the object passed to it.
+func Normalize(doc any) {
+	switch obj := doc.(type) {
+	case *tax.Identity:
+		tax.NormalizeIdentity(obj)
+	case *org.Identity:
+		normalizeOrgIdentity(obj)
+	}
+}

--- a/regimes/nz/nz.go
+++ b/regimes/nz/nz.go
@@ -72,7 +72,7 @@ func New() *tax.RegimeDef {
 		Normalizer: Normalize,
 		Identities: identityDefs,
 		Scenarios: []*tax.ScenarioSet{
-			bill.InvoiceScenarios(),
+			invoiceScenarios,
 		},
 		Categories: taxCategories(),
 		Corrections: []*tax.CorrectionDefinition{

--- a/regimes/nz/nz_test.go
+++ b/regimes/nz/nz_test.go
@@ -1,0 +1,20 @@
+package nz_test
+
+import (
+	"testing"
+
+	"github.com/invopop/gobl/regimes/nz"
+	"github.com/invopop/gobl/tax"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalize(t *testing.T) {
+	t.Run("normalize tax identity", func(t *testing.T) {
+		id := &tax.Identity{
+			Country: "NZ",
+			Code:    "123-456-785",
+		}
+		nz.New().Normalizer(id)
+		assert.Equal(t, "123456785", id.Code.String())
+	})
+}

--- a/regimes/nz/org_identities.go
+++ b/regimes/nz/org_identities.go
@@ -1,0 +1,94 @@
+package nz
+
+import (
+	"strings"
+
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/i18n"
+	"github.com/invopop/gobl/l10n"
+	"github.com/invopop/gobl/org"
+	"github.com/invopop/gobl/pkg/here"
+	"github.com/invopop/gobl/rules"
+	"github.com/invopop/gobl/rules/is"
+	"github.com/invopop/gobl/tax"
+)
+
+// Reference: https://www.nzbn.govt.nz/whats-an-nzbn/about/
+// Reference: https://www.gs1nz.org/services/glns/
+
+const (
+	// IdentityTypeNZBN represents the New Zealand Business Number (NZBN), a 13-digit
+	// GS1 Global Location Number used as the primary business identifier and
+	// Peppol participant ID.
+	IdentityTypeNZBN cbc.Code = "NZBN"
+)
+
+const nzbnPattern = `^\d{13}$`
+
+var identityDefs = []*cbc.Definition{
+	{
+		Code: IdentityTypeNZBN,
+		Name: i18n.String{
+			i18n.EN: "New Zealand Business Number (NZBN)",
+		},
+		Desc: i18n.String{
+			i18n.EN: here.Doc(`
+				The New Zealand Business Number (NZBN) is a unique 13-digit identifier
+				issued to all businesses registered in New Zealand. It is based on the
+				GS1 Global Location Number (GLN) standard and is used as the Peppol
+				participant identifier for e-invoicing. Mandatory for businesses with
+				annual turnover of NZD 60,000 or more.
+			`),
+		},
+	},
+}
+
+func normalizeOrgIdentity(id *org.Identity) {
+	if id == nil || id.Type != IdentityTypeNZBN {
+		return
+	}
+	code := strings.ToUpper(id.Code.String())
+	code = tax.IdentityCodeBadCharsRegexp.ReplaceAllString(code, "")
+	id.Code = cbc.Code(strings.TrimPrefix(code, string(l10n.NZ)))
+}
+
+func orgIdentityRules() *rules.Set {
+	return rules.For(new(org.Identity),
+		rules.When(
+			is.InContext(tax.RegimeIn(CountryCode)),
+			rules.When(
+				org.IdentityTypeIn(IdentityTypeNZBN),
+				rules.Field("code",
+					rules.Assert("01", "NZBN must be 13 digits",
+						is.Matches(nzbnPattern),
+					),
+					rules.Assert("02", "NZBN check digit mismatch",
+						is.Func("checksum", nzbnChecksumValid),
+					),
+				),
+			),
+		),
+	)
+}
+
+// nzbnChecksumValid verifies the GS1 Modulo-10 check digit of a 13-digit NZBN.
+func nzbnChecksumValid(value any) bool {
+	code, ok := value.(cbc.Code)
+	// Guard: wrong length is caught by the format rule; don't emit a misleading checksum error.
+	if !ok || len(code) != 13 {
+		return true
+	}
+	val := code.String()
+
+	sum := 0
+	for i := 0; i < 12; i++ {
+		d := int(val[i] - '0')
+		if i%2 == 0 {
+			sum += d * 1
+		} else {
+			sum += d * 3
+		}
+	}
+	check := (10 - sum%10) % 10
+	return check == int(val[12]-'0')
+}

--- a/regimes/nz/scenarios.go
+++ b/regimes/nz/scenarios.go
@@ -1,0 +1,21 @@
+package nz
+
+import (
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/tax"
+)
+
+var invoiceScenarios = &tax.ScenarioSet{
+	Schema: bill.ShortSchemaInvoice,
+	List: []*tax.Scenario{
+		// Reverse Charges
+		{
+			Tags: []cbc.Key{tax.TagReverseCharge},
+			Note: &tax.Note{
+				Key:  tax.KeyReverseCharge,
+				Text: "Reverse charge: Recipient to account for GST to Inland Revenue.",
+			},
+		},
+	},
+}

--- a/regimes/nz/tax_categories.go
+++ b/regimes/nz/tax_categories.go
@@ -1,0 +1,86 @@
+package nz
+
+import (
+	"github.com/invopop/gobl/cal"
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/i18n"
+	"github.com/invopop/gobl/num"
+	"github.com/invopop/gobl/tax"
+)
+
+func taxCategories() []*tax.CategoryDef {
+	return []*tax.CategoryDef{
+		//
+		// GST
+		//
+		{
+			Code: tax.CategoryGST,
+			Name: i18n.String{
+				i18n.EN: "GST",
+			},
+			Title: i18n.String{
+				i18n.EN: "Goods and Services Tax",
+			},
+			Sources: []*cbc.Source{
+				{
+					Title: i18n.String{
+						i18n.EN: "GST - Inland Revenue New Zealand",
+					},
+					URL: "https://www.ird.govt.nz/gst",
+				},
+			},
+			Retained: false,
+			Keys:     tax.GlobalGSTKeys(),
+			Rates: []*tax.RateDef{
+				{
+					Keys: []cbc.Key{tax.KeyStandard},
+					Rate: tax.RateGeneral,
+					Name: i18n.String{
+						i18n.EN: "Standard Rate",
+					},
+					Description: i18n.String{
+						i18n.EN: "Applies to most goods and services in New Zealand.",
+					},
+					Values: []*tax.RateValueDef{
+						{
+							Since:   cal.NewDate(2010, 10, 1),
+							Percent: num.MakePercentage(15, 2),
+						},
+						{
+							Since:   cal.NewDate(1989, 7, 1),
+							Percent: num.MakePercentage(125, 3),
+						},
+						{
+							Since:   cal.NewDate(1986, 10, 1),
+							Percent: num.MakePercentage(10, 2),
+						},
+					},
+				},
+				{
+					Keys: []cbc.Key{tax.KeyStandard},
+					Rate: tax.RateReduced,
+					Name: i18n.String{
+						i18n.EN: "Accommodation Rate",
+					},
+					Description: i18n.String{
+						i18n.EN: "Applies to long-term accommodation of 28 or more consecutive days. Equivalent to 60% of the standard rate applied to the full charge.",
+					},
+					Values: []*tax.RateValueDef{
+						{
+							Since:   cal.NewDate(2010, 10, 1),
+							Percent: num.MakePercentage(9, 2),
+						},
+						{
+							Since:   cal.NewDate(1989, 7, 1),
+							Percent: num.MakePercentage(75, 3),
+						},
+						{
+							Since:   cal.NewDate(1986, 10, 1),
+							Percent: num.MakePercentage(6, 2),
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/regimes/nz/tax_categories.go
+++ b/regimes/nz/tax_categories.go
@@ -80,6 +80,22 @@ func taxCategories() []*tax.CategoryDef {
 						},
 					},
 				},
+				{
+					Keys: []cbc.Key{tax.KeyStandard},
+					Rate: tax.RateZero,
+					Name: i18n.String{
+						i18n.EN: "Zero Rate",
+					},
+					Description: i18n.String{
+						i18n.EN: "Zero-rated supplies including exported goods, international transport, and certain land transactions between GST-registered parties.",
+					},
+					Values: []*tax.RateValueDef{
+						{
+							Since:   cal.NewDate(1986, 10, 1),
+							Percent: num.MakePercentage(0, 2),
+						},
+					},
+				},
 			},
 		},
 	}

--- a/regimes/nz/tax_identity.go
+++ b/regimes/nz/tax_identity.go
@@ -1,0 +1,97 @@
+package nz
+
+import (
+	"strconv"
+
+	"github.com/invopop/gobl/rules"
+	"github.com/invopop/gobl/rules/is"
+	"github.com/invopop/gobl/tax"
+)
+
+// Reference: https://www.ird.govt.nz/digital-service-providers/services-catalogue/customer-and-account/ird-number-validation
+// Reference: https://www.oecd.org/content/dam/oecd/en/topics/policy-issue-focus/aeoi/new-zealand-tin.pdf
+
+const (
+	taxIdentityCodePattern = `^\d{8,9}$`
+
+	irdMinValue = 10_000_000
+	irdMaxValue = 150_000_000
+)
+
+var (
+	// weightsPass1 are the primary weights used for the IRD modulo-11 check digit algorithm.
+	weightsPass1 = []int{3, 2, 7, 6, 5, 4, 3, 2}
+	// weightsPass2 are the fallback weights used when pass 1 produces a check digit of 10.
+	weightsPass2 = []int{7, 4, 3, 2, 5, 2, 7, 6}
+)
+
+func taxIdentityRules() *rules.Set {
+	return rules.For(new(tax.Identity),
+		rules.When(tax.IdentityIn(CountryCode),
+			rules.Field("code",
+				rules.AssertIfPresent("01", "invalid NZ IRD number format",
+					is.Matches(taxIdentityCodePattern),
+				),
+				rules.AssertIfPresent("02", "IRD number out of valid range",
+					is.StringFunc("range", irdInValidRange),
+				),
+				rules.AssertIfPresent("03", "IRD number checksum mismatch",
+					is.StringFunc("checksum", irdChecksumValid),
+				),
+			),
+		),
+	)
+}
+
+func irdInValidRange(code string) bool {
+	n, err := strconv.Atoi(code)
+	if err != nil {
+		return false
+	}
+	return n >= irdMinValue && n <= irdMaxValue
+}
+
+// irdChecksumValid validates the IRD number checksum using a two-pass modulo-11 algorithm.
+// Pass 1 uses weights [3,2,7,6,5,4,3,2]. When pass 1 produces an impossible check digit of 10,
+// pass 2 falls back to weights [7,4,3,2,5,2,7,6]. If both passes yield 10, the number is invalid.
+func irdChecksumValid(code string) bool {
+	// Guard: checksum requires exactly 8 or 9 digits; let the format rule handle other lengths.
+	if len(code) < 8 || len(code) > 9 {
+		return true
+	}
+
+	// Split into base digits and check digit.
+	base := code[:len(code)-1]
+	checkDigit := int(code[len(code)-1] - '0')
+
+	// If the base is 7 digits (8-digit IRD), pad left with a zero.
+	if len(base) == 7 {
+		base = "0" + base
+	}
+
+	computed := irdComputeCheckDigit(base, weightsPass1)
+	if computed == 10 {
+		// Pass 1 produced an impossible digit — fall back to pass 2 weights.
+		computed = irdComputeCheckDigit(base, weightsPass2)
+		if computed == 10 {
+			// Both passes failed; the number is structurally invalid.
+			return false
+		}
+	}
+
+	return computed == checkDigit
+}
+
+// irdComputeCheckDigit applies a set of weights to the 8-digit base string
+// and returns the modulo-11 check digit (may return 10 on failure).
+func irdComputeCheckDigit(base string, weights []int) int {
+	sum := 0
+	for i, w := range weights {
+		sum += int(base[i]-'0') * w
+	}
+	rem := sum % 11
+	if rem == 0 {
+		return 0
+	}
+	return 11 - rem
+}

--- a/regimes/nz/tax_identity_test.go
+++ b/regimes/nz/tax_identity_test.go
@@ -1,0 +1,83 @@
+package nz_test
+
+import (
+	"testing"
+
+	"github.com/invopop/gobl/cbc"
+	_ "github.com/invopop/gobl/regimes/nz"
+	"github.com/invopop/gobl/rules"
+	"github.com/invopop/gobl/tax"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTaxIdentityValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		code cbc.Code
+		err  string
+	}{
+		// Valid IRD numbers
+		{name: "valid 9-digit", code: "123456785"},
+		{name: "valid 8-digit", code: "12345674"},
+		{name: "valid 9-digit requiring pass-2 weights", code: "100000305"},
+
+		// Format failures
+		{name: "too short", code: "1234567", err: "IDENTITY-01"},
+		{name: "too long", code: "1234567890", err: "IDENTITY-01"},
+		{name: "non-numeric characters", code: "1234abc89", err: "IDENTITY-01"},
+		{name: "letters in code", code: "1234abc89", err: "IDENTITY-01"},
+
+		// Range failures
+		{name: "below minimum", code: "09999999", err: "IDENTITY-02"},
+		{name: "above maximum", code: "150000001", err: "IDENTITY-02"},
+
+		// Checksum failures
+		{name: "wrong check digit", code: "123456789", err: "IDENTITY-03"},
+		{name: "wrong check digit 8-digit", code: "12345670", err: "IDENTITY-03"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id := &tax.Identity{
+				Country: "NZ",
+				Code:    tt.code,
+			}
+			err := rules.Validate(id)
+			if tt.err == "" {
+				assert.NoError(t, err)
+			} else {
+				if assert.Error(t, err) {
+					assert.Contains(t, err.Error(), tt.err)
+				}
+			}
+		})
+	}
+}
+
+func TestTaxIdentityNormalization(t *testing.T) {
+	tests := []struct {
+		name string
+		in   cbc.Code
+		out  cbc.Code
+	}{
+		{name: "hyphens stripped", in: "123-456-785", out: "123456785"},
+		{name: "spaces stripped", in: "123 456 785", out: "123456785"},
+		{name: "NZ prefix stripped", in: "NZ123456785", out: "123456785"},
+		{name: "mixed formatting", in: "NZ 123-456-785", out: "123456785"},
+		{name: "already clean", in: "123456785", out: "123456785"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id := &tax.Identity{
+				Country: "NZ",
+				Code:    tt.in,
+			}
+			regime := tax.RegimeDefFor("NZ")
+			require.NotNil(t, regime)
+			regime.Normalizer(id)
+			assert.Equal(t, tt.out, id.Code)
+		})
+	}
+}

--- a/regimes/nz/tax_identity_test.go
+++ b/regimes/nz/tax_identity_test.go
@@ -26,7 +26,7 @@ func TestTaxIdentityValidation(t *testing.T) {
 		{name: "too short", code: "1234567", err: "IDENTITY-01"},
 		{name: "too long", code: "1234567890", err: "IDENTITY-01"},
 		{name: "non-numeric characters", code: "1234abc89", err: "IDENTITY-01"},
-		{name: "letters in code", code: "1234abc89", err: "IDENTITY-01"},
+		{name: "special characters", code: "1234+6789", err: "IDENTITY-01"},
 
 		// Range failures
 		{name: "below minimum", code: "09999999", err: "IDENTITY-02"},

--- a/regimes/regimes.go
+++ b/regimes/regimes.go
@@ -25,6 +25,7 @@ import (
 	_ "github.com/invopop/gobl/regimes/mx"
 	_ "github.com/invopop/gobl/regimes/nl"
 	_ "github.com/invopop/gobl/regimes/no"
+	_ "github.com/invopop/gobl/regimes/nz"
 	_ "github.com/invopop/gobl/regimes/pl"
 	_ "github.com/invopop/gobl/regimes/pt"
 	_ "github.com/invopop/gobl/regimes/sa"

--- a/tax/constants.go
+++ b/tax/constants.go
@@ -119,6 +119,11 @@ var globalCategories = []*CategoryDef{
 				Name: i18n.NewString("Zero"),
 			},
 			{
+				Key:       KeyReverseCharge,
+				Name:      i18n.NewString("Reverse charge"),
+				NoPercent: true,
+			},
+			{
 				Key:       KeyExempt,
 				Name:      i18n.NewString("Exempt"),
 				NoPercent: true,


### PR DESCRIPTION
### Adds a tax regime for New Zealand (NZ).

- GST category with standard rate (15%, since Oct 2010), historical rates (12.5% since Jul 1989, 10% since Oct 1986), and accommodation reduced rate (9%, applying to stays of 28 or more consecutive days, equivalent to 60% of the standard rate)
- Zero-rated and exempt supply categories via the global GST keys
- IRD number (Inland Revenue Department number) validation using a two-pass modulo-11 checksum; pass-2 fallback weights handle the edge case where pass-1 produces an impossible check digit of 10
- NZBN (New Zealand Business Number) as an optional org identity, validated with a GS1 Modulo-10 check digit
- Credit note and debit note correction types, mapping to NZ's Supply Correction Information (SCI)
- Example invoice demonstrating a standard-rated services line and a zero-rated export line

*Invoice-level threshold requirements (the $200/$1,000 Taxable Supply Information rules) and Peppol/PINT A-NZ e-invoicing format support are intentionally deferred to a future addon, following the precedent set by the Singapore (SG) and Uruguay (UY) base regime implementations.*

Sources:
- IRD number validation: https://www.ird.govt.nz/digital-service-providers/services-catalogue/customer-and-account/ird-number-validation
- OECD NZ TIN documentation: https://www.oecd.org/content/dam/oecd/en/topics/policy-issue-focus/aeoi/new-zealand-tin.pdf
- GST rates and history: https://www.ird.govt.nz/gst
- NZBN specification: https://www.nzbn.govt.nz/whats-an-nzbn/about/
- GS1 GLN check digit: https://www.gs1nz.org/services/glns/

## Pre-Review Checklist

- [x] Opened this PR as a draft
- [x] Read the CONTRIBUTING.md guide.
- [x] Performed a self-review of my code.
- [x] Added thorough tests with at **least** 90% code coverage.
- [x] Modified or created example GOBL documents to show my changes in use, if appropriate.
- [x] Added links to the source of the changes in tax regimes or addons, either structured or in the comments.
- [x] Run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [x] Reviewed and fixed all linter warnings.
- [x] Been obsessive with pointer nil checks to avoid panics.
- [x] Updated the CHANGELOG.md with an overview of my changes.
- [x] Marked this PR as ready for review.
