### PR TITLE
org: add LiquidationState and SoleShareholder to Registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Added
+
+- `org`: added `LiquidationState` and `SoleShareholder` free-form fields to `org.Registration`, supporting the Italian FatturaPA `<StatoLiquidazione>` (`LS`/`LN`) and `<SocioUnico>` (`SU`/`SM`) elements of the `IscrizioneREA` block.
+
 ## [v0.500.0] - 2026-06-10
 
 GOBL is now a pure document library. The CLI, HTTP API, MCP server, and WASM build have moved to the [gobl.dev](https://github.com/invopop/gobl.dev) project, which composes this library with the complete set of addons. Install the CLI from its new home: `go install github.com/invopop/gobl.dev/cmd/gobl@latest`.

--- a/data/schemas/org/registration.json
+++ b/data/schemas/org/registration.json
@@ -57,6 +57,16 @@
         "other": {
           "type": "string",
           "title": "Other"
+        },
+        "liquidation_state": {
+          "type": "string",
+          "title": "Liquidation State",
+          "description": "LiquidationState indicates whether the company is in liquidation. Used by\nItalian FatturaPA as \u003cStatoLiquidazione\u003e with values \"LS\" (in liquidation)\nor \"LN\" (not in liquidation). See the IscrizioneREA block in the FatturaPA\nschema: https://www.fatturapa.gov.it/it/norme-e-regole/documentazione-fattura-elettronica/formato-fatturapa/"
+        },
+        "sole_shareholder": {
+          "type": "string",
+          "title": "Sole Shareholder",
+          "description": "SoleShareholder indicates the company's shareholder configuration. Used by\nItalian FatturaPA as \u003cSocioUnico\u003e with values \"SU\" (sole shareholder) or\n\"SM\" (multiple shareholders). See the IscrizioneREA block in the FatturaPA\nschema: https://www.fatturapa.gov.it/it/norme-e-regole/documentazione-fattura-elettronica/formato-fatturapa/"
         }
       },
       "type": "object",

--- a/examples/it/hotel.yaml
+++ b/examples/it/hotel.yaml
@@ -18,6 +18,8 @@ supplier:
     currency: EUR
     entry: "123456"
     office: RM
+    liquidation_state: LN
+    sole_shareholder: SM
   addresses:
     - num: "102"
       street: Via California

