### PR TITLE
Add co-dian-item-identification and co-dian-tax-scheme extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Added
+
+- `co-dian-v2`: added `co-dian-item-identification` and `co-dian-regime` extensions.
+- `co-dian-v2`: new validation rules for invoice code format, credit notes without a `dian-cude` stamp (91-22), payment due dates, and line quantities.
+
 ## [v0.503.0] - 2026-07-15
 
 ### Added

--- a/addons/co/dian/bill_invoices.go
+++ b/addons/co/dian/bill_invoices.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 
 	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/cal"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/currency"
+	"github.com/invopop/gobl/head"
 	"github.com/invopop/gobl/org"
 	"github.com/invopop/gobl/rules"
 	"github.com/invopop/gobl/rules/is"
@@ -163,6 +165,42 @@ func billInvoiceRules() *rules.Set {
 				),
 			),
 		),
+		// Code 15: DIAN numbering requires plain positive integers
+		rules.Field("code",
+			rules.Assert("15", "invoice code must be a positive integer without leading zeroes",
+				is.Matches(`^[1-9][0-9]*$`),
+			),
+		),
+		// Codes 16/17: DIAN restricts credit notes without a referenced document (91-22)
+		rules.When(
+			bill.InvoiceTypeIn(bill.InvoiceTypeCreditNote),
+			rules.Field("preceding",
+				rules.Each(
+					rules.When(
+						is.Func("missing dian-cude stamp", precedingMissingCUDE),
+						// Code 16: DIAN rule CBF03a forbids revoking (credit code 2) unreferenced invoices
+						rules.Field("ext",
+							rules.Assert("16", fmt.Sprintf("extension '%s' cannot be '2' (revoked) without a '%s' stamp", ExtKeyCreditCode, StampCUDE),
+								tax.ExtensionsExcludeCodes(ExtKeyCreditCode, "2"),
+							),
+						),
+						// Code 17: DIAN rule CAE02 limits the credited period to a single calendar month
+						rules.Field("period",
+							rules.Assert("17", fmt.Sprintf("period must be within a single calendar month without a '%s' stamp", StampCUDE),
+								is.Func("single calendar month", periodInSingleMonth),
+							),
+						),
+					),
+				),
+			),
+		),
+		// Code 18: DIAN rule IA04 requires a payment due date on credit sales
+		rules.When(
+			bill.InvoiceTypeIn(bill.InvoiceTypeStandard, bill.InvoiceTypeCreditNote, bill.InvoiceTypeDebitNote),
+			rules.Assert("18", "payment due date is required when the invoice is not fully paid",
+				is.Func("credit sale has due date", invoiceCreditSaleHasDueDate),
+			),
+		),
 	)
 }
 
