### PR TITLE
it-sdi: add registration extensions for IscrizioneREA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 - `cbc.Code`: `HasPrefix`, `HasSuffix`, `TrimPrefix`, and `TrimSuffix` helpers.
 - `org`: `Registration` object includes `ext` for addon-specific registration details.
+- `it-sdi`: `it-sdi-liquidation-state` and `it-sdi-shareholder-state` registration extensions for the FatturaPA `IscrizioneREA` block (`StatoLiquidazione` and `SocioUnico`).
 
 ### Fixed
 

--- a/addons/it/sdi/extensions.go
+++ b/addons/it/sdi/extensions.go
@@ -17,6 +17,9 @@ const (
 	ExtKeyPaymentMeans cbc.Key = "it-sdi-payment-means"
 	ExtKeyVATLiability cbc.Key = "it-sdi-vat-liability"
 	ExtKeyFundType     cbc.Key = "it-sdi-fund-type"
+
+	ExtKeyLiquidationState cbc.Key = "it-sdi-liquidation-state"
+	ExtKeyShareholderState cbc.Key = "it-sdi-shareholder-state"
 )
 
 var extensions = []*cbc.Definition{
@@ -1055,6 +1058,66 @@ var extensions = []*cbc.Definition{
 				Name: i18n.String{
 					i18n.EN: "National Social Security Institute (INPS)",
 					i18n.IT: "Istituto nazionale della previdenza sociale (INPS)",
+				},
+			},
+		},
+	},
+	{
+		Key: ExtKeyLiquidationState,
+		Name: i18n.String{
+			i18n.EN: "Liquidation State",
+			i18n.IT: "Stato di Liquidazione",
+		},
+		Desc: i18n.String{
+			i18n.EN: here.Doc(`
+				Indicates whether the company is in liquidation, used in the
+				IscrizioneREA block of a FatturaPA document as the
+				StatoLiquidazione field.
+			`),
+		},
+		Values: []*cbc.Definition{
+			{
+				Code: "LS",
+				Name: i18n.String{
+					i18n.EN: "In liquidation",
+					i18n.IT: "In liquidazione",
+				},
+			},
+			{
+				Code: "LN",
+				Name: i18n.String{
+					i18n.EN: "Not in liquidation",
+					i18n.IT: "Non in liquidazione",
+				},
+			},
+		},
+	},
+	{
+		Key: ExtKeyShareholderState,
+		Name: i18n.String{
+			i18n.EN: "Shareholder State",
+			i18n.IT: "Stato di Socio",
+		},
+		Desc: i18n.String{
+			i18n.EN: here.Doc(`
+				Indicates the company's shareholder configuration, used in the
+				IscrizioneREA block of a FatturaPA document as the SocioUnico
+				field.
+			`),
+		},
+		Values: []*cbc.Definition{
+			{
+				Code: "SU",
+				Name: i18n.String{
+					i18n.EN: "Sole shareholder",
+					i18n.IT: "Socio unico",
+				},
+			},
+			{
+				Code: "SM",
+				Name: i18n.String{
+					i18n.EN: "Multiple shareholders",
+					i18n.IT: "Più soci",
 				},
 			},
 		},

--- a/data/addons/it-sdi-v1.json
+++ b/data/addons/it-sdi-v1.json
@@ -1083,6 +1083,58 @@
           }
         }
       ]
+    },
+    {
+      "key": "it-sdi-liquidation-state",
+      "name": {
+        "en": "Liquidation State",
+        "it": "Stato di Liquidazione"
+      },
+      "desc": {
+        "en": "Indicates whether the company is in liquidation, used in the\nIscrizioneREA block of a FatturaPA document as the\nStatoLiquidazione field."
+      },
+      "values": [
+        {
+          "code": "LS",
+          "name": {
+            "en": "In liquidation",
+            "it": "In liquidazione"
+          }
+        },
+        {
+          "code": "LN",
+          "name": {
+            "en": "Not in liquidation",
+            "it": "Non in liquidazione"
+          }
+        }
+      ]
+    },
+    {
+      "key": "it-sdi-shareholder-state",
+      "name": {
+        "en": "Shareholder State",
+        "it": "Stato di Socio"
+      },
+      "desc": {
+        "en": "Indicates the company's shareholder configuration, used in the\nIscrizioneREA block of a FatturaPA document as the SocioUnico\nfield."
+      },
+      "values": [
+        {
+          "code": "SU",
+          "name": {
+            "en": "Sole shareholder",
+            "it": "Socio unico"
+          }
+        },
+        {
+          "code": "SM",
+          "name": {
+            "en": "Multiple shareholders",
+            "it": "Più soci"
+          }
+        }
+      ]
     }
   ],
   "tags": [

--- a/examples/it/hotel.yaml
+++ b/examples/it/hotel.yaml
@@ -18,6 +18,9 @@ supplier:
     currency: EUR
     entry: "123456"
     office: RM
+    ext:
+      it-sdi-liquidation-state: LN
+      it-sdi-shareholder-state: SM
   addresses:
     - num: "102"
       street: Via California

--- a/examples/it/out/hotel.json
+++ b/examples/it/out/hotel.json
@@ -4,7 +4,7 @@
 		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
 		"dig": {
 			"alg": "sha256",
-			"val": "23d27fc3273a9b31b0f3f4b54483159db3a133c9411cd8224f4935f8bdb18fd5"
+			"val": "cba9205cf6b8eed3558b16d01798f72e23ae96c0111a9ec20c578e92230b31e4"
 		}
 	},
 	"doc": {
@@ -46,7 +46,11 @@
 				"capital": "50000.00",
 				"currency": "EUR",
 				"office": "RM",
-				"entry": "123456"
+				"entry": "123456",
+				"ext": {
+					"it-sdi-liquidation-state": "LN",
+					"it-sdi-shareholder-state": "SM"
+				}
 			},
 			"ext": {
 				"it-sdi-fiscal-regime": "RF01"


### PR DESCRIPTION
## Summary

Adds two registration extensions to the `it-sdi` addon for the FatturaPA `IscrizioneREA` block, using the generic `org.Registration.ext` field added in #863:

- `it-sdi-liquidation-state` → `<StatoLiquidazione>` (values `LS` / `LN`)
- `it-sdi-shareholder-state` → `<SocioUnico>` (values `SU` / `SM`)

The `it/hotel` example demonstrates both extensions in use.

## Background

This supersedes #856, where I originally proposed adding `LiquidationState` and `SoleShareholder` as region-specific string fields directly on `org.Registration`. Per @samlown's review there, the right approach is a generic `ext` field on `Registration` (landed in #863) plus addon-specific extensions. @pmenendz confirmed these should follow the `it-sdi` addon convention rather than a separate `fatturapa` addon. This PR implements that.

It unblocks invopop/gobl.fatturapa#68, which maps these extensions to the FatturaPA XML.

## Checklist

- [x] Performed a self-review of my code.
- [x] Added thorough tests / coverage (extensions exercised via the `it/hotel` example).
- [x] Modified example GOBL documents to show the change in use.
- [x] Ran `go generate .` to keep schemas and addon data up to date.
- [x] Updated the CHANGELOG.md.
