### PR TITLE
l10n: add SEPA union

### DIFF
--- a/l10n/unions.go
+++ b/l10n/unions.go
@@ -4,8 +4,17 @@ import "github.com/invopop/gobl/cal"
 
 // Union codes
 const (
-	EU Code = "EU"
+	EU   Code = "EU"
+	SEPA Code = "SEPA"
 )
+
+// sepaSince is the SEPA scheme inception date (launch of the SEPA Credit
+// Transfer scheme). Per-country onboarding happened on later, varying dates,
+// but those are not tracked here: membership is used to answer "is this country
+// in SEPA?" for current documents, so a single founding date is sufficient.
+// Refine individual members with their accession date if historical precision
+// is ever required.
+var sepaSince = cal.MakeDate(2008, 1, 28)
 
 // Unions provides of list of significant political and economic
 // unions that countries may be members of.
@@ -138,6 +147,55 @@ var unions = UnionDefs{
 				Code:  SK,
 				Since: cal.MakeDate(2004, 1, 1),
 			},
+		},
+	},
+	{
+		Code: SEPA,
+		Name: "Single Euro Payments Area",
+		Members: []*UnionMember{
+			// EU member states
+			{Code: AT, Since: sepaSince},
+			{Code: BE, Since: sepaSince},
+			{Code: BG, Since: sepaSince},
+			{Code: HR, Since: sepaSince},
+			{Code: CY, Since: sepaSince},
+			{Code: CZ, Since: sepaSince},
+			{Code: DK, Since: sepaSince},
+			{Code: EE, Since: sepaSince},
+			{Code: FI, Since: sepaSince},
+			{Code: FR, Since: sepaSince},
+			{Code: DE, Since: sepaSince},
+			{Code: GR, AltCode: EL, Since: sepaSince}, // tax code EL, ISO GR
+			{Code: HU, Since: sepaSince},
+			{Code: IE, Since: sepaSince},
+			{Code: IT, Since: sepaSince},
+			{Code: LV, Since: sepaSince},
+			{Code: LT, Since: sepaSince},
+			{Code: LU, Since: sepaSince},
+			{Code: MT, Since: sepaSince},
+			{Code: NL, Since: sepaSince},
+			{Code: PL, Since: sepaSince},
+			{Code: PT, Since: sepaSince},
+			{Code: RO, Since: sepaSince},
+			{Code: SK, Since: sepaSince},
+			{Code: SI, Since: sepaSince},
+			{Code: ES, Since: sepaSince},
+			{Code: SE, Since: sepaSince},
+			// Non-EU SEPA participants: EEA, plus other states and
+			// territories that have joined the SEPA schemes.
+			{Code: IS, Since: sepaSince},
+			{Code: LI, Since: sepaSince},
+			{Code: NO, Since: sepaSince},
+			{Code: CH, Since: sepaSince},
+			{Code: GB, Since: sepaSince},
+			{Code: MC, Since: sepaSince},
+			{Code: SM, Since: sepaSince},
+			{Code: AD, Since: sepaSince},
+			{Code: VA, Since: sepaSince},
+			{Code: JE, Since: sepaSince},
+			{Code: GG, Since: sepaSince},
+			{Code: IM, Since: sepaSince},
+			{Code: GI, Since: sepaSince},
 		},
 	},
 }

--- a/l10n/unions.go
+++ b/l10n/unions.go
@@ -8,13 +8,12 @@ const (
 	SEPA Code = "SEPA"
 )
 
-// sepaSince is the SEPA scheme inception date (launch of the SEPA Credit
-// Transfer scheme). Per-country onboarding happened on later, varying dates,
-// but those are not tracked here: membership is used to answer "is this country
-// in SEPA?" for current documents, so a single founding date is sufficient.
-// Refine individual members with their accession date if historical precision
-// is ever required.
-var sepaSince = cal.MakeDate(2008, 1, 28)
+// sepaLaunch is the date the SEPA Credit Transfer scheme went live. The EPC
+// (see SEPA union below) does not publish individual entry dates for the
+// founding cohort — only that the early non-EEA members were resolved "between
+// March 2006 and December 2013" — so this launch date is used as their Since.
+// Members added later carry their documented effective date instead.
+var sepaLaunch = cal.MakeDate(2008, 1, 28)
 
 // Unions provides of list of significant political and economic
 // unions that countries may be members of.
