### PR TITLE
Add Luxembourg (LU) tax regime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 - `org`: new `Attribute` model with `Item.Attributes` for named item features such as color or size (EN 16931 BG-32). Attributes replace the previous practice of mapping `Item.Meta` into output formats — meta is internal-only data. Each attribute is identified by a `key` or `type` and holds exactly one of a `text`, `code`, `amount` (with optional `unit`), or `date` value. Standard keys cover physical properties of the item, dates, nutritional declarations, and CO2e emissions. Item attribute keys must be unique.
 - `org`: `kj` (kilojoule) and `kcal` (kilocalorie) units.
+- `regimes/lu`: new tax regime for Luxembourg, with full VAT rate history (including the temporary 2023 rate reduction), mod-89 TVA number validation, and RCS company-registry identities.
 
 ### Changed
 

--- a/data/regimes/lu.json
+++ b/data/regimes/lu.json
@@ -6,7 +6,7 @@
     "lb": "Lëtzebuerg"
   },
   "description": {
-    "en": "Luxembourg applies VAT (Taxe sur la Valeur Ajoutée, TVA) administered by\nthe Administration de l'Enregistrement, des Domaines et de la TVA (AED).\nAs an EU member state, Luxembourg follows the EU VAT Directive 2006/112/EC.\n\nLuxembourg has four non-zero VAT rates: a standard rate, an intermediate\n(\"parking\") rate, a reduced rate, and a super-reduced rate. A temporary\none-percentage-point reduction was applied across all rates throughout 2023\nas a cost-of-living measure, before the rates were restored to their\npre-2023 levels on 1 January 2024.\n\nBusinesses are identified by their TVA number (LU followed by 8 digits,\nwhere the last two digits are a mod-89 check code) and optionally by their\ncompany registration number (RCS number) from the Registre de Commerce et\ndes Sociétés.",
+    "en": "Luxembourg applies VAT (Taxe sur la Valeur Ajoutée, TVA) administered by\nthe Administration de l'Enregistrement, des Domaines et de la TVA (AED).\nAs an EU member state, Luxembourg follows the EU VAT Directive 2006/112/EC.\n\nLuxembourg has four non-zero VAT rates: a standard rate, an intermediate\n(\"parking\") rate, a reduced rate, and a super-reduced rate. A temporary\none-percentage-point reduction applied to the standard, intermediate, and\nreduced rates throughout 2023 as a cost-of-living measure (Law of 26\nOctober 2022), before the rates were restored to their pre-2023 levels\non 1 January 2024.\n\nBusinesses are identified by their TVA number (LU followed by 8 digits,\nwhere the last two digits are a mod-89 check code) and optionally by their\ncompany registration number (RCS number) from the Registre de Commerce et\ndes Sociétés.",
     "fr": "Le Luxembourg applique la TVA (Taxe sur la Valeur Ajoutée) administrée par\nl'Administration de l'Enregistrement, des Domaines et de la TVA (AED).\nEn tant qu'État membre de l'UE, le Luxembourg suit la Directive TVA\n2006/112/CE."
   },
   "sources": [
@@ -223,7 +223,7 @@
           },
           "values": [
             {
-              "since": "2015-01-01",
+              "since": "1992-01-01",
               "percent": "3.0%"
             }
           ]