--- a/examples/it/out/hotel.json
+++ b/examples/it/out/hotel.json
@@ -4,7 +4,7 @@
 		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
 		"dig": {
 			"alg": "sha256",
-			"val": "23d27fc3273a9b31b0f3f4b54483159db3a133c9411cd8224f4935f8bdb18fd5"
+			"val": "f0f92fed423723e581b1553f5a9232ff37f51c8e082711a16ecfdcfaba12757d"
 		}
 	},
 	"doc": {
@@ -46,7 +46,9 @@
 				"capital": "50000.00",
 				"currency": "EUR",
 				"office": "RM",
-				"entry": "123456"
+				"entry": "123456",
+				"liquidation_state": "LN",
+				"sole_shareholder": "SM"
 			},
 			"ext": {
 				"it-sdi-fiscal-regime": "RF01"

--- a/org/registration.go
+++ b/org/registration.go
@@ -26,6 +26,16 @@ type Registration struct {
 	Page     string        `json:"page,omitempty" jsonschema:"title=Page"`
 	Entry    string        `json:"entry,omitempty" jsonschema:"title=Entry"`
 	Other    string        `json:"other,omitempty" jsonschema:"title=Other"`
+	// LiquidationState indicates whether the company is in liquidation. Used by
+	// Italian FatturaPA as <StatoLiquidazione> with values "LS" (in liquidation)
+	// or "LN" (not in liquidation). See the IscrizioneREA block in the FatturaPA
+	// schema: https://www.fatturapa.gov.it/it/norme-e-regole/documentazione-fattura-elettronica/formato-fatturapa/
+	LiquidationState string `json:"liquidation_state,omitempty" jsonschema:"title=Liquidation State"`
+	// SoleShareholder indicates the company's shareholder configuration. Used by
+	// Italian FatturaPA as <SocioUnico> with values "SU" (sole shareholder) or
+	// "SM" (multiple shareholders). See the IscrizioneREA block in the FatturaPA
+	// schema: https://www.fatturapa.gov.it/it/norme-e-regole/documentazione-fattura-elettronica/formato-fatturapa/
+	SoleShareholder string `json:"sole_shareholder,omitempty" jsonschema:"title=Sole Shareholder"`
 }
 
 func registrationRules() *rules.Set {
@@ -52,4 +62,6 @@ func normalizeRegistration(r *Registration) {
 	r.Page = cbc.NormalizeString(r.Page)
 	r.Entry = cbc.NormalizeString(r.Entry)
 	r.Other = cbc.NormalizeString(r.Other)
+	r.LiquidationState = cbc.NormalizeString(r.LiquidationState)
+	r.SoleShareholder = cbc.NormalizeString(r.SoleShareholder)
 }

--- a/org/registration_test.go
+++ b/org/registration_test.go
@@ -12,15 +12,17 @@ import (
 
 func TestRegistrationNormalize_TrimsFieldsAndSetsUUID(t *testing.T) {
 	r := &org.Registration{
-		Label:   "  My Label  ",
-		Office:  "\tOffice Name  ",
-		Book:    "  Book ",
-		Volume:  "  Volume  ",
-		Sheet:   "  Sheet  ",
-		Section: "  Section  ",
-		Page:    "  Page  ",
-		Entry:   "  Entry  ",
-		Other:   "  Other  ",
+		Label:            "  My Label  ",
+		Office:           "\tOffice Name  ",
+		Book:             "  Book ",
+		Volume:           "  Volume  ",
+		Sheet:            "  Sheet  ",
+		Section:          "  Section  ",
+		Page:             "  Page  ",
+		Entry:            "  Entry  ",
+		Other:            "  Other  ",
+		LiquidationState: "  LS  ",
+		SoleShareholder:  "\tSU  ",
 	}
 
 	assert.NotPanics(t, func() {
@@ -36,6 +38,8 @@ func TestRegistrationNormalize_TrimsFieldsAndSetsUUID(t *testing.T) {
 	assert.Equal(t, "Page", r.Page)
 	assert.Equal(t, "Entry", r.Entry)
 	assert.Equal(t, "Other", r.Other)
+	assert.Equal(t, "LS", r.LiquidationState)
+	assert.Equal(t, "SU", r.SoleShareholder)
 }
 
 func TestRegistrationNormalize_OnNilReceiverDoesNotPanic(t *testing.T) {


### PR DESCRIPTION
Two free-form string fields on org.Registration for the Italian FatturaPA IscrizioneREA block: LiquidationState maps to <StatoLiquidazione> (LS/LN) and SoleShareholder maps to <SocioUnico> (SU/SM). Both are normalized via cbc.NormalizeString, matching the existing free-form treatment of Office, Entry, and the other registration fields. No enum validation.

The org.Registration doc-comment invites country-specific extensions; these fields let gobl.fatturapa emit a structurally correct IscrizioneREA for companies in liquidation and sole-shareholder SRLs instead of hardcoding <StatoLiquidazione> to "LN" and omitting <SocioUnico>.

The it/hotel example demonstrates both fields in use.

## Pre-Review Checklist

  - [x] Opened this PR as a draft
  - [x] Read the CONTRIBUTING.md guide.
  - [x] Performed a self-review of my code.
  - [x] Added thorough tests with at **least** 90% code coverage.
  - [x] Modified or created example GOBL documents to show my changes in use, if appropriate.
  - [x] Added links to the source of the changes in tax regimes or addons, either structured or in the comments.
  - [x] Run `go generate .` to ensure that the Schemas and Regime data are up to date.
  - [x] Reviewed and fixed all linter warnings.
  - [x] Been obsessive with pointer nil checks to avoid panics.
  - [x] Updated the CHANGELOG.md with an overview of my changes.
  - [x] Marked this PR as ready for review.