### PR TITLE
br: fill issue date and time in regime time zone for NF-e and NFS-e

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Fixed
 
+- `br-nfe-v4` / `br-nfse-v1`: invoices now normalize the issue date and time to the current moment in the regime's time zone (`America/Sao_Paulo`) when the issue time is unset or zero, instead of leaving them empty for downstream services to interpret. Documents explicitly dated on another day are left untouched. Prevents tax authority rejections caused by emission timestamps stamped from a UTC clock.
+- `tax`: the IANA time zone database is now embedded (via `time/tzdata`), so `RegimeDef.TimeLocation()` no longer silently falls back to UTC on runtimes without OS tzdata (e.g. scratch or slim containers). The OS database still takes precedence when present (~450KB binary size cost).
 - `norm`: normalization now prunes `nil` pointer/interface entries from every slice in the document graph (e.g. a JSON `null` in an `identities`, `preceding`, or status `lines` array). This removes a class of panics in regime/addon normalizers and validators that iterated such slices, and means downstream consumers never see `nil` array elements. Slices with no `nil`s are left untouched (no reallocation).
 - `tax`: `CorrectionDefinition.Merge` now deduplicates merged types, extensions, and stamps, preventing duplicate entries when both a regime and an addon declare the same keys.
 - `pt-saft-v1`: Removed correction definition types already defined in the PT regime.

--- a/addons/br/nfe/bill_invoices.go
+++ b/addons/br/nfe/bill_invoices.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/cal"
 	"github.com/invopop/gobl/currency"
 	"github.com/invopop/gobl/num"
 	"github.com/invopop/gobl/org"
