### PR TITLE
Keeping the MVA suffix on Norwegian VAT identities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Fixed
+
+- `regimes/no`: Norwegian VAT identities now keep — and gain, when given as a bare organisation number — the `MVA` suffix, so serialized VAT numbers take the `NO<orgnr>MVA` form that the EHF and Peppol national rules (NO-R-001) require. Validation expects the suffixed form; organisation-number identities are unchanged.
+
 ## [v0.500.0] - 2026-06-10
 
 GOBL is now a pure document library. The CLI, HTTP API, MCP server, and WASM build have moved to the [gobl.dev](https://github.com/invopop/gobl.dev) project, which composes this library with the complete set of addons. Install the CLI from its new home: `go install github.com/invopop/gobl.dev/cmd/gobl@latest`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Added
+
+- `cbc.Code`: `HasPrefix`, `HasSuffix`, `TrimPrefix`, and `TrimSuffix` helpers.
+
 ### Fixed
 
 - `regimes/no`: Norwegian VAT identities now keep — and gain, when given as a bare organisation number — the `MVA` suffix, so serialized VAT numbers take the `NO<orgnr>MVA` form that the EHF and Peppol national rules (NO-R-001) require. Validation expects the suffixed form; organisation-number identities are unchanged.

--- a/cbc/code.go
+++ b/cbc/code.go
@@ -189,6 +189,28 @@ func (c Code) JoinWith(separator Code, c2 Code) Code {
 	return c + separator + c2
 }
 
+// HasPrefix reports whether the code begins with the given prefix.
+func (c Code) HasPrefix(prefix Code) bool {
+	return strings.HasPrefix(string(c), string(prefix))
+}
+
+// HasSuffix reports whether the code ends with the given suffix.
+func (c Code) HasSuffix(suffix Code) bool {
+	return strings.HasSuffix(string(c), string(suffix))
+}
+
+// TrimPrefix returns the code without the given leading prefix. If the code
+// does not start with the prefix, it is returned unchanged.
+func (c Code) TrimPrefix(prefix Code) Code {
+	return Code(strings.TrimPrefix(string(c), string(prefix)))
+}
+
+// TrimSuffix returns the code without the given trailing suffix. If the code
+// does not end with the suffix, it is returned unchanged.
+func (c Code) TrimSuffix(suffix Code) Code {
+	return Code(strings.TrimSuffix(string(c), string(suffix)))
+}
+
 // JSONSchema provides a representation of the struct for usage in Schema.
 func (Code) JSONSchema() *jsonschema.Schema {
 	return &jsonschema.Schema{

--- a/cbc/code.go
+++ b/cbc/code.go
@@ -189,24 +189,22 @@ func (c Code) JoinWith(separator Code, c2 Code) Code {
 	return c + separator + c2
 }
 
-// HasPrefix reports whether the code begins with the given prefix.
+// HasPrefix reports whether the code starts with prefix.
 func (c Code) HasPrefix(prefix Code) bool {
 	return strings.HasPrefix(string(c), string(prefix))
 }
 
-// HasSuffix reports whether the code ends with the given suffix.
+// HasSuffix reports whether the code ends with suffix.
 func (c Code) HasSuffix(suffix Code) bool {
 	return strings.HasSuffix(string(c), string(suffix))
 }
 
-// TrimPrefix returns the code without the given leading prefix. If the code
-// does not start with the prefix, it is returned unchanged.
+// TrimPrefix returns the code with the leading prefix removed.
 func (c Code) TrimPrefix(prefix Code) Code {
 	return Code(strings.TrimPrefix(string(c), string(prefix)))
 }
 
-// TrimSuffix returns the code without the given trailing suffix. If the code
-// does not end with the suffix, it is returned unchanged.
+// TrimSuffix returns the code with the trailing suffix removed.
 func (c Code) TrimSuffix(suffix Code) Code {
 	return Code(strings.TrimSuffix(string(c), string(suffix)))
 }

--- a/cbc/code_test.go
+++ b/cbc/code_test.go
@@ -42,6 +42,29 @@ func TestCodeJoin(t *testing.T) {
 	})
 }
 
+func TestCodePrefixSuffix(t *testing.T) {
+	c := cbc.Code("NO923456783MVA")
+
+	t.Run("HasPrefix", func(t *testing.T) {
+		assert.True(t, c.HasPrefix("NO"))
+		assert.False(t, c.HasPrefix("SE"))
+	})
+	t.Run("HasSuffix", func(t *testing.T) {
+		assert.True(t, c.HasSuffix("MVA"))
+		assert.False(t, c.HasSuffix("VAT"))
+	})
+	t.Run("TrimPrefix", func(t *testing.T) {
+		assert.Equal(t, cbc.Code("923456783MVA"), c.TrimPrefix("NO"))
+		// unchanged when the prefix is absent
+		assert.Equal(t, c, c.TrimPrefix("SE"))
+	})
+	t.Run("TrimSuffix", func(t *testing.T) {
+		assert.Equal(t, cbc.Code("NO923456783"), c.TrimSuffix("MVA"))
+		// unchanged when the suffix is absent
+		assert.Equal(t, c, c.TrimSuffix("VAT"))
+	})
+}
+
 func TestNormalizeCode(t *testing.T) {
 	tests := []struct {
 		name string

--- a/data/rules/no.json
+++ b/data/rules/no.json
@@ -17,8 +17,8 @@
                   "assert": [
                     {
                       "id": "GOBL-NO-TAX-IDENTITY-01",
-                      "desc": "invalid organisasjonsnummer",
-                      "tests": "valid mod-11 org number"
+                      "desc": "invalid Norwegian VAT number",
+                      "tests": "valid MVA-suffixed mod-11 org number"
                     }
                   ]
                 }

--- a/examples/no/out/credit-note-no.json
+++ b/examples/no/out/credit-note-no.json
@@ -4,7 +4,7 @@
 		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
 		"dig": {
 			"alg": "sha256",
-			"val": "4f9d189b2ce526b6a830848eb0e279984da47c6228889547fd8ab6f25612f435"
+			"val": "e0082e013c5c9d60a8e6698cd6ebebf69760d41134a81432ccc3375c6653c03b"
 		}
 	},
 	"doc": {
@@ -26,7 +26,7 @@
 			"name": "Eksempel AS",
 			"tax_id": {
 				"country": "NO",
-				"code": "923456783"
+				"code": "923456783MVA"
 			},
 			"addresses": [
 				{
@@ -41,7 +41,7 @@
 			"name": "Mottaker AS",
 			"tax_id": {
 				"country": "NO",
-				"code": "987654325"
+				"code": "987654325MVA"
 			},
 			"addresses": [
 				{

--- a/examples/no/out/invoice-no-multi-rate.json
+++ b/examples/no/out/invoice-no-multi-rate.json
@@ -4,7 +4,7 @@
 		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
 		"dig": {
 			"alg": "sha256",
-			"val": "c8e62e8385dcc752dd76836a8b93fb03e713737541c886cf1e1b946bcbfa420a"
+			"val": "7014cb292d5c8a09d179dfb1fd9123a752c4140b87956486e57957d48610d15b"
 		}
 	},
 	"doc": {
@@ -20,7 +20,7 @@
 			"name": "Reisebyrå AS",
 			"tax_id": {
 				"country": "NO",
-				"code": "923456783"
+				"code": "923456783MVA"
 			},
 			"addresses": [
 				{
@@ -35,7 +35,7 @@
 			"name": "Mottaker AS",
 			"tax_id": {
 				"country": "NO",
-				"code": "987654325"
+				"code": "987654325MVA"
 			},
 			"addresses": [
 				{

--- a/examples/no/out/invoice-no-simplified.json
+++ b/examples/no/out/invoice-no-simplified.json
@@ -4,7 +4,7 @@
 		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
 		"dig": {
 			"alg": "sha256",
-			"val": "68a205e6cff7a6e62f55fd8ef6f8df207d635cf1aac91447329ad9a8e988b4bb"
+			"val": "a90506df6a69a7a44f126b96bda08f2928d8ce0a2c9575d831c438109b23db0e"
 		}
 	},
 	"doc": {
@@ -24,7 +24,7 @@
 			"name": "Eksempel AS",
 			"tax_id": {
 				"country": "NO",
-				"code": "923456783"
+				"code": "923456783MVA"
 			}
 		},
 		"lines": [

--- a/examples/no/out/invoice-no-standard.json
+++ b/examples/no/out/invoice-no-standard.json
@@ -4,7 +4,7 @@
 		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
 		"dig": {
 			"alg": "sha256",
-			"val": "2f05cf922e557829992557bad25d26828f7f76f2b2faad3a9decfd1fdc14deaf"
+			"val": "e877ffbe3ed399c6335c915738a05a23e2e31fec8ed970a043c4979b5c0ea984"
 		}
 	},
 	"doc": {
@@ -20,7 +20,7 @@
 			"name": "Eksempel AS",
 			"tax_id": {
 				"country": "NO",
-				"code": "923456783"
+				"code": "923456783MVA"
 			},
 			"addresses": [
 				{
@@ -35,7 +35,7 @@
 			"name": "Mottaker AS",
 			"tax_id": {
 				"country": "NO",
-				"code": "987654325"
+				"code": "987654325MVA"
 			},
 			"addresses": [
 				{

--- a/regimes/no/tax_identity.go
+++ b/regimes/no/tax_identity.go
@@ -18,8 +18,8 @@ func taxIdentityRules() *rules.Set {
 	return rules.For(new(tax.Identity),
 		rules.When(tax.IdentityIn(CountryCode),
 			rules.Field("code",
-				rules.AssertIfPresent("01", "invalid organisasjonsnummer",
-					is.Func("valid mod-11 org number", isValidOrgNumber),
+				rules.AssertIfPresent("01", "invalid Norwegian VAT number",
+					is.Func("valid MVA-suffixed mod-11 org number", isValidVATCode),
 				),
 			),
 		),
@@ -27,11 +27,25 @@ func taxIdentityRules() *rules.Set {
 }
 
 // normalizeTaxIdentity performs standard tax identity normalization, and then
-// removes the "MVA" suffix common in Norwegian VAT numbers
-// (e.g. "NO 923 456 783 MVA").
+// ensures the "MVA" suffix that Norwegian VAT numbers carry (e.g.
+// "NO 923 456 783 MVA"): a VAT identity given as a bare organisation number
+// gains the suffix, so the serialized form is always NO<orgnr>MVA as the
+// EHF and Peppol national rules require.
 func normalizeTaxIdentity(tID *tax.Identity) {
 	tax.NormalizeIdentity(tID)
-	tID.Code = cbc.Code(strings.TrimSuffix(string(tID.Code), "MVA"))
+	if tID.Code != "" && !strings.HasSuffix(string(tID.Code), "MVA") {
+		tID.Code += "MVA"
+	}
+}
+
+// isValidVATCode reports whether the value is a valid Norwegian VAT number
+// code: a mod-11 organisation number followed by the "MVA" suffix.
+func isValidVATCode(value any) bool {
+	code, ok := value.(cbc.Code)
+	if !ok || !strings.HasSuffix(string(code), "MVA") {
+		return false
+	}
+	return isValidOrgNumber(cbc.Code(strings.TrimSuffix(string(code), "MVA")))
 }
 
 // isValidOrgNumber reports whether the value is a valid Norwegian

--- a/regimes/no/tax_identity.go
+++ b/regimes/no/tax_identity.go
@@ -1,8 +1,6 @@
 package no
 
 import (
-	"strings"
-
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/rules"
 	"github.com/invopop/gobl/rules/is"
@@ -33,7 +31,7 @@ func taxIdentityRules() *rules.Set {
 // EHF and Peppol national rules require.
 func normalizeTaxIdentity(tID *tax.Identity) {
 	tax.NormalizeIdentity(tID)
-	if tID.Code != "" && !strings.HasSuffix(string(tID.Code), "MVA") {
+	if tID.Code != "" && !tID.Code.HasSuffix("MVA") {
 		tID.Code += "MVA"
 	}
 }
@@ -42,10 +40,10 @@ func normalizeTaxIdentity(tID *tax.Identity) {
 // code: a mod-11 organisation number followed by the "MVA" suffix.
 func isValidVATCode(value any) bool {
 	code, ok := value.(cbc.Code)
-	if !ok || !strings.HasSuffix(string(code), "MVA") {
+	if !ok || !code.HasSuffix("MVA") {
 		return false
 	}
-	return isValidOrgNumber(cbc.Code(strings.TrimSuffix(string(code), "MVA")))
+	return isValidOrgNumber(code.TrimSuffix("MVA"))
 }
 
 // isValidOrgNumber reports whether the value is a valid Norwegian

--- a/regimes/no/tax_identity.go
+++ b/regimes/no/tax_identity.go
@@ -7,6 +7,8 @@ import (
 	"github.com/invopop/gobl/tax"
 )
 
+const vatIDSuffix cbc.Code = "MVA"
+
 // taxCodeWeights are the mod-11 multipliers for Norwegian organisasjonsnummer
 // validation, as specified by Brønnøysundregistrene.
 // See: https://www.brreg.no/en/about-us-2/our-registers/about-the-central-coordinating-register-for-legal-entities-ccr/about-the-organisation-number/
@@ -31,8 +33,8 @@ func taxIdentityRules() *rules.Set {
 // EHF and Peppol national rules require.
 func normalizeTaxIdentity(tID *tax.Identity) {
 	tax.NormalizeIdentity(tID)
-	if tID.Code != "" && !tID.Code.HasSuffix("MVA") {
-		tID.Code += "MVA"
+	if tID.Code != "" && !tID.Code.HasSuffix(vatIDSuffix) {
+		tID.Code += vatIDSuffix
 	}
 }
 
@@ -40,10 +42,10 @@ func normalizeTaxIdentity(tID *tax.Identity) {
 // code: a mod-11 organisation number followed by the "MVA" suffix.
 func isValidVATCode(value any) bool {
 	code, ok := value.(cbc.Code)
-	if !ok || !code.HasSuffix("MVA") {
+	if !ok || !code.HasSuffix(vatIDSuffix) {
 		return false
 	}
-	return isValidOrgNumber(code.TrimSuffix("MVA"))
+	return isValidOrgNumber(code.TrimSuffix(vatIDSuffix))
 }
 
 // isValidOrgNumber reports whether the value is a valid Norwegian

--- a/regimes/no/tax_identity_test.go
+++ b/regimes/no/tax_identity_test.go
@@ -25,6 +25,8 @@ func TestNormalizeTaxIdentity(t *testing.T) {
 		{name: "spaces only", input: "923 456 783", expected: "923456783MVA"},
 		{name: "with dashes", input: "923-456-783", expected: "923456783MVA"},
 		{name: "prefix only", input: "NO923456783", expected: "923456783MVA"},
+		{name: "unrecognised code also gains the suffix", input: "ABC123", expected: "ABC123MVA"},
+		{name: "already double-suffixed left as typed", input: "923456783MVAMVA", expected: "923456783MVAMVA"},
 		{name: "empty code", input: "", expected: ""},
 	}
 
@@ -49,6 +51,7 @@ func TestValidateTaxIdentity(t *testing.T) {
 		{name: "valid code not starting with 8 or 9", code: "123456785MVA", valid: true},
 		{name: "empty code", code: "", valid: true},
 		{name: "missing MVA suffix", code: "923456783"},
+		{name: "double suffix", code: "923456783MVAMVA"},
 		{name: "too short", code: "92345678MVA"},
 		{name: "too long", code: "9234567830MVA"},
 		{name: "non-numeric", code: "92345678AMVA"},

--- a/regimes/no/tax_identity_test.go
+++ b/regimes/no/tax_identity_test.go
@@ -18,13 +18,13 @@ func TestNormalizeTaxIdentity(t *testing.T) {
 		input    cbc.Code
 		expected cbc.Code
 	}{
-		{name: "already normalized", input: "923456783", expected: "923456783"},
-		{name: "with prefix and suffix", input: "NO 923 456 783 MVA", expected: "923456783"},
-		{name: "lowercase prefix", input: "no923456783mva", expected: "923456783"},
-		{name: "spaces only", input: "923 456 783", expected: "923456783"},
-		{name: "with dashes", input: "923-456-783", expected: "923456783"},
-		{name: "prefix only", input: "NO923456783", expected: "923456783"},
-		{name: "suffix only", input: "923456783MVA", expected: "923456783"},
+		{name: "already normalized", input: "923456783MVA", expected: "923456783MVA"},
+		{name: "bare org number gains the suffix", input: "923456783", expected: "923456783MVA"},
+		{name: "with prefix and suffix", input: "NO 923 456 783 MVA", expected: "923456783MVA"},
+		{name: "lowercase prefix and suffix", input: "no923456783mva", expected: "923456783MVA"},
+		{name: "spaces only", input: "923 456 783", expected: "923456783MVA"},
+		{name: "with dashes", input: "923-456-783", expected: "923456783MVA"},
+		{name: "prefix only", input: "NO923456783", expected: "923456783MVA"},
 		{name: "empty code", input: "", expected: ""},
 	}
 
@@ -44,16 +44,17 @@ func TestValidateTaxIdentity(t *testing.T) {
 		code  cbc.Code
 		valid bool
 	}{
-		{name: "valid code", code: "923456783", valid: true},
-		{name: "valid code starting with 8", code: "889640782", valid: true},
-		{name: "valid code not starting with 8 or 9", code: "123456785", valid: true},
+		{name: "valid code", code: "923456783MVA", valid: true},
+		{name: "valid code starting with 8", code: "889640782MVA", valid: true},
+		{name: "valid code not starting with 8 or 9", code: "123456785MVA", valid: true},
 		{name: "empty code", code: "", valid: true},
-		{name: "too short", code: "92345678"},
-		{name: "too long", code: "9234567830"},
-		{name: "non-numeric", code: "92345678A"},
-		{name: "bad check digit", code: "923456780"},
+		{name: "missing MVA suffix", code: "923456783"},
+		{name: "too short", code: "92345678MVA"},
+		{name: "too long", code: "9234567830MVA"},
+		{name: "non-numeric", code: "92345678AMVA"},
+		{name: "bad check digit", code: "923456780MVA"},
 		// 850000000: sum = 8*3 + 5*2 = 34, 34 % 11 = 1, check = 10 → invalid
-		{name: "check digit would be 10", code: "850000000"},
+		{name: "check digit would be 10", code: "850000000MVA"},
 	}
 
 	for _, tt := range tests {
@@ -63,7 +64,7 @@ func TestValidateTaxIdentity(t *testing.T) {
 			if tt.valid {
 				assert.NoError(t, err)
 			} else if assert.Error(t, err) {
-				assert.Contains(t, err.Error(), "invalid organisasjonsnummer")
+				assert.Contains(t, err.Error(), "invalid Norwegian VAT number")
 			}
 		})
 	}


### PR DESCRIPTION
Norwegian VAT numbers take the form `NO<orgnr>MVA` — the MVA suffix is part of
the identifier, and the Peppol national rule NO-R-001 rejects supplier VAT
numbers without it ("For Norwegian suppliers, a VAT number MUST be the country
code prefix NO followed by a valid Norwegian organization number (nine numbers)
followed by the letters MVA"). The NO regime's normalizer was stripping the
suffix, so every serialized Norwegian VAT identity went out as `NO<orgnr>` and
failed validation at receiving access points (reported via support).

## Changes

- `normalizeTaxIdentity` now keeps the suffix and appends it to identities
  given as a bare organisation number, making `<orgnr>MVA` the canonical stored
  code. Serializers compose the country prefix as usual, so the wire form is
  `NO<orgnr>MVA` everywhere with no downstream changes.
- Validation requires the suffixed form (mod-11 checksum on the nine digits).
- Organisation-number identities (`org.Identity`) are unchanged — the orgnr
  itself carries no suffix.
- NO examples regenerated.

## Tests

Normalization table covers bare, suffixed, lowercase, spaced, dashed and
NO-prefixed inputs; validation rejects bad checksums, wrong lengths,
double-suffixed and non-numeric codes. Verified end-to-end against the Peppol
2025.5 schematron (phive): invoices and credit notes with the suffixed form
pass; the previous stripped form fails NO-R-001 fatally. Full suite and
`mage check` green.


## Pre-Review Checklist

- [x] Opened this PR as a draft
- [x] Read the CONTRIBUTING.md guide.
- [x] Performed a self-review of my code.
- [x] Added thorough tests with at **least** 90% code coverage.
- [x] Modified or created example GOBL documents to show my changes in use, if appropriate.
- [x] Added links to the source of the changes in tax regimes or addons, either structured or in the comments.
- [x] Run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [x] Reviewed and fixed all linter warnings.
- [x] Been obsessive with pointer nil checks to avoid panics.
- [x] Updated the CHANGELOG.md with an overview of my changes.
- [x] Marked this PR as ready for review.

And if you are part of the org:
- [x] Requested a review from Copilot and fixed or dismissed (with a reason) all the feedback raised.
- [x] Requested a review from @samlown.
