### PR TITLE
Add extensions to `br-nfe-v4` for simples nacional and other cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - `regimes/br`: Party address country is now inferred automatically from tax ID or identities.
 - `addons/br/nfe`: Allow foreign customers to provide an identity (e.g. a passport) alternatively to a tax ID.
 - `addons/br/nfe`: Supplier and customer addresses now require the `country` field, as mandated by the NF-e spec.
+- `addons/br/nfe`: Tax status code (CST) extensions for ICMS (`br-nfe-icms-cst` / `br-nfe-icms-csosn`), PIS (`br-nfe-pis-cst`) and COFINS (`br-nfe-cofins-cst`), with defaults applied during normalization.
+- `addons/br/nfe/`: ICMS goods origin extension (`br-nfe-icms-origin`) with default applied during normalization.
 
 ### Changed
 
 - `addons/br/nfe`: Customer address `state` presence validation and the `br-ibge-municipality` extension are now applied to Brazilian parties only.
+- `addons/br/nfe`: The invoice supplier now requires the `br-nfe-regime` extension which now supports value `4` (MEI – Individual Micro-entrepreneur) and defaults to `3` (normal regime) during normalization.
 
 ## [v0.500.0] - 2026-06-10
 

--- a/addons/br/nfe/bill_invoices.go
+++ b/addons/br/nfe/bill_invoices.go
@@ -19,6 +19,14 @@ const (
 	seriesPattern = `^(?:0|[1-9]{1}[0-9]{0,2})$` // extracted from the NFe XSD to validate the series
 )
 