@@ -200,6 +238,45 @@ func customerIsColombian(val any) bool {
 func customerMunicipalityRequired(val any) bool {
 	p, ok := val.(*org.Party)
 	return ok && p != nil && municipalityCodeRequired(p.TaxID)
+}
+
+// invoiceCreditSaleHasDueDate passes when the invoice is fully paid or its payment terms carry a due date.
+func invoiceCreditSaleHasDueDate(val any) bool {
+	inv, ok := val.(*bill.Invoice)
+	if !ok || inv == nil || inv.Totals == nil {
+		return true
+	}
+	if inv.Totals.Paid() {
+		return true
+	}
+	if inv.Payment == nil || inv.Payment.Terms == nil {
+		return false
+	}
+	for _, dd := range inv.Payment.Terms.DueDates {
+		if dd != nil && dd.Date != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// periodInSingleMonth reports whether a complete period starts and ends in the same calendar month.
+func periodInSingleMonth(val any) bool {
+	p, ok := val.(*cal.Period)
+	if !ok || p == nil || p.Start.IsZero() || p.End.IsZero() {
+		return true
+	}
+	return p.Start.Year == p.End.Year && p.Start.Month == p.End.Month
+}
+
+// precedingMissingCUDE reports whether a preceding ref lacks a usable dian-cude stamp, making the note a 91-22.
+func precedingMissingCUDE(val any) bool {
+	ref, ok := val.(*org.DocumentRef)
+	if !ok || ref == nil {
+		return false
+	}
+	st := head.GetStamp(ref.Stamps, StampCUDE)
+	return st == nil || st.Value == ""
 }
 
 func invoiceNotSimplified(val any) bool {

--- a/addons/co/dian/bill_invoices_test.go
+++ b/addons/co/dian/bill_invoices_test.go
@@ -9,9 +9,11 @@ import (
 	"github.com/invopop/gobl/cal"
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/currency"
+	"github.com/invopop/gobl/head"
 	"github.com/invopop/gobl/norm"
 	"github.com/invopop/gobl/num"
 	"github.com/invopop/gobl/org"
+	"github.com/invopop/gobl/pay"
 	"github.com/invopop/gobl/rules"
 	"github.com/invopop/gobl/tax"
 	"github.com/stretchr/testify/assert"
@@ -23,7 +25,7 @@ func baseInvoice() *bill.Invoice {
 		Regime:    tax.WithRegime("CO"),
 		Addons:    tax.WithAddons(dian.V2),
 		Currency:  currency.COP,
-		Code:      "TEST",
+		Code:      "12345",
 		IssueDate: cal.MakeDate(2022, 12, 27),
 		Type:      bill.InvoiceTypeStandard,
 		Supplier: &org.Party{
@@ -62,10 +64,17 @@ func baseInvoice() *bill.Invoice {
 		},
 		Lines: []*bill.Line{
 			{
-				Quantity: num.MakeAmount(1, 3),
+				Quantity: num.MakeAmount(1000, 3),
 				Item: &org.Item{
 					Name:  "bogus",
 					Price: num.NewAmount(1000, 3),
+				},
+			},
+		},
+		Payment: &bill.PaymentDetails{
+			Terms: &pay.Terms{
+				DueDates: []*pay.DueDate{
+					{Date: cal.NewDate(2023, 1, 27), Percent: num.NewPercentage(1, 0)},
 				},
 			},
 		},
@@ -78,13 +87,16 @@ func creditNote() *bill.Invoice {
 		Regime:    tax.WithRegime("CO"),
 		Addons:    tax.WithAddons(dian.V2),
 		Currency:  currency.COP,
-		Code:      "TEST",
+		Code:      "12346",
 		Type:      bill.InvoiceTypeCreditNote,
 		IssueDate: cal.MakeDate(2022, 12, 29),
 		Preceding: []*org.DocumentRef{
 			{
-				Code:      "TEST",
+				Code:      "12345",
 				IssueDate: cal.NewDate(2022, 12, 27),
+				Stamps: []*head.Stamp{
+					{Provider: dian.StampCUDE, Value: "a1b2c3d4e5f6"},
+				},
 				Ext: tax.ExtensionsOf(cbc.CodeMap{
 					dian.ExtKeyCreditCode: "2", // revoked
 				}),
@@ -126,10 +138,17 @@ func creditNote() *bill.Invoice {
 		},
 		Lines: []*bill.Line{
 			{
-				Quantity: num.MakeAmount(1, 3),
+				Quantity: num.MakeAmount(1000, 3),
 				Item: &org.Item{
 					Name:  "bogus",
 					Price: num.NewAmount(1000, 3),
+				},
+			},
+		},
+		Payment: &bill.PaymentDetails{
+			Terms: &pay.Terms{
+				DueDates: []*pay.DueDate{
+					{Date: cal.NewDate(2023, 1, 29), Percent: num.NewPercentage(1, 0)},
 				},
 			},
 		},
@@ -327,5 +346,134 @@ func TestNormalizeInvoice(t *testing.T) {
 
 		assert.Equal(t, cbc.Code("R-99-PN"), inv.Supplier.Ext.Get(dian.ExtKeyFiscalResponsibility))
 		assert.Equal(t, cbc.Code("R-99-PN"), inv.Customer.Ext.Get(dian.ExtKeyFiscalResponsibility))
+	})
+}
+
+func TestInvoiceCodeValidation(t *testing.T) {
+	t.Run("rejects non-numeric codes", func(t *testing.T) {
+		inv := baseInvoice()
+		inv.Code = "TEST"
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "GOBL-CO-DIAN-BILL-INVOICE-15")
+	})
+
+	t.Run("rejects leading zeroes", func(t *testing.T) {
+		inv := baseInvoice()
+		inv.Code = "0123"
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "GOBL-CO-DIAN-BILL-INVOICE-15")
+	})
+
+	t.Run("allows empty draft codes", func(t *testing.T) {
+		inv := baseInvoice()
+		inv.Code = ""
+		require.NoError(t, inv.Calculate())
+		assert.NoError(t, rules.Validate(inv))
+	})
+}
+
+func TestCreditNoteWithoutReferenceValidation(t *testing.T) {
+	// unreferenced returns a credit note whose preceding ref has no dian-cude stamp (91-22).
+	unreferenced := func() *bill.Invoice {
+		inv := creditNote()
+		inv.Preceding[0].Stamps = nil
+		inv.Preceding[0].Reason = "Correcting an error"
+		inv.Preceding[0].Ext = inv.Preceding[0].Ext.Set(dian.ExtKeyCreditCode, "3")
+		return inv
+	}
+
+	t.Run("rejects revoking without a referenced document", func(t *testing.T) {
+		inv := unreferenced()
+		inv.Preceding[0].Ext = inv.Preceding[0].Ext.Set(dian.ExtKeyCreditCode, "2")
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "GOBL-CO-DIAN-BILL-INVOICE-16")
+	})
+
+	t.Run("treats empty stamp values as unreferenced", func(t *testing.T) {
+		inv := creditNote()
+		inv.Preceding[0].Reason = "Correcting an error"
+		inv.Preceding[0].Stamps[0].Value = ""
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "GOBL-CO-DIAN-BILL-INVOICE-16")
+	})
+
+	t.Run("allows revoking with a referenced document", func(t *testing.T) {
+		inv := creditNote()
+		inv.Preceding[0].Reason = "Correcting an error"
+		require.NoError(t, inv.Calculate())
+		assert.NoError(t, rules.Validate(inv))
+	})
+
+	t.Run("rejects periods crossing calendar months", func(t *testing.T) {
+		inv := unreferenced()
+		inv.Preceding[0].Period = &cal.Period{Start: cal.MakeDate(2022, 11, 15), End: cal.MakeDate(2022, 12, 15)}
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "GOBL-CO-DIAN-BILL-INVOICE-17")
+	})
+
+	t.Run("allows periods within one calendar month", func(t *testing.T) {
+		inv := unreferenced()
+		inv.Preceding[0].Period = &cal.Period{Start: cal.MakeDate(2022, 12, 1), End: cal.MakeDate(2022, 12, 28)}
+		require.NoError(t, inv.Calculate())
+		assert.NoError(t, rules.Validate(inv))
+	})
+
+	t.Run("drops nil preceding entries on calculation", func(t *testing.T) {
+		inv := creditNote()
+		inv.Preceding = append(inv.Preceding, nil)
+		inv.Preceding[0].Reason = "Correcting an error"
+		require.NoError(t, inv.Calculate())
+		assert.Len(t, inv.Preceding, 1)
+		assert.NoError(t, rules.Validate(inv))
+	})
+}
+
+func TestPaymentDueDateValidation(t *testing.T) {
+	t.Run("rejects unpaid invoices without due dates", func(t *testing.T) {
+		inv := baseInvoice()
+		inv.Payment = nil
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "GOBL-CO-DIAN-BILL-INVOICE-18")
+	})
+
+	t.Run("rejects unpaid invoices with only nil due dates", func(t *testing.T) {
+		inv := baseInvoice()
+		inv.Payment.Terms.DueDates = []*pay.DueDate{nil}
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "GOBL-CO-DIAN-BILL-INVOICE-18")
+	})
+
+	t.Run("allows fully paid invoices without due dates", func(t *testing.T) {
+		inv := baseInvoice()
+		inv.Payment = &bill.PaymentDetails{
+			Advances: []*pay.Record{
+				{Description: "prepaid", Percent: num.NewPercentage(1, 0)},
+			},
+		}
+		require.NoError(t, inv.Calculate())
+		assert.NoError(t, rules.Validate(inv))
+	})
+
+	t.Run("skips proforma invoices", func(t *testing.T) {
+		inv := baseInvoice()
+		inv.Type = bill.InvoiceTypeProforma
+		inv.Payment = nil
+		require.NoError(t, inv.Calculate())
+		assert.NoError(t, rules.Validate(inv))
+	})
+
+	t.Run("skips uncalculated drafts", func(t *testing.T) {
+		inv := baseInvoice()
+		inv.Payment = nil
+		err := rules.Validate(inv)
+		require.Error(t, err) // core totals faults, but no due date fault
+		assert.NotContains(t, err.Error(), "GOBL-CO-DIAN-BILL-INVOICE-18")
 	})
 }

--- a/addons/co/dian/bill_line.go
+++ b/addons/co/dian/bill_line.go
@@ -1,0 +1,16 @@
+package dian
+
+import (
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/num"
+	"github.com/invopop/gobl/rules"
+)
+
+func billLineRules() *rules.Set {
+	return rules.For(new(bill.Line),
+		// Code 01: DIAN rule FAW01 rejects zero-amount lines, so quantities must be positive
+		rules.Field("quantity",
+			rules.Assert("01", "must be greater than 0", num.Positive),
+		),
+	)
+}

--- a/addons/co/dian/bill_line_test.go
+++ b/addons/co/dian/bill_line_test.go
@@ -1,0 +1,28 @@
+package dian_test
+
+import (
+	"testing"
+
+	"github.com/invopop/gobl/num"
+	"github.com/invopop/gobl/rules"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBillLineQuantityValidation(t *testing.T) {
+	t.Run("rejects zero quantities", func(t *testing.T) {
+		inv := baseInvoice()
+		inv.Lines[0].Quantity = num.MakeAmount(0, 0)
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "GOBL-CO-DIAN-BILL-LINE-01")
+	})
+
+	t.Run("rejects negative quantities", func(t *testing.T) {
+		inv := baseInvoice()
+		inv.Lines[0].Quantity = num.MakeAmount(-1, 0)
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "GOBL-CO-DIAN-BILL-LINE-01")
+	})
+}

