### PR TITLE
Remove unecessary rule

### DIFF
--- a/addons/eu/en16931/tax_combo.go
+++ b/addons/eu/en16931/tax_combo.go
@@ -132,11 +132,6 @@ func taxComboIsOutsideScope(val any) bool {
 	return ok && tc != nil && !tc.Category.In(tax.CategoryVAT, es.TaxCategoryIGIC, es.TaxCategoryIPSI)
 }
 
-func taxComboIsExempt(val any) bool {
-	tc, ok := val.(*tax.Combo)
-	return ok && tc != nil && tc.Ext.Get(untdid.ExtKeyTaxCategory) == TaxCategoryExempt
-}
-
 func taxComboIsNonExempt(val any) bool {
 	tc, ok := val.(*tax.Combo)
 	return ok && tc != nil && tc.Ext.Get(untdid.ExtKeyTaxCategory).In(TaxCategoryStandard, TaxCategoryZero, TaxCategoryIGIC, TaxCategoryIPSI)

--- a/addons/eu/en16931/tax_combo.go
+++ b/addons/eu/en16931/tax_combo.go
@@ -101,14 +101,6 @@ func taxComboRules() *rules.Set {
 				),
 			),
 		),
-		rules.When(is.Func("is exempt", taxComboIsExempt),
-			rules.Field("ext",
-				// BR-E-10: VATEX extension required for exempt tax
-				rules.Assert("06", "VATEX extension is required for exempt tax (BR-E-10)",
-					tax.ExtensionsRequire(cef.ExtKeyVATEX),
-				),
-			),
-		),
 		// BR-S-10, BR-Z-10: standard, zero-rated, IGIC, and IPSI shall NOT have a VATEX code
 		rules.When(is.Func("is non-exempt", taxComboIsNonExempt),
 			rules.Field("ext",

--- a/addons/eu/en16931/tax_combo_test.go
+++ b/addons/eu/en16931/tax_combo_test.go
@@ -128,17 +128,6 @@ func TestTaxComboValidation(t *testing.T) {
 		assert.NoError(t, rules.Validate(c, tax.AddonContext(en16931.V2017)))
 	})
 
-	t.Run("exempt without vatex", func(t *testing.T) {
-		// VATEX extension is now required at the combo level for exempt tax
-		c := &tax.Combo{
-			Category: tax.CategoryVAT,
-			Key:      tax.KeyExempt,
-		}
-		norm.Normalize(c, tax.AddonContext(en16931.V2017))
-		err := rules.Validate(c, tax.AddonContext(en16931.V2017))
-		assert.ErrorContains(t, err, "VATEX extension is required for exempt tax")
-	})
-
 	t.Run("reverse charge without vatex", func(t *testing.T) {
 		c := &tax.Combo{
 			Category: tax.CategoryVAT,

--- a/addons/eu/en16931/tax_combo_test.go
+++ b/addons/eu/en16931/tax_combo_test.go
@@ -128,6 +128,18 @@ func TestTaxComboValidation(t *testing.T) {
 		assert.NoError(t, rules.Validate(c, tax.AddonContext(en16931.V2017)))
 	})
 
+	t.Run("exempt without vatex", func(t *testing.T) {
+		// BR-E-10 is no longer enforced at the combo level (the invoice-level
+		// exemption-note rule covers the remaining requirement), so an exempt
+		// combo without a VATEX extension must validate.
+		c := &tax.Combo{
+			Category: tax.CategoryVAT,
+			Key:      tax.KeyExempt,
+		}
+		norm.Normalize(c, tax.AddonContext(en16931.V2017))
+		assert.NoError(t, rules.Validate(c, tax.AddonContext(en16931.V2017)))
+	})
+
 	t.Run("reverse charge without vatex", func(t *testing.T) {
 		c := &tax.Combo{
 			Category: tax.CategoryVAT,


### PR DESCRIPTION
* Remove BR-E-10 as already covered in another rule

## Pre-Review Checklist

- [X] Opened this PR as a draft
- [X] Read the CONTRIBUTING.md guide.
- [X] Performed a self-review of my code.
- [X] Added thorough tests with at **least** 90% code coverage.
- [X] Modified or created example GOBL documents to show my changes in use, if appropriate.
- [X] Added links to the source of the changes in tax regimes or addons, either structured or in the comments.
- [X] Run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [X] Reviewed and fixed all linter warnings.
- [X] Been obsessive with pointer nil checks to avoid panics.
- [X] Updated the CHANGELOG.md with an overview of my changes.
- [X] Marked this PR as ready for review.

And if you are part of the org:

- [X] Requested a review from Copilot and fixed or dismissed (with a reason) all the feedback raised.
- [X] Requested a review from @samlown.