+// normalizeInvoice applies NF-e invoice-level defaults.
+func normalizeInvoice(inv *bill.Invoice) {
+	if inv == nil || inv.Supplier == nil {
+		return
+	}
+	inv.Supplier.Ext = inv.Supplier.Ext.SetIfEmpty(ExtKeyRegime, "3") // Normal regime
+}
+
 func billInvoiceRules() *rules.Set {
 	return rules.For(new(bill.Invoice),
 		rules.Assert("34", "invoice currency must be BRL or provide exchange rate for conversion", currency.CanConvertTo(currency.BRL)),
@@ -59,6 +67,11 @@ func billInvoiceRules() *rules.Set {
 					rules.Assert("09", fmt.Sprintf("invoice supplier requires '%s' extension when addresses are present", br.ExtKeyMunicipality),
 						tax.ExtensionsRequire(br.ExtKeyMunicipality),
 					),
+				),
+			),
+			rules.Field("ext",
+				rules.Assert("39", fmt.Sprintf("invoice supplier requires '%s' extension", ExtKeyRegime),
+					tax.ExtensionsRequire(ExtKeyRegime),
 				),
 			),
 			rules.Field("name",

--- a/addons/br/nfe/bill_invoices_test.go
+++ b/addons/br/nfe/bill_invoices_test.go
@@ -208,6 +208,7 @@ func TestSupplierValidation(t *testing.T) {
 		inv.Supplier.Addresses = []*org.Address{nil}
 		inv.Supplier.Ext = tax.ExtensionsOf(cbc.CodeMap{
 			"br-ibge-municipality": "3304557",
+			nfe.ExtKeyRegime:       "3",
 		})
 		err = rules.Validate(inv)
 		assert.ErrorContains(t, err, "supplier address must not be empty")
@@ -251,6 +252,7 @@ func TestSupplierValidation(t *testing.T) {
 
 		inv.Supplier.Ext = tax.ExtensionsOf(cbc.CodeMap{
 			"br-ibge-municipality": "3304557",
+			nfe.ExtKeyRegime:       "3",
 		})
 		err = rules.Validate(inv)
 		assert.NoError(t, err)

--- a/addons/br/nfe/bill_line_test.go
+++ b/addons/br/nfe/bill_line_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/invopop/gobl/addons/br/nfe"
 	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/num"
 	"github.com/invopop/gobl/org"
 	"github.com/invopop/gobl/regimes/br"
@@ -33,12 +34,18 @@ func TestLineValidation(t *testing.T) {
 				Taxes: tax.Set{
 					{
 						Category: br.TaxCategoryICMS,
+						Ext: tax.ExtensionsOf(cbc.CodeMap{
+							nfe.ExtKeyICMSCST:    "00",
+							nfe.ExtKeyICMSOrigin: "0",
+						}),
 					},
 					{
 						Category: br.TaxCategoryPIS,
+						Ext:      tax.ExtensionsOf(cbc.CodeMap{nfe.ExtKeyPISCST: "01"}),
 					},
 					{
 						Category: br.TaxCategoryCOFINS,
+						Ext:      tax.ExtensionsOf(cbc.CodeMap{nfe.ExtKeyCOFINSCST: "01"}),
 					},
 				},
 			},

--- a/addons/br/nfe/extensions.go
+++ b/addons/br/nfe/extensions.go
@@ -15,6 +15,11 @@ const (
 	ExtKeyFiscalIncentive = "br-nfe-fiscal-incentive"
 	ExtKeyRegime          = "br-nfe-regime"
 	ExtKeySpecialRegime   = "br-nfe-special-regime"
+	ExtKeyICMSCST         = "br-nfe-icms-cst"
+	ExtKeyICMSCSOSN       = "br-nfe-icms-csosn"
+	ExtKeyICMSOrigin      = "br-nfe-icms-origin"
+	ExtKeyPISCST          = "br-nfe-pis-cst"
+	ExtKeyCOFINSCST       = "br-nfe-cofins-cst"
 )
 
 // Model Codes
@@ -397,10 +402,18 @@ var extensions = []*cbc.Definition{
 					i18n.PT: "Normal",
 				},
 			},
+			{
+				Code: "4",
+				Name: i18n.String{
+					i18n.EN: "MEI - Individual Micro-entrepreneur",
+					i18n.PT: "MEI - Microempreendedor Individual",
+				},
+			},
 		},
 		Desc: i18n.String{
 			i18n.EN: here.Doc(`
-				Indicates the tax regime that a party is subject to.
+				Indicates the tax regime that a party is subject to. Defaults to ~3~
+				(normal regime) during normalization when not provided.
 			`),
 		},
 		Sources: []*cbc.Source{
@@ -410,6 +423,14 @@ var extensions = []*cbc.Definition{
 					i18n.PT: "Manual de Orientação ao Contribuinte v7.0 - Anexo I – Leiaute e Regras de Validação da NF-e e da NFC-e",
 				},
 				URL:         "https://www.nfe.fazenda.gov.br/portal/exibirArquivo.aspx?conteudo=J%20I%20v4eN00E=",
+				ContentType: "application/pdf",
+			},
+			{
+				Title: i18n.String{
+					i18n.EN: "NF-e/NFC-e Technical Note 2024.001 - CRT=4 MEI",
+					i18n.PT: "Nota Técnica NF-e/NFC-e 2024.001 - CRT=4 MEI",
+				},
+				URL:         "https://www.nfe.fazenda.gov.br/portal/exibirArquivo.aspx?conteudo=kIiniiSkpKc=",
 				ContentType: "application/pdf",
 			},
 		},
@@ -468,6 +489,837 @@ var extensions = []*cbc.Definition{
 			i18n.EN: here.Doc(`
 				Indicates a special tax regime that a party is subject to.
 			`),
+		},
+		Sources: []*cbc.Source{
+			{
+				Title: i18n.String{
+					i18n.EN: "Taxpayer Guidance Manual v7.0 - Annex I – Layout and Validation Rules for NF-e and NFC-e",
+					i18n.PT: "Manual de Orientação ao Contribuinte v7.0 - Anexo I – Leiaute e Regras de Validação da NF-e e da NFC-e",
+				},
+				URL:         "https://www.nfe.fazenda.gov.br/portal/exibirArquivo.aspx?conteudo=J%20I%20v4eN00E=",
+				ContentType: "application/pdf",
+			},
+		},
+	},
+	{
+		Key: ExtKeyICMSCST,
+		Name: i18n.String{
+			i18n.EN: "ICMS Tax Status Code (CST)",
+			i18n.PT: "Código de Situação Tributária do ICMS (CST)",
+		},
+		Desc: i18n.String{
+			i18n.EN: here.Doc(`
+				ICMS tax status code (CST) for the line item, used by issuers under the normal
+				regime (~br-nfe-regime~ ~3~). Simples Nacional issuers must use the CSOSN code
+				(~br-nfe-icms-csosn~) instead. Defaults to ~00~ (taxed in full) during
+				normalization when not provided.
+			`),
+		},
+		Values: []*cbc.Definition{
+			{
+				Code: "00",
+				Name: i18n.String{
+					i18n.EN: "Taxed in full",
+					i18n.PT: "Tributada integralmente",
+				},
+			},
+			{
+				Code: "02",
+				Name: i18n.String{
+					i18n.EN: "Monophasic taxation (fuels)",
+					i18n.PT: "Tributação monofásica própria sobre combustíveis",
+				},
+			},
+			{
+				Code: "10",
+				Name: i18n.String{
+					i18n.EN: "Taxed with ICMS charged by tax substitution",
+					i18n.PT: "Tributada e com cobrança do ICMS por substituição tributária",
+				},
+			},
+			{
+				Code: "15",
+				Name: i18n.String{
+					i18n.EN: "Fuel operation with ICMS retention",
+					i18n.PT: "Operação com combustível e retenção do ICMS",
+				},
+			},
+			{
+				Code: "20",
+				Name: i18n.String{
+					i18n.EN: "Taxed with tax base reduction",
+					i18n.PT: "Com redução da base de cálculo",
+				},
+			},
+			{
+				Code: "30",
+				Name: i18n.String{
+					i18n.EN: "Exempt/non-taxed with ICMS charged by tax substitution",
+					i18n.PT: "Isenta/não tributada e com cobrança do ICMS por substituição tributária",
+				},
+			},
+			{
+				Code: "40",
+				Name: i18n.String{
+					i18n.EN: "Exempt",
+					i18n.PT: "Isenta",
+				},
+			},
+			{
+				Code: "41",
+				Name: i18n.String{
+					i18n.EN: "Non-taxed",
+					i18n.PT: "Não tributada",
+				},
+			},
+			{
+				Code: "50",
+				Name: i18n.String{
+					i18n.EN: "Suspended",
+					i18n.PT: "Com suspensão",
+				},
+			},
+			{
+				Code: "51",
+				Name: i18n.String{
+					i18n.EN: "Deferred",
+					i18n.PT: "Com diferimento",
+				},
+			},
+			{
+				Code: "53",
+				Name: i18n.String{
+					i18n.EN: "Fuel operation with deferral",
+					i18n.PT: "Operação com combustível e diferimento",
+				},
+			},
+			{
+				Code: "60",
+				Name: i18n.String{
+					i18n.EN: "ICMS charged previously by tax substitution",
+					i18n.PT: "ICMS cobrado anteriormente por substituição tributária",
+				},
+			},
+			{
+				Code: "61",
+				Name: i18n.String{
+					i18n.EN: "Fuel operation with ICMS withheld",
+					i18n.PT: "Operação com combustível e ICMS retido anteriormente",
+				},
+			},
+			{
+				Code: "70",
+				Name: i18n.String{
+					i18n.EN: "Taxed with base reduction and ICMS charged by tax substitution",
+					i18n.PT: "Com redução da base de cálculo e cobrança do ICMS por substituição tributária",
+				},
+			},
+			{
+				Code: "90",
+				Name: i18n.String{
+					i18n.EN: "Others",
+					i18n.PT: "Outras",
+				},
+			},
+		},
+		Sources: []*cbc.Source{
+			{
+				Title: i18n.String{
+					i18n.EN: "Taxpayer Guidance Manual v7.0 - Annex I – Layout and Validation Rules for NF-e and NFC-e",
+					i18n.PT: "Manual de Orientação ao Contribuinte v7.0 - Anexo I – Leiaute e Regras de Validação da NF-e e da NFC-e",
+				},
+				URL:         "https://www.nfe.fazenda.gov.br/portal/exibirArquivo.aspx?conteudo=J%20I%20v4eN00E=",
+				ContentType: "application/pdf",
+			},
+		},
+	},
+	{
+		Key: ExtKeyICMSCSOSN,
+		Name: i18n.String{
+			i18n.EN: "ICMS Simples Nacional Status Code (CSOSN)",
+			i18n.PT: "Código de Situação da Operação no Simples Nacional (CSOSN)",
+		},
+		Desc: i18n.String{
+			i18n.EN: here.Doc(`
+				ICMS status code (CSOSN) for the line item, used by issuers under the Simples
+				Nacional regime (~br-nfe-regime~ ~1~, ~2~ or ~4~). Normal-regime issuers must
+				use the CST code (~br-nfe-icms-cst~) instead.
+			`),
+		},
+		Values: []*cbc.Definition{
+			{
+				Code: "101",
+				Name: i18n.String{
+					i18n.EN: "Taxed under Simples Nacional with credit permission",
+					i18n.PT: "Tributada pelo Simples Nacional com permissão de crédito",
+				},
+			},
+			{
+				Code: "102",
+				Name: i18n.String{
+					i18n.EN: "Taxed under Simples Nacional without credit permission",
+					i18n.PT: "Tributada pelo Simples Nacional sem permissão de crédito",
+				},
+			},
+			{
+				Code: "103",
+				Name: i18n.String{
+					i18n.EN: "ICMS exemption under Simples Nacional for gross revenue range",
+					i18n.PT: "Isenção do ICMS no Simples Nacional para faixa de receita bruta",
+				},
+			},
+			{
+				Code: "201",
+				Name: i18n.String{
+					i18n.EN: "Taxed under Simples Nacional with credit permission and ICMS by tax substitution",
+					i18n.PT: "Tributada pelo Simples Nacional com permissão de crédito e com cobrança do ICMS por substituição tributária",
+				},
+			},
+			{
+				Code: "202",
+				Name: i18n.String{
+					i18n.EN: "Taxed under Simples Nacional without credit permission and ICMS by tax substitution",
+					i18n.PT: "Tributada pelo Simples Nacional sem permissão de crédito e com cobrança do ICMS por substituição tributária",
+				},
+			},
+			{
+				Code: "203",
+				Name: i18n.String{
+					i18n.EN: "ICMS exemption under Simples Nacional for revenue range and ICMS by tax substitution",
+					i18n.PT: "Isenção do ICMS no Simples Nacional para faixa de receita bruta e com cobrança do ICMS por substituição tributária",
+				},
+			},
+			{
+				Code: "300",
+				Name: i18n.String{
+					i18n.EN: "Immune",
+					i18n.PT: "Imune",
+				},
+			},
+			{
+				Code: "400",
+				Name: i18n.String{
+					i18n.EN: "Non-taxed under Simples Nacional",
+					i18n.PT: "Não tributada pelo Simples Nacional",
+				},
+			},
+			{
+				Code: "500",
+				Name: i18n.String{
+					i18n.EN: "ICMS charged previously by tax substitution or anticipation",
+					i18n.PT: "ICMS cobrado anteriormente por substituição tributária ou por antecipação",
+				},
+			},
+			{
+				Code: "900",
+				Name: i18n.String{
+					i18n.EN: "Others",
+					i18n.PT: "Outros",
+				},
+			},
+		},
+		Sources: []*cbc.Source{
+			{
+				Title: i18n.String{
+					i18n.EN: "Taxpayer Guidance Manual v7.0 - Annex I – Layout and Validation Rules for NF-e and NFC-e",
+					i18n.PT: "Manual de Orientação ao Contribuinte v7.0 - Anexo I – Leiaute e Regras de Validação da NF-e e da NFC-e",
+				},
+				URL:         "https://www.nfe.fazenda.gov.br/portal/exibirArquivo.aspx?conteudo=J%20I%20v4eN00E=",
+				ContentType: "application/pdf",
+			},
+		},
+	},
+	{
+		Key: ExtKeyICMSOrigin,
+		Name: i18n.String{
+			i18n.EN: "ICMS Goods Origin",
+			i18n.PT: "Origem da Mercadoria (ICMS)",
+		},
+		Desc: i18n.String{
+			i18n.EN: here.Doc(`
+				Origin of the goods for ICMS purposes. Defaults to ~0~ (national) during
+				normalization when not provided.
+			`),
+		},
+		Values: []*cbc.Definition{
+			{
+				Code: "0",
+				Name: i18n.String{
+					i18n.EN: "National (except codes 3, 4, 5 and 8)",
+					i18n.PT: "Nacional, exceto as indicadas nos códigos 3, 4, 5 e 8",
+				},
+			},
+			{
+				Code: "1",
+				Name: i18n.String{
+					i18n.EN: "Foreign, direct import (except code 6)",
+					i18n.PT: "Estrangeira - Importação direta, exceto a indicada no código 6",
+				},
+			},
+			{
+				Code: "2",
+				Name: i18n.String{
+					i18n.EN: "Foreign, acquired in the domestic market (except code 7)",
+					i18n.PT: "Estrangeira - Adquirida no mercado interno, exceto a indicada no código 7",
+				},
+			},
+			{
+				Code: "3",
+				Name: i18n.String{
+					i18n.EN: "National, import content above 40% and up to 70%",
+					i18n.PT: "Nacional, mercadoria ou bem com Conteúdo de Importação superior a 40% e inferior ou igual a 70%",
+				},
+			},
+			{
+				Code: "4",
+				Name: i18n.String{
+					i18n.EN: "National, produced under the basic productive processes",
+					i18n.PT: "Nacional, cuja produção tenha sido feita em conformidade com os processos produtivos básicos de que tratam as legislações citadas nos Ajustes",
+				},
+			},
+			{
+				Code: "5",
+				Name: i18n.String{
+					i18n.EN: "National, import content up to 40%",
+					i18n.PT: "Nacional, mercadoria ou bem com Conteúdo de Importação inferior ou igual a 40%",
+				},
+			},
+			{
+				Code: "6",
+				Name: i18n.String{
+					i18n.EN: "Foreign, direct import, no domestic equivalent (CAMEX list / natural gas)",
+					i18n.PT: "Estrangeira - Importação direta, sem similar nacional, constante em lista da CAMEX e gás natural",
+				},
+			},
+			{
+				Code: "7",
+				Name: i18n.String{
+					i18n.EN: "Foreign, acquired domestically, no domestic equivalent (CAMEX list / natural gas)",
+					i18n.PT: "Estrangeira - Adquirida no mercado interno, sem similar nacional, constante lista CAMEX e gás natural",
+				},
+			},
+			{
+				Code: "8",
+				Name: i18n.String{
+					i18n.EN: "National, import content above 70%",
+					i18n.PT: "Nacional, mercadoria ou bem com Conteúdo de Importação superior a 70%",
+				},
+			},
+		},
+		Sources: []*cbc.Source{
+			{
+				Title: i18n.String{
+					i18n.EN: "Taxpayer Guidance Manual v7.0 - Annex I – Layout and Validation Rules for NF-e and NFC-e",
+					i18n.PT: "Manual de Orientação ao Contribuinte v7.0 - Anexo I – Leiaute e Regras de Validação da NF-e e da NFC-e",
+				},
+				URL:         "https://www.nfe.fazenda.gov.br/portal/exibirArquivo.aspx?conteudo=J%20I%20v4eN00E=",
+				ContentType: "application/pdf",
+			},
+		},
+	},
+	{
+		Key: ExtKeyPISCST,
+		Name: i18n.String{
+			i18n.EN: "PIS Tax Status Code (CST)",
+			i18n.PT: "Código de Situação Tributária do PIS (CST)",
+		},
+		Desc: i18n.String{
+			i18n.EN: here.Doc(`
+				PIS tax status code for the line item. Simples Nacional issuers typically use
+				~49~ or ~99~, as PIS is settled within the unified DAS collection. Defaults to
+				~01~ (standard-rate taxable operation) during normalization when not provided.
+			`),
+		},
+		Values: []*cbc.Definition{
+			{
+				Code: "01",
+				Name: i18n.String{
+					i18n.EN: "Taxable operation, standard rate",
+					i18n.PT: "Operação Tributável com Alíquota Básica",
+				},
+			},
+			{
+				Code: "02",
+				Name: i18n.String{
+					i18n.EN: "Taxable operation, differentiated rate",
+					i18n.PT: "Operação Tributável com Alíquota Diferenciada",
+				},
+			},
+			{
+				Code: "03",
+				Name: i18n.String{
+					i18n.EN: "Taxable operation, rate per unit of measure",
+					i18n.PT: "Operação Tributável com Alíquota por Unidade de Medida de Produto",
+				},
+			},
+			{
+				Code: "04",
+				Name: i18n.String{
+					i18n.EN: "Taxable monophasic operation, zero-rate resale",
+					i18n.PT: "Operação Tributável Monofásica - Revenda a Alíquota Zero",
+				},
+			},
+			{
+				Code: "05",
+				Name: i18n.String{
+					i18n.EN: "Taxable operation by tax substitution",
+					i18n.PT: "Operação Tributável por Substituição Tributária",
+				},
+			},
+			{
+				Code: "06",
+				Name: i18n.String{
+					i18n.EN: "Taxable operation, zero rate",
+					i18n.PT: "Operação Tributável a Alíquota Zero",
+				},
+			},
+			{
+				Code: "07",
+				Name: i18n.String{
+					i18n.EN: "Operation exempt from the contribution",
+					i18n.PT: "Operação Isenta da Contribuição",
+				},
+			},
+			{
+				Code: "08",
+				Name: i18n.String{
+					i18n.EN: "Operation without incidence of the contribution",
+					i18n.PT: "Operação Sem Incidência da Contribuição",
+				},
+			},
+			{
+				Code: "09",
+				Name: i18n.String{
+					i18n.EN: "Operation with suspension of the contribution",
+					i18n.PT: "Operação com Suspensão da Contribuição",
+				},
+			},
+			{
+				Code: "49",
+				Name: i18n.String{
+					i18n.EN: "Other outbound operations",
+					i18n.PT: "Outras Operações de Saída",
+				},
+			},
+			{
+				Code: "50",
+				Name: i18n.String{
+					i18n.EN: "Credit operation, exclusively taxed domestic revenue",
+					i18n.PT: "Operação com Direito a Crédito - Vinculada Exclusivamente a Receita Tributada no Mercado Interno",
+				},
+			},
+			{
+				Code: "51",
+				Name: i18n.String{
+					i18n.EN: "Credit operation, exclusively non-taxed domestic revenue",
+					i18n.PT: "Operação com Direito a Crédito - Vinculada Exclusivamente a Receita Não Tributada no Mercado Interno",
+				},
+			},
+			{
+				Code: "52",
+				Name: i18n.String{
+					i18n.EN: "Credit operation, exclusively export revenue",
+					i18n.PT: "Operação com Direito a Crédito - Vinculada Exclusivamente a Receita de Exportação",
+				},
+			},
+			{
+				Code: "53",
+				Name: i18n.String{
+					i18n.EN: "Credit operation, taxed and non-taxed domestic revenue",
+					i18n.PT: "Operação com Direito a Crédito - Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno",
+				},
+			},
+			{
+				Code: "54",
+				Name: i18n.String{
+					i18n.EN: "Credit operation, taxed domestic and export revenue",
+					i18n.PT: "Operação com Direito a Crédito - Vinculada a Receitas Tributadas no Mercado Interno e de Exportação",
+				},
+			},
+			{
+				Code: "55",
+				Name: i18n.String{
+					i18n.EN: "Credit operation, non-taxed domestic and export revenue",
+					i18n.PT: "Operação com Direito a Crédito - Vinculada a Receitas Não-Tributadas no Mercado Interno e de Exportação",
+				},
+			},
+			{
+				Code: "56",
+				Name: i18n.String{
+					i18n.EN: "Credit operation, taxed/non-taxed domestic and export revenue",
+					i18n.PT: "Operação com Direito a Crédito - Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno e de Exportação",
+				},
+			},
+			{
+				Code: "60",
+				Name: i18n.String{
+					i18n.EN: "Presumed credit, exclusively taxed domestic revenue",
+					i18n.PT: "Crédito Presumido - Operação de Aquisição Vinculada Exclusivamente a Receita Tributada no Mercado Interno",
+				},
+			},
+			{
+				Code: "61",
+				Name: i18n.String{
+					i18n.EN: "Presumed credit, exclusively non-taxed domestic revenue",
+					i18n.PT: "Crédito Presumido - Operação de Aquisição Vinculada Exclusivamente a Receita Não-Tributada no Mercado Interno",
+				},
+			},
+			{
+				Code: "62",
+				Name: i18n.String{
+					i18n.EN: "Presumed credit, exclusively export revenue",
+					i18n.PT: "Crédito Presumido - Operação de Aquisição Vinculada Exclusivamente a Receita de Exportação",
+				},
+			},
+			{
+				Code: "63",
+				Name: i18n.String{
+					i18n.EN: "Presumed credit, taxed and non-taxed domestic revenue",
+					i18n.PT: "Crédito Presumido - Operação de Aquisição Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno",
+				},
+			},
+			{
+				Code: "64",
+				Name: i18n.String{
+					i18n.EN: "Presumed credit, taxed domestic and export revenue",
+					i18n.PT: "Crédito Presumido - Operação de Aquisição Vinculada a Receitas Tributadas no Mercado Interno e de Exportação",
+				},
+			},
+			{
+				Code: "65",
+				Name: i18n.String{
+					i18n.EN: "Presumed credit, non-taxed domestic and export revenue",
+					i18n.PT: "Crédito Presumido - Operação de Aquisição Vinculada a Receitas Não-Tributadas no Mercado Interno e de Exportação",
+				},
+			},
+			{
+				Code: "66",
+				Name: i18n.String{
+					i18n.EN: "Presumed credit, taxed/non-taxed domestic and export revenue",
+					i18n.PT: "Crédito Presumido - Operação de Aquisição Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno e de Exportação",
+				},
+			},
+			{
+				Code: "67",
+				Name: i18n.String{
+					i18n.EN: "Presumed credit, other operations",
+					i18n.PT: "Crédito Presumido - Outras Operações",
+				},
+			},
+			{
+				Code: "70",
+				Name: i18n.String{
+					i18n.EN: "Acquisition operation without credit right",
+					i18n.PT: "Operação de Aquisição sem Direito a Crédito",
+				},
+			},
+			{
+				Code: "71",
+				Name: i18n.String{
+					i18n.EN: "Acquisition operation with exemption",
+					i18n.PT: "Operação de Aquisição com Isenção",
+				},
+			},
+			{
+				Code: "72",
+				Name: i18n.String{
+					i18n.EN: "Acquisition operation with suspension",
+					i18n.PT: "Operação de Aquisição com Suspensão",
+				},
+			},
+			{
+				Code: "73",
+				Name: i18n.String{
+					i18n.EN: "Acquisition operation at zero rate",
+					i18n.PT: "Operação de Aquisição a Alíquota Zero",
+				},
+			},
+			{
+				Code: "74",
+				Name: i18n.String{
+					i18n.EN: "Acquisition operation without incidence of the contribution",
+					i18n.PT: "Operação de Aquisição sem Incidência da Contribuição",
+				},
+			},
+			{
+				Code: "75",
+				Name: i18n.String{
+					i18n.EN: "Acquisition operation by tax substitution",
+					i18n.PT: "Operação de Aquisição por Substituição Tributária",
+				},
+			},
+			{
+				Code: "98",
+				Name: i18n.String{
+					i18n.EN: "Other inbound operations",
+					i18n.PT: "Outras Operações de Entrada",
+				},
+			},
+			{
+				Code: "99",
+				Name: i18n.String{
+					i18n.EN: "Other operations",
+					i18n.PT: "Outras Operações",
+				},
+			},
+		},
+		Sources: []*cbc.Source{
+			{
+				Title: i18n.String{
+					i18n.EN: "Taxpayer Guidance Manual v7.0 - Annex I – Layout and Validation Rules for NF-e and NFC-e",
+					i18n.PT: "Manual de Orientação ao Contribuinte v7.0 - Anexo I – Leiaute e Regras de Validação da NF-e e da NFC-e",
+				},
+				URL:         "https://www.nfe.fazenda.gov.br/portal/exibirArquivo.aspx?conteudo=J%20I%20v4eN00E=",
+				ContentType: "application/pdf",
+			},
+		},
+	},
+	{
+		Key: ExtKeyCOFINSCST,
+		Name: i18n.String{
+			i18n.EN: "COFINS Tax Status Code (CST)",
+			i18n.PT: "Código de Situação Tributária do COFINS (CST)",
+		},
+		Desc: i18n.String{
+			i18n.EN: here.Doc(`
+				COFINS tax status code for the line item. Simples Nacional issuers typically
+				use ~49~ or ~99~, as COFINS is settled within the unified DAS collection.
+				Defaults to ~01~ (standard-rate taxable operation) during normalization when
+				not provided.
+			`),
+		},
+		Values: []*cbc.Definition{
+			{
+				Code: "01",
+				Name: i18n.String{
+					i18n.EN: "Taxable operation, standard rate",
+					i18n.PT: "Operação Tributável com Alíquota Básica",
+				},
+			},
+			{
+				Code: "02",
+				Name: i18n.String{
+					i18n.EN: "Taxable operation, differentiated rate",
+					i18n.PT: "Operação Tributável com Alíquota Diferenciada",
+				},
+			},
+			{
+				Code: "03",
+				Name: i18n.String{
+					i18n.EN: "Taxable operation, rate per unit of measure",
+					i18n.PT: "Operação Tributável com Alíquota por Unidade de Medida de Produto",
+				},
+			},
+			{
+				Code: "04",
+				Name: i18n.String{
+					i18n.EN: "Taxable monophasic operation, zero-rate resale",
+					i18n.PT: "Operação Tributável Monofásica - Revenda a Alíquota Zero",
+				},
+			},
+			{
+				Code: "05",
+				Name: i18n.String{
+					i18n.EN: "Taxable operation by tax substitution",
+					i18n.PT: "Operação Tributável por Substituição Tributária",
+				},
+			},
+			{
+				Code: "06",
+				Name: i18n.String{
+					i18n.EN: "Taxable operation, zero rate",
+					i18n.PT: "Operação Tributável a Alíquota Zero",
+				},
+			},
+			{
+				Code: "07",
+				Name: i18n.String{
+					i18n.EN: "Operation exempt from the contribution",
+					i18n.PT: "Operação Isenta da Contribuição",
+				},
+			},
+			{
+				Code: "08",
+				Name: i18n.String{
+					i18n.EN: "Operation without incidence of the contribution",
+					i18n.PT: "Operação Sem Incidência da Contribuição",
+				},
+			},
+			{
+				Code: "09",
+				Name: i18n.String{
+					i18n.EN: "Operation with suspension of the contribution",
+					i18n.PT: "Operação com Suspensão da Contribuição",
+				},
+			},
+			{
+				Code: "49",
+				Name: i18n.String{
+					i18n.EN: "Other outbound operations",
+					i18n.PT: "Outras Operações de Saída",
+				},
+			},
+			{
+				Code: "50",
+				Name: i18n.String{
+					i18n.EN: "Credit operation, exclusively taxed domestic revenue",
+					i18n.PT: "Operação com Direito a Crédito - Vinculada Exclusivamente a Receita Tributada no Mercado Interno",
+				},
+			},
+			{
+				Code: "51",
+				Name: i18n.String{
+					i18n.EN: "Credit operation, exclusively non-taxed domestic revenue",
+					i18n.PT: "Operação com Direito a Crédito - Vinculada Exclusivamente a Receita Não Tributada no Mercado Interno",
+				},
+			},
+			{
+				Code: "52",
+				Name: i18n.String{
+					i18n.EN: "Credit operation, exclusively export revenue",
+					i18n.PT: "Operação com Direito a Crédito - Vinculada Exclusivamente a Receita de Exportação",
+				},
+			},
+			{
+				Code: "53",
+				Name: i18n.String{
+					i18n.EN: "Credit operation, taxed and non-taxed domestic revenue",
+					i18n.PT: "Operação com Direito a Crédito - Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno",
+				},
+			},
+			{
+				Code: "54",
+				Name: i18n.String{
+					i18n.EN: "Credit operation, taxed domestic and export revenue",
+					i18n.PT: "Operação com Direito a Crédito - Vinculada a Receitas Tributadas no Mercado Interno e de Exportação",
+				},
+			},
+			{
+				Code: "55",
+				Name: i18n.String{
+					i18n.EN: "Credit operation, non-taxed domestic and export revenue",
+					i18n.PT: "Operação com Direito a Crédito - Vinculada a Receitas Não-Tributadas no Mercado Interno e de Exportação",
+				},
+			},
+			{
+				Code: "56",
+				Name: i18n.String{
+					i18n.EN: "Credit operation, taxed/non-taxed domestic and export revenue",
+					i18n.PT: "Operação com Direito a Crédito - Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno e de Exportação",
+				},
+			},
+			{
+				Code: "60",
+				Name: i18n.String{
+					i18n.EN: "Presumed credit, exclusively taxed domestic revenue",
+					i18n.PT: "Crédito Presumido - Operação de Aquisição Vinculada Exclusivamente a Receita Tributada no Mercado Interno",
+				},
+			},
+			{
+				Code: "61",
+				Name: i18n.String{
+					i18n.EN: "Presumed credit, exclusively non-taxed domestic revenue",
+					i18n.PT: "Crédito Presumido - Operação de Aquisição Vinculada Exclusivamente a Receita Não-Tributada no Mercado Interno",
+				},
+			},
+			{
+				Code: "62",
+				Name: i18n.String{
+					i18n.EN: "Presumed credit, exclusively export revenue",
+					i18n.PT: "Crédito Presumido - Operação de Aquisição Vinculada Exclusivamente a Receita de Exportação",
+				},
+			},
+			{
+				Code: "63",
+				Name: i18n.String{
+					i18n.EN: "Presumed credit, taxed and non-taxed domestic revenue",
+					i18n.PT: "Crédito Presumido - Operação de Aquisição Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno",
+				},
+			},
+			{
+				Code: "64",
+				Name: i18n.String{
+					i18n.EN: "Presumed credit, taxed domestic and export revenue",
+					i18n.PT: "Crédito Presumido - Operação de Aquisição Vinculada a Receitas Tributadas no Mercado Interno e de Exportação",
+				},
+			},
+			{
+				Code: "65",
+				Name: i18n.String{
+					i18n.EN: "Presumed credit, non-taxed domestic and export revenue",
+					i18n.PT: "Crédito Presumido - Operação de Aquisição Vinculada a Receitas Não-Tributadas no Mercado Interno e de Exportação",
+				},
+			},
+			{
+				Code: "66",
+				Name: i18n.String{
+					i18n.EN: "Presumed credit, taxed/non-taxed domestic and export revenue",
+					i18n.PT: "Crédito Presumido - Operação de Aquisição Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno e de Exportação",
+				},
+			},
+			{
+				Code: "67",
+				Name: i18n.String{
+					i18n.EN: "Presumed credit, other operations",
+					i18n.PT: "Crédito Presumido - Outras Operações",
+				},
+			},
+			{
+				Code: "70",
+				Name: i18n.String{
+					i18n.EN: "Acquisition operation without credit right",
+					i18n.PT: "Operação de Aquisição sem Direito a Crédito",
+				},
+			},
+			{
+				Code: "71",
+				Name: i18n.String{
+					i18n.EN: "Acquisition operation with exemption",
+					i18n.PT: "Operação de Aquisição com Isenção",
+				},
+			},
+			{
+				Code: "72",
+				Name: i18n.String{
+					i18n.EN: "Acquisition operation with suspension",
+					i18n.PT: "Operação de Aquisição com Suspensão",
+				},
+			},
+			{
+				Code: "73",
+				Name: i18n.String{
+					i18n.EN: "Acquisition operation at zero rate",
+					i18n.PT: "Operação de Aquisição a Alíquota Zero",
+				},
+			},
+			{
+				Code: "74",
+				Name: i18n.String{
+					i18n.EN: "Acquisition operation without incidence of the contribution",
+					i18n.PT: "Operação de Aquisição sem Incidência da Contribuição",
+				},
+			},
+			{
+				Code: "75",
+				Name: i18n.String{
+					i18n.EN: "Acquisition operation by tax substitution",
+					i18n.PT: "Operação de Aquisição por Substituição Tributária",
+				},
+			},
+			{
+				Code: "98",
+				Name: i18n.String{
+					i18n.EN: "Other inbound operations",
+					i18n.PT: "Outras Operações de Entrada",
+				},
+			},
+			{
+				Code: "99",
+				Name: i18n.String{
+					i18n.EN: "Other operations",
+					i18n.PT: "Outras Operações",
+				},
+			},
 		},
 		Sources: []*cbc.Source{
 			{

--- a/addons/br/nfe/nfe.go
+++ b/addons/br/nfe/nfe.go
@@ -41,13 +41,16 @@ func init() {
 		is.InContext(tax.AddonIn(V4)),
 		billInvoiceRules(),
 		billLineRules(),
+		taxComboRules(),
 		payInstructionsRules(),
 		payAdvanceRules(),
 	)
 	norm.RegisterWithGuard(
 		is.InContext(tax.AddonIn(V4)),
+		norm.For(normalizeInvoice),
 		norm.For(normalizePayInstructions),
 		norm.For(normalizePayRecord),
+		norm.For(normalizeTaxCombo),
 	)
 }
 

--- a/addons/br/nfe/tax_combo.go
+++ b/addons/br/nfe/tax_combo.go
@@ -1,0 +1,72 @@
+package nfe
+
+import (
+	"fmt"
+
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/regimes/br"
+	"github.com/invopop/gobl/rules"
+	"github.com/invopop/gobl/rules/is"
+	"github.com/invopop/gobl/tax"
+)
+
+// normalizeTaxCombo sets default situation codes on ICMS, PIS and COFINS combos.
+func normalizeTaxCombo(tc *tax.Combo) {
+	if tc == nil {
+		return
+	}
+	switch tc.Category {
+	case br.TaxCategoryICMS:
+		if !tc.Ext.Has(ExtKeyICMSCSOSN) {
+			tc.Ext = tc.Ext.SetIfEmpty(ExtKeyICMSCST, "00") // Taxed in full
+		}
+		tc.Ext = tc.Ext.SetIfEmpty(ExtKeyICMSOrigin, "0") // National
+	case br.TaxCategoryPIS:
+		tc.Ext = tc.Ext.SetIfEmpty(ExtKeyPISCST, "01") // Standard-rate taxable operation
+	case br.TaxCategoryCOFINS:
+		tc.Ext = tc.Ext.SetIfEmpty(ExtKeyCOFINSCST, "01") // Standard-rate taxable operation
+	}
+}
+
+func taxComboRules() *rules.Set {
+	return rules.For(new(tax.Combo),
+		rules.When(
+			is.Func("ICMS category", taxCategoryIs(br.TaxCategoryICMS)),
+			rules.Field("ext",
+				rules.Assert("01", fmt.Sprintf("ICMS tax combo requires '%s' or '%s' extension", ExtKeyICMSCST, ExtKeyICMSCSOSN),
+					is.AnyOf(
+						tax.ExtensionsRequire(ExtKeyICMSCST),
+						tax.ExtensionsRequire(ExtKeyICMSCSOSN),
+					),
+				),
+				rules.Assert("02", fmt.Sprintf("ICMS tax combo requires '%s' extension", ExtKeyICMSOrigin),
+					tax.ExtensionsRequire(ExtKeyICMSOrigin),
+				),
+			),
+		),
+		rules.When(
+			is.Func("PIS category", taxCategoryIs(br.TaxCategoryPIS)),
+			rules.Field("ext",
+				rules.Assert("03", fmt.Sprintf("PIS tax combo requires '%s' extension", ExtKeyPISCST),
+					tax.ExtensionsRequire(ExtKeyPISCST),
+				),
+			),
+		),
+		rules.When(
+			is.Func("COFINS category", taxCategoryIs(br.TaxCategoryCOFINS)),
+			rules.Field("ext",
+				rules.Assert("04", fmt.Sprintf("COFINS tax combo requires '%s' extension", ExtKeyCOFINSCST),
+					tax.ExtensionsRequire(ExtKeyCOFINSCST),
+				),
+			),
+		),
+	)
+}
+
+// taxCategoryIs returns a tester that matches a tax combo of the given category.
+func taxCategoryIs(cat cbc.Code) func(any) bool {
+	return func(val any) bool {
+		tc, ok := val.(*tax.Combo)
+		return ok && tc != nil && tc.Category == cat
+	}
+}

--- a/addons/br/nfe/tax_combo_test.go
+++ b/addons/br/nfe/tax_combo_test.go
@@ -1,0 +1,224 @@
+package nfe_test
+
+import (
+	"testing"
+
+	"github.com/invopop/gobl/addons/br/nfe"
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/norm"
+	"github.com/invopop/gobl/org"
+	"github.com/invopop/gobl/regimes/br"
+	"github.com/invopop/gobl/rules"
+	"github.com/invopop/gobl/tax"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTaxComboValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		tc   *tax.Combo
+		err  string
+	}{
+		{
+			name: "valid ICMS with CST",
+			tc: &tax.Combo{
+				Category: br.TaxCategoryICMS,
+				Ext: tax.ExtensionsOf(cbc.CodeMap{
+					nfe.ExtKeyICMSCST:    "00",
+					nfe.ExtKeyICMSOrigin: "0",
+				}),
+			},
+		},
+		{
+			name: "valid ICMS with CSOSN",
+			tc: &tax.Combo{
+				Category: br.TaxCategoryICMS,
+				Ext: tax.ExtensionsOf(cbc.CodeMap{
+					nfe.ExtKeyICMSCSOSN:  "102",
+					nfe.ExtKeyICMSOrigin: "0",
+				}),
+			},
+		},
+		{
+			name: "ICMS missing situation code",
+			tc: &tax.Combo{
+				Category: br.TaxCategoryICMS,
+				Ext: tax.ExtensionsOf(cbc.CodeMap{
+					nfe.ExtKeyICMSOrigin: "0",
+				}),
+			},
+			err: "ICMS tax combo requires 'br-nfe-icms-cst' or 'br-nfe-icms-csosn' extension",
+		},
+		{
+			name: "ICMS missing origin",
+			tc: &tax.Combo{
+				Category: br.TaxCategoryICMS,
+				Ext: tax.ExtensionsOf(cbc.CodeMap{
+					nfe.ExtKeyICMSCST: "00",
+				}),
+			},
+			err: "ICMS tax combo requires 'br-nfe-icms-origin' extension",
+		},
+		{
+			name: "valid PIS",
+			tc: &tax.Combo{
+				Category: br.TaxCategoryPIS,
+				Ext: tax.ExtensionsOf(cbc.CodeMap{
+					nfe.ExtKeyPISCST: "01",
+				}),
+			},
+		},
+		{
+			name: "PIS missing CST",
+			tc: &tax.Combo{
+				Category: br.TaxCategoryPIS,
+			},
+			err: "PIS tax combo requires 'br-nfe-pis-cst' extension",
+		},
+		{
+			name: "valid COFINS",
+			tc: &tax.Combo{
+				Category: br.TaxCategoryCOFINS,
+				Ext: tax.ExtensionsOf(cbc.CodeMap{
+					nfe.ExtKeyCOFINSCST: "01",
+				}),
+			},
+		},
+		{
+			name: "COFINS missing CST",
+			tc: &tax.Combo{
+				Category: br.TaxCategoryCOFINS,
+			},
+			err: "COFINS tax combo requires 'br-nfe-cofins-cst' extension",
+		},
+		{
+			name: "unrelated category is not constrained",
+			tc: &tax.Combo{
+				Category: br.TaxCategoryIPI,
+			},
+		},
+	}
+	for _, ts := range tests {
+		t.Run(ts.name, func(t *testing.T) {
+			err := rules.Validate(ts.tc, withAddonContext())
+			if ts.err == "" {
+				assert.NoError(t, err)
+			} else if assert.Error(t, err) {
+				assert.ErrorContains(t, err, ts.err)
+			}
+		})
+	}
+}
+
+func TestTaxComboNormalization(t *testing.T) {
+	tests := []struct {
+		name   string
+		tc     *tax.Combo
+		expect map[cbc.Key]cbc.Code // expected codes; "" means the key must be absent
+	}{
+		{
+			name: "ICMS sets default CST and origin",
+			tc:   &tax.Combo{Category: br.TaxCategoryICMS},
+			expect: map[cbc.Key]cbc.Code{
+				nfe.ExtKeyICMSCST:    "00",
+				nfe.ExtKeyICMSOrigin: "0",
+			},
+		},
+		{
+			name: "ICMS keeps CSOSN and does not add CST",
+			tc: &tax.Combo{
+				Category: br.TaxCategoryICMS,
+				Ext:      tax.ExtensionsOf(cbc.CodeMap{nfe.ExtKeyICMSCSOSN: "102"}),
+			},
+			expect: map[cbc.Key]cbc.Code{
+				nfe.ExtKeyICMSCSOSN:  "102",
+				nfe.ExtKeyICMSCST:    "",
+				nfe.ExtKeyICMSOrigin: "0",
+			},
+		},
+		{
+			name: "ICMS does not override CST or origin",
+			tc: &tax.Combo{
+				Category: br.TaxCategoryICMS,
+				Ext: tax.ExtensionsOf(cbc.CodeMap{
+					nfe.ExtKeyICMSCST:    "40",
+					nfe.ExtKeyICMSOrigin: "2",
+				}),
+			},
+			expect: map[cbc.Key]cbc.Code{
+				nfe.ExtKeyICMSCST:    "40",
+				nfe.ExtKeyICMSOrigin: "2",
+			},
+		},
+		{
+			name:   "PIS sets default CST",
+			tc:     &tax.Combo{Category: br.TaxCategoryPIS},
+			expect: map[cbc.Key]cbc.Code{nfe.ExtKeyPISCST: "01"},
+		},
+		{
+			name: "PIS does not override CST",
+			tc: &tax.Combo{
+				Category: br.TaxCategoryPIS,
+				Ext:      tax.ExtensionsOf(cbc.CodeMap{nfe.ExtKeyPISCST: "49"}),
+			},
+			expect: map[cbc.Key]cbc.Code{nfe.ExtKeyPISCST: "49"},
+		},
+		{
+			name:   "COFINS sets default CST",
+			tc:     &tax.Combo{Category: br.TaxCategoryCOFINS},
+			expect: map[cbc.Key]cbc.Code{nfe.ExtKeyCOFINSCST: "01"},
+		},
+		{
+			name: "COFINS does not override CST",
+			tc: &tax.Combo{
+				Category: br.TaxCategoryCOFINS,
+				Ext:      tax.ExtensionsOf(cbc.CodeMap{nfe.ExtKeyCOFINSCST: "49"}),
+			},
+			expect: map[cbc.Key]cbc.Code{nfe.ExtKeyCOFINSCST: "49"},
+		},
+		{
+			name:   "unrelated category is untouched",
+			tc:     &tax.Combo{Category: br.TaxCategoryIPI},
+			expect: map[cbc.Key]cbc.Code{nfe.ExtKeyICMSCST: ""},
+		},
+	}
+	for _, ts := range tests {
+		t.Run(ts.name, func(t *testing.T) {
+			norm.Normalize(ts.tc, tax.AddonContext(nfe.V4))
+			for k, v := range ts.expect {
+				assert.Equal(t, v, ts.tc.Ext.Get(k), "ext %s", k)
+			}
+		})
+	}
+}
+
+func TestInvoiceRegimeNormalization(t *testing.T) {
+	t.Run("defaults supplier regime to normal", func(t *testing.T) {
+		inv := &bill.Invoice{
+			Addons:   tax.WithAddons(nfe.V4),
+			Supplier: &org.Party{Name: "Test Supplier"},
+		}
+		norm.Normalize(inv, tax.AddonContext(nfe.V4))
+		assert.Equal(t, cbc.Code("3"), inv.Supplier.Ext.Get(nfe.ExtKeyRegime))
+	})
+
+	t.Run("does not override an existing supplier regime", func(t *testing.T) {
+		inv := &bill.Invoice{
+			Addons: tax.WithAddons(nfe.V4),
+			Supplier: &org.Party{
+				Name: "Test Supplier",
+				Ext:  tax.ExtensionsOf(cbc.CodeMap{nfe.ExtKeyRegime: "1"}),
+			},
+		}
+		norm.Normalize(inv, tax.AddonContext(nfe.V4))
+		assert.Equal(t, cbc.Code("1"), inv.Supplier.Ext.Get(nfe.ExtKeyRegime))
+	})
+
+	t.Run("nil supplier is a no-op", func(t *testing.T) {
+		inv := &bill.Invoice{Addons: tax.WithAddons(nfe.V4)}
+		assert.NotPanics(t, func() {
+			norm.Normalize(inv, tax.AddonContext(nfe.V4))
+		})
+	})
+}

--- a/data/addons/br-nfe-v4.json
+++ b/data/addons/br-nfe-v4.json
@@ -316,7 +316,7 @@
         "pt": "Código de Regime Tributário"
       },
       "desc": {
-        "en": "Indicates the tax regime that a party is subject to."
+        "en": "Indicates the tax regime that a party is subject to. Defaults to `3`\n(normal regime) during normalization when not provided."
       },
       "sources": [
         {
@@ -325,6 +325,14 @@
             "pt": "Manual de Orientação ao Contribuinte v7.0 - Anexo I – Leiaute e Regras de Validação da NF-e e da NFC-e"
           },
           "url": "https://www.nfe.fazenda.gov.br/portal/exibirArquivo.aspx?conteudo=J%20I%20v4eN00E=",
+          "content_type": "application/pdf"
+        },
+        {
+          "title": {
+            "en": "NF-e/NFC-e Technical Note 2024.001 - CRT=4 MEI",
+            "pt": "Nota Técnica NF-e/NFC-e 2024.001 - CRT=4 MEI"
+          },
+          "url": "https://www.nfe.fazenda.gov.br/portal/exibirArquivo.aspx?conteudo=kIiniiSkpKc=",
           "content_type": "application/pdf"
         }
       ],