@@ -239,10 +239,10 @@
         },
         {
           "title": {
-            "en": "Law of 30 November 2022 – Temporary rate reduction",
-            "fr": "Loi du 30 novembre 2022 – Réduction temporaire des taux"
+            "en": "Law of 26 October 2022 – Temporary rate reduction",
+            "fr": "Loi du 26 octobre 2022 – Réduction temporaire des taux"
           },
-          "url": "https://www.legilux.public.lu/eli/etat/leg/loi/2022/11/30/a559/jo"
+          "url": "https://legilux.public.lu/eli/etat/leg/loi/2022/10/26/a534/jo"
         },
         {
           "title": {

--- a/data/regimes/lu.json
+++ b/data/regimes/lu.json
@@ -1,0 +1,263 @@
+{
+  "$schema": "https://gobl.org/draft-0/tax/regime-def",
+  "name": {
+    "en": "Luxembourg",
+    "fr": "Luxembourg",
+    "lb": "Lëtzebuerg"
+  },
+  "description": {
+    "en": "Luxembourg applies VAT (Taxe sur la Valeur Ajoutée, TVA) administered by\nthe Administration de l'Enregistrement, des Domaines et de la TVA (AED).\nAs an EU member state, Luxembourg follows the EU VAT Directive 2006/112/EC.\n\nLuxembourg has four non-zero VAT rates: a standard rate, an intermediate\n(\"parking\") rate, a reduced rate, and a super-reduced rate. A temporary\none-percentage-point reduction was applied across all rates throughout 2023\nas a cost-of-living measure, before the rates were restored to their\npre-2023 levels on 1 January 2024.\n\nBusinesses are identified by their TVA number (LU followed by 8 digits,\nwhere the last two digits are a mod-89 check code) and optionally by their\ncompany registration number (RCS number) from the Registre de Commerce et\ndes Sociétés.",
+    "fr": "Le Luxembourg applique la TVA (Taxe sur la Valeur Ajoutée) administrée par\nl'Administration de l'Enregistrement, des Domaines et de la TVA (AED).\nEn tant qu'État membre de l'UE, le Luxembourg suit la Directive TVA\n2006/112/CE."
+  },
+  "sources": [
+    {
+      "title": {
+        "en": "AED – VAT rates",
+        "fr": "AED – Taux de TVA"
+      },
+      "url": "https://www.aed.public.lu/en/tva/taux-tva.html"
+    }
+  ],
+  "time_zone": "Europe/Luxembourg",
+  "country": "LU",
+  "currency": "EUR",
+  "tax_scheme": "VAT",
+  "identities": [
+    {
+      "code": "RCS",
+      "name": {
+        "en": "RCS Number",
+        "fr": "Numéro RCS",
+        "lb": "RCS-Nummer"
+      },
+      "desc": {
+        "en": "Luxembourg company registration number assigned by the Luxembourg Business Registers (LBR).",
+        "fr": "Numéro d'immatriculation au Registre de Commerce et des Sociétés attribué par le Registre luxembourgeois des entreprises."
+      }
+    }
+  ],
+  "corrections": [
+    {
+      "schema": "bill/invoice",
+      "types": [
+        "credit-note",
+        "debit-note"
+      ]
+    }
+  ],
+  "categories": [
+    {
+      "code": "VAT",
+      "name": {
+        "en": "VAT",
+        "fr": "TVA",
+        "lb": "TVA"
+      },
+      "title": {
+        "en": "Value Added Tax",
+        "fr": "Taxe sur la Valeur Ajoutée",
+        "lb": "Taxe sur la Valeur Ajoutée"
+      },
+      "keys": [
+        {
+          "key": "standard",
+          "name": {
+            "en": "Standard"
+          }
+        },
+        {
+          "key": "zero",
+          "name": {
+            "en": "Zero"
+          }
+        },
+        {
+          "key": "reverse-charge",
+          "name": {
+            "en": "Reverse charge"
+          },
+          "no_percent": true
+        },
+        {
+          "key": "exempt",
+          "name": {
+            "en": "Exempt"
+          },
+          "no_percent": true
+        },
+        {
+          "key": "export",
+          "name": {
+            "en": "Export"
+          },
+          "no_percent": true
+        },
+        {
+          "key": "intra-community",
+          "name": {
+            "en": "Intra-community"
+          },
+          "no_percent": true
+        },
+        {
+          "key": "outside-scope",
+          "name": {
+            "en": "Outside scope"
+          },
+          "no_percent": true
+        }
+      ],
+      "rates": [
+        {
+          "rate": "general",
+          "keys": [
+            "standard"
+          ],
+          "name": {
+            "en": "Standard Rate",
+            "fr": "Taux normal",
+            "lb": "Normalsaz"
+          },
+          "desc": {
+            "en": "General rate applicable to most goods and services.",
+            "fr": "Taux applicable à la plupart des biens et services."
+          },
+          "values": [
+            {
+              "since": "2024-01-01",
+              "percent": "17.0%"
+            },
+            {
+              "since": "2023-01-01",
+              "percent": "16.0%"
+            },
+            {
+              "since": "2015-01-01",
+              "percent": "17.0%"
+            },
+            {
+              "since": "1992-01-01",
+              "percent": "15.0%"
+            }
+          ]
+        },
+        {
+          "rate": "intermediate",
+          "keys": [
+            "standard"
+          ],
+          "name": {
+            "en": "Intermediate Rate",
+            "fr": "Taux intermédiaire",
+            "lb": "Taux intermédiaire"
+          },
+          "desc": {
+            "en": "Applies to wine, certain fuels, printed advertising material, and similar goods (EU parking rate).",
+            "fr": "Applicable aux vins, certains combustibles, imprimés publicitaires et biens similaires (taux parking UE)."
+          },
+          "values": [
+            {
+              "since": "2024-01-01",
+              "percent": "14.0%"
+            },
+            {
+              "since": "2023-01-01",
+              "percent": "13.0%"
+            },
+            {
+              "since": "2015-01-01",
+              "percent": "14.0%"
+            },
+            {
+              "since": "1992-01-01",
+              "percent": "12.0%"
+            }
+          ]
+        },
+        {
+          "rate": "reduced",
+          "keys": [
+            "standard"
+          ],
+          "name": {
+            "en": "Reduced Rate",
+            "fr": "Taux réduit",
+            "lb": "Reduzéierter Saz"
+          },
+          "desc": {
+            "en": "Applies to food, non-alcoholic beverages, pharmaceuticals, books, newspapers, water, and passenger transport.",
+            "fr": "Applicable aux denrées alimentaires, boissons non alcoolisées, médicaments, livres, journaux, eau et transport de personnes."
+          },
+          "values": [
+            {
+              "since": "2024-01-01",
+              "percent": "8.0%"
+            },
+            {
+              "since": "2023-01-01",
+              "percent": "7.0%"
+            },
+            {
+              "since": "2015-01-01",
+              "percent": "8.0%"
+            },
+            {
+              "since": "1992-01-01",
+              "percent": "6.0%"
+            }
+          ]
+        },
+        {
+          "rate": "super-reduced",
+          "keys": [
+            "standard"
+          ],
+          "name": {
+            "en": "Super-reduced Rate",
+            "fr": "Taux super-réduit",
+            "lb": "Super-reduzéierter Saz"
+          },
+          "desc": {
+            "en": "Applies to certain pharmaceutical products, footwear and clothing for children, social housing, natural gas, and electricity.",
+            "fr": "Applicable à certains médicaments, chaussures et vêtements pour enfants, logements sociaux, gaz naturel et électricité."
+          },
+          "values": [
+            {
+              "since": "2015-01-01",
+              "percent": "3.0%"
+            }
+          ]
+        }
+      ],
+      "sources": [
+        {
+          "title": {
+            "en": "AED – VAT rates",
+            "fr": "AED – Taux de TVA"
+          },
+          "url": "https://www.aed.public.lu/en/tva/taux-tva.html"
+        },
+        {
+          "title": {
+            "en": "Law of 30 November 2022 – Temporary rate reduction",
+            "fr": "Loi du 30 novembre 2022 – Réduction temporaire des taux"
+          },
+          "url": "https://www.legilux.public.lu/eli/etat/leg/loi/2022/11/30/a559/jo"
+        },
+        {
+          "title": {
+            "en": "Law of 19 December 2014 – Rate increase to current levels",
+            "fr": "Loi du 19 décembre 2014 – Augmentation des taux"
+          },
+          "url": "https://www.legilux.public.lu/eli/etat/leg/loi/2014/12/19/n1/jo"
+        },
+        {
+          "title": {
+            "en": "European Commission – VAT rates"
+          },
+          "url": "https://taxation-customs.ec.europa.eu/taxation/vat/eu-vat-rules/vat-rates_en"
+        }
+      ]
+    }
+  ]
+}

--- a/data/rules/lu.json
+++ b/data/rules/lu.json
@@ -66,8 +66,8 @@
               "assert": [
                 {
                   "id": "GOBL-LU-BILL-INVOICE-01",
-                  "desc": "invoice LU supplier must have either a TVA tax ID code or an identity of type 'RCS'",
-                  "tests": "has TVA code or RCS identity"
+                  "desc": "invoice LU supplier must have a TVA tax ID code or an RCS identity",
+                  "tests": "has TVA tax ID code, or has RCS identity"
                 }
               ]
             }

--- a/data/rules/lu.json
+++ b/data/rules/lu.json
@@ -1,0 +1,79 @@
+{
+  "id": "GOBL-LU",
+  "package": "lu",
+  "subsets": [
+    {
+      "id": "GOBL-LU-TAX-IDENTITY",
+      "object": "tax.Identity",
+      "subsets": [
+        {
+          "guard": "code in [LU]",
+          "subsets": [
+            {
+              "field": "code",
+              "subsets": [
+                {
+                  "guard": "present",
+                  "assert": [
+                    {
+                      "id": "GOBL-LU-TAX-IDENTITY-01",
+                      "desc": "invalid Luxembourg TVA number",
+                      "tests": "valid mod-89 TVA code"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "GOBL-LU-ORG-IDENTITY",
+      "object": "org.Identity",
+      "subsets": [
+        {
+          "guard": "context: regime in [LU]",
+          "subsets": [
+            {
+              "guard": "type in [RCS]",
+              "subsets": [
+                {
+                  "field": "code",
+                  "assert": [
+                    {
+                      "id": "GOBL-LU-ORG-IDENTITY-01",
+                      "desc": "invalid RCS number",
+                      "tests": "valid RCS format"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "GOBL-LU-BILL-INVOICE",
+      "object": "bill.Invoice",
+      "subsets": [
+        {
+          "guard": "context: regime in [LU]",
+          "subsets": [
+            {
+              "field": "supplier",
+              "assert": [
+                {
+                  "id": "GOBL-LU-BILL-INVOICE-01",
+                  "desc": "invoice LU supplier must have either a TVA tax ID code or an identity of type 'RCS'",
+                  "tests": "has TVA code or RCS identity"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/data/rules/lu.json
+++ b/data/rules/lu.json
@@ -17,8 +17,28 @@
                   "assert": [
                     {
                       "id": "GOBL-LU-TAX-IDENTITY-01",
-                      "desc": "invalid Luxembourg TVA number",
-                      "tests": "valid mod-89 TVA code"
+                      "desc": "Luxembourg TVA number must be exactly 8 digits",
+                      "tests": "length between 8 and 8"
+                    }
+                  ]
+                },
+                {
+                  "guard": "present",
+                  "assert": [
+                    {
+                      "id": "GOBL-LU-TAX-IDENTITY-02",
+                      "desc": "Luxembourg TVA number must contain only digits",
+                      "tests": "digit"
+                    }
+                  ]
+                },
+                {
+                  "guard": "present",
+                  "assert": [
+                    {
+                      "id": "GOBL-LU-TAX-IDENTITY-03",
+                      "desc": "invalid Luxembourg TVA number: mod-89 checksum mismatch",
+                      "tests": "valid mod-89 checksum"
                     }
                   ]
                 }
@@ -44,7 +64,7 @@
                     {
                       "id": "GOBL-LU-ORG-IDENTITY-01",
                       "desc": "invalid RCS number",
-                      "tests": "valid RCS format"
+                      "tests": "matches ^[A-Z]\\d{1,6}$"
                     }
                   ]
                 }
@@ -63,11 +83,21 @@
           "subsets": [
             {
               "field": "supplier",
-              "assert": [
+              "subsets": [
                 {
-                  "id": "GOBL-LU-BILL-INVOICE-01",
-                  "desc": "invoice LU supplier must have a TVA tax ID code or an RCS identity",
-                  "tests": "has TVA tax ID code, or has RCS identity"
+                  "guard": "supplier has no TVA tax ID code",
+                  "subsets": [
+                    {
+                      "field": "identities",
+                      "assert": [
+                        {
+                          "id": "GOBL-LU-BILL-INVOICE-01",
+                          "desc": "invoice LU supplier without TVA tax ID code must have an RCS identity",
+                          "tests": "type in [RCS]"
+                        }
+                      ]
+                    }
+                  ]
                 }
               ]
             }

--- a/data/schemas/tax/regime-code.json
+++ b/data/schemas/tax/regime-code.json
@@ -78,6 +78,10 @@
           "title": "Italy"
         },
         {
+          "const": "LU",
+          "title": "Luxembourg"
+        },
+        {
           "const": "MX",
           "title": "Mexico"
         },

--- a/examples/lu/credit-note-lu.yaml
+++ b/examples/lu/credit-note-lu.yaml
@@ -1,0 +1,48 @@
+$schema: https://gobl.org/draft-0/bill/invoice
+$regime: "LU"
+uuid: "9d0e1f2a-3b4c-5d6e-7f8a-9b0c1d2e3f4a"
+type: credit-note
+currency: EUR
+series: "2024"
+code: "0001"
+issue_date: "2024-07-01"
+
+# Corrects invoice 2024/0001 issued on 2024-06-15 (full reversal of 2 lines)
+preceding:
+  - code: "2024/0001"
+    issue_date: "2024-06-15"
+
+supplier:
+  name: Acme Luxembourg S.A.
+  tax_id:
+    country: "LU"
+    # 263752 mod 89 = 45
+    code: "26375245"
+  identities:
+    - type: RCS
+      code: "B263475"
+  addresses:
+    - street: 14 Rue Erasme
+      locality: Luxembourg
+      code: "1468"
+      country: "LU"
+
+customer:
+  name: GlobalTech Solutions NV
+  tax_id:
+    country: "BE"
+    code: "0413172884"
+  addresses:
+    - street: Keizersgracht 123
+      locality: Brussels
+      code: "1000"
+      country: "BE"
+
+lines:
+  - quantity: "3"
+    item:
+      name: Software consulting services (returned hours)
+      price: "2500.00"
+    taxes:
+      - cat: VAT
+        rate: standard

--- a/examples/lu/invoice-lu-2023-reduced.yaml
+++ b/examples/lu/invoice-lu-2023-reduced.yaml
@@ -1,0 +1,53 @@
+$schema: https://gobl.org/draft-0/bill/invoice
+$regime: "LU"
+uuid: "2b3c4d5e-6f7a-8b9c-0d1e-2f3a4b5c6d7e"
+currency: EUR
+series: "2023"
+code: "0015"
+# Dated within 2023: GOBL applies the temporary reduced rates in effect that year
+# (standard 16%, intermediate 13%, reduced 7%, super-reduced 3%) per the
+# Law of 30 November 2022 (Mémorial A No. 559 of 1 December 2022).
+issue_date: "2023-06-15"
+
+supplier:
+  name: Acme Luxembourg S.A.
+  tax_id:
+    country: "LU"
+    # 263752 mod 89 = 45
+    code: "26375245"
+  identities:
+    - type: RCS
+      code: "B263475"
+  addresses:
+    - street: 14 Rue Erasme
+      locality: Luxembourg
+      code: "1468"
+      country: "LU"
+
+customer:
+  name: Entreprise Martin S.à r.l.
+  tax_id:
+    country: "LU"
+    # 123456 mod 89 = 13
+    code: "12345613"
+  addresses:
+    - street: 5 Boulevard Royal
+      locality: Luxembourg
+      code: "2449"
+      country: "LU"
+
+lines:
+  - quantity: "5"
+    item:
+      name: Legal advisory services
+      price: "4000.00"
+    taxes:
+      - cat: VAT
+        rate: standard
+  - quantity: "50"
+    item:
+      name: Still water (1L)
+      price: "1.80"
+    taxes:
+      - cat: VAT
+        rate: reduced

--- a/examples/lu/invoice-lu-2023-reduced.yaml
+++ b/examples/lu/invoice-lu-2023-reduced.yaml
@@ -5,8 +5,8 @@ currency: EUR
 series: "2023"
 code: "0015"
 # Dated within 2023: GOBL applies the temporary reduced rates in effect that year
-# (standard 16%, intermediate 13%, reduced 7%, super-reduced 3%) per the
-# Law of 30 November 2022 (Mémorial A No. 559 of 1 December 2022).
+# (standard 16%, intermediate 13%, reduced 7%; the super-reduced 3% rate was
+# unaffected) per the Law of 26 October 2022 (Mémorial A No. 534).
 issue_date: "2023-06-15"
 
 supplier:

--- a/examples/lu/invoice-lu-multi-rate.yaml
+++ b/examples/lu/invoice-lu-multi-rate.yaml
@@ -1,0 +1,57 @@
+$schema: https://gobl.org/draft-0/bill/invoice
+$regime: "LU"
+uuid: "7a8b9c0d-1e2f-3a4b-5c6d-7e8f9a0b1c2d"
+currency: EUR
+series: "2024"
+code: "0002"
+issue_date: "2024-09-20"
+
+supplier:
+  name: Acme Luxembourg S.A.
+  tax_id:
+    country: "LU"
+    # 263752 mod 89 = 45
+    code: "26375245"
+  identities:
+    - type: RCS
+      code: "B263475"
+  addresses:
+    - street: 14 Rue Erasme
+      locality: Luxembourg
+      code: "1468"
+      country: "LU"
+
+customer:
+  name: Entreprise Martin S.à r.l.
+  tax_id:
+    country: "LU"
+    # 123456 mod 89 = 13
+    code: "12345613"
+  addresses:
+    - street: 5 Boulevard Royal
+      locality: Luxembourg
+      code: "2449"
+      country: "LU"
+
+lines:
+  - quantity: "8"
+    item:
+      name: IT infrastructure services
+      price: "3000.00"
+    taxes:
+      - cat: VAT
+        rate: standard
+  - quantity: "200"
+    item:
+      name: Mineral water (5L)
+      price: "2.50"
+    taxes:
+      - cat: VAT
+        rate: reduced
+  - quantity: "1"
+    item:
+      name: Children's clothing (set)
+      price: "45.00"
+    taxes:
+      - cat: VAT
+        rate: super-reduced

--- a/examples/lu/invoice-lu-standard.yaml
+++ b/examples/lu/invoice-lu-standard.yaml
@@ -1,0 +1,49 @@
+$schema: https://gobl.org/draft-0/bill/invoice
+$regime: "LU"
+uuid: "3c4e1f2a-9b7d-4e5c-8a1b-6f0e2d3c4b5a"
+currency: EUR
+series: "2024"
+code: "0001"
+issue_date: "2024-06-15"
+
+supplier:
+  name: Acme Luxembourg S.A.
+  tax_id:
+    country: "LU"
+    # 263752 mod 89 = 45
+    code: "26375245"
+  identities:
+    - type: RCS
+      code: "B263475"
+  addresses:
+    - street: 14 Rue Erasme
+      locality: Luxembourg
+      code: "1468"
+      country: "LU"
+
+customer:
+  name: GlobalTech Solutions NV
+  tax_id:
+    country: "BE"
+    code: "0413172884"
+  addresses:
+    - street: Keizersgracht 123
+      locality: Brussels
+      code: "1000"
+      country: "BE"
+
+lines:
+  - quantity: "10"
+    item:
+      name: Software consulting services
+      price: "2500.00"
+    taxes:
+      - cat: VAT
+        rate: standard
+  - quantity: "5"
+    item:
+      name: Project management
+      price: "1800.00"
+    taxes:
+      - cat: VAT
+        rate: standard

--- a/examples/lu/out/credit-note-lu.json
+++ b/examples/lu/out/credit-note-lu.json
@@ -1,0 +1,106 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
+		"dig": {
+			"alg": "sha256",
+			"val": "3333b841e94cbcb4834d9bef7bd32272b675d7d82eb929a9275666a25dfba12c"
+		}
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"$regime": "LU",
+		"uuid": "9d0e1f2a-3b4c-5d6e-7f8a-9b0c1d2e3f4a",
+		"type": "credit-note",
+		"series": "2024",
+		"code": "0001",
+		"issue_date": "2024-07-01",
+		"currency": "EUR",
+		"preceding": [
+			{
+				"issue_date": "2024-06-15",
+				"code": "2024/0001"
+			}
+		],
+		"supplier": {
+			"name": "Acme Luxembourg S.A.",
+			"tax_id": {
+				"country": "LU",
+				"code": "26375245"
+			},
+			"identities": [
+				{
+					"type": "RCS",
+					"code": "B263475"
+				}
+			],
+			"addresses": [
+				{
+					"street": "14 Rue Erasme",
+					"locality": "Luxembourg",
+					"code": "1468",
+					"country": "LU"
+				}
+			]
+		},
+		"customer": {
+			"name": "GlobalTech Solutions NV",
+			"tax_id": {
+				"country": "BE",
+				"code": "0413172884"
+			},
+			"addresses": [
+				{
+					"street": "Keizersgracht 123",
+					"locality": "Brussels",
+					"code": "1000",
+					"country": "BE"
+				}
+			]
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "3",
+				"item": {
+					"name": "Software consulting services (returned hours)",
+					"price": "2500.00"
+				},
+				"sum": "7500.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "general",
+						"percent": "17.0%"
+					}
+				],
+				"total": "7500.00"
+			}
+		],
+		"totals": {
+			"sum": "7500.00",
+			"total": "7500.00",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"base": "7500.00",
+								"percent": "17.0%",
+								"amount": "1275.00"
+							}
+						],
+						"amount": "1275.00"
+					}
+				],
+				"sum": "1275.00"
+			},
+			"tax": "1275.00",
+			"total_with_tax": "8775.00",
+			"payable": "8775.00"
+		}
+	}
+}

--- a/examples/lu/out/invoice-lu-2023-reduced.json
+++ b/examples/lu/out/invoice-lu-2023-reduced.json
@@ -1,0 +1,124 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
+		"dig": {
+			"alg": "sha256",
+			"val": "10806af504448415db3f39f856027d65ca06a62d5bada30713eea87246b58a48"
+		}
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"$regime": "LU",
+		"uuid": "2b3c4d5e-6f7a-8b9c-0d1e-2f3a4b5c6d7e",
+		"type": "standard",
+		"series": "2023",
+		"code": "0015",
+		"issue_date": "2023-06-15",
+		"currency": "EUR",
+		"supplier": {
+			"name": "Acme Luxembourg S.A.",
+			"tax_id": {
+				"country": "LU",
+				"code": "26375245"
+			},
+			"identities": [
+				{
+					"type": "RCS",
+					"code": "B263475"
+				}
+			],
+			"addresses": [
+				{
+					"street": "14 Rue Erasme",
+					"locality": "Luxembourg",
+					"code": "1468",
+					"country": "LU"
+				}
+			]
+		},
+		"customer": {
+			"name": "Entreprise Martin S.à r.l.",
+			"tax_id": {
+				"country": "LU",
+				"code": "12345613"
+			},
+			"addresses": [
+				{
+					"street": "5 Boulevard Royal",
+					"locality": "Luxembourg",
+					"code": "2449",
+					"country": "LU"
+				}
+			]
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "5",
+				"item": {
+					"name": "Legal advisory services",
+					"price": "4000.00"
+				},
+				"sum": "20000.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "general",
+						"percent": "16.0%"
+					}
+				],
+				"total": "20000.00"
+			},
+			{
+				"i": 2,
+				"quantity": "50",
+				"item": {
+					"name": "Still water (1L)",
+					"price": "1.80"
+				},
+				"sum": "90.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "reduced",
+						"percent": "7.0%"
+					}
+				],
+				"total": "90.00"
+			}
+		],
+		"totals": {
+			"sum": "20090.00",
+			"total": "20090.00",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"base": "20000.00",
+								"percent": "16.0%",
+								"amount": "3200.00"
+							},
+							{
+								"key": "standard",
+								"base": "90.00",
+								"percent": "7.0%",
+								"amount": "6.30"
+							}
+						],
+						"amount": "3206.30"
+					}
+				],
+				"sum": "3206.30"
+			},
+			"tax": "3206.30",
+			"total_with_tax": "23296.30",
+			"payable": "23296.30"
+		}
+	}
+}

--- a/examples/lu/out/invoice-lu-multi-rate.json
+++ b/examples/lu/out/invoice-lu-multi-rate.json
@@ -1,0 +1,148 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
+		"dig": {
+			"alg": "sha256",
+			"val": "231204063b9b6855ff92ccd69b9d87176a0874edc3eb39c0ed83fdc6651973a0"
+		}
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"$regime": "LU",
+		"uuid": "7a8b9c0d-1e2f-3a4b-5c6d-7e8f9a0b1c2d",
+		"type": "standard",
+		"series": "2024",
+		"code": "0002",
+		"issue_date": "2024-09-20",
+		"currency": "EUR",
+		"supplier": {
+			"name": "Acme Luxembourg S.A.",
+			"tax_id": {
+				"country": "LU",
+				"code": "26375245"
+			},
+			"identities": [
+				{
+					"type": "RCS",
+					"code": "B263475"
+				}
+			],
+			"addresses": [
+				{
+					"street": "14 Rue Erasme",
+					"locality": "Luxembourg",
+					"code": "1468",
+					"country": "LU"
+				}
+			]
+		},
+		"customer": {
+			"name": "Entreprise Martin S.à r.l.",
+			"tax_id": {
+				"country": "LU",
+				"code": "12345613"
+			},
+			"addresses": [
+				{
+					"street": "5 Boulevard Royal",
+					"locality": "Luxembourg",
+					"code": "2449",
+					"country": "LU"
+				}
+			]
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "8",
+				"item": {
+					"name": "IT infrastructure services",
+					"price": "3000.00"
+				},
+				"sum": "24000.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "general",
+						"percent": "17.0%"
+					}
+				],
+				"total": "24000.00"
+			},
+			{
+				"i": 2,
+				"quantity": "200",
+				"item": {
+					"name": "Mineral water (5L)",
+					"price": "2.50"
+				},
+				"sum": "500.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "reduced",
+						"percent": "8.0%"
+					}
+				],
+				"total": "500.00"
+			},
+			{
+				"i": 3,
+				"quantity": "1",
+				"item": {
+					"name": "Children's clothing (set)",
+					"price": "45.00"
+				},
+				"sum": "45.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "super-reduced",
+						"percent": "3.0%"
+					}
+				],
+				"total": "45.00"
+			}
+		],
+		"totals": {
+			"sum": "24545.00",
+			"total": "24545.00",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"base": "24000.00",
+								"percent": "17.0%",
+								"amount": "4080.00"
+							},
+							{
+								"key": "standard",
+								"base": "500.00",
+								"percent": "8.0%",
+								"amount": "40.00"
+							},
+							{
+								"key": "standard",
+								"base": "45.00",
+								"percent": "3.0%",
+								"amount": "1.35"
+							}
+						],
+						"amount": "4121.35"
+					}
+				],
+				"sum": "4121.35"
+			},
+			"tax": "4121.35",
+			"total_with_tax": "28666.35",
+			"payable": "28666.35"
+		}
+	}
+}