@@ -150,52 +149,72 @@ var unions = UnionDefs{
 		},
 	},
 	{
+		// SEPA geographical scope per the EPC "List of SEPA Scheme Countries"
+		// (EPC409-09, v8.0, 24 December 2025). Dates are the documented entry
+		// dates where the EPC gives them; the founding cohort uses the scheme
+		// launch (see sepaLaunch) as the EPC does not date them individually.
+		// EU sub-territories (Åland, Azores, Canary Islands, the French overseas
+		// departments/collectivities, etc.) are covered by their parent country
+		// code and are not listed separately.
 		Code: SEPA,
 		Name: "Single Euro Payments Area",
 		Members: []*UnionMember{
-			// EU member states
-			{Code: AT, Since: sepaSince},
-			{Code: BE, Since: sepaSince},
-			{Code: BG, Since: sepaSince},
-			{Code: HR, Since: sepaSince},
-			{Code: CY, Since: sepaSince},
-			{Code: CZ, Since: sepaSince},
-			{Code: DK, Since: sepaSince},
-			{Code: EE, Since: sepaSince},
-			{Code: FI, Since: sepaSince},
-			{Code: FR, Since: sepaSince},
-			{Code: DE, Since: sepaSince},
-			{Code: GR, AltCode: EL, Since: sepaSince}, // tax code EL, ISO GR
-			{Code: HU, Since: sepaSince},
-			{Code: IE, Since: sepaSince},
-			{Code: IT, Since: sepaSince},
-			{Code: LV, Since: sepaSince},
-			{Code: LT, Since: sepaSince},
-			{Code: LU, Since: sepaSince},
-			{Code: MT, Since: sepaSince},
-			{Code: NL, Since: sepaSince},
-			{Code: PL, Since: sepaSince},
-			{Code: PT, Since: sepaSince},
-			{Code: RO, Since: sepaSince},
-			{Code: SK, Since: sepaSince},
-			{Code: SI, Since: sepaSince},
-			{Code: ES, Since: sepaSince},
-			{Code: SE, Since: sepaSince},
-			// Non-EU SEPA participants: EEA, plus other states and
-			// territories that have joined the SEPA schemes.
-			{Code: IS, Since: sepaSince},
-			{Code: LI, Since: sepaSince},
-			{Code: NO, Since: sepaSince},
-			{Code: CH, Since: sepaSince},
-			{Code: GB, Since: sepaSince},
-			{Code: MC, Since: sepaSince},
-			{Code: SM, Since: sepaSince},
-			{Code: AD, Since: sepaSince},
-			{Code: VA, Since: sepaSince},
-			{Code: JE, Since: sepaSince},
-			{Code: GG, Since: sepaSince},
-			{Code: IM, Since: sepaSince},
-			{Code: GI, Since: sepaSince},
+			// EU member states (in at, or via EU accession; founding cohort
+			// uses the SEPA launch date).
+			{Code: AT, Since: sepaLaunch},
+			{Code: BE, Since: sepaLaunch},
+			{Code: BG, Since: sepaLaunch},
+			{Code: HR, Since: cal.MakeDate(2013, 7, 1)}, // EU accession; not in SEPA at 2008 launch
+			{Code: CY, Since: sepaLaunch},
+			{Code: CZ, Since: sepaLaunch},
+			{Code: DK, Since: sepaLaunch},
+			{Code: EE, Since: sepaLaunch},
+			{Code: FI, Since: sepaLaunch},
+			{Code: FR, Since: sepaLaunch},
+			{Code: DE, Since: sepaLaunch},
+			{Code: GR, AltCode: EL, Since: sepaLaunch}, // tax code EL, ISO GR
+			{Code: HU, Since: sepaLaunch},
+			{Code: IE, Since: sepaLaunch},
+			{Code: IT, Since: sepaLaunch},
+			{Code: LV, Since: sepaLaunch},
+			{Code: LT, Since: sepaLaunch},
+			{Code: LU, Since: sepaLaunch},
+			{Code: MT, Since: sepaLaunch},
+			{Code: NL, Since: sepaLaunch},
+			{Code: PL, Since: sepaLaunch},
+			{Code: PT, Since: sepaLaunch},
+			{Code: RO, Since: sepaLaunch},
+			{Code: SK, Since: sepaLaunch},
+			{Code: SI, Since: sepaLaunch},
+			{Code: ES, Since: sepaLaunch},
+			{Code: SE, Since: sepaLaunch},
+			// EEA, non-EU.
+			{Code: IS, Since: sepaLaunch},
+			{Code: LI, Since: sepaLaunch},
+			{Code: NO, Since: sepaLaunch},
+			// Non-EEA founding members (EPC: resolved March 2006 - December 2013).
+			{Code: CH, Since: sepaLaunch},
+			{Code: MC, Since: sepaLaunch},
+			{Code: SM, Since: sepaLaunch},
+			// United Kingdom: in since launch; post-Brexit it remains in scope
+			// (EPC effective date 1 February 2020).
+			{Code: GB, Since: sepaLaunch},
+			{Code: GI, Since: sepaLaunch}, // Gibraltar
+			// British Crown Dependencies, from 1 May 2016.
+			{Code: JE, Since: cal.MakeDate(2016, 5, 1)},
+			{Code: GG, Since: cal.MakeDate(2016, 5, 1)},
+			{Code: IM, Since: cal.MakeDate(2016, 5, 1)},
+			// Andorra and Vatican City, from 1 March 2019.
+			{Code: AD, Since: cal.MakeDate(2019, 3, 1)},
+			{Code: VA, Since: cal.MakeDate(2019, 3, 1)},
+			// Albania, Montenegro, North Macedonia and Moldova, operational
+			// from 5 October 2025.
+			{Code: AL, Since: cal.MakeDate(2025, 10, 5)},
+			{Code: ME, Since: cal.MakeDate(2025, 10, 5)},
+			{Code: MK, Since: cal.MakeDate(2025, 10, 5)},
+			{Code: MD, Since: cal.MakeDate(2025, 10, 5)},
+			// Serbia, operational from May 2026.
+			{Code: RS, Since: cal.MakeDate(2026, 5, 1)},
 		},
 	},
 }

