### PR TITLE
Add: Org Registration 'ext' field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Added
 
-- `org`: `Registration` object includes `ext` for addon specific registration details.
+- `org`: `Registration` object includes `ext` for addon-specific registration details.
 
 ## [v0.500.0] - 2026-06-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Added
+
+- `org`: `Registration` object includes `ext` for addon specific registration details.
+
 ## [v0.500.0] - 2026-06-10
 
 GOBL is now a pure document library. The CLI, HTTP API, MCP server, and WASM build have moved to the [gobl.dev](https://github.com/invopop/gobl.dev) project, which composes this library with the complete set of addons. Install the CLI from its new home: `go install github.com/invopop/gobl.dev/cmd/gobl@latest`.

--- a/data/rules/org.json
+++ b/data/rules/org.json
@@ -426,7 +426,7 @@
                 {
                   "id": "GOBL-ORG-REGISTRATION-01",
                   "desc": "registration currency must be a valid ISO 4217 code",
-                  "tests": "is valid currency"
+                  "tests": "valid currency code"
                 }
               ]
             }

--- a/data/schemas/org/registration.json
+++ b/data/schemas/org/registration.json
@@ -57,6 +57,11 @@
         "other": {
           "type": "string",
           "title": "Other"
+        },
+        "ext": {
+          "$ref": "https://gobl.org/draft-0/tax/extensions",
+          "title": "Extensions",
+          "description": "Ext holds any additional information that may be required by specific tax authorities."
         }
       },
       "type": "object",

--- a/org/registration.go
+++ b/org/registration.go
@@ -28,7 +28,7 @@ type Registration struct {
 	Other    string        `json:"other,omitempty" jsonschema:"title=Other"`
 
 	// Ext holds any additional information that may be required by specific tax authorities.
-	Ext tax.Extensions `json:"ext,omitempty" jsonschema:"title=Extensions"`
+	Ext tax.Extensions `json:"ext,omitzero" jsonschema:"title=Extensions"`
 }
 
 func registrationRules() *rules.Set {

--- a/org/registration.go
+++ b/org/registration.go
@@ -5,7 +5,7 @@ import (
 	"github.com/invopop/gobl/currency"
 	"github.com/invopop/gobl/num"
 	"github.com/invopop/gobl/rules"
-	"github.com/invopop/gobl/rules/is"
+	"github.com/invopop/gobl/tax"
 	"github.com/invopop/gobl/uuid"
 )
 
@@ -26,16 +26,16 @@ type Registration struct {
 	Page     string        `json:"page,omitempty" jsonschema:"title=Page"`
 	Entry    string        `json:"entry,omitempty" jsonschema:"title=Entry"`
 	Other    string        `json:"other,omitempty" jsonschema:"title=Other"`
+
+	// Ext holds any additional information that may be required by specific tax authorities.
+	Ext tax.Extensions `json:"ext,omitempty" jsonschema:"title=Extensions"`
 }
 
 func registrationRules() *rules.Set {
 	return rules.For(new(Registration),
 		rules.Field("currency",
 			rules.AssertIfPresent("01", "registration currency must be a valid ISO 4217 code",
-				is.FuncError("is valid currency", func(val any) error {
-					c, _ := val.(currency.Code)
-					return c.Validate()
-				}),
+				currency.IsCodeDefined,
 			),
 		),
 	)


### PR DESCRIPTION
- Quick change to add support for extensions to the `org.Registration` model.

## Pre-Review Checklist

- [x] Performed a self-review of my code.
- [x] Added thorough tests with at **least** 90% code coverage.
- [x] Modified or created example GOBL documents to show my changes in use, if appropriate.
- [x] Added links to the source of the changes in tax regimes or addons, either structured or in the comments.
- [x] Run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [x] Reviewed and fixed all linter warnings.
- [x] Been obsessive with pointer nil checks to avoid panics.
- [x] Updated the CHANGELOG.md with an overview of my changes.
- [ ] Marked this PR as ready for review.

And if you are part of the org:
- [ ] Requested a review from Copilot and fixed or dismissed (with a reason) all the feedback raised.
- [ ] Requested a review from @samlown.