--- a/examples/lu/out/invoice-lu-standard.json
+++ b/examples/lu/out/invoice-lu-standard.json
@@ -1,0 +1,118 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
+		"dig": {
+			"alg": "sha256",
+			"val": "c3f49ec67d7001d33ae7906154a418c49185daa2d534c36aaff6bc85f29816b6"
+		}
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"$regime": "LU",
+		"uuid": "3c4e1f2a-9b7d-4e5c-8a1b-6f0e2d3c4b5a",
+		"type": "standard",
+		"series": "2024",
+		"code": "0001",
+		"issue_date": "2024-06-15",
+		"currency": "EUR",
+		"supplier": {
+			"name": "Acme Luxembourg S.A.",
+			"tax_id": {
+				"country": "LU",
+				"code": "26375245"
+			},
+			"identities": [
+				{
+					"type": "RCS",
+					"code": "B263475"
+				}
+			],
+			"addresses": [
+				{
+					"street": "14 Rue Erasme",
+					"locality": "Luxembourg",
+					"code": "1468",
+					"country": "LU"
+				}
+			]
+		},
+		"customer": {
+			"name": "GlobalTech Solutions NV",
+			"tax_id": {
+				"country": "BE",
+				"code": "0413172884"
+			},
+			"addresses": [
+				{
+					"street": "Keizersgracht 123",
+					"locality": "Brussels",
+					"code": "1000",
+					"country": "BE"
+				}
+			]
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "10",
+				"item": {
+					"name": "Software consulting services",
+					"price": "2500.00"
+				},
+				"sum": "25000.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "general",
+						"percent": "17.0%"
+					}
+				],
+				"total": "25000.00"
+			},
+			{
+				"i": 2,
+				"quantity": "5",
+				"item": {
+					"name": "Project management",
+					"price": "1800.00"
+				},
+				"sum": "9000.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "general",
+						"percent": "17.0%"
+					}
+				],
+				"total": "9000.00"
+			}
+		],
+		"totals": {
+			"sum": "34000.00",
+			"total": "34000.00",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"base": "34000.00",
+								"percent": "17.0%",
+								"amount": "5780.00"
+							}
+						],
+						"amount": "5780.00"
+					}
+				],
+				"sum": "5780.00"
+			},
+			"tax": "5780.00",
+			"total_with_tax": "39780.00",
+			"payable": "39780.00"
+		}
+	}
+}