@@ -348,6 +356,13 @@
           "name": {
             "en": "Normal",
             "pt": "Normal"
+          }
+        },
+        {
+          "code": "4",
+          "name": {
+            "en": "MEI - Individual Micro-entrepreneur",
+            "pt": "MEI - Microempreendedor Individual"
           }
         }
       ]
@@ -412,6 +427,816 @@
           "name": {
             "en": "Micro-enterprise or Small Business (ME EPP)",
             "pt": "Microempresa ou Empresa de Pequeno Porte (ME EPP)."
+          }
+        }
+      ]
+    },
+    {
+      "key": "br-nfe-icms-cst",
+      "name": {
+        "en": "ICMS Tax Status Code (CST)",
+        "pt": "Código de Situação Tributária do ICMS (CST)"
+      },
+      "desc": {
+        "en": "ICMS tax status code (CST) for the line item, used by issuers under the normal\nregime (`br-nfe-regime` `3`). Simples Nacional issuers must use the CSOSN code\n(`br-nfe-icms-csosn`) instead. Defaults to `00` (taxed in full) during\nnormalization when not provided."
+      },
+      "sources": [
+        {
+          "title": {
+            "en": "Taxpayer Guidance Manual v7.0 - Annex I – Layout and Validation Rules for NF-e and NFC-e",
+            "pt": "Manual de Orientação ao Contribuinte v7.0 - Anexo I – Leiaute e Regras de Validação da NF-e e da NFC-e"
+          },
+          "url": "https://www.nfe.fazenda.gov.br/portal/exibirArquivo.aspx?conteudo=J%20I%20v4eN00E=",
+          "content_type": "application/pdf"
+        }
+      ],
+      "values": [
+        {
+          "code": "00",
+          "name": {
+            "en": "Taxed in full",
+            "pt": "Tributada integralmente"
+          }
+        },
+        {
+          "code": "02",
+          "name": {
+            "en": "Monophasic taxation (fuels)",
+            "pt": "Tributação monofásica própria sobre combustíveis"
+          }
+        },
+        {
+          "code": "10",
+          "name": {
+            "en": "Taxed with ICMS charged by tax substitution",
+            "pt": "Tributada e com cobrança do ICMS por substituição tributária"
+          }
+        },
+        {
+          "code": "15",
+          "name": {
+            "en": "Fuel operation with ICMS retention",
+            "pt": "Operação com combustível e retenção do ICMS"
+          }
+        },
+        {
+          "code": "20",
+          "name": {
+            "en": "Taxed with tax base reduction",
+            "pt": "Com redução da base de cálculo"
+          }
+        },
+        {
+          "code": "30",
+          "name": {
+            "en": "Exempt/non-taxed with ICMS charged by tax substitution",
+            "pt": "Isenta/não tributada e com cobrança do ICMS por substituição tributária"
+          }
+        },
+        {
+          "code": "40",
+          "name": {
+            "en": "Exempt",
+            "pt": "Isenta"
+          }
+        },
+        {
+          "code": "41",
+          "name": {
+            "en": "Non-taxed",
+            "pt": "Não tributada"
+          }
+        },
+        {
+          "code": "50",
+          "name": {
+            "en": "Suspended",
+            "pt": "Com suspensão"
+          }
+        },
+        {
+          "code": "51",
+          "name": {
+            "en": "Deferred",
+            "pt": "Com diferimento"
+          }
+        },
+        {
+          "code": "53",
+          "name": {
+            "en": "Fuel operation with deferral",
+            "pt": "Operação com combustível e diferimento"
+          }
+        },
+        {
+          "code": "60",
+          "name": {
+            "en": "ICMS charged previously by tax substitution",
+            "pt": "ICMS cobrado anteriormente por substituição tributária"
+          }
+        },
+        {
+          "code": "61",
+          "name": {
+            "en": "Fuel operation with ICMS withheld",
+            "pt": "Operação com combustível e ICMS retido anteriormente"
+          }
+        },
+        {
+          "code": "70",
+          "name": {
+            "en": "Taxed with base reduction and ICMS charged by tax substitution",
+            "pt": "Com redução da base de cálculo e cobrança do ICMS por substituição tributária"
+          }
+        },
+        {
+          "code": "90",
+          "name": {
+            "en": "Others",
+            "pt": "Outras"
+          }
+        }
+      ]
+    },
+    {
+      "key": "br-nfe-icms-csosn",
+      "name": {
+        "en": "ICMS Simples Nacional Status Code (CSOSN)",
+        "pt": "Código de Situação da Operação no Simples Nacional (CSOSN)"
+      },
+      "desc": {
+        "en": "ICMS status code (CSOSN) for the line item, used by issuers under the Simples\nNacional regime (`br-nfe-regime` `1`, `2` or `4`). Normal-regime issuers must\nuse the CST code (`br-nfe-icms-cst`) instead."
+      },
+      "sources": [
+        {
+          "title": {
+            "en": "Taxpayer Guidance Manual v7.0 - Annex I – Layout and Validation Rules for NF-e and NFC-e",
+            "pt": "Manual de Orientação ao Contribuinte v7.0 - Anexo I – Leiaute e Regras de Validação da NF-e e da NFC-e"
+          },
+          "url": "https://www.nfe.fazenda.gov.br/portal/exibirArquivo.aspx?conteudo=J%20I%20v4eN00E=",
+          "content_type": "application/pdf"
+        }
+      ],
+      "values": [
+        {
+          "code": "101",
+          "name": {
+            "en": "Taxed under Simples Nacional with credit permission",
+            "pt": "Tributada pelo Simples Nacional com permissão de crédito"
+          }
+        },
+        {
+          "code": "102",
+          "name": {
+            "en": "Taxed under Simples Nacional without credit permission",
+            "pt": "Tributada pelo Simples Nacional sem permissão de crédito"
+          }
+        },
+        {
+          "code": "103",
+          "name": {
+            "en": "ICMS exemption under Simples Nacional for gross revenue range",
+            "pt": "Isenção do ICMS no Simples Nacional para faixa de receita bruta"
+          }
+        },
+        {
+          "code": "201",
+          "name": {
+            "en": "Taxed under Simples Nacional with credit permission and ICMS by tax substitution",
+            "pt": "Tributada pelo Simples Nacional com permissão de crédito e com cobrança do ICMS por substituição tributária"
+          }
+        },
+        {
+          "code": "202",
+          "name": {
+            "en": "Taxed under Simples Nacional without credit permission and ICMS by tax substitution",
+            "pt": "Tributada pelo Simples Nacional sem permissão de crédito e com cobrança do ICMS por substituição tributária"
+          }
+        },
+        {
+          "code": "203",
+          "name": {
+            "en": "ICMS exemption under Simples Nacional for revenue range and ICMS by tax substitution",
+            "pt": "Isenção do ICMS no Simples Nacional para faixa de receita bruta e com cobrança do ICMS por substituição tributária"
+          }
+        },
+        {
+          "code": "300",
+          "name": {
+            "en": "Immune",
+            "pt": "Imune"
+          }
+        },
+        {
+          "code": "400",
+          "name": {
+            "en": "Non-taxed under Simples Nacional",
+            "pt": "Não tributada pelo Simples Nacional"
+          }
+        },
+        {
+          "code": "500",
+          "name": {
+            "en": "ICMS charged previously by tax substitution or anticipation",
+            "pt": "ICMS cobrado anteriormente por substituição tributária ou por antecipação"
+          }
+        },
+        {
+          "code": "900",
+          "name": {
+            "en": "Others",
+            "pt": "Outros"
+          }
+        }
+      ]
+    },
+    {
+      "key": "br-nfe-icms-origin",
+      "name": {
+        "en": "ICMS Goods Origin",
+        "pt": "Origem da Mercadoria (ICMS)"
+      },
+      "desc": {
+        "en": "Origin of the goods for ICMS purposes. Defaults to `0` (national) during\nnormalization when not provided."
+      },
+      "sources": [
+        {
+          "title": {
+            "en": "Taxpayer Guidance Manual v7.0 - Annex I – Layout and Validation Rules for NF-e and NFC-e",
+            "pt": "Manual de Orientação ao Contribuinte v7.0 - Anexo I – Leiaute e Regras de Validação da NF-e e da NFC-e"
+          },
+          "url": "https://www.nfe.fazenda.gov.br/portal/exibirArquivo.aspx?conteudo=J%20I%20v4eN00E=",
+          "content_type": "application/pdf"
+        }
+      ],
+      "values": [
+        {
+          "code": "0",
+          "name": {
+            "en": "National (except codes 3, 4, 5 and 8)",
+            "pt": "Nacional, exceto as indicadas nos códigos 3, 4, 5 e 8"
+          }
+        },
+        {
+          "code": "1",
+          "name": {
+            "en": "Foreign, direct import (except code 6)",
+            "pt": "Estrangeira - Importação direta, exceto a indicada no código 6"
+          }
+        },
+        {
+          "code": "2",
+          "name": {
+            "en": "Foreign, acquired in the domestic market (except code 7)",
+            "pt": "Estrangeira - Adquirida no mercado interno, exceto a indicada no código 7"
+          }
+        },
+        {
+          "code": "3",
+          "name": {
+            "en": "National, import content above 40% and up to 70%",
+            "pt": "Nacional, mercadoria ou bem com Conteúdo de Importação superior a 40% e inferior ou igual a 70%"
+          }
+        },
+        {
+          "code": "4",
+          "name": {
+            "en": "National, produced under the basic productive processes",
+            "pt": "Nacional, cuja produção tenha sido feita em conformidade com os processos produtivos básicos de que tratam as legislações citadas nos Ajustes"
+          }
+        },
+        {
+          "code": "5",
+          "name": {
+            "en": "National, import content up to 40%",
+            "pt": "Nacional, mercadoria ou bem com Conteúdo de Importação inferior ou igual a 40%"
+          }
+        },
+        {
+          "code": "6",
+          "name": {
+            "en": "Foreign, direct import, no domestic equivalent (CAMEX list / natural gas)",
+            "pt": "Estrangeira - Importação direta, sem similar nacional, constante em lista da CAMEX e gás natural"
+          }
+        },
+        {
+          "code": "7",
+          "name": {
+            "en": "Foreign, acquired domestically, no domestic equivalent (CAMEX list / natural gas)",
+            "pt": "Estrangeira - Adquirida no mercado interno, sem similar nacional, constante lista CAMEX e gás natural"
+          }
+        },
+        {
+          "code": "8",
+          "name": {
+            "en": "National, import content above 70%",
+            "pt": "Nacional, mercadoria ou bem com Conteúdo de Importação superior a 70%"
+          }
+        }
+      ]
+    },
+    {
+      "key": "br-nfe-pis-cst",
+      "name": {
+        "en": "PIS Tax Status Code (CST)",
+        "pt": "Código de Situação Tributária do PIS (CST)"
+      },
+      "desc": {
+        "en": "PIS tax status code for the line item. Simples Nacional issuers typically use\n`49` or `99`, as PIS is settled within the unified DAS collection. Defaults to\n`01` (standard-rate taxable operation) during normalization when not provided."
+      },
+      "sources": [
+        {
+          "title": {
+            "en": "Taxpayer Guidance Manual v7.0 - Annex I – Layout and Validation Rules for NF-e and NFC-e",
+            "pt": "Manual de Orientação ao Contribuinte v7.0 - Anexo I – Leiaute e Regras de Validação da NF-e e da NFC-e"
+          },
+          "url": "https://www.nfe.fazenda.gov.br/portal/exibirArquivo.aspx?conteudo=J%20I%20v4eN00E=",
+          "content_type": "application/pdf"
+        }
+      ],
+      "values": [
+        {
+          "code": "01",
+          "name": {
+            "en": "Taxable operation, standard rate",
+            "pt": "Operação Tributável com Alíquota Básica"
+          }
+        },
+        {
+          "code": "02",
+          "name": {
+            "en": "Taxable operation, differentiated rate",
+            "pt": "Operação Tributável com Alíquota Diferenciada"
+          }
+        },
+        {
+          "code": "03",
+          "name": {
+            "en": "Taxable operation, rate per unit of measure",
+            "pt": "Operação Tributável com Alíquota por Unidade de Medida de Produto"
+          }
+        },
+        {
+          "code": "04",
+          "name": {
+            "en": "Taxable monophasic operation, zero-rate resale",
+            "pt": "Operação Tributável Monofásica - Revenda a Alíquota Zero"
+          }
+        },
+        {
+          "code": "05",
+          "name": {
+            "en": "Taxable operation by tax substitution",
+            "pt": "Operação Tributável por Substituição Tributária"
+          }
+        },
+        {
+          "code": "06",
+          "name": {
+            "en": "Taxable operation, zero rate",
+            "pt": "Operação Tributável a Alíquota Zero"
+          }
+        },
+        {
+          "code": "07",
+          "name": {
+            "en": "Operation exempt from the contribution",
+            "pt": "Operação Isenta da Contribuição"
+          }
+        },
+        {
+          "code": "08",
+          "name": {
+            "en": "Operation without incidence of the contribution",
+            "pt": "Operação Sem Incidência da Contribuição"
+          }
+        },
+        {
+          "code": "09",
+          "name": {
+            "en": "Operation with suspension of the contribution",
+            "pt": "Operação com Suspensão da Contribuição"
+          }
+        },
+        {
+          "code": "49",
+          "name": {
+            "en": "Other outbound operations",
+            "pt": "Outras Operações de Saída"
+          }
+        },
+        {
+          "code": "50",
+          "name": {
+            "en": "Credit operation, exclusively taxed domestic revenue",
+            "pt": "Operação com Direito a Crédito - Vinculada Exclusivamente a Receita Tributada no Mercado Interno"
+          }
+        },
+        {
+          "code": "51",
+          "name": {
+            "en": "Credit operation, exclusively non-taxed domestic revenue",
+            "pt": "Operação com Direito a Crédito - Vinculada Exclusivamente a Receita Não Tributada no Mercado Interno"
+          }
+        },
+        {
+          "code": "52",
+          "name": {
+            "en": "Credit operation, exclusively export revenue",
+            "pt": "Operação com Direito a Crédito - Vinculada Exclusivamente a Receita de Exportação"
+          }
+        },
+        {
+          "code": "53",
+          "name": {
+            "en": "Credit operation, taxed and non-taxed domestic revenue",
+            "pt": "Operação com Direito a Crédito - Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno"
+          }
+        },
+        {
+          "code": "54",
+          "name": {
+            "en": "Credit operation, taxed domestic and export revenue",
+            "pt": "Operação com Direito a Crédito - Vinculada a Receitas Tributadas no Mercado Interno e de Exportação"
+          }
+        },
+        {
+          "code": "55",
+          "name": {
+            "en": "Credit operation, non-taxed domestic and export revenue",
+            "pt": "Operação com Direito a Crédito - Vinculada a Receitas Não-Tributadas no Mercado Interno e de Exportação"
+          }
+        },
+        {
+          "code": "56",
+          "name": {
+            "en": "Credit operation, taxed/non-taxed domestic and export revenue",
+            "pt": "Operação com Direito a Crédito - Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno e de Exportação"
+          }
+        },
+        {
+          "code": "60",
+          "name": {
+            "en": "Presumed credit, exclusively taxed domestic revenue",
+            "pt": "Crédito Presumido - Operação de Aquisição Vinculada Exclusivamente a Receita Tributada no Mercado Interno"
+          }
+        },
+        {
+          "code": "61",
+          "name": {
+            "en": "Presumed credit, exclusively non-taxed domestic revenue",
+            "pt": "Crédito Presumido - Operação de Aquisição Vinculada Exclusivamente a Receita Não-Tributada no Mercado Interno"
+          }
+        },
+        {
+          "code": "62",
+          "name": {
+            "en": "Presumed credit, exclusively export revenue",
+            "pt": "Crédito Presumido - Operação de Aquisição Vinculada Exclusivamente a Receita de Exportação"
+          }
+        },
+        {
+          "code": "63",
+          "name": {
+            "en": "Presumed credit, taxed and non-taxed domestic revenue",
+            "pt": "Crédito Presumido - Operação de Aquisição Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno"
+          }
+        },
+        {
+          "code": "64",
+          "name": {
+            "en": "Presumed credit, taxed domestic and export revenue",
+            "pt": "Crédito Presumido - Operação de Aquisição Vinculada a Receitas Tributadas no Mercado Interno e de Exportação"
+          }
+        },
+        {
+          "code": "65",
+          "name": {
+            "en": "Presumed credit, non-taxed domestic and export revenue",
+            "pt": "Crédito Presumido - Operação de Aquisição Vinculada a Receitas Não-Tributadas no Mercado Interno e de Exportação"
+          }
+        },
+        {
+          "code": "66",
+          "name": {
+            "en": "Presumed credit, taxed/non-taxed domestic and export revenue",
+            "pt": "Crédito Presumido - Operação de Aquisição Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno e de Exportação"
+          }
+        },
+        {
+          "code": "67",
+          "name": {
+            "en": "Presumed credit, other operations",
+            "pt": "Crédito Presumido - Outras Operações"
+          }
+        },
+        {
+          "code": "70",
+          "name": {
+            "en": "Acquisition operation without credit right",
+            "pt": "Operação de Aquisição sem Direito a Crédito"
+          }
+        },
+        {
+          "code": "71",
+          "name": {
+            "en": "Acquisition operation with exemption",
+            "pt": "Operação de Aquisição com Isenção"
+          }
+        },
+        {
+          "code": "72",
+          "name": {
+            "en": "Acquisition operation with suspension",
+            "pt": "Operação de Aquisição com Suspensão"
+          }
+        },
+        {
+          "code": "73",
+          "name": {
+            "en": "Acquisition operation at zero rate",
+            "pt": "Operação de Aquisição a Alíquota Zero"
+          }
+        },
+        {
+          "code": "74",
+          "name": {
+            "en": "Acquisition operation without incidence of the contribution",
+            "pt": "Operação de Aquisição sem Incidência da Contribuição"
+          }
+        },
+        {
+          "code": "75",
+          "name": {
+            "en": "Acquisition operation by tax substitution",
+            "pt": "Operação de Aquisição por Substituição Tributária"
+          }
+        },
+        {
+          "code": "98",
+          "name": {
+            "en": "Other inbound operations",
+            "pt": "Outras Operações de Entrada"
+          }
+        },
+        {
+          "code": "99",
+          "name": {
+            "en": "Other operations",
+            "pt": "Outras Operações"
+          }
+        }
+      ]
+    },
+    {
+      "key": "br-nfe-cofins-cst",
+      "name": {
+        "en": "COFINS Tax Status Code (CST)",
+        "pt": "Código de Situação Tributária do COFINS (CST)"
+      },
+      "desc": {
+        "en": "COFINS tax status code for the line item. Simples Nacional issuers typically\nuse `49` or `99`, as COFINS is settled within the unified DAS collection.\nDefaults to `01` (standard-rate taxable operation) during normalization when\nnot provided."
+      },
+      "sources": [
+        {
+          "title": {
+            "en": "Taxpayer Guidance Manual v7.0 - Annex I – Layout and Validation Rules for NF-e and NFC-e",
+            "pt": "Manual de Orientação ao Contribuinte v7.0 - Anexo I – Leiaute e Regras de Validação da NF-e e da NFC-e"
+          },
+          "url": "https://www.nfe.fazenda.gov.br/portal/exibirArquivo.aspx?conteudo=J%20I%20v4eN00E=",
+          "content_type": "application/pdf"
+        }
+      ],
+      "values": [
+        {
+          "code": "01",
+          "name": {
+            "en": "Taxable operation, standard rate",
+            "pt": "Operação Tributável com Alíquota Básica"
+          }
+        },
+        {
+          "code": "02",
+          "name": {
+            "en": "Taxable operation, differentiated rate",
+            "pt": "Operação Tributável com Alíquota Diferenciada"
+          }
+        },
+        {
+          "code": "03",
+          "name": {
+            "en": "Taxable operation, rate per unit of measure",
+            "pt": "Operação Tributável com Alíquota por Unidade de Medida de Produto"
+          }
+        },
+        {
+          "code": "04",
+          "name": {
+            "en": "Taxable monophasic operation, zero-rate resale",
+            "pt": "Operação Tributável Monofásica - Revenda a Alíquota Zero"
+          }
+        },
+        {
+          "code": "05",
+          "name": {
+            "en": "Taxable operation by tax substitution",
+            "pt": "Operação Tributável por Substituição Tributária"
+          }
+        },
+        {
+          "code": "06",
+          "name": {
+            "en": "Taxable operation, zero rate",
+            "pt": "Operação Tributável a Alíquota Zero"
+          }
+        },
+        {
+          "code": "07",
+          "name": {
+            "en": "Operation exempt from the contribution",
+            "pt": "Operação Isenta da Contribuição"
+          }
+        },
+        {
+          "code": "08",
+          "name": {
+            "en": "Operation without incidence of the contribution",
+            "pt": "Operação Sem Incidência da Contribuição"
+          }
+        },
+        {
+          "code": "09",
+          "name": {
+            "en": "Operation with suspension of the contribution",
+            "pt": "Operação com Suspensão da Contribuição"
+          }
+        },
+        {
+          "code": "49",
+          "name": {
+            "en": "Other outbound operations",
+            "pt": "Outras Operações de Saída"
+          }
+        },
+        {
+          "code": "50",
+          "name": {
+            "en": "Credit operation, exclusively taxed domestic revenue",
+            "pt": "Operação com Direito a Crédito - Vinculada Exclusivamente a Receita Tributada no Mercado Interno"
+          }
+        },
+        {
+          "code": "51",
+          "name": {
+            "en": "Credit operation, exclusively non-taxed domestic revenue",
+            "pt": "Operação com Direito a Crédito - Vinculada Exclusivamente a Receita Não Tributada no Mercado Interno"
+          }
+        },
+        {
+          "code": "52",
+          "name": {
+            "en": "Credit operation, exclusively export revenue",
+            "pt": "Operação com Direito a Crédito - Vinculada Exclusivamente a Receita de Exportação"
+          }
+        },
+        {
+          "code": "53",
+          "name": {
+            "en": "Credit operation, taxed and non-taxed domestic revenue",
+            "pt": "Operação com Direito a Crédito - Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno"
+          }
+        },
+        {
+          "code": "54",
+          "name": {
+            "en": "Credit operation, taxed domestic and export revenue",
+            "pt": "Operação com Direito a Crédito - Vinculada a Receitas Tributadas no Mercado Interno e de Exportação"
+          }
+        },
+        {
+          "code": "55",
+          "name": {
+            "en": "Credit operation, non-taxed domestic and export revenue",
+            "pt": "Operação com Direito a Crédito - Vinculada a Receitas Não-Tributadas no Mercado Interno e de Exportação"
+          }
+        },
+        {
+          "code": "56",
+          "name": {
+            "en": "Credit operation, taxed/non-taxed domestic and export revenue",
+            "pt": "Operação com Direito a Crédito - Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno e de Exportação"
+          }
+        },
+        {
+          "code": "60",
+          "name": {
+            "en": "Presumed credit, exclusively taxed domestic revenue",
+            "pt": "Crédito Presumido - Operação de Aquisição Vinculada Exclusivamente a Receita Tributada no Mercado Interno"
+          }
+        },
+        {
+          "code": "61",
+          "name": {
+            "en": "Presumed credit, exclusively non-taxed domestic revenue",
+            "pt": "Crédito Presumido - Operação de Aquisição Vinculada Exclusivamente a Receita Não-Tributada no Mercado Interno"
+          }
+        },
+        {
+          "code": "62",
+          "name": {
+            "en": "Presumed credit, exclusively export revenue",
+            "pt": "Crédito Presumido - Operação de Aquisição Vinculada Exclusivamente a Receita de Exportação"
+          }
+        },
+        {
+          "code": "63",
+          "name": {
+            "en": "Presumed credit, taxed and non-taxed domestic revenue",
+            "pt": "Crédito Presumido - Operação de Aquisição Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno"
+          }
+        },
+        {
+          "code": "64",
+          "name": {
+            "en": "Presumed credit, taxed domestic and export revenue",
+            "pt": "Crédito Presumido - Operação de Aquisição Vinculada a Receitas Tributadas no Mercado Interno e de Exportação"
+          }
+        },
+        {
+          "code": "65",
+          "name": {
+            "en": "Presumed credit, non-taxed domestic and export revenue",
+            "pt": "Crédito Presumido - Operação de Aquisição Vinculada a Receitas Não-Tributadas no Mercado Interno e de Exportação"
+          }
+        },
+        {
+          "code": "66",
+          "name": {
+            "en": "Presumed credit, taxed/non-taxed domestic and export revenue",
+            "pt": "Crédito Presumido - Operação de Aquisição Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno e de Exportação"
+          }
+        },
+        {
+          "code": "67",
+          "name": {
+            "en": "Presumed credit, other operations",
+            "pt": "Crédito Presumido - Outras Operações"
+          }
+        },
+        {
+          "code": "70",
+          "name": {
+            "en": "Acquisition operation without credit right",
+            "pt": "Operação de Aquisição sem Direito a Crédito"
+          }
+        },
+        {
+          "code": "71",
+          "name": {
+            "en": "Acquisition operation with exemption",
+            "pt": "Operação de Aquisição com Isenção"
+          }
+        },
+        {
+          "code": "72",
+          "name": {
+            "en": "Acquisition operation with suspension",
+            "pt": "Operação de Aquisição com Suspensão"
+          }
+        },
+        {
+          "code": "73",
+          "name": {
+            "en": "Acquisition operation at zero rate",
+            "pt": "Operação de Aquisição a Alíquota Zero"
+          }
+        },
+        {
+          "code": "74",
+          "name": {
+            "en": "Acquisition operation without incidence of the contribution",
+            "pt": "Operação de Aquisição sem Incidência da Contribuição"
+          }
+        },
+        {
+          "code": "75",
+          "name": {
+            "en": "Acquisition operation by tax substitution",
+            "pt": "Operação de Aquisição por Substituição Tributária"
+          }
+        },
+        {
+          "code": "98",
+          "name": {
+            "en": "Other inbound operations",
+            "pt": "Outras Operações de Entrada"
+          }
+        },
+        {
+          "code": "99",
+          "name": {
+            "en": "Other operations",
+            "pt": "Outras Operações"
           }
         }
       ]

--- a/data/rules/br-nfe.json
+++ b/data/rules/br-nfe.json
@@ -137,6 +137,16 @@
               ]
             },
             {
+              "field": "ext",
+              "assert": [
+                {
+                  "id": "GOBL-BR-NFE-BILL-INVOICE-39",
+                  "desc": "invoice supplier requires 'br-nfe-regime' extension",
+                  "tests": "ext require [br-nfe-regime]"
+                }
+              ]
+            },
+            {
               "field": "name",
               "assert": [
                 {
@@ -493,6 +503,62 @@
           "id": "GOBL-BR-NFE-BILL-LINE-03",
           "desc": "line taxes must include the COFINS category",
           "tests": "line has tax category COFINS"
+        }
+      ]
+    },
+    {
+      "id": "GOBL-BR-NFE-TAX-COMBO",
+      "object": "tax.Combo",
+      "subsets": [
+        {
+          "guard": "ICMS category",
+          "subsets": [
+            {
+              "field": "ext",
+              "assert": [
+                {
+                  "id": "GOBL-BR-NFE-TAX-COMBO-01",
+                  "desc": "ICMS tax combo requires 'br-nfe-icms-cst' or 'br-nfe-icms-csosn' extension",
+                  "tests": "ext require [br-nfe-icms-cst], or ext require [br-nfe-icms-csosn]"
+                },
+                {
+                  "id": "GOBL-BR-NFE-TAX-COMBO-02",
+                  "desc": "ICMS tax combo requires 'br-nfe-icms-origin' extension",
+                  "tests": "ext require [br-nfe-icms-origin]"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "guard": "PIS category",
+          "subsets": [
+            {
+              "field": "ext",
+              "assert": [
+                {
+                  "id": "GOBL-BR-NFE-TAX-COMBO-03",
+                  "desc": "PIS tax combo requires 'br-nfe-pis-cst' extension",
+                  "tests": "ext require [br-nfe-pis-cst]"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "guard": "COFINS category",
+          "subsets": [
+            {
+              "field": "ext",
+              "assert": [
+                {
+                  "id": "GOBL-BR-NFE-TAX-COMBO-04",
+                  "desc": "COFINS tax combo requires 'br-nfe-cofins-cst' extension",
+                  "tests": "ext require [br-nfe-cofins-cst]"
+                }
+              ]
+            }
+          ]
         }
       ]
     },

--- a/examples/br/invoice-nfce.json
+++ b/examples/br/invoice-nfce.json
@@ -46,7 +46,8 @@
       }
     ],
     "ext": {
-      "br-ibge-municipality": "3304557"
+      "br-ibge-municipality": "3304557",
+      "br-nfe-regime": "1"
     }
   },
   "lines": [
@@ -60,15 +61,24 @@
       "taxes": [
         {
           "cat": "ICMS",
-          "percent": "4.0%"
+          "percent": "0%",
+          "ext": {
+            "br-nfe-icms-csosn": "102"
+          }
         },
         {
           "cat": "PIS",
-          "percent": "1.65%"
+          "percent": "0%",
+          "ext": {
+            "br-nfe-pis-cst": "49"
+          }
         },
         {
           "cat": "COFINS",
-          "percent": "7.60%"
+          "percent": "0%",
+          "ext": {
+            "br-nfe-cofins-cst": "49"
+          }
         }
       ]
     }

--- a/examples/br/invoice-nfce.json
+++ b/examples/br/invoice-nfce.json
@@ -47,7 +47,7 @@
     ],
     "ext": {
       "br-ibge-municipality": "3304557",
-      "br-nfe-regime": "1"
+      "br-nfe-regime": "3"
     }
   },
   "lines": [
@@ -61,24 +61,15 @@
       "taxes": [
         {
           "cat": "ICMS",
-          "percent": "0%",
-          "ext": {
-            "br-nfe-icms-csosn": "102"
-          }
+          "percent": "4.0%"
         },
         {
           "cat": "PIS",
-          "percent": "0%",
-          "ext": {
-            "br-nfe-pis-cst": "49"
-          }
+          "percent": "1.65%"
         },
         {
           "cat": "COFINS",
-          "percent": "0%",
-          "ext": {
-            "br-nfe-cofins-cst": "49"
-          }
+          "percent": "7.60%"
         }
       ]
     }

--- a/examples/br/invoice-nfe-simples.json
+++ b/examples/br/invoice-nfe-simples.json
@@ -1,0 +1,131 @@
+{
+  "$schema": "https://gobl.org/draft-0/bill/invoice",
+  "$addons": [
+    "br-nfe-v4"
+  ],
+  "uuid": "01937e2b-6c3d-7e4f-9a50-2b3c4d5e6f70",
+  "tax": {
+    "ext": {
+      "br-nfe-presence": "1"
+    }
+  },
+  "series": "1",
+  "code": "2048",
+  "issue_date": "2024-11-20",
+  "currency": "BRL",
+  "supplier": {
+    "name": "Marcenaria Arte & Design ME",
+    "tax_id": {
+      "country": "BR",
+      "code": "12345678000195"
+    },
+    "identities": [
+      {
+        "key": "br-nfe-state-reg",
+        "code": "0623458900"
+      }
+    ],
+    "addresses": [
+      {
+        "num": "85",
+        "street": "Rua dos Artesãos",
+        "locality": "Savassi",
+        "region": "Minas Gerais",
+        "state": "MG",
+        "code": "30140-071",
+        "country": "BR"
+      }
+    ],
+    "emails": [
+      {
+        "addr": "contato@artedesign.com.br"
+      }
+    ],
+    "ext": {
+      "br-ibge-municipality": "3106200",
+      "br-nfe-regime": "1"
+    }
+  },
+  "customer": {
+    "name": "Comércio de Móveis Paulista Ltda.",
+    "tax_id": {
+      "country": "BR",
+      "code": "55263640000186"
+    },
+    "identities": [
+      {
+        "key": "br-nfe-state-reg",
+        "code": "112233445566"
+      }
+    ],
+    "addresses": [
+      {
+        "num": "742",
+        "street": "Avenida Paulista",
+        "locality": "Bela Vista",
+        "region": "São Paulo",
+        "state": "SP",
+        "code": "01310-100",
+        "country": "BR"
+      }
+    ],
+    "ext": {
+      "br-ibge-municipality": "3550308"
+    }
+  },
+  "lines": [
+    {
+      "i": 1,
+      "quantity": "5",
+      "item": {
+        "ref": "MES-CARV",
+        "name": "Mesa de Jantar em Madeira Maciça",
+        "identities": [
+          {
+            "key": "ncm",
+            "code": "9403.60.00"
+          }
+        ],
+        "price": "900.00",
+        "unit": "piece"
+      },
+      "taxes": [
+        {
+          "cat": "ICMS",
+          "percent": "2.56%",
+          "ext": {
+            "br-nfe-icms-csosn": "101"
+          }
+        },
+        {
+          "cat": "PIS",
+          "percent": "0%",
+          "ext": {
+            "br-nfe-pis-cst": "49"
+          }
+        },
+        {
+          "cat": "COFINS",
+          "percent": "0%",
+          "ext": {
+            "br-nfe-cofins-cst": "49"
+          }
+        }
+      ],
+      "ext": {
+        "br-nfe-cfop": "6102"
+      }
+    }
+  ],
+  "payment": {
+    "instructions": {
+      "key": "credit-transfer"
+    }
+  },
+  "notes": [
+    {
+      "key": "reason",
+      "text": "Venda de mercadoria"
+    }
+  ]
+}

--- a/examples/br/invoice-nfe.json
+++ b/examples/br/invoice-nfe.json
@@ -1,0 +1,121 @@
+{
+  "$schema": "https://gobl.org/draft-0/bill/invoice",
+  "$addons": [
+    "br-nfe-v4"
+  ],
+  "uuid": "01937e1a-5b2c-7d3e-8f40-1a2b3c4d5e6f",
+  "tax": {
+    "ext": {
+      "br-nfe-presence": "1"
+    }
+  },
+  "series": "1",
+  "code": "1024",
+  "issue_date": "2024-11-20",
+  "currency": "BRL",
+  "supplier": {
+    "name": "Eletro Components Indústria Ltda.",
+    "tax_id": {
+      "country": "BR",
+      "code": "18069577000115"
+    },
+    "identities": [
+      {
+        "key": "br-nfe-state-reg",
+        "code": "110042490114"
+      }
+    ],
+    "addresses": [
+      {
+        "num": "1500",
+        "street": "Avenida Engenheiro Luís Carlos Berrini",
+        "locality": "Cidade Monções",
+        "region": "São Paulo",
+        "state": "SP",
+        "code": "04571-000",
+        "country": "BR"
+      }
+    ],
+    "emails": [
+      {
+        "addr": "fiscal@eletrocomponents.com.br"
+      }
+    ],
+    "ext": {
+      "br-ibge-municipality": "3550308"
+    }
+  },
+  "customer": {
+    "name": "Instaladora Predial Campinas Ltda.",
+    "tax_id": {
+      "country": "BR",
+      "code": "05700736000196"
+    },
+    "identities": [
+      {
+        "key": "br-nfe-state-reg",
+        "code": "244889012117"
+      }
+    ],
+    "addresses": [
+      {
+        "num": "300",
+        "street": "Rua Barão de Jaguara",
+        "locality": "Centro",
+        "region": "São Paulo",
+        "state": "SP",
+        "code": "13015-000",
+        "country": "BR"
+      }
+    ],
+    "ext": {
+      "br-ibge-municipality": "3509502"
+    }
+  },
+  "lines": [
+    {
+      "i": 1,
+      "quantity": "20",
+      "item": {
+        "ref": "DJ-60A",
+        "name": "Disjuntor Tripolar 60A",
+        "identities": [
+          {
+            "key": "ncm",
+            "code": "8536.20.00"
+          }
+        ],
+        "price": "85.00",
+        "unit": "piece"
+      },
+      "taxes": [
+        {
+          "cat": "ICMS",
+          "percent": "18.0%"
+        },
+        {
+          "cat": "PIS",
+          "percent": "1.65%"
+        },
+        {
+          "cat": "COFINS",
+          "percent": "7.60%"
+        }
+      ],
+      "ext": {
+        "br-nfe-cfop": "5102"
+      }
+    }
+  ],
+  "payment": {
+    "instructions": {
+      "key": "credit-transfer"
+    }
+  },
+  "notes": [
+    {
+      "key": "reason",
+      "text": "Venda de mercadoria"
+    }
+  ]
+}

--- a/examples/br/out/invoice-nfce.json
+++ b/examples/br/out/invoice-nfce.json
@@ -4,7 +4,7 @@
 		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
 		"dig": {
 			"alg": "sha256",
-			"val": "3db53cd52c0153ed77336d0eb38a189d87c7b9f4079a6ec75328a6fe73a30823"
+			"val": "4e5b569a3bd5d140735ee46a2d2f5b5d7f760e1d3aa519325a3a71f2aa7bc2db"
 		}
 	},
 	"doc": {
@@ -58,7 +58,8 @@
 				}
 			],
 			"ext": {
-				"br-ibge-municipality": "3304557"
+				"br-ibge-municipality": "3304557",
+				"br-nfe-regime": "1"
 			}
 		},
 		"lines": [
@@ -73,15 +74,25 @@
 				"taxes": [
 					{
 						"cat": "ICMS",
-						"percent": "4.0%"
+						"percent": "0%",
+						"ext": {
+							"br-nfe-icms-csosn": "102",
+							"br-nfe-icms-origin": "0"
+						}
 					},
 					{
 						"cat": "PIS",
-						"percent": "1.65%"
+						"percent": "0%",
+						"ext": {
+							"br-nfe-pis-cst": "49"
+						}
 					},
 					{
 						"cat": "COFINS",
-						"percent": "7.60%"
+						"percent": "0%",
+						"ext": {
+							"br-nfe-cofins-cst": "49"
+						}
 					}
 				],
 				"total": "20.00"
@@ -105,36 +116,46 @@
 						"informative": true,
 						"rates": [
 							{
+								"ext": {
+									"br-nfe-icms-csosn": "102",
+									"br-nfe-icms-origin": "0"
+								},
 								"base": "20.00",
-								"percent": "4.0%",
-								"amount": "0.80"
+								"percent": "0%",
+								"amount": "0.00"
 							}
 						],
-						"amount": "0.80"
+						"amount": "0.00"
 					},
 					{
 						"code": "PIS",
 						"informative": true,
 						"rates": [
 							{
+								"ext": {
+									"br-nfe-pis-cst": "49"
+								},
 								"base": "20.00",
-								"percent": "1.65%",
-								"amount": "0.33"
+								"percent": "0%",
+								"amount": "0.00"
 							}
 						],
-						"amount": "0.33"
+						"amount": "0.00"
 					},
 					{
 						"code": "COFINS",
 						"informative": true,
 						"rates": [
 							{
+								"ext": {
+									"br-nfe-cofins-cst": "49"
+								},
 								"base": "20.00",
-								"percent": "7.60%",
-								"amount": "1.52"
+								"percent": "0%",
+								"amount": "0.00"
 							}
 						],
-						"amount": "1.52"
+						"amount": "0.00"
 					}
 				],
 				"sum": "0.00"