--- a/addons/co/dian/dian.go
+++ b/addons/co/dian/dian.go
@@ -34,6 +34,7 @@ func init() {
 		rules.GOBL.Add("CO-DIAN"),
 		is.InContext(tax.AddonIn(V2)),
 		billInvoiceRules(),
+		billLineRules(),
 	)
 	norm.RegisterWithGuard(
 		is.InContext(tax.AddonIn(V2)),

--- a/addons/co/dian/extensions.go
+++ b/addons/co/dian/extensions.go
@@ -12,6 +12,8 @@ const (
 	ExtKeyCreditCode           cbc.Key = "co-dian-credit-code"
 	ExtKeyDebitCode            cbc.Key = "co-dian-debit-code"
 	ExtKeyFiscalResponsibility cbc.Key = "co-dian-fiscal-responsibility"
+	ExtKeyItemIdentification   cbc.Key = "co-dian-item-identification"
+	ExtKeyRegime               cbc.Key = "co-dian-regime"
 )
 
 var extensions = []*cbc.Definition{
@@ -296,6 +298,87 @@ var extensions = []*cbc.Definition{
 				Desc: i18n.String{
 					i18n.EN: "Used when the issuer/acquirer does not have any of the first 4 responsibilities. Applies to legal entities, individuals, or final consumers.",
 					i18n.ES: "Se utiliza cuando el emisor/adquiriente no cuenta con las primeras 4 responsabilidades. Aplica para personas jurídicas, personas naturales o consumidor final.",
+				},
+			},
+		},
+	},
+	{
+		Key: ExtKeyItemIdentification,
+		Name: i18n.String{
+			i18n.EN: "Item Identification Standard",
+			i18n.ES: "Estándar de identificación de producto",
+		},
+		Desc: i18n.String{
+			i18n.EN: here.Doc(`
+				Identifies the product-coding standard used for an invoice line's item code,
+				mapped to the UBL's ~StandardItemIdentification/ID@schemeID~.
+
+				For example:
+
+				~~~js
+				"item": {
+					"name": "Producto",
+					"ref": "7702004003489",
+					"ext": { "co-dian-item-identification": "010" }
+				}
+				~~~
+			`),
+		},
+		Values: []*cbc.Definition{
+			{
+				Code: "001",
+				Name: i18n.String{
+					i18n.EN: "UNSPSC",
+					i18n.ES: "UNSPSC",
+				},
+			},
+			{
+				Code: "010",
+				Name: i18n.String{
+					i18n.EN: "GTIN",
+					i18n.ES: "GTIN",
+				},
+			},
+			{
+				Code: "020",
+				Name: i18n.String{
+					i18n.EN: "Customs tariff",
+					i18n.ES: "Partida arancelaria",
+				},
+			},
+			{
+				Code: "999",
+				Name: i18n.String{
+					i18n.EN: "Taxpayer's own standard",
+					i18n.ES: "Estándar de adopción del contribuyente",
+				},
+			},
+		},
+	},
+	{
+		Key: ExtKeyRegime,
+		Name: i18n.String{
+			i18n.EN: "VAT Regime",
+			i18n.ES: "Régimen de IVA",
+		},
+		Desc: i18n.String{
+			i18n.EN: here.Doc(`
+				Indicates whether the party is responsible for VAT (IVA) according to the DIAN.
+			`),
+		},
+		Values: []*cbc.Definition{
+			{
+				Code: "1",
+				Name: i18n.String{
+					i18n.EN: "VAT responsible",
+					i18n.ES: "Responsable de IVA",
+				},
+			},
+			{
+				Code: "2",
+				Name: i18n.String{
+					i18n.EN: "Not VAT responsible",
+					i18n.ES: "No Responsable de IVA",
 				},
 			},
 		},

--- a/data/addons/co-dian-v2.json
+++ b/data/addons/co-dian-v2.json
@@ -196,6 +196,72 @@
           }
         }
       ]