--- a/regimes/lu/bill_invoices.go
+++ b/regimes/lu/bill_invoices.go
@@ -16,11 +16,13 @@ func billInvoiceRules() *rules.Set {
 		rules.When(
 			is.InContext(tax.RegimeIn(l10n.LU.Tax())),
 			rules.Field("supplier",
-				rules.Assert("01",
-					"invoice LU supplier must have a TVA tax ID code or an RCS identity",
-					is.AnyOf(
-						is.Func("has TVA tax ID code", hasTaxIDCode),
-						is.Func("has RCS identity", hasRCSIdentity),
+				rules.When(
+					is.Func("supplier has no TVA tax ID code", supplierHasNoTVACode),
+					rules.Field("identities",
+						rules.Assert("01",
+							"invoice LU supplier without TVA tax ID code must have an RCS identity",
+							org.IdentityTypeIn(IdentityTypeRCS),
+						),
 					),
 				),
 			),
@@ -28,15 +30,7 @@ func billInvoiceRules() *rules.Set {
 	)
 }
 
-func hasTaxIDCode(value any) bool {
+func supplierHasNoTVACode(value any) bool {
 	party, _ := value.(*org.Party)
-	return party != nil && party.TaxID != nil && party.TaxID.Code != ""
-}
-
-func hasRCSIdentity(value any) bool {
-	party, _ := value.(*org.Party)
-	if party == nil || len(party.Identities) == 0 {
-		return false
-	}
-	return org.IdentityForType(party.Identities, IdentityTypeRCS) != nil
+	return party == nil || party.TaxID == nil || party.TaxID.Code == ""
 }

--- a/regimes/lu/bill_invoices.go
+++ b/regimes/lu/bill_invoices.go
@@ -1,8 +1,6 @@
 package lu
 
 import (
-	"fmt"
-
 	"github.com/invopop/gobl/bill"
 	"github.com/invopop/gobl/l10n"
 	"github.com/invopop/gobl/org"
@@ -11,37 +9,32 @@ import (
 	"github.com/invopop/gobl/tax"
 )
 
-// billInvoiceRules requires the supplier to carry at least one official
-// identifier. Note that the RCS number is a company-registry reference, not
-// a tax identifier: a VAT-registered supplier is still legally required to
-// state its TVA number on invoices. Accepting an RCS identity as an
-// alternative is a deliberate baseline so that businesses below the VAT
-// registration threshold (e.g. small franchised businesses) can still issue
-// valid GOBL invoices; it is not a claim of legal equivalence.
+// billInvoiceRules requires the supplier to have a TVA tax ID code or an RCS
+// identity; the latter covers businesses below the VAT registration threshold.
 func billInvoiceRules() *rules.Set {
 	return rules.For(new(bill.Invoice),
 		rules.When(
 			is.InContext(tax.RegimeIn(l10n.LU.Tax())),
 			rules.Field("supplier",
 				rules.Assert("01",
-					fmt.Sprintf("invoice LU supplier must have either a TVA tax ID code or an identity of type '%s'", IdentityTypeRCS),
-					is.Func("has TVA code or RCS identity", hasVATCodeOrRCSIdentity),
+					"invoice LU supplier must have a TVA tax ID code or an RCS identity",
+					is.AnyOf(
+						is.Func("has TVA tax ID code", hasTaxIDCode),
+						is.Func("has RCS identity", hasRCSIdentity),
+					),
 				),
 			),
 		),
 	)
 }
 
-func hasVATCodeOrRCSIdentity(value any) bool {
+func hasTaxIDCode(value any) bool {
 	party, _ := value.(*org.Party)
-	return hasTaxIDCode(party) || hasRCSIdentity(party)
-}
-
-func hasTaxIDCode(party *org.Party) bool {
 	return party != nil && party.TaxID != nil && party.TaxID.Code != ""
 }
 
-func hasRCSIdentity(party *org.Party) bool {
+func hasRCSIdentity(value any) bool {
+	party, _ := value.(*org.Party)
 	if party == nil || len(party.Identities) == 0 {
 		return false
 	}

--- a/regimes/lu/bill_invoices.go
+++ b/regimes/lu/bill_invoices.go
@@ -11,6 +11,13 @@ import (
 	"github.com/invopop/gobl/tax"
 )
 
+// billInvoiceRules requires the supplier to carry at least one official
+// identifier. Note that the RCS number is a company-registry reference, not
+// a tax identifier: a VAT-registered supplier is still legally required to
+// state its TVA number on invoices. Accepting an RCS identity as an
+// alternative is a deliberate baseline so that businesses below the VAT
+// registration threshold (e.g. small franchised businesses) can still issue
+// valid GOBL invoices; it is not a claim of legal equivalence.
 func billInvoiceRules() *rules.Set {
 	return rules.For(new(bill.Invoice),
 		rules.When(

--- a/regimes/lu/bill_invoices.go
+++ b/regimes/lu/bill_invoices.go
@@ -1,0 +1,42 @@
+package lu
+
+import (
+	"fmt"
+
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/l10n"
+	"github.com/invopop/gobl/org"
+	"github.com/invopop/gobl/rules"
+	"github.com/invopop/gobl/rules/is"
+	"github.com/invopop/gobl/tax"
+)
+
+func billInvoiceRules() *rules.Set {
+	return rules.For(new(bill.Invoice),
+		rules.When(
+			is.InContext(tax.RegimeIn(l10n.LU.Tax())),
+			rules.Field("supplier",
+				rules.Assert("01",
+					fmt.Sprintf("invoice LU supplier must have either a TVA tax ID code or an identity of type '%s'", IdentityTypeRCS),
+					is.Func("has TVA code or RCS identity", hasVATCodeOrRCSIdentity),
+				),
+			),
+		),
+	)
+}
+
+func hasVATCodeOrRCSIdentity(value any) bool {
+	party, _ := value.(*org.Party)
+	return hasTaxIDCode(party) || hasRCSIdentity(party)
+}
+
+func hasTaxIDCode(party *org.Party) bool {
+	return party != nil && party.TaxID != nil && party.TaxID.Code != ""
+}
+
+func hasRCSIdentity(party *org.Party) bool {
+	if party == nil || len(party.Identities) == 0 {
+		return false
+	}
+	return org.IdentityForType(party.Identities, IdentityTypeRCS) != nil
+}

--- a/regimes/lu/bill_invoices_test.go
+++ b/regimes/lu/bill_invoices_test.go
@@ -1,0 +1,80 @@
+package lu_test
+
+import (
+	"testing"
+
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/num"
+	"github.com/invopop/gobl/org"
+	"github.com/invopop/gobl/regimes/lu"
+	"github.com/invopop/gobl/rules"
+	"github.com/invopop/gobl/tax"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func validLUInvoice() *bill.Invoice {
+	return &bill.Invoice{
+		Regime: tax.WithRegime("LU"),
+		Series: "2024",
+		Code:   "0001",
+		Supplier: &org.Party{
+			Name: "Acme Luxembourg S.A.",
+			TaxID: &tax.Identity{
+				Country: "LU",
+				// 263752 mod 89 = 45  →  valid
+				Code: "26375245",
+			},
+		},
+		Customer: &org.Party{
+			Name: "Client International B.V.",
+		},
+		Lines: []*bill.Line{
+			{
+				Quantity: num.MakeAmount(1, 0),
+				Item: &org.Item{
+					Name:  "Software consulting",
+					Price: num.NewAmount(100000, 2),
+					Unit:  org.UnitService,
+				},
+				Taxes: tax.Set{
+					{Category: "VAT", Rate: "standard"},
+				},
+			},
+		},
+	}
+}
+
+func TestInvoiceLUValidation(t *testing.T) {
+	t.Run("valid invoice with TVA code", func(t *testing.T) {
+		inv := validLUInvoice()
+		require.NoError(t, inv.Calculate())
+		assert.NoError(t, rules.Validate(inv))
+	})
+
+	t.Run("valid invoice with RCS identity instead of TVA", func(t *testing.T) {
+		inv := validLUInvoice()
+		inv.Supplier.TaxID = nil
+		inv.Supplier.Identities = []*org.Identity{
+			{Type: lu.IdentityTypeRCS, Code: "B263475"},
+		}
+		require.NoError(t, inv.Calculate())
+		assert.NoError(t, rules.Validate(inv))
+	})
+
+	t.Run("invalid when supplier has neither TVA nor RCS", func(t *testing.T) {
+		inv := validLUInvoice()
+		inv.Supplier.TaxID = nil
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "[GOBL-LU-BILL-INVOICE-01]")
+	})
+
+	t.Run("invalid when supplier TVA code is empty and no RCS", func(t *testing.T) {
+		inv := validLUInvoice()
+		inv.Supplier.TaxID.Code = ""
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "[GOBL-LU-BILL-INVOICE-01]")
+	})
+}

--- a/regimes/lu/lu.go
+++ b/regimes/lu/lu.go
@@ -50,9 +50,10 @@ func New() *tax.RegimeDef {
 
 				Luxembourg has four non-zero VAT rates: a standard rate, an intermediate
 				("parking") rate, a reduced rate, and a super-reduced rate. A temporary
-				one-percentage-point reduction was applied across all rates throughout 2023
-				as a cost-of-living measure, before the rates were restored to their
-				pre-2023 levels on 1 January 2024.
+				one-percentage-point reduction applied to the standard, intermediate, and
+				reduced rates throughout 2023 as a cost-of-living measure (Law of 26
+				October 2022), before the rates were restored to their pre-2023 levels
+				on 1 January 2024.
 
 				Businesses are identified by their TVA number (LU followed by 8 digits,
 				where the last two digits are a mod-89 check code) and optionally by their

--- a/regimes/lu/lu.go
+++ b/regimes/lu/lu.go
@@ -1,0 +1,91 @@
+// Package lu provides the tax regime definition for Luxembourg.
+package lu
+
+import (
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/currency"
+	"github.com/invopop/gobl/i18n"
+	"github.com/invopop/gobl/norm"
+	"github.com/invopop/gobl/pkg/here"
+	"github.com/invopop/gobl/rules"
+	"github.com/invopop/gobl/rules/is"
+	"github.com/invopop/gobl/tax"
+)
+
+// CountryCode is the tax country code for Luxembourg.
+const CountryCode = "LU"
+
+func init() {
+	tax.RegisterRegimeDef(New())
+	rules.Register("lu", rules.GOBL.Add(CountryCode),
+		taxIdentityRules(),
+		orgIdentityRules(),
+		billInvoiceRules(),
+	)
+	norm.Register(
+		norm.When(tax.IdentityIn(CountryCode), norm.For(normalizeTaxIdentity)),
+	)
+	norm.RegisterWithGuard(is.InContext(tax.RegimeIn(CountryCode)),
+		norm.For(normalizeOrgIdentity),
+	)
+}
+
+// New instantiates a new Luxembourg tax regime.
+func New() *tax.RegimeDef {
+	return &tax.RegimeDef{
+		Country:   CountryCode,
+		Currency:  currency.EUR,
+		TaxScheme: tax.CategoryVAT,
+		Name: i18n.String{
+			i18n.EN: "Luxembourg",
+			i18n.FR: "Luxembourg",
+			i18n.LB: "Lëtzebuerg",
+		},
+		Description: i18n.String{
+			i18n.EN: here.Doc(`
+				Luxembourg applies VAT (Taxe sur la Valeur Ajoutée, TVA) administered by
+				the Administration de l'Enregistrement, des Domaines et de la TVA (AED).
+				As an EU member state, Luxembourg follows the EU VAT Directive 2006/112/EC.
+
+				Luxembourg has four non-zero VAT rates: a standard rate, an intermediate
+				("parking") rate, a reduced rate, and a super-reduced rate. A temporary
+				one-percentage-point reduction was applied across all rates throughout 2023
+				as a cost-of-living measure, before the rates were restored to their
+				pre-2023 levels on 1 January 2024.
+
+				Businesses are identified by their TVA number (LU followed by 8 digits,
+				where the last two digits are a mod-89 check code) and optionally by their
+				company registration number (RCS number) from the Registre de Commerce et
+				des Sociétés.
+			`),
+			i18n.FR: here.Doc(`
+				Le Luxembourg applique la TVA (Taxe sur la Valeur Ajoutée) administrée par
+				l'Administration de l'Enregistrement, des Domaines et de la TVA (AED).
+				En tant qu'État membre de l'UE, le Luxembourg suit la Directive TVA
+				2006/112/CE.
+			`),
+		},
+		Sources: []*cbc.Source{
+			{
+				Title: i18n.String{
+					i18n.EN: "AED – VAT rates",
+					i18n.FR: "AED – Taux de TVA",
+				},
+				URL: "https://www.aed.public.lu/en/tva/taux-tva.html",
+			},
+		},
+		TimeZone:   "Europe/Luxembourg",
+		Identities: identityTypeDefinitions,
+		Categories: taxCategories,
+		Corrections: []*tax.CorrectionDefinition{
+			{
+				Schema: bill.ShortSchemaInvoice,
+				Types: []cbc.Key{
+					bill.InvoiceTypeCreditNote,
+					bill.InvoiceTypeDebitNote,
+				},
+			},
+		},
+	}
+}

--- a/regimes/lu/lu_test.go
+++ b/regimes/lu/lu_test.go
@@ -1,0 +1,35 @@
+package lu_test
+
+import (
+	"testing"
+
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/l10n"
+	"github.com/invopop/gobl/regimes/lu"
+	"github.com/invopop/gobl/tax"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNew(t *testing.T) {
+	t.Parallel()
+	regime := lu.New()
+	require.NotNil(t, regime)
+
+	assert.Equal(t, l10n.LU, regime.Country.Code())
+	assert.Equal(t, "Luxembourg", regime.Name.String())
+	assert.NotEmpty(t, regime.Description)
+
+	require.Len(t, regime.Categories, 1)
+	cat := regime.Categories[0]
+	assert.Equal(t, tax.CategoryVAT, cat.Code)
+	assert.Len(t, cat.Rates, 4, "expect standard, intermediate, reduced, and super-reduced rates")
+
+	require.Len(t, regime.Identities, 1)
+	assert.Equal(t, lu.IdentityTypeRCS, regime.Identities[0].Code)
+
+	require.Len(t, regime.Corrections, 1)
+	assert.Equal(t, bill.ShortSchemaInvoice, regime.Corrections[0].Schema)
+	assert.Contains(t, regime.Corrections[0].Types, bill.InvoiceTypeCreditNote)
+	assert.Contains(t, regime.Corrections[0].Types, bill.InvoiceTypeDebitNote)
+}

--- a/regimes/lu/org_identities.go
+++ b/regimes/lu/org_identities.go
@@ -14,17 +14,25 @@ import (
 const (
 	// IdentityTypeRCS represents a Luxembourg Registre de Commerce et des Sociétés
 	// (RCS) number, assigned by the Luxembourg Business Registers (LBR) to
-	// businesses registered in Luxembourg.
+	// entities registered in Luxembourg.
 	//
-	// Format: one letter (B, F, G, or H) followed by up to six digits.
-	// Examples: B263475, F12345, G45678
+	// Format: a section letter followed by up to six digits. The letter
+	// identifies the RCS section, e.g. A for sole traders (commerçants
+	// personnes physiques), B for commercial companies (sociétés
+	// commerciales), C for economic interest groupings (GIE), or E for
+	// civil companies (sociétés civiles).
+	// Examples: A12345, B263475, E4567
+	//
+	// Any single uppercase letter is accepted as the section indicator:
+	// the published list of sections has grown over time, so restricting
+	// it would risk rejecting valid registrations.
 	//
 	// Source: https://www.lbr.lu
 	IdentityTypeRCS cbc.Code = "RCS"
 )
 
-// rcsRegexp validates a normalised RCS number: register letter + 1–6 digits.
-var rcsRegexp = regexp.MustCompile(`^[BFGH]\d{1,6}$`)
+// rcsRegexp validates a normalised RCS number: section letter + 1–6 digits.
+var rcsRegexp = regexp.MustCompile(`^[A-Z]\d{1,6}$`)
 
 var identityTypeDefinitions = []*cbc.Definition{
 	{

--- a/regimes/lu/org_identities.go
+++ b/regimes/lu/org_identities.go
@@ -57,7 +57,7 @@ func orgIdentityRules() *rules.Set {
 				org.IdentityTypeIn(IdentityTypeRCS),
 				rules.Field("code",
 					rules.Assert("01", "invalid RCS number",
-						is.Func("valid RCS format", isValidRCSCode),
+						is.MatchesRegexp(rcsRegexp),
 					),
 				),
 			),
@@ -72,12 +72,4 @@ func normalizeOrgIdentity(id *org.Identity) {
 		return
 	}
 	id.Code = cbc.NormalizeAlphanumericalCode(id.Code)
-}
-
-func isValidRCSCode(value any) bool {
-	code, ok := value.(cbc.Code)
-	if !ok || code == "" {
-		return false
-	}
-	return rcsRegexp.MatchString(code.String())
 }

--- a/regimes/lu/org_identities.go
+++ b/regimes/lu/org_identities.go
@@ -1,0 +1,75 @@
+package lu
+
+import (
+	"regexp"
+
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/i18n"
+	"github.com/invopop/gobl/org"
+	"github.com/invopop/gobl/rules"
+	"github.com/invopop/gobl/rules/is"
+	"github.com/invopop/gobl/tax"
+)
+
+const (
+	// IdentityTypeRCS represents a Luxembourg Registre de Commerce et des Sociétés
+	// (RCS) number, assigned by the Luxembourg Business Registers (LBR) to
+	// businesses registered in Luxembourg.
+	//
+	// Format: one letter (B, F, G, or H) followed by up to six digits.
+	// Examples: B263475, F12345, G45678
+	//
+	// Source: https://www.lbr.lu
+	IdentityTypeRCS cbc.Code = "RCS"
+)
+
+// rcsRegexp validates a normalised RCS number: register letter + 1–6 digits.
+var rcsRegexp = regexp.MustCompile(`^[BFGH]\d{1,6}$`)
+
+var identityTypeDefinitions = []*cbc.Definition{
+	{
+		Code: IdentityTypeRCS,
+		Name: i18n.String{
+			i18n.EN: "RCS Number",
+			i18n.FR: "Numéro RCS",
+			i18n.LB: "RCS-Nummer",
+		},
+		Desc: i18n.String{
+			i18n.EN: "Luxembourg company registration number assigned by the Luxembourg Business Registers (LBR).",
+			i18n.FR: "Numéro d'immatriculation au Registre de Commerce et des Sociétés attribué par le Registre luxembourgeois des entreprises.",
+		},
+	},
+}
+
+func orgIdentityRules() *rules.Set {
+	return rules.For(new(org.Identity),
+		rules.When(
+			is.InContext(tax.RegimeIn(CountryCode)),
+			rules.When(
+				org.IdentityTypeIn(IdentityTypeRCS),
+				rules.Field("code",
+					rules.Assert("01", "invalid RCS number",
+						is.Func("valid RCS format", isValidRCSCode),
+					),
+				),
+			),
+		),
+	)
+}
+
+// normalizeOrgIdentity strips spaces and non-alphanumeric characters from an
+// RCS number and uppercases it (e.g. "b 263 475" → "B263475").
+func normalizeOrgIdentity(id *org.Identity) {
+	if id.Type != IdentityTypeRCS {
+		return
+	}
+	id.Code = cbc.NormalizeAlphanumericalCode(id.Code)
+}
+
+func isValidRCSCode(value any) bool {
+	code, ok := value.(cbc.Code)
+	if !ok || code == "" {
+		return false
+	}
+	return rcsRegexp.MatchString(code.String())
+}

--- a/regimes/lu/org_identities.go
+++ b/regimes/lu/org_identities.go
@@ -31,7 +31,7 @@ const (
 	IdentityTypeRCS cbc.Code = "RCS"
 )
 
-// rcsRegexp validates a normalised RCS number: section letter + 1–6 digits.
+// rcsRegexp validates a normalized RCS number: section letter + 1–6 digits.
 var rcsRegexp = regexp.MustCompile(`^[A-Z]\d{1,6}$`)
 
 var identityTypeDefinitions = []*cbc.Definition{

--- a/regimes/lu/org_identities_test.go
+++ b/regimes/lu/org_identities_test.go
@@ -56,17 +56,18 @@ func TestValidateOrgIdentity(t *testing.T) {
 		code  cbc.Code
 		valid bool
 	}{
-		{name: "B register", code: "B263475", valid: true},
-		{name: "F register", code: "F12345", valid: true},
-		{name: "G register", code: "G45678", valid: true},
-		{name: "H register", code: "H1234", valid: true},
+		{name: "section A (sole trader)", code: "A12345", valid: true},
+		{name: "section B (commercial company)", code: "B263475", valid: true},
+		{name: "section C (GIE)", code: "C123", valid: true},
+		{name: "section E (civil company)", code: "E4567", valid: true},
 		{name: "single digit", code: "B1", valid: true},
 		// invalid cases
-		{name: "wrong letter", code: "A263475"},
+		{name: "two letters", code: "AB12345"},
 		{name: "lowercase", code: "b263475"},
 		{name: "no digits", code: "B"},
 		{name: "too many digits", code: "B1234567"},
 		{name: "digits only", code: "263475"},
+		{name: "letter at end", code: "263475B"},
 		{name: "empty code", code: ""},
 	}
 

--- a/regimes/lu/org_identities_test.go
+++ b/regimes/lu/org_identities_test.go
@@ -37,7 +37,7 @@ func TestNormalizeOrgIdentity(t *testing.T) {
 		})
 	}
 
-	t.Run("unknown type not normalised", func(t *testing.T) {
+	t.Run("unknown type not normalized", func(t *testing.T) {
 		id := &org.Identity{Type: "OTHER", Code: "b 123"}
 		norm.Normalize(id, tax.RegimeContext(lu.CountryCode))
 		assert.Equal(t, cbc.Code("b 123"), id.Code)

--- a/regimes/lu/org_identities_test.go
+++ b/regimes/lu/org_identities_test.go
@@ -1,0 +1,93 @@
+package lu_test
+
+import (
+	"testing"
+
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/norm"
+	"github.com/invopop/gobl/org"
+	"github.com/invopop/gobl/regimes/lu"
+	"github.com/invopop/gobl/rules"
+	"github.com/invopop/gobl/tax"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizeOrgIdentity(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		input    cbc.Code
+		expected cbc.Code
+	}{
+		{name: "already normalized", input: "B263475", expected: "B263475"},
+		{name: "with spaces", input: "B 263 475", expected: "B263475"},
+		{name: "lowercase", input: "b263475", expected: "B263475"},
+		{name: "lowercase with spaces", input: "b 263 475", expected: "B263475"},
+		{name: "F register", input: "F 12345", expected: "F12345"},
+		{name: "G register", input: "G 45678", expected: "G45678"},
+		{name: "H register", input: "H 1234", expected: "H1234"},
+		{name: "empty", input: "", expected: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id := &org.Identity{Type: lu.IdentityTypeRCS, Code: tt.input}
+			norm.Normalize(id, tax.RegimeContext(lu.CountryCode))
+			assert.Equal(t, tt.expected, id.Code)
+		})
+	}
+
+	t.Run("unknown type not normalised", func(t *testing.T) {
+		id := &org.Identity{Type: "OTHER", Code: "b 123"}
+		norm.Normalize(id, tax.RegimeContext(lu.CountryCode))
+		assert.Equal(t, cbc.Code("b 123"), id.Code)
+	})
+}
+
+func TestValidateOrgIdentity(t *testing.T) {
+	t.Parallel()
+
+	opts := []rules.WithContext{
+		tax.RegimeContext(lu.CountryCode),
+	}
+
+	tests := []struct {
+		name  string
+		code  cbc.Code
+		valid bool
+	}{
+		{name: "B register", code: "B263475", valid: true},
+		{name: "F register", code: "F12345", valid: true},
+		{name: "G register", code: "G45678", valid: true},
+		{name: "H register", code: "H1234", valid: true},
+		{name: "single digit", code: "B1", valid: true},
+		// invalid cases
+		{name: "wrong letter", code: "A263475"},
+		{name: "lowercase", code: "b263475"},
+		{name: "no digits", code: "B"},
+		{name: "too many digits", code: "B1234567"},
+		{name: "digits only", code: "263475"},
+		{name: "empty code", code: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id := &org.Identity{Type: lu.IdentityTypeRCS, Code: tt.code}
+			err := rules.Validate(id, opts...)
+			if tt.valid {
+				assert.NoError(t, err)
+			} else if assert.Error(t, err) {
+				assert.Contains(t, err.Error(), "invalid RCS number")
+			}
+		})
+	}
+
+	t.Run("nil identity", func(t *testing.T) {
+		assert.NoError(t, rules.Validate((*org.Identity)(nil), opts...))
+	})
+
+	t.Run("unknown type skipped", func(t *testing.T) {
+		id := &org.Identity{Type: "OTHER", Code: "A9999999"}
+		assert.NoError(t, rules.Validate(id, opts...))
+	})
+}

--- a/regimes/lu/org_identities_test.go
+++ b/regimes/lu/org_identities_test.go
@@ -52,23 +52,25 @@ func TestValidateOrgIdentity(t *testing.T) {
 	}
 
 	tests := []struct {
-		name  string
-		code  cbc.Code
-		valid bool
+		name     string
+		code     cbc.Code
+		valid    bool
+		errorMsg string
 	}{
 		{name: "section A (sole trader)", code: "A12345", valid: true},
 		{name: "section B (commercial company)", code: "B263475", valid: true},
 		{name: "section C (GIE)", code: "C123", valid: true},
 		{name: "section E (civil company)", code: "E4567", valid: true},
 		{name: "single digit", code: "B1", valid: true},
-		// invalid cases
-		{name: "two letters", code: "AB12345"},
-		{name: "lowercase", code: "b263475"},
-		{name: "no digits", code: "B"},
-		{name: "too many digits", code: "B1234567"},
-		{name: "digits only", code: "263475"},
-		{name: "letter at end", code: "263475B"},
-		{name: "empty code", code: ""},
+		// invalid format
+		{name: "two letters", code: "AB12345", errorMsg: "invalid RCS number"},
+		{name: "lowercase", code: "b263475", errorMsg: "invalid RCS number"},
+		{name: "no digits", code: "B", errorMsg: "invalid RCS number"},
+		{name: "too many digits", code: "B1234567", errorMsg: "invalid RCS number"},
+		{name: "digits only", code: "263475", errorMsg: "invalid RCS number"},
+		{name: "letter at end", code: "263475B", errorMsg: "invalid RCS number"},
+		// empty code is caught by the core identity rule
+		{name: "empty code", code: "", errorMsg: "identity code must be provided"},
 	}
 
 	for _, tt := range tests {
@@ -78,7 +80,7 @@ func TestValidateOrgIdentity(t *testing.T) {
 			if tt.valid {
 				assert.NoError(t, err)
 			} else if assert.Error(t, err) {
-				assert.Contains(t, err.Error(), "invalid RCS number")
+				assert.Contains(t, err.Error(), tt.errorMsg)
 			}
 		})
 	}

--- a/regimes/lu/tax_categories.go
+++ b/regimes/lu/tax_categories.go
@@ -1,0 +1,142 @@
+package lu
+
+import (
+	"github.com/invopop/gobl/cal"
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/i18n"
+	"github.com/invopop/gobl/num"
+	"github.com/invopop/gobl/tax"
+)
+
+// taxCategories defines Luxembourg's VAT rates with full rate history.
+//
+// Luxembourg applies a standard, intermediate ("parking"), reduced, and
+// super-reduced rate.  In 2023 all four rates were temporarily reduced by
+// one percentage point (cost-of-living measure; Law of 30 Nov 2022) and
+// restored to their pre-2023 values on 1 January 2024.
+var taxCategories = []*tax.CategoryDef{
+	{
+		Code: tax.CategoryVAT,
+		Name: i18n.String{
+			i18n.EN: "VAT",
+			i18n.FR: "TVA",
+			i18n.LB: "TVA",
+		},
+		Title: i18n.String{
+			i18n.EN: "Value Added Tax",
+			i18n.FR: "Taxe sur la Valeur Ajoutée",
+			i18n.LB: "Taxe sur la Valeur Ajoutée",
+		},
+		Retained: false,
+		Keys:     tax.GlobalVATKeys(),
+		Rates: []*tax.RateDef{
+			{
+				Keys: []cbc.Key{tax.KeyStandard},
+				Rate: tax.RateGeneral,
+				Name: i18n.String{
+					i18n.EN: "Standard Rate",
+					i18n.FR: "Taux normal",
+					i18n.LB: "Normalsaz",
+				},
+				Description: i18n.String{
+					i18n.EN: "General rate applicable to most goods and services.",
+					i18n.FR: "Taux applicable à la plupart des biens et services.",
+				},
+				Values: []*tax.RateValueDef{
+					// Restored after temporary 2023 reduction (Law of 19 Dec 2023).
+					{Since: cal.NewDate(2024, 1, 1), Percent: num.MakePercentage(170, 3)},
+					// Temporary 1 pp reduction throughout 2023 (Law of 30 Nov 2022).
+					{Since: cal.NewDate(2023, 1, 1), Percent: num.MakePercentage(160, 3)},
+					// Increased from 15% to 17% (Law of 19 Dec 2014, effective 2015).
+					{Since: cal.NewDate(2015, 1, 1), Percent: num.MakePercentage(170, 3)},
+					// Original rate when Luxembourg's TVA was introduced.
+					{Since: cal.NewDate(1992, 1, 1), Percent: num.MakePercentage(150, 3)},
+				},
+			},
+			{
+				Keys: []cbc.Key{tax.KeyStandard},
+				Rate: tax.RateIntermediate,
+				Name: i18n.String{
+					i18n.EN: "Intermediate Rate",
+					i18n.FR: "Taux intermédiaire",
+					i18n.LB: "Taux intermédiaire",
+				},
+				Description: i18n.String{
+					i18n.EN: "Applies to wine, certain fuels, printed advertising material, and similar goods (EU parking rate).",
+					i18n.FR: "Applicable aux vins, certains combustibles, imprimés publicitaires et biens similaires (taux parking UE).",
+				},
+				Values: []*tax.RateValueDef{
+					{Since: cal.NewDate(2024, 1, 1), Percent: num.MakePercentage(140, 3)},
+					{Since: cal.NewDate(2023, 1, 1), Percent: num.MakePercentage(130, 3)},
+					{Since: cal.NewDate(2015, 1, 1), Percent: num.MakePercentage(140, 3)},
+					{Since: cal.NewDate(1992, 1, 1), Percent: num.MakePercentage(120, 3)},
+				},
+			},
+			{
+				Keys: []cbc.Key{tax.KeyStandard},
+				Rate: tax.RateReduced,
+				Name: i18n.String{
+					i18n.EN: "Reduced Rate",
+					i18n.FR: "Taux réduit",
+					i18n.LB: "Reduzéierter Saz",
+				},
+				Description: i18n.String{
+					i18n.EN: "Applies to food, non-alcoholic beverages, pharmaceuticals, books, newspapers, water, and passenger transport.",
+					i18n.FR: "Applicable aux denrées alimentaires, boissons non alcoolisées, médicaments, livres, journaux, eau et transport de personnes.",
+				},
+				Values: []*tax.RateValueDef{
+					{Since: cal.NewDate(2024, 1, 1), Percent: num.MakePercentage(80, 3)},
+					{Since: cal.NewDate(2023, 1, 1), Percent: num.MakePercentage(70, 3)},
+					{Since: cal.NewDate(2015, 1, 1), Percent: num.MakePercentage(80, 3)},
+					{Since: cal.NewDate(1992, 1, 1), Percent: num.MakePercentage(60, 3)},
+				},
+			},
+			{
+				Keys: []cbc.Key{tax.KeyStandard},
+				Rate: tax.RateSuperReduced,
+				Name: i18n.String{
+					i18n.EN: "Super-reduced Rate",
+					i18n.FR: "Taux super-réduit",
+					i18n.LB: "Super-reduzéierter Saz",
+				},
+				Description: i18n.String{
+					i18n.EN: "Applies to certain pharmaceutical products, footwear and clothing for children, social housing, natural gas, and electricity.",
+					i18n.FR: "Applicable à certains médicaments, chaussures et vêtements pour enfants, logements sociaux, gaz naturel et électricité.",
+				},
+				// The super-reduced rate was not changed during the 2023 reduction.
+				Values: []*tax.RateValueDef{
+					{Since: cal.NewDate(2015, 1, 1), Percent: num.MakePercentage(30, 3)},
+				},
+			},
+		},
+		Sources: []*cbc.Source{
+			{
+				Title: i18n.String{
+					i18n.EN: "AED – VAT rates",
+					i18n.FR: "AED – Taux de TVA",
+				},
+				URL: "https://www.aed.public.lu/en/tva/taux-tva.html",
+			},
+			{
+				Title: i18n.String{
+					i18n.EN: "Law of 30 November 2022 – Temporary rate reduction",
+					i18n.FR: "Loi du 30 novembre 2022 – Réduction temporaire des taux",
+				},
+				URL: "https://www.legilux.public.lu/eli/etat/leg/loi/2022/11/30/a559/jo",
+			},
+			{
+				Title: i18n.String{
+					i18n.EN: "Law of 19 December 2014 – Rate increase to current levels",
+					i18n.FR: "Loi du 19 décembre 2014 – Augmentation des taux",
+				},
+				URL: "https://www.legilux.public.lu/eli/etat/leg/loi/2014/12/19/n1/jo",
+			},
+			{
+				Title: i18n.String{
+					i18n.EN: "European Commission – VAT rates",
+				},
+				URL: "https://taxation-customs.ec.europa.eu/taxation/vat/eu-vat-rules/vat-rates_en",
+			},
+		},
+	},
+}

--- a/regimes/lu/tax_categories.go
+++ b/regimes/lu/tax_categories.go
@@ -11,9 +11,11 @@ import (
 // taxCategories defines Luxembourg's VAT rates with full rate history.
 //
 // Luxembourg applies a standard, intermediate ("parking"), reduced, and
-// super-reduced rate.  In 2023 all four rates were temporarily reduced by
-// one percentage point (cost-of-living measure; Law of 30 Nov 2022) and
-// restored to their pre-2023 values on 1 January 2024.
+// super-reduced rate. In 2023 the standard, intermediate, and reduced rates
+// were temporarily lowered by one percentage point as a cost-of-living
+// measure (Law of 26 October 2022, Mémorial A No. 534) and restored to
+// their pre-2023 values on 1 January 2024. The super-reduced rate was not
+// affected by the reduction.
 var taxCategories = []*tax.CategoryDef{
 	{
 		Code: tax.CategoryVAT,
@@ -43,9 +45,9 @@ var taxCategories = []*tax.CategoryDef{
 					i18n.FR: "Taux applicable à la plupart des biens et services.",
 				},
 				Values: []*tax.RateValueDef{
-					// Restored after temporary 2023 reduction (Law of 19 Dec 2023).
+					// Restored after the temporary 2023 reduction expired.
 					{Since: cal.NewDate(2024, 1, 1), Percent: num.MakePercentage(170, 3)},
-					// Temporary 1 pp reduction throughout 2023 (Law of 30 Nov 2022).
+					// Temporary 1 pp reduction throughout 2023 (Law of 26 Oct 2022).
 					{Since: cal.NewDate(2023, 1, 1), Percent: num.MakePercentage(160, 3)},
 					// Increased from 15% to 17% (Law of 19 Dec 2014, effective 2015).
 					{Since: cal.NewDate(2015, 1, 1), Percent: num.MakePercentage(170, 3)},
@@ -103,9 +105,12 @@ var taxCategories = []*tax.CategoryDef{
 					i18n.EN: "Applies to certain pharmaceutical products, footwear and clothing for children, social housing, natural gas, and electricity.",
 					i18n.FR: "Applicable à certains médicaments, chaussures et vêtements pour enfants, logements sociaux, gaz naturel et électricité.",
 				},
-				// The super-reduced rate was not changed during the 2023 reduction.
+				// The 3% rate predates the other entries and was not changed
+				// by either the 2015 increase or the 2023 temporary reduction,
+				// so a single value anchored at the regime's history baseline
+				// is sufficient.
 				Values: []*tax.RateValueDef{
-					{Since: cal.NewDate(2015, 1, 1), Percent: num.MakePercentage(30, 3)},
+					{Since: cal.NewDate(1992, 1, 1), Percent: num.MakePercentage(30, 3)},
 				},
 			},
 		},
@@ -119,10 +124,10 @@ var taxCategories = []*tax.CategoryDef{
 			},
 			{
 				Title: i18n.String{
-					i18n.EN: "Law of 30 November 2022 – Temporary rate reduction",
-					i18n.FR: "Loi du 30 novembre 2022 – Réduction temporaire des taux",
+					i18n.EN: "Law of 26 October 2022 – Temporary rate reduction",
+					i18n.FR: "Loi du 26 octobre 2022 – Réduction temporaire des taux",
 				},
-				URL: "https://www.legilux.public.lu/eli/etat/leg/loi/2022/11/30/a559/jo",
+				URL: "https://legilux.public.lu/eli/etat/leg/loi/2022/10/26/a534/jo",
 			},
 			{
 				Title: i18n.String{

--- a/regimes/lu/tax_identity.go
+++ b/regimes/lu/tax_identity.go
@@ -1,0 +1,59 @@
+package lu
+
+import (
+	"errors"
+	"strconv"
+
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/rules"
+	"github.com/invopop/gobl/rules/is"
+	"github.com/invopop/gobl/tax"
+)
+
+func taxIdentityRules() *rules.Set {
+	return rules.For(new(tax.Identity),
+		rules.When(tax.IdentityIn(CountryCode),
+			rules.Field("code",
+				rules.AssertIfPresent("01", "invalid Luxembourg TVA number",
+					is.Func("valid mod-89 TVA code", isValidTVACode),
+				),
+			),
+		),
+	)
+}
+
+// normalizeTaxIdentity strips whitespace, dashes, and the "LU" country prefix
+// from a Luxembourg TVA number, leaving the raw 8-digit code.
+func normalizeTaxIdentity(tID *tax.Identity) {
+	tax.NormalizeIdentity(tID)
+}
+
+// isValidTVACode reports whether the value is a valid Luxembourg TVA number:
+// exactly 8 digits where the last two digits equal the first six digits mod 89.
+//
+// Source: https://www.aed.public.lu/en/tva/numero-tva.html
+func isValidTVACode(value any) bool {
+	code, ok := value.(cbc.Code)
+	if !ok {
+		return false
+	}
+	return validateTVACode(code) == nil
+}
+
+func validateTVACode(code cbc.Code) error {
+	val := code.String()
+	if len(val) != 8 {
+		return errors.New("must be exactly 8 digits")
+	}
+	for _, r := range val {
+		if r < '0' || r > '9' {
+			return errors.New("must contain only digits")
+		}
+	}
+	base, _ := strconv.Atoi(val[:6])
+	check, _ := strconv.Atoi(val[6:])
+	if base%89 != check {
+		return errors.New("checksum mismatch")
+	}
+	return nil
+}

--- a/regimes/lu/tax_identity.go
+++ b/regimes/lu/tax_identity.go
@@ -1,7 +1,6 @@
 package lu
 
 import (
-	"errors"
 	"strconv"
 
 	"github.com/invopop/gobl/cbc"
@@ -14,8 +13,14 @@ func taxIdentityRules() *rules.Set {
 	return rules.For(new(tax.Identity),
 		rules.When(tax.IdentityIn(CountryCode),
 			rules.Field("code",
-				rules.AssertIfPresent("01", "invalid Luxembourg TVA number",
-					is.Func("valid mod-89 TVA code", isValidTVACode),
+				rules.AssertIfPresent("01", "Luxembourg TVA number must be exactly 8 digits",
+					is.Length(8, 8),
+				),
+				rules.AssertIfPresent("02", "Luxembourg TVA number must contain only digits",
+					is.Digit,
+				),
+				rules.AssertIfPresent("03", "invalid Luxembourg TVA number: mod-89 checksum mismatch",
+					is.Func("valid mod-89 checksum", tvaChecksumValid),
 				),
 			),
 		),
@@ -28,32 +33,23 @@ func normalizeTaxIdentity(tID *tax.Identity) {
 	tax.NormalizeIdentity(tID)
 }
 
-// isValidTVACode reports whether the value is a valid Luxembourg TVA number:
-// exactly 8 digits where the last two digits equal the first six digits mod 89.
+// tvaChecksumValid reports whether the last two digits of a Luxembourg TVA
+// number equal the first six digits mod 89.
 //
 // Source: https://www.aed.public.lu/en/tva/numero-tva.html
-func isValidTVACode(value any) bool {
+func tvaChecksumValid(value any) bool {
 	code, ok := value.(cbc.Code)
 	if !ok {
-		return false
+		return true
 	}
-	return validateTVACode(code) == nil
-}
-
-func validateTVACode(code cbc.Code) error {
 	val := code.String()
 	if len(val) != 8 {
-		return errors.New("must be exactly 8 digits")
+		return true // length rule handles this
 	}
-	for _, r := range val {
-		if r < '0' || r > '9' {
-			return errors.New("must contain only digits")
-		}
+	base, err1 := strconv.Atoi(val[:6])
+	check, err2 := strconv.Atoi(val[6:])
+	if err1 != nil || err2 != nil {
+		return true // digit rule handles this
 	}
-	base, _ := strconv.Atoi(val[:6])
-	check, _ := strconv.Atoi(val[6:])
-	if base%89 != check {
-		return errors.New("checksum mismatch")
-	}
-	return nil
+	return base%89 == check
 }

--- a/regimes/lu/tax_identity_test.go
+++ b/regimes/lu/tax_identity_test.go
@@ -1,0 +1,73 @@
+package lu_test
+
+import (
+	"testing"
+
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/norm"
+	"github.com/invopop/gobl/regimes/lu"
+	"github.com/invopop/gobl/rules"
+	"github.com/invopop/gobl/tax"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizeTaxIdentity(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		input    cbc.Code
+		expected cbc.Code
+	}{
+		{name: "already normalized", input: "26375245", expected: "26375245"},
+		{name: "with LU prefix", input: "LU26375245", expected: "26375245"},
+		{name: "lowercase prefix", input: "lu26375245", expected: "26375245"},
+		{name: "with spaces", input: "LU 2637 5245", expected: "26375245"},
+		{name: "dashes", input: "LU-2637-5245", expected: "26375245"},
+		{name: "no prefix with spaces", input: "2637 5245", expected: "26375245"},
+		{name: "empty", input: "", expected: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tID := &tax.Identity{Country: lu.CountryCode, Code: tt.input}
+			norm.Normalize(tID)
+			assert.Equal(t, tt.expected, tID.Code)
+		})
+	}
+}
+
+func TestValidateTaxIdentity(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		code  cbc.Code
+		valid bool
+	}{
+		// 263752 mod 89 = 45  →  valid
+		{name: "valid code", code: "26375245", valid: true},
+		// 123456 mod 89 = 13  →  valid
+		{name: "valid code 2", code: "12345613", valid: true},
+		// empty code is allowed (TVA registration is not mandatory for all businesses)
+		{name: "empty code", code: "", valid: true},
+		// wrong check digits
+		{name: "bad checksum", code: "26375200"},
+		{name: "bad checksum 2", code: "12345699"},
+		// wrong length
+		{name: "too short", code: "2637524"},
+		{name: "too long", code: "263752450"},
+		// non-numeric
+		{name: "contains letter", code: "2637524A"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tID := &tax.Identity{Country: lu.CountryCode, Code: tt.code}
+			err := rules.Validate(tID)
+			if tt.valid {
+				assert.NoError(t, err)
+			} else if assert.Error(t, err) {
+				assert.Contains(t, err.Error(), "IDENTITY-01")
+			}
+		})
+	}
+}

--- a/regimes/lu/tax_identity_test.go
+++ b/regimes/lu/tax_identity_test.go
@@ -39,9 +39,10 @@ func TestNormalizeTaxIdentity(t *testing.T) {
 func TestValidateTaxIdentity(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name  string
-		code  cbc.Code
-		valid bool
+		name      string
+		code      cbc.Code
+		valid     bool
+		errorCode string
 	}{
 		// 263752 mod 89 = 45  →  valid
 		{name: "valid code", code: "26375245", valid: true},
@@ -50,13 +51,13 @@ func TestValidateTaxIdentity(t *testing.T) {
 		// empty code is allowed (TVA registration is not mandatory for all businesses)
 		{name: "empty code", code: "", valid: true},
 		// wrong check digits
-		{name: "bad checksum", code: "26375200"},
-		{name: "bad checksum 2", code: "12345699"},
+		{name: "bad checksum", code: "26375200", errorCode: "IDENTITY-03"},
+		{name: "bad checksum 2", code: "12345699", errorCode: "IDENTITY-03"},
 		// wrong length
-		{name: "too short", code: "2637524"},
-		{name: "too long", code: "263752450"},
+		{name: "too short", code: "2637524", errorCode: "IDENTITY-01"},
+		{name: "too long", code: "263752450", errorCode: "IDENTITY-01"},
 		// non-numeric
-		{name: "contains letter", code: "2637524A"},
+		{name: "contains letter", code: "2637524A", errorCode: "IDENTITY-02"},
 	}
 
 	for _, tt := range tests {
@@ -66,7 +67,7 @@ func TestValidateTaxIdentity(t *testing.T) {
 			if tt.valid {
 				assert.NoError(t, err)
 			} else if assert.Error(t, err) {
-				assert.Contains(t, err.Error(), "IDENTITY-01")
+				assert.Contains(t, err.Error(), tt.errorCode)
 			}
 		})
 	}

--- a/regimes/regimes.go
+++ b/regimes/regimes.go
@@ -23,6 +23,7 @@ import (
 	_ "github.com/invopop/gobl/regimes/ie"
 	_ "github.com/invopop/gobl/regimes/in"
 	_ "github.com/invopop/gobl/regimes/it"
+	_ "github.com/invopop/gobl/regimes/lu"
 	_ "github.com/invopop/gobl/regimes/mx"
 	_ "github.com/invopop/gobl/regimes/nl"
 	_ "github.com/invopop/gobl/regimes/no"


### PR DESCRIPTION
Adds Luxembourg (`LU`) as a new tax regime.

## What's included

- **`regimes/lu`** — regime definition following the structure of the recently merged Norway regime (#849):
  - **Four VAT rates** with full `Since`-dated history: standard 17%, intermediate ("parking") 14%, reduced 8%, super-reduced 3%. The history includes the temporary one-point reduction in force throughout 2023 (Law of 26 October 2022, Mémorial A No. 534) — the standard, intermediate, and reduced rates dropped to 16/13/7% and were restored on 2024-01-01; the super-reduced rate was excluded from the measure. An invoice dated within 2023 automatically calculates with the temporary rates.
  - **TVA number validation**: 8 digits where the last two must equal the first six mod 89, plus normalization of the `LU` prefix, spaces, and dashes.
  - **RCS identity** (`RCS`): Luxembourg Business Registers company number, format `<section letter> + 1–6 digits` (e.g. `B263475`). Any single uppercase section letter is accepted — the published list of sections (A sole traders, B commercial companies, C GIEs, E civil companies, …) has grown over time, so a closed list risks rejecting valid registrations.
  - **Invoice rule**: the supplier must carry either a TVA code or an RCS identity. Note this is a structural baseline so businesses below the VAT registration threshold can still issue valid invoices — not a claim that an RCS number legally substitutes for the TVA number, which VAT-registered suppliers must always state.
  - **Corrections**: credit notes and debit notes, both recognised in Luxembourg practice.
- **`examples/lu`** — four documents with golden outputs: standard B2B invoice (17%), multi-rate invoice (17/8/3%), a 2023-dated invoice demonstrating the historical 16%/7% rates, and a credit note.
- Generated data (`data/regimes/lu.json`, `data/rules/lu.json`, regime-code schema) and a CHANGELOG entry.

## Scope decisions

- **No addon.** Luxembourg has no domestic B2B e-invoicing mandate; B2G uses Peppol/EN 16931, already covered by the existing `eu-en16931-v2017` addon. A `lu-*` addon would be speculative at this point (pending ViDA).
- **No withholding taxes, OSS/IOSS, or VAT-group handling** — respectively income-tax mechanisms, EU-level machinery, and registration arrangements invisible at the single-invoice level.
- **Pre-2015 rate history** (15/12/6/3%) is anchored at a conservative 1992-01-01 baseline; the values are well documented but I could not verify the exact original effective dates under the amended 1979 law against primary sources. Happy to adjust if you have a preferred convention for historical anchors.

## Sources

- AED – VAT rates: https://www.aed.public.lu/en/tva/taux-tva.html
- Law of 26 October 2022 (temporary reduction): https://legilux.public.lu/eli/etat/leg/loi/2022/10/26/a534/jo
- Law of 19 December 2014 (2015 increase): https://www.legilux.public.lu/eli/etat/leg/loi/2014/12/19/n1/jo
- European Commission – VAT rates: https://taxation-customs.ec.europa.eu/taxation/vat/eu-vat-rules/vat-rates_en
- Luxembourg Business Registers (RCS): https://www.lbr.lu

Structured sources are also embedded in the regime and category definitions.

## Pre-Review Checklist

- [x] Opened this PR as a draft
- [x] Read the CONTRIBUTING.md guide.
- [x] Performed a self-review of my code.
- [x] Added thorough tests with at **least** 90% code coverage. *(97.3% of statements)*
- [x] Modified or created example GOBL documents to show my changes in use, if appropriate.
- [x] Added links to the source of the changes in tax regimes or addons, either structured or in the comments.
- [x] Run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [x] Reviewed and fixed all linter warnings.
- [x] Been obsessive with pointer nil checks to avoid panics.
- [x] Updated the CHANGELOG.md with an overview of my changes.
- [ ] Marked this PR as ready for review.