--- a/examples/br/out/invoice-nfe-simples.json
+++ b/examples/br/out/invoice-nfe-simples.json
@@ -1,0 +1,208 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
+		"dig": {
+			"alg": "sha256",
+			"val": "6fadefeecf0655ccb5c3944eb0fab2f1190a97f91610127d29d8123a9ad1cceb"
+		}
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"$regime": "BR",
+		"$addons": [
+			"br-nfe-v4"
+		],
+		"uuid": "01937e2b-6c3d-7e4f-9a50-2b3c4d5e6f70",
+		"type": "standard",
+		"series": "1",
+		"code": "2048",
+		"issue_date": "2024-11-20",
+		"currency": "BRL",
+		"tax": {
+			"ext": {
+				"br-nfe-model": "55",
+				"br-nfe-presence": "1"
+			}
+		},
+		"supplier": {
+			"name": "Marcenaria Arte \u0026 Design ME",
+			"tax_id": {
+				"country": "BR",
+				"code": "12345678000195"
+			},
+			"identities": [
+				{
+					"key": "br-nfe-state-reg",
+					"code": "0623458900"
+				}
+			],
+			"addresses": [
+				{
+					"num": "85",
+					"street": "Rua dos Artesãos",
+					"locality": "Savassi",
+					"region": "Minas Gerais",
+					"state": "MG",
+					"code": "30140-071",
+					"country": "BR"
+				}
+			],
+			"emails": [
+				{
+					"addr": "contato@artedesign.com.br"
+				}
+			],
+			"ext": {
+				"br-ibge-municipality": "3106200",
+				"br-nfe-regime": "1"
+			}
+		},
+		"customer": {
+			"name": "Comércio de Móveis Paulista Ltda.",
+			"tax_id": {
+				"country": "BR",
+				"code": "55263640000186"
+			},
+			"identities": [
+				{
+					"key": "br-nfe-state-reg",
+					"code": "112233445566"
+				}
+			],
+			"addresses": [
+				{
+					"num": "742",
+					"street": "Avenida Paulista",
+					"locality": "Bela Vista",
+					"region": "São Paulo",
+					"state": "SP",
+					"code": "01310-100",
+					"country": "BR"
+				}
+			],
+			"ext": {
+				"br-ibge-municipality": "3550308"
+			}
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "5",
+				"item": {
+					"ref": "MES-CARV",
+					"name": "Mesa de Jantar em Madeira Maciça",
+					"identities": [
+						{
+							"key": "ncm",
+							"code": "9403.60.00"
+						}
+					],
+					"price": "900.00",
+					"unit": "piece"
+				},
+				"sum": "4500.00",
+				"taxes": [
+					{
+						"cat": "ICMS",
+						"percent": "2.56%",
+						"ext": {
+							"br-nfe-icms-csosn": "101",
+							"br-nfe-icms-origin": "0"
+						}
+					},
+					{
+						"cat": "PIS",
+						"percent": "0%",
+						"ext": {
+							"br-nfe-pis-cst": "49"
+						}
+					},
+					{
+						"cat": "COFINS",
+						"percent": "0%",
+						"ext": {
+							"br-nfe-cofins-cst": "49"
+						}
+					}
+				],
+				"total": "4500.00",
+				"ext": {
+					"br-nfe-cfop": "6102"
+				}
+			}
+		],
+		"payment": {
+			"instructions": {
+				"key": "credit-transfer",
+				"ext": {
+					"br-nfe-payment-means": "18"
+				}
+			}
+		},
+		"totals": {
+			"sum": "4500.00",
+			"total": "4500.00",
+			"taxes": {
+				"categories": [
+					{
+						"code": "ICMS",
+						"informative": true,
+						"rates": [
+							{
+								"ext": {
+									"br-nfe-icms-csosn": "101",
+									"br-nfe-icms-origin": "0"
+								},
+								"base": "4500.00",
+								"percent": "2.56%",
+								"amount": "115.20"
+							}
+						],
+						"amount": "115.20"
+					},
+					{
+						"code": "PIS",
+						"informative": true,
+						"rates": [
+							{
+								"ext": {
+									"br-nfe-pis-cst": "49"
+								},
+								"base": "4500.00",
+								"percent": "0%",
+								"amount": "0.00"
+							}
+						],
+						"amount": "0.00"
+					},
+					{
+						"code": "COFINS",
+						"informative": true,
+						"rates": [
+							{
+								"ext": {
+									"br-nfe-cofins-cst": "49"
+								},
+								"base": "4500.00",
+								"percent": "0%",
+								"amount": "0.00"
+							}
+						],
+						"amount": "0.00"
+					}
+				],
+				"sum": "0.00"
+			},
+			"tax": "0.00",
+			"total_with_tax": "4500.00",
+			"payable": "4500.00"
+		},
+		"notes": [
+			{
+				"key": "reason",
+				"text": "Venda de mercadoria"
+			}
+		]
+	}
+}