+    },
+    {
+      "key": "co-dian-item-identification",
+      "name": {
+        "en": "Item Identification Standard",
+        "es": "Estándar de identificación de producto"
+      },
+      "desc": {
+        "en": "Identifies the product-coding standard used for an invoice line's item code,\nmapped to the UBL's `StandardItemIdentification/ID@schemeID`.\n\nFor example:\n\n```js\n\"item\": {\n\t\"name\": \"Producto\",\n\t\"ref\": \"7702004003489\",\n\t\"ext\": { \"co-dian-item-identification\": \"010\" }\n}\n```"
+      },
+      "values": [
+        {
+          "code": "001",
+          "name": {
+            "en": "UNSPSC",
+            "es": "UNSPSC"
+          }
+        },
+        {
+          "code": "010",
+          "name": {
+            "en": "GTIN",
+            "es": "GTIN"
+          }
+        },
+        {
+          "code": "020",
+          "name": {
+            "en": "Customs tariff",
+            "es": "Partida arancelaria"
+          }
+        },
+        {
+          "code": "999",
+          "name": {
+            "en": "Taxpayer's own standard",
+            "es": "Estándar de adopción del contribuyente"
+          }
+        }
+      ]
+    },
+    {
+      "key": "co-dian-regime",
+      "name": {
+        "en": "VAT Regime",
+        "es": "Régimen de IVA"
+      },
+      "desc": {
+        "en": "Indicates whether the party is responsible for VAT (IVA) according to the DIAN."
+      },
+      "values": [
+        {
+          "code": "1",
+          "name": {
+            "en": "VAT responsible",
+            "es": "Responsable de IVA"
+          }
+        },
+        {
+          "code": "2",
+          "name": {
+            "en": "Not VAT responsible",
+            "es": "No Responsable de IVA"
+          }
+        }
+      ]
     }
   ],
   "scenarios": null,