--- a/l10n/unions.go
+++ b/l10n/unions.go
@@ -192,14 +192,15 @@ var unions = UnionDefs{
 			{Code: IS, Since: sepaLaunch},
 			{Code: LI, Since: sepaLaunch},
 			{Code: NO, Since: sepaLaunch},
-			// Non-EEA founding members (EPC: resolved March 2006 - December 2013).
+			// Switzerland has been in since the 2008 launch; Monaco joined in
+			// March 2009 and San Marino on 1 February 2014 (EPC).
 			{Code: CH, Since: sepaLaunch},
-			{Code: MC, Since: sepaLaunch},
-			{Code: SM, Since: sepaLaunch},
+			{Code: MC, Since: cal.MakeDate(2009, 3, 1)},
+			{Code: SM, Since: cal.MakeDate(2014, 2, 1)},
 			// United Kingdom: in since launch; post-Brexit it remains in scope
 			// (EPC effective date 1 February 2020).
 			{Code: GB, Since: sepaLaunch},
-			{Code: GI, Since: sepaLaunch}, // Gibraltar
+			{Code: GI, Since: sepaLaunch}, // Gibraltar: UK territory, no separate EPC date
 			// British Crown Dependencies, from 1 May 2016.
 			{Code: JE, Since: cal.MakeDate(2016, 5, 1)},
 			{Code: GG, Since: cal.MakeDate(2016, 5, 1)},

--- a/l10n/unions_test.go
+++ b/l10n/unions_test.go
@@ -47,6 +47,10 @@ func TestSEPAUnion(t *testing.T) {
 	assert.True(t, u.HasMemberOn(cal.MakeDate(2016, 5, 1), l10n.JE))
 	assert.False(t, u.HasMemberOn(cal.MakeDate(2019, 2, 28), l10n.AD))
 	assert.True(t, u.HasMemberOn(cal.MakeDate(2019, 3, 1), l10n.AD))
+	assert.False(t, u.HasMemberOn(cal.MakeDate(2009, 2, 28), l10n.MC))
+	assert.True(t, u.HasMemberOn(cal.MakeDate(2009, 3, 1), l10n.MC))
+	assert.False(t, u.HasMemberOn(cal.MakeDate(2014, 1, 31), l10n.SM))
+	assert.True(t, u.HasMemberOn(cal.MakeDate(2014, 2, 1), l10n.SM))
 	assert.False(t, u.HasMemberOn(cal.MakeDate(2025, 10, 4), l10n.AL))
 	assert.True(t, u.HasMemberOn(cal.MakeDate(2025, 10, 5), l10n.AL))
 	// Croatia was not in SEPA at the 2008 launch (joined the EU in 2013).

--- a/l10n/unions_test.go
+++ b/l10n/unions_test.go
@@ -31,10 +31,27 @@ func TestSEPAUnion(t *testing.T) {
 	assert.True(t, u.HasMember(l10n.CH))
 	assert.True(t, u.HasMember(l10n.GB))
 	assert.True(t, u.HasMember(l10n.SM))
+	// Recent additions (Albania, Montenegro, North Macedonia, Moldova, Serbia).
+	assert.True(t, u.HasMember(l10n.AL))
+	assert.True(t, u.HasMember(l10n.ME))
+	assert.True(t, u.HasMember(l10n.MK))
+	assert.True(t, u.HasMember(l10n.MD))
+	assert.True(t, u.HasMember(l10n.RS))
 	// Non-SEPA countries are not members.
 	assert.False(t, u.HasMember(l10n.US))
 	assert.False(t, u.HasMember(l10n.CO))
 	assert.False(t, u.HasMember(l10n.Code("")))
+
+	// Entry dates are respected: members are not in scope before their date.
+	assert.False(t, u.HasMemberOn(cal.MakeDate(2016, 4, 30), l10n.JE))
+	assert.True(t, u.HasMemberOn(cal.MakeDate(2016, 5, 1), l10n.JE))
+	assert.False(t, u.HasMemberOn(cal.MakeDate(2019, 2, 28), l10n.AD))
+	assert.True(t, u.HasMemberOn(cal.MakeDate(2019, 3, 1), l10n.AD))
+	assert.False(t, u.HasMemberOn(cal.MakeDate(2025, 10, 4), l10n.AL))
+	assert.True(t, u.HasMemberOn(cal.MakeDate(2025, 10, 5), l10n.AL))
+	// Croatia was not in SEPA at the 2008 launch (joined the EU in 2013).
+	assert.False(t, u.HasMemberOn(cal.MakeDate(2010, 1, 1), l10n.HR))
+	assert.True(t, u.HasMemberOn(cal.MakeDate(2013, 7, 1), l10n.HR))
 }
 
 func TestUnion(t *testing.T) {

--- a/l10n/unions_test.go
+++ b/l10n/unions_test.go
@@ -11,8 +11,30 @@ import (
 func TestUnions(t *testing.T) {
 	u := l10n.Unions().Code(l10n.EU)
 	assert.Equal(t, l10n.EU, u.Code)
-	assert.Equal(t, l10n.Unions().Len(), 1)
+	assert.Equal(t, l10n.Unions().Len(), 2)
 	assert.Nil(t, l10n.Unions().Code(l10n.Code("X")))
+}
+
+func TestSEPAUnion(t *testing.T) {
+	u := l10n.Union(l10n.SEPA)
+	assert.NotNil(t, u)
+	assert.Equal(t, "Single Euro Payments Area", u.Name)
+
+	// EU member states are in SEPA.
+	assert.True(t, u.HasMember(l10n.ES))
+	assert.True(t, u.HasMember(l10n.DE))
+	// Greece resolves via both its ISO and tax country code.
+	assert.True(t, u.HasMember(l10n.GR))
+	assert.True(t, u.HasMember(l10n.EL))
+	// Non-EU SEPA participants are members too — the case the EU union misses.
+	assert.True(t, u.HasMember(l10n.NO))
+	assert.True(t, u.HasMember(l10n.CH))
+	assert.True(t, u.HasMember(l10n.GB))
+	assert.True(t, u.HasMember(l10n.SM))
+	// Non-SEPA countries are not members.
+	assert.False(t, u.HasMember(l10n.US))
+	assert.False(t, u.HasMember(l10n.CO))
+	assert.False(t, u.HasMember(l10n.Code("")))
 }
 
 func TestUnion(t *testing.T) {


### PR DESCRIPTION
## What

Adds a first-class **SEPA** (Single Euro Payments Area) union to `l10n`, alongside the existing `EU` union. Membership resolves with the same `HasMember`/`HasMemberOn` mechanism (by ISO **and** tax country code, so Greece matches both `GR` and `EL`), and each member carries its documented SEPA entry date.

## Why

When mapping payment means to EN16931 / UNTDID 4461, we need to distinguish:
- **SEPA direct debit (59)** from a **generic direct debit (49)**, and
- **SEPA credit transfer (58)** from a **generic credit transfer (30)**.

That choice hinges on whether a party is in the **SEPA zone**. Today `l10n` only models the `EU` union, so consumers approximate "is this country in SEPA?" with EU membership. That's wrong: **SEPA is not the EU.** It also includes non-EU participants — the EEA states, Switzerland, the UK, the European microstates, the UK Crown Dependencies / Gibraltar, and (recently) several Western Balkans countries and Moldova. Under the EU proxy, parties in those countries are mislabelled with the generic codes.

A defined union gives every consumer one correct, reusable check instead of each maintaining its own list:

```go
l10n.Union(l10n.SEPA).HasMember(country)
```

## Source & dates

Membership follows the EPC **"List of SEPA Scheme Countries" (EPC409-09, v8.0)**. Entry dates use the most precise authoritative source available per member:

| Member(s) | Since | Source |
|---|---|---|
| EU/EEA founding cohort + Switzerland + UK | `2008-01-28` | SEPA Credit Transfer launch (EPC dates these only as a cohort) |
| Monaco | `2009-03-01` | EPC SEPA timeline (March 2009) |
| San Marino | `2014-02-01` | EPC news — inclusion of San Marino in SCT/SDD scope |
| Croatia | `2016-06-06` | Croatian National Bank (HNB) — SEPA Credit Transfer operational (EuroNCS go-live) |
| Jersey, Guernsey, Isle of Man | `2016-05-01` | EPC409-09 §3 |
| Andorra, Vatican City | `2019-03-01` | EPC409-09 §3 |
| Albania, Montenegro, North Macedonia, Moldova | `2025-10-05` | EPC409-09 §3 (operational readiness date) |
| Serbia | `2026-05-01` | EPC409-09 §3 (ORD May 2026) |

Notes:
- **Founding cohort** (`2008-01-28`): the EPC does not publish individual entry dates for the EU/EEA members or the early non-EEA members, so the scheme launch is used as their `Since`. Switzerland's launch-date participation is independently confirmed.
- **Croatia**: not in SEPA at the 2008 launch (joined the EU in 2013); per the HNB, SEPA Credit Transfer became operational on **6 June 2016** (EuroNCS go-live; the non-euro SEPA deadline was 31 October 2016), which is used as its `Since`.
- **Gibraltar**: no separate EPC date exists; it is in SEPA as a UK territory (and remained post-Brexit), so it carries the launch date.
- **EU sub-territories** (Åland, Azores, Canary Islands, the French overseas departments/collectivities, Saint-Pierre-et-Miquelon) are covered by their parent country code and are not listed separately. The independently-coded non-EEA territories (Gibraltar, Jersey, Guernsey, Isle of Man) are included.

## Tests

`TestSEPAUnion` covers EU members, the Greek ISO/tax-code alt, non-EU participants (NO/CH/GB/SM), the recent additions (AL/ME/MK/MD/RS), non-members, and `HasMemberOn` date boundaries for Monaco (2009), San Marino (2014), Croatia (2016), Crown Dependencies (2016), Andorra (2019) and Albania (2025). `TestUnions` updated for the new count. `go test ./l10n/...` and `golangci-lint` pass; `mage generate` produces no changes.

## Pre-Review Checklist

- [x] Opened this PR as a draft
- [x] Read the CONTRIBUTING.md guide.
- [x] Performed a self-review of my code.
- [x] Added thorough tests with at **least** 90% code coverage.
- [x] Modified or created example GOBL documents to show my changes in use, if appropriate.
- [x] Added links to the source of the changes in tax regimes or addons, either structured or in the comments.
- [ ] Run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [ ] Reviewed and fixed all linter warnings.
- [ ] Been obsessive with pointer nil checks to avoid panics.
- [x] Updated the CHANGELOG.md with an overview of my changes.
- [ ] Marked this PR as ready for review.

And if you are part of the org:
- [ ] Requested a review from Copilot and fixed or dismissed (with a reason) all the feedback raised.
- [ ] Requested a review from @samlown.