--- a/examples/br/out/invoice-nfe.json
+++ b/examples/br/out/invoice-nfe.json
@@ -4,7 +4,7 @@
 		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
 		"dig": {
 			"alg": "sha256",
-			"val": "bd5431998239813564d14cc27ee4c4511800578a98e86d6c67a3bce4edf00b89"
+			"val": "558ba58097ced216aae846ffe6a03f385c22a6a245eee9e01739f39cfe541ca0"
 		}
 	},
 	"doc": {
@@ -13,68 +13,99 @@
 		"$addons": [
 			"br-nfe-v4"
 		],
-		"$tags": [
-			"simplified"
-		],
-		"uuid": "0193305c-a7be-730d-b552-2093f0df2df7",
+		"uuid": "01937e1a-5b2c-7d3e-8f40-1a2b3c4d5e6f",
 		"type": "standard",
-		"series": "123",
-		"code": "1",
-		"issue_date": "2024-11-15",
+		"series": "1",
+		"code": "1024",
+		"issue_date": "2024-11-20",
 		"currency": "BRL",
 		"tax": {
 			"ext": {
-				"br-nfe-model": "65",
+				"br-nfe-model": "55",
 				"br-nfe-presence": "1"
 			}
 		},
 		"supplier": {
-			"name": "Drogaria Vida Saudável Ltda.",
+			"name": "Eletro Components Indústria Ltda.",
 			"tax_id": {
 				"country": "BR",
-				"code": "55263640000186"
+				"code": "18069577000115"
 			},
 			"identities": [
 				{
 					"key": "br-nfe-state-reg",
-					"code": "35503304557308"
+					"code": "110042490114"
 				}
 			],
 			"addresses": [
 				{
-					"num": "200",
-					"street": "Rua Primeiro de Março",
-					"street_extra": "Torre A",
-					"locality": "Centro",
-					"region": "Rio de Janeiro",
-					"state": "RJ",
-					"code": "20010-000",
+					"num": "1500",
+					"street": "Avenida Engenheiro Luís Carlos Berrini",
+					"locality": "Cidade Monções",
+					"region": "São Paulo",
+					"state": "SP",
+					"code": "04571-000",
 					"country": "BR"
 				}
 			],
 			"emails": [
 				{
-					"addr": "saudemais@example.com"
+					"addr": "fiscal@eletrocomponents.com.br"
 				}
 			],
 			"ext": {
-				"br-ibge-municipality": "3304557",
+				"br-ibge-municipality": "3550308",
 				"br-nfe-regime": "3"
+			}
+		},
+		"customer": {
+			"name": "Instaladora Predial Campinas Ltda.",
+			"tax_id": {
+				"country": "BR",
+				"code": "05700736000196"
+			},
+			"identities": [
+				{
+					"key": "br-nfe-state-reg",
+					"code": "244889012117"
+				}
+			],
+			"addresses": [
+				{
+					"num": "300",
+					"street": "Rua Barão de Jaguara",
+					"locality": "Centro",
+					"region": "São Paulo",
+					"state": "SP",
+					"code": "13015-000",
+					"country": "BR"
+				}
+			],
+			"ext": {
+				"br-ibge-municipality": "3509502"
 			}
 		},
 		"lines": [
 			{
 				"i": 1,
-				"quantity": "2",
+				"quantity": "20",
 				"item": {
-					"name": "Caixa de Máscaras Cirúrgicas",
-					"price": "10.00"
+					"ref": "DJ-60A",
+					"name": "Disjuntor Tripolar 60A",
+					"identities": [
+						{
+							"key": "ncm",
+							"code": "8536.20.00"
+						}
+					],
+					"price": "85.00",
+					"unit": "piece"
 				},
-				"sum": "20.00",
+				"sum": "1700.00",
 				"taxes": [
 					{
 						"cat": "ICMS",
-						"percent": "4.0%",
+						"percent": "18.0%",
 						"ext": {
 							"br-nfe-icms-cst": "00",
 							"br-nfe-icms-origin": "0"
@@ -95,20 +126,23 @@
 						}
 					}
 				],
-				"total": "20.00"
+				"total": "1700.00",
+				"ext": {
+					"br-nfe-cfop": "5102"
+				}
 			}
 		],
 		"payment": {
 			"instructions": {
-				"key": "card",
+				"key": "credit-transfer",
 				"ext": {
-					"br-nfe-payment-means": "03"
+					"br-nfe-payment-means": "18"
 				}
 			}
 		},
 		"totals": {
-			"sum": "20.00",
-			"total": "20.00",
+			"sum": "1700.00",
+			"total": "1700.00",
 			"taxes": {
 				"categories": [
 					{
@@ -120,12 +154,12 @@
 									"br-nfe-icms-cst": "00",
 									"br-nfe-icms-origin": "0"
 								},
-								"base": "20.00",
-								"percent": "4.0%",
-								"amount": "0.80"
+								"base": "1700.00",
+								"percent": "18.0%",
+								"amount": "306.00"
 							}
 						],
-						"amount": "0.80"
+						"amount": "306.00"
 					},
 					{
 						"code": "PIS",
@@ -135,12 +169,12 @@
 								"ext": {
 									"br-nfe-pis-cst": "01"
 								},
-								"base": "20.00",
+								"base": "1700.00",
 								"percent": "1.65%",
-								"amount": "0.33"
+								"amount": "28.05"
 							}
 						],