--- a/data/rules/co-dian.json
+++ b/data/rules/co-dian.json
@@ -223,6 +223,82 @@
               ]
             }
           ]
+        },
+        {
+          "field": "code",
+          "assert": [
+            {
+              "id": "GOBL-CO-DIAN-BILL-INVOICE-15",
+              "desc": "invoice code must be a positive integer without leading zeroes",
+              "tests": "matches ^[1-9][0-9]*$"
+            }
+          ]
+        },
+        {
+          "guard": "invoice type in [credit-note]",
+          "subsets": [
+            {
+              "field": "preceding",
+              "subsets": [
+                {
+                  "each": true,
+                  "subsets": [
+                    {
+                      "guard": "missing dian-cude stamp",
+                      "subsets": [
+                        {
+                          "field": "ext",
+                          "assert": [
+                            {
+                              "id": "GOBL-CO-DIAN-BILL-INVOICE-16",
+                              "desc": "extension 'co-dian-credit-code' cannot be '2' (revoked) without a 'dian-cude' stamp",
+                              "tests": "ext 'co-dian-credit-code' not in [2]"
+                            }
+                          ]
+                        },
+                        {
+                          "field": "period",
+                          "assert": [
+                            {
+                              "id": "GOBL-CO-DIAN-BILL-INVOICE-17",
+                              "desc": "period must be within a single calendar month without a 'dian-cude' stamp",
+                              "tests": "single calendar month"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "guard": "invoice type in [standard, credit-note, debit-note]",
+          "assert": [
+            {
+              "id": "GOBL-CO-DIAN-BILL-INVOICE-18",
+              "desc": "payment due date is required when the invoice is not fully paid",
+              "tests": "credit sale has due date"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "GOBL-CO-DIAN-BILL-LINE",
+      "object": "bill.Line",
+      "subsets": [
+        {
+          "field": "quantity",
+          "assert": [
+            {
+              "id": "GOBL-CO-DIAN-BILL-LINE-01",
+              "desc": "must be greater than 0",
+              "tests": "min 0"
+            }
+          ]
         }
       ]
     }


### PR DESCRIPTION
- Added the `co-dian-item-identification` extension to carry the DIAN standard product code on line items.
- Added the `co-dian-tax-scheme` extension to declare the party's tributo per DIAN table 13.2.6.2 (`01` IVA / `04` INC / `ZA` IVA e INC / `ZZ` No aplica), with the Anexo Técnico v1.8 PDF as structured source.
- Added validation rules, each verified against the DIAN habilitación environment:
  - `15`: invoice code must be a positive integer (empty draft codes still pass).
  - `16`: credit notes without a `dian-cude` stamp (91-22, sin referencia) cannot use credit code `2` (DIAN rule CBF03a).
  - `17`: the period credited by a 91-22 note must stay within one calendar month (DIAN rule CAE02).
  - `18`: a payment due date is required when the invoice is not fully paid (DIAN rule IA04).
  - `BILL-LINE-01`: line quantities must be positive (DIAN rule FAW01 rejects zero-amount lines).

## Pre-Review Checklist

- [x] Opened this PR as a draft
- [x] Read the CONTRIBUTING.md guide.
- [x] Performed a self-review of my code.
- [x] Added thorough tests with at **least** 90% code coverage.
- [ ] Modified or created example GOBL documents to show my changes in use, if appropriate.
- [x] Added links to the source of the changes in tax regimes or addons, either structured or in the comments.
- [x] Run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [x] Reviewed and fixed all linter warnings.
- [x] Been obsessive with pointer nil checks to avoid panics.
- [x] Updated the CHANGELOG.md with an overview of my changes.
- [ ] Marked this PR as ready for review.

And if you are part of the org:
- [x] Requested a review from Copilot and fixed or dismissed (with a reason) all the feedback raised.
- [ ] Requested a review from @samlown.