@@ -17,6 +18,26 @@ import (
 const (
 	seriesPattern = `^(?:0|[1-9]{1}[0-9]{0,2})$` // extracted from the NFe XSD to validate the series
 )
+
+// normalizeInvoiceIssueDateAndTime fills the issue date and time with the
+// current date and time in the regime's time zone when the time hasn't been
+// set. SEFAZ expects the emission timestamp to be close to the moment of
+// transmission and rejects documents whose time is in the future, as happens
+// when the time is stamped from a UTC clock. Documents explicitly dated on
+// another day are left untouched, as backdated issue dates may be
+// legitimate for NF-e.
+func normalizeInvoiceIssueDateAndTime(inv *bill.Invoice) {
+	if inv.IssueTime != nil && !inv.IssueTime.IsZero() {
+		return
+	}
+	dn := cal.ThisSecondIn(inv.RegimeDef().TimeLocation())
+	if !inv.IssueDate.IsZero() && inv.IssueDate != dn.Date() {
+		return
+	}
+	tn := dn.Time()
+	inv.IssueDate = dn.Date()
+	inv.IssueTime = &tn
+}
 
 func billInvoiceRules() *rules.Set {
 	return rules.For(new(bill.Invoice),

--- a/addons/br/nfe/bill_invoices_test.go
+++ b/addons/br/nfe/bill_invoices_test.go
@@ -3,9 +3,11 @@ package nfe_test
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/invopop/gobl/addons/br/nfe"
 	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/cal"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/currency"
 	"github.com/invopop/gobl/num"
@@ -478,6 +480,58 @@ func TestInvoiceCurrencyValidation(t *testing.T) {
 }
 
 // validInvoice creates a raw invoice suitable for scenario tests that call Calculate() themselves.
+func TestInvoiceIssueDateAndTimeNormalization(t *testing.T) {
+	// These tests can fail very rarely if run on the exact transition of a second
+	tz, err := time.LoadLocation("America/Sao_Paulo")
+	require.NoError(t, err)
+
+	t.Run("fills date and time when neither is set", func(t *testing.T) {
+		inv := validInvoice()
+		require.True(t, inv.IssueDate.IsZero())
+		require.Nil(t, inv.IssueTime)
+		tn := time.Now().In(tz)
+		require.NoError(t, inv.Calculate())
+		require.NotNil(t, inv.IssueTime)
+		assert.Equal(t, tn.Format("2006-01-02"), inv.IssueDate.String())
+		assert.Equal(t, tn.Format("15:04:05"), inv.IssueTime.String())
+	})
+
+	t.Run("fills date and time when time is present but zero", func(t *testing.T) {
+		inv := validInvoice()
+		inv.IssueTime = new(cal.Time)
+		tn := time.Now().In(tz)
+		require.NoError(t, inv.Calculate())
+		assert.Equal(t, tn.Format("2006-01-02"), inv.IssueDate.String())
+		assert.Equal(t, tn.Format("15:04:05"), inv.IssueTime.String())
+	})
+
+	t.Run("fills time when date is today", func(t *testing.T) {
+		inv := validInvoice()
+		inv.IssueDate = cal.TodayIn(tz)
+		tn := time.Now().In(tz)
+		require.NoError(t, inv.Calculate())
+		require.NotNil(t, inv.IssueTime)
+		assert.Equal(t, tn.Format("15:04:05"), inv.IssueTime.String())
+	})
+
+	t.Run("leaves backdated invoices untouched", func(t *testing.T) {
+		inv := validInvoice()
+		inv.IssueDate = cal.MakeDate(2024, time.January, 15)
+		require.NoError(t, inv.Calculate())
+		assert.Equal(t, "2024-01-15", inv.IssueDate.String())
+		assert.Nil(t, inv.IssueTime)
+	})
+
+	t.Run("respects explicit issue time", func(t *testing.T) {
+		inv := validInvoice()
+		inv.IssueDate = cal.MakeDate(2024, time.January, 15)
+		inv.IssueTime = cal.NewTime(12, 34, 10)
+		require.NoError(t, inv.Calculate())
+		assert.Equal(t, "2024-01-15", inv.IssueDate.String())
+		assert.Equal(t, "12:34:10", inv.IssueTime.String())
+	})
+}
+
 func validInvoice() *bill.Invoice {
 	return &bill.Invoice{
 		Addons:   tax.WithAddons(nfe.V4),

--- a/addons/br/nfe/nfe.go
+++ b/addons/br/nfe/nfe.go
@@ -46,6 +46,7 @@ func init() {
 	)
 	norm.RegisterWithGuard(
 		is.InContext(tax.AddonIn(V4)),
+		norm.For(normalizeInvoiceIssueDateAndTime),
 		norm.For(normalizePayInstructions),
 		norm.For(normalizePayRecord),
 	)

--- a/addons/br/nfse/bill_invoices.go
+++ b/addons/br/nfse/bill_invoices.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 
 	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/cal"
 	"github.com/invopop/gobl/currency"
 	"github.com/invopop/gobl/org"
 	"github.com/invopop/gobl/regimes/br"
@@ -22,6 +23,26 @@ var (
 	// CodeRegexp is the regular expression used to validate the invoice code
 	CodeRegexp = regexp.MustCompile(`^[1-9][0-9]*$`)
 )
+
+// normalizeInvoiceIssueDateAndTime fills the issue date and time with the
+// current date and time in the regime's time zone when the time hasn't been
+// set. Tax authorities expect the emission timestamp to be close to the
+// moment of transmission and reject documents whose time is in the future,
+// as happens when the time is stamped from a UTC clock. Documents
+// explicitly dated on another day are left untouched, as backdated issue
+// dates may be legitimate for NFS-e.
+func normalizeInvoiceIssueDateAndTime(inv *bill.Invoice) {
+	if inv.IssueTime != nil && !inv.IssueTime.IsZero() {
+		return
+	}
+	dn := cal.ThisSecondIn(inv.RegimeDef().TimeLocation())
+	if !inv.IssueDate.IsZero() && inv.IssueDate != dn.Date() {
+		return
+	}
+	tn := dn.Time()
+	inv.IssueDate = dn.Date()
+	inv.IssueTime = &tn
+}
 
 func billInvoiceRules() *rules.Set {
 	return rules.For(new(bill.Invoice),

--- a/addons/br/nfse/bill_invoices_test.go
+++ b/addons/br/nfse/bill_invoices_test.go
@@ -2,9 +2,11 @@ package nfse_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/invopop/gobl/addons/br/nfse"
 	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/cal"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/currency"
 	"github.com/invopop/gobl/norm"
@@ -13,6 +15,7 @@ import (
 	"github.com/invopop/gobl/rules"
 	"github.com/invopop/gobl/tax"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func withAddonContext() rules.WithContext {
@@ -239,6 +242,63 @@ func TestSuppliersValidation(t *testing.T) {
 		if assert.Error(t, err) {
 			assert.NotContains(t, err.Error(), "supplier requires 'br-ibge-municipality', 'br-nfse-simples', and 'br-nfse-fiscal-incentive' extensions")
 		}
+	})
+}
+
+func TestInvoiceIssueDateAndTimeNormalization(t *testing.T) {
+	// These tests can fail very rarely if run on the exact transition of a second
+	tz, err := time.LoadLocation("America/Sao_Paulo")
+	require.NoError(t, err)
+
+	newInvoice := func() *bill.Invoice {
+		return &bill.Invoice{
+			Regime: tax.WithRegime("BR"),
+			Series: "SAMPLE",
+		}
+	}
+
+	t.Run("fills date and time when neither is set", func(t *testing.T) {
+		inv := newInvoice()
+		tn := time.Now().In(tz)
+		norm.Normalize(inv, tax.AddonContext(nfse.V1))
+		require.NotNil(t, inv.IssueTime)
+		assert.Equal(t, tn.Format("2006-01-02"), inv.IssueDate.String())
+		assert.Equal(t, tn.Format("15:04:05"), inv.IssueTime.String())
+	})
+
+	t.Run("fills date and time when time is present but zero", func(t *testing.T) {
+		inv := newInvoice()
+		inv.IssueTime = new(cal.Time)
+		tn := time.Now().In(tz)
+		norm.Normalize(inv, tax.AddonContext(nfse.V1))
+		assert.Equal(t, tn.Format("2006-01-02"), inv.IssueDate.String())
+		assert.Equal(t, tn.Format("15:04:05"), inv.IssueTime.String())
+	})
+
+	t.Run("fills time when date is today", func(t *testing.T) {
+		inv := newInvoice()
+		inv.IssueDate = cal.TodayIn(tz)
+		tn := time.Now().In(tz)
+		norm.Normalize(inv, tax.AddonContext(nfse.V1))
+		require.NotNil(t, inv.IssueTime)
+		assert.Equal(t, tn.Format("15:04:05"), inv.IssueTime.String())
+	})
+
+	t.Run("leaves backdated invoices untouched", func(t *testing.T) {
+		inv := newInvoice()
+		inv.IssueDate = cal.MakeDate(2024, time.January, 15)
+		norm.Normalize(inv, tax.AddonContext(nfse.V1))
+		assert.Equal(t, "2024-01-15", inv.IssueDate.String())
+		assert.Nil(t, inv.IssueTime)
+	})
+
+	t.Run("respects explicit issue time", func(t *testing.T) {
+		inv := newInvoice()
+		inv.IssueDate = cal.MakeDate(2024, time.January, 15)
+		inv.IssueTime = cal.NewTime(12, 34, 10)
+		norm.Normalize(inv, tax.AddonContext(nfse.V1))
+		assert.Equal(t, "2024-01-15", inv.IssueDate.String())
+		assert.Equal(t, "12:34:10", inv.IssueTime.String())
 	})
 }
 

--- a/addons/br/nfse/nfse.go
+++ b/addons/br/nfse/nfse.go
@@ -35,6 +35,7 @@ func init() {
 	)
 	norm.RegisterWithGuard(
 		is.InContext(tax.AddonIn(V1)),
+		norm.For(normalizeInvoiceIssueDateAndTime),
 		norm.For(func(inv *bill.Invoice) { normalizeSupplier(inv.Supplier) }),
 		norm.For(normalizeTaxCombo),
 	)

--- a/tax/regime_def.go
+++ b/tax/regime_def.go
@@ -5,6 +5,12 @@ import (
 	"strings"
 	"time"
 
+	// Embed the IANA time zone database so that regime time zones resolve
+	// even on runtimes without OS tzdata (e.g. scratch or slim containers),
+	// where TimeLocation would otherwise silently fall back to UTC. The OS
+	// database still takes precedence when available.
+	_ "time/tzdata"
+
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/currency"
 	"github.com/invopop/gobl/i18n"


### PR DESCRIPTION
Invoices using the br-nfe-v4 or br-nfse-v1 addons now normalize the issue date and time to the current moment in America/Sao_Paulo when the issue time is unset or zero, mirroring the mx-cfdi-v4 behaviour. Documents explicitly dated on another day are left untouched so that legitimate backdated documents are not modified.

Also embeds the IANA tzdata database in the tax package so that RegimeDef.TimeLocation no longer silently degrades to UTC on runtimes without OS tzdata, which produced future-dated emission timestamps that tax authorities reject.

- Replace this bullet list with your changes

## Pre-Review Checklist

- [ ] Opened this PR as a draft
- [ ] Read the CONTRIBUTING.md guide.
- [ ] Performed a self-review of my code.
- [ ] Added thorough tests with at **least** 90% code coverage.
- [ ] Modified or created example GOBL documents to show my changes in use, if appropriate.
- [ ] Added links to the source of the changes in tax regimes or addons, either structured or in the comments.
- [ ] Run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [ ] Reviewed and fixed all linter warnings.
- [ ] Been obsessive with pointer nil checks to avoid panics.
- [ ] Updated the CHANGELOG.md with an overview of my changes.
- [ ] Marked this PR as ready for review.

And if you are part of the org:
- [ ] Requested a review from Copilot and fixed or dismissed (with a reason) all the feedback raised.
- [ ] Requested a review from @samlown.