-						"amount": "0.33"
+						"amount": "28.05"
 					},
 					{
 						"code": "COFINS",
@@ -150,19 +184,19 @@
 								"ext": {
 									"br-nfe-cofins-cst": "01"
 								},
-								"base": "20.00",
+								"base": "1700.00",
 								"percent": "7.60%",
-								"amount": "1.52"
+								"amount": "129.20"
 							}
 						],
-						"amount": "1.52"
+						"amount": "129.20"
 					}
 				],
 				"sum": "0.00"
 			},
 			"tax": "0.00",
-			"total_with_tax": "20.00",
-			"payable": "20.00"
+			"total_with_tax": "1700.00",
+			"payable": "1700.00"
 		},
 		"notes": [
 			{


### PR DESCRIPTION
- Adds CST extensions for all NF-e taxes (ICMS, PIS, COFINS) with validation and defaults
- Adds ICMS goods origin extension for NF-e with validation and default
- Extends regime extension with MEI value. Adding validation and default

## Pre-Review Checklist

- [x] Opened this PR as a draft
- [x] Read the CONTRIBUTING.md guide.
- [x] Performed a self-review of my code.
- [x] Added thorough tests with at **least** 90% code coverage.
- [x] Modified or created example GOBL documents to show my changes in use, if appropriate.
- [x] Added links to the source of the changes in tax regimes or addons, either structured or in the comments.
- [x] Run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [x] Reviewed and fixed all linter warnings.
- [x] Been obsessive with pointer nil checks to avoid panics.
- [x] Updated the CHANGELOG.md with an overview of my changes.
- [x] Marked this PR as ready for review.

And if you are part of the org:
- [x] Requested a review from Copilot and fixed or dismissed (with a reason) all the feedback raised.
- [x] Requested a review from @samlown.
