### PR TITLE
Add Estonia (EE) tax regime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Added
 
+- `regimes/ee`: new Estonian (EE) tax regime with VAT rates (standard, reduced, super-reduced, zero), historical standard-rate changes, and KMKR VAT identity validation.
 - `cbc.Code`: `HasPrefix`, `HasSuffix`, `TrimPrefix`, and `TrimSuffix` helpers.
 - `org`: `Registration` object includes `ext` for addon-specific registration details.
 

--- a/data/regimes/ee.json
+++ b/data/regimes/ee.json
@@ -1,0 +1,187 @@
+{
+  "$schema": "https://gobl.org/draft-0/tax/regime-def",
+  "name": {
+    "en": "Estonia",
+    "et": "Eesti"
+  },
+  "description": {
+    "en": "Estonia's tax system is administered by the Estonian Tax and Customs\nBoard (Maksu- ja Tolliamet, EMTA). As an EU member state, Estonia follows\nthe EU VAT Directive with standard and reduced rates.\n\nVAT (Käibemaks) is applied to most goods and services. The standard rate\nis 24% since 1 July 2025, raised from 22% (in force since 1 January 2024),\nwhich in turn replaced the long-standing 20% rate in force since 2009.\n\nBusinesses register for VAT via a KMKR number (käibemaksukohustuslase\nregistreerimisnumber) in the format EE followed by 9 digits. Credit notes\nare supported for invoice corrections."
+  },
+  "sources": [
+    {
+      "title": {
+        "en": "Estonian Tax and Customs Board - VAT rates"
+      },
+      "url": "https://www.emta.ee/en/business-client/taxes-and-payment/value-added-tax/vat-rates-and-supply-exempt-tax/standard-vat-rate"
+    }
+  ],
+  "time_zone": "Europe/Tallinn",
+  "country": "EE",
+  "currency": "EUR",
+  "tax_scheme": "VAT",
+  "scenarios": [
+    {
+      "schema": "bill/invoice",
+      "list": [
+        {
+          "tags": [
+            "reverse-charge"
+          ],
+          "cat": [
+            "VAT"
+          ],
+          "note": {
+            "cat": "VAT",
+            "key": "reverse-charge",
+            "text": "Reverse charge: Customer to account for VAT to the relevant tax authority."
+          }
+        }
+      ]
+    }
+  ],
+  "corrections": [
+    {
+      "schema": "bill/invoice",
+      "types": [
+        "credit-note"
+      ]
+    }
+  ],
+  "categories": [
+    {
+      "code": "VAT",
+      "name": {
+        "en": "VAT",
+        "et": "Käibemaks"
+      },
+      "title": {
+        "en": "Value Added Tax",
+        "et": "Käibemaks"
+      },
+      "keys": [
+        {
+          "key": "standard",
+          "name": {
+            "en": "Standard"
+          }
+        },
+        {
+          "key": "zero",
+          "name": {
+            "en": "Zero"
+          }
+        },
+        {
+          "key": "reverse-charge",
+          "name": {
+            "en": "Reverse charge"
+          },
+          "no_percent": true
+        },
+        {
+          "key": "exempt",
+          "name": {
+            "en": "Exempt"
+          },
+          "no_percent": true
+        },
+        {
+          "key": "export",
+          "name": {
+            "en": "Export"
+          },
+          "no_percent": true
+        },
+        {
+          "key": "intra-community",
+          "name": {
+            "en": "Intra-community"
+          },
+          "no_percent": true
+        },
+        {
+          "key": "outside-scope",
+          "name": {
+            "en": "Outside scope"
+          },
+          "no_percent": true
+        }
+      ],
+      "rates": [
+        {
+          "rate": "general",
+          "keys": [
+            "standard"
+          ],
+          "name": {
+            "en": "Standard Rate"
+          },
+          "values": [
+            {
+              "since": "2025-07-01",
+              "percent": "24.0%"
+            },
+            {
+              "since": "2024-01-01",
+              "percent": "22.0%"
+            },
+            {
+              "since": "2009-07-01",
+              "percent": "20.0%"
+            }
+          ]
+        },
+        {
+          "rate": "reduced",
+          "keys": [
+            "standard"
+          ],
+          "name": {
+            "en": "Reduced Rate"
+          },
+          "values": [
+            {
+              "percent": "13.0%"
+            }
+          ]
+        },
+        {
+          "rate": "super-reduced",
+          "keys": [
+            "standard"
+          ],
+          "name": {
+            "en": "Super-Reduced Rate"
+          },
+          "values": [
+            {
+              "percent": "9.0%"
+            }
+          ]
+        },
+        {
+          "rate": "zero",
+          "keys": [
+            "zero"
+          ],
+          "name": {
+            "en": "Zero Rate"
+          },
+          "values": [
+            {
+              "percent": "0.0%"
+            }
+          ]
+        }
+      ],
+      "sources": [
+        {
+          "title": {
+            "en": "Estonian Tax and Customs Board - VAT rates"
+          },
+          "url": "https://www.emta.ee/en/business-client/taxes-and-payment/value-added-tax/vat-rates-and-supply-exempt-tax/standard-vat-rate"
+        }
+      ]
+    }
+  ]
+}

--- a/regimes/ee/ee.go
+++ b/regimes/ee/ee.go
@@ -1,0 +1,71 @@
+// Package ee provides the Estonian tax regime.
+package ee
+
+import (
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/currency"
+	"github.com/invopop/gobl/i18n"
+	"github.com/invopop/gobl/norm"
+	"github.com/invopop/gobl/pkg/here"
+	"github.com/invopop/gobl/rules"
+	"github.com/invopop/gobl/tax"
+)
+
+// CountryCode is the tax country code for Estonia.
+const CountryCode = "EE"
+
+func init() {
+	tax.RegisterRegimeDef(New())
+	rules.Register("ee", rules.GOBL.Add(CountryCode), taxIdentityRules())
+	norm.Register(
+		norm.When(tax.IdentityIn(CountryCode), norm.For(func(id *tax.Identity) { tax.NormalizeIdentity(id) })),
+	)
+}
+
+// New provides the tax regime definition for Estonia.
+func New() *tax.RegimeDef {
+	return &tax.RegimeDef{
+		Country:   CountryCode,
+		Currency:  currency.EUR,
+		TaxScheme: tax.CategoryVAT,
+		Name: i18n.String{
+			i18n.EN: "Estonia",
+			i18n.ET: "Eesti",
+		},
+		Description: i18n.String{
+			i18n.EN: here.Doc(`
+				Estonia's tax system is administered by the Estonian Tax and Customs
+				Board (Maksu- ja Tolliamet, EMTA). As an EU member state, Estonia follows
+				the EU VAT Directive with standard and reduced rates.
+
+				VAT (Käibemaks) is applied to most goods and services. The standard rate
+				is 24% since 1 July 2025, raised from 22% (in force since 1 January 2024),
+				which in turn replaced the long-standing 20% rate in force since 2009.
+
+				Businesses register for VAT via a KMKR number (käibemaksukohustuslase
+				registreerimisnumber) in the format EE followed by 9 digits. Credit notes
+				are supported for invoice corrections.
+			`),
+		},
+		Sources: []*cbc.Source{
+			{
+				Title: i18n.NewString("Estonian Tax and Customs Board - VAT rates"),
+				URL:   "https://www.emta.ee/en/business-client/taxes-and-payment/value-added-tax/vat-rates-and-supply-exempt-tax/standard-vat-rate",
+			},
+		},
+		TimeZone: "Europe/Tallinn",
+		Scenarios: []*tax.ScenarioSet{
+			bill.InvoiceScenarios(),
+		},
+		Categories: taxCategories,
+		Corrections: []*tax.CorrectionDefinition{
+			{
+				Schema: bill.ShortSchemaInvoice,
+				Types: []cbc.Key{
+					bill.InvoiceTypeCreditNote,
+				},
+			},
+		},
+	}
+}

--- a/regimes/ee/ee_test.go
+++ b/regimes/ee/ee_test.go
@@ -1,0 +1,20 @@
+package ee_test
+
+import (
+	"testing"
+
+	"github.com/invopop/gobl/l10n"
+	"github.com/invopop/gobl/regimes/ee"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNew(t *testing.T) {
+	regime := ee.New()
+	require.NotNil(t, regime)
+	assert.Equal(t, l10n.EE, regime.Country.Code())
+	assert.Equal(t, "Estonia", regime.Name.String())
+	assert.NotNil(t, regime.Categories)
+	assert.Len(t, regime.Categories, 1)
+	assert.Equal(t, "VAT", regime.Categories[0].Code.String())
+}

--- a/regimes/ee/tax_categories.go
+++ b/regimes/ee/tax_categories.go
@@ -1,0 +1,98 @@
+package ee
+
+import (
+	"github.com/invopop/gobl/cal"
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/i18n"
+	"github.com/invopop/gobl/num"
+	"github.com/invopop/gobl/tax"
+)
+
+var taxCategories = []*tax.CategoryDef{
+	//
+	// VAT (Käibemaks)
+	//
+	{
+		Code: tax.CategoryVAT,
+		Name: i18n.String{
+			i18n.EN: "VAT",
+			i18n.ET: "Käibemaks",
+		},
+		Title: i18n.String{
+			i18n.EN: "Value Added Tax",
+			i18n.ET: "Käibemaks",
+		},
+		Sources: []*cbc.Source{
+			{
+				Title: i18n.String{
+					i18n.EN: "Estonian Tax and Customs Board - VAT rates",
+				},
+				URL: "https://www.emta.ee/en/business-client/taxes-and-payment/value-added-tax/vat-rates-and-supply-exempt-tax/standard-vat-rate",
+			},
+		},
+		Retained: false,
+		Keys:     tax.GlobalVATKeys(),
+		Rates: []*tax.RateDef{
+			{
+				Rate: tax.RateGeneral,
+				Keys: []cbc.Key{tax.KeyStandard},
+				Name: i18n.String{
+					i18n.EN: "Standard Rate",
+				},
+				// Values are kept in descending date order, as required by GOBL.
+				Values: []*tax.RateValueDef{
+					{
+						Since:   cal.NewDate(2025, 7, 1),
+						Percent: num.MakePercentage(240, 3),
+					},
+					{
+						Since:   cal.NewDate(2024, 1, 1),
+						Percent: num.MakePercentage(220, 3),
+					},
+					{
+						Since:   cal.NewDate(2009, 7, 1),
+						Percent: num.MakePercentage(200, 3),
+					},
+				},
+			},
+			{
+				// Higher reduced rate, currently applied to accommodation services.
+				Rate: tax.RateReduced,
+				Keys: []cbc.Key{tax.KeyStandard},
+				Name: i18n.String{
+					i18n.EN: "Reduced Rate",
+				},
+				Values: []*tax.RateValueDef{
+					{
+						Percent: num.MakePercentage(130, 3),
+					},
+				},
+			},
+			{
+				// Lower reduced rate for books, press publications and certain medicines.
+				Rate: tax.RateSuperReduced,
+				Keys: []cbc.Key{tax.KeyStandard},
+				Name: i18n.String{
+					i18n.EN: "Super-Reduced Rate",
+				},
+				Values: []*tax.RateValueDef{
+					{
+						Percent: num.MakePercentage(90, 3),
+					},
+				},
+			},
+			{
+				Rate: tax.RateZero,
+				Keys: []cbc.Key{tax.KeyZero},
+				Name: i18n.String{
+					i18n.EN: "Zero Rate",
+				},
+				Values: []*tax.RateValueDef{
+					{
+						Percent: num.MakePercentage(0, 3),
+					},
+				},
+			},
+		},
+	},
+}

--- a/regimes/ee/tax_identity.go
+++ b/regimes/ee/tax_identity.go
@@ -1,0 +1,65 @@
+package ee
+
+import (
+	"errors"
+	"regexp"
+
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/rules"
+	"github.com/invopop/gobl/rules/is"
+	"github.com/invopop/gobl/tax"
+)
+
+// Estonian VAT numbers (KMKR, käibemaksukohustuslase registreerimisnumber) consist
+// of exactly 9 digits. The EE country prefix is stripped by NormalizeIdentity before
+// this validation runs, so the rules below only see the 9 digits.
+//
+// Checksum: weighted sum of the first 8 digits with weights [3,7,1,3,7,1,3,7]. The
+// 9th digit must equal (10 - sum%10) % 10.
+//
+// Reference: https://meta.cdq.com/DataModel:CDQ/Business_Partner/Identifier/EU_VAT_ID_EE
+
+var (
+	taxCodeRegexp  = regexp.MustCompile(`^\d{9}$`)
+	taxCodeWeights = []int{3, 7, 1, 3, 7, 1, 3, 7}
+)
+
+func taxIdentityRules() *rules.Set {
+	return rules.For(new(tax.Identity),
+		rules.When(tax.IdentityIn(CountryCode),
+			rules.Field("code",
+				rules.AssertIfPresent("01", "invalid Estonian VAT identity code",
+					is.Func("valid", isValidTaxIdentityCode),
+				),
+			),
+		),
+	)
+}
+
+func isValidTaxIdentityCode(value any) bool {
+	code, ok := value.(cbc.Code)
+	if !ok || code == "" {
+		return false
+	}
+	return validateTaxCode(code) == nil
+}
+
+func validateTaxCode(code cbc.Code) error {
+	val := code.String()
+	if !taxCodeRegexp.MatchString(val) {
+		return errors.New("invalid format")
+	}
+	return validateChecksum(val)
+}
+
+func validateChecksum(val string) error {
+	var sum int
+	for i, w := range taxCodeWeights {
+		sum += w * int(val[i]-'0')
+	}
+	expected := (10 - sum%10) % 10
+	if int(val[8]-'0') != expected {
+		return errors.New("checksum mismatch")
+	}
+	return nil
+}

--- a/regimes/ee/tax_identity_test.go
+++ b/regimes/ee/tax_identity_test.go
@@ -1,0 +1,71 @@
+package ee_test
+
+import (
+	"testing"
+
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/rules"
+	"github.com/invopop/gobl/tax"
+	"github.com/stretchr/testify/assert"
+
+	_ "github.com/invopop/gobl/regimes/ee"
+)
+
+func TestTaxIdentityRules(t *testing.T) {
+	tests := []struct {
+		name string
+		code cbc.Code
+		err  string
+	}{
+		// Valid KMKR numbers (format + checksum verified against EMTA/VIES)
+		{name: "valid 1", code: "100207415"},
+		{name: "valid 2", code: "100931558"},
+		{name: "valid 3", code: "100594102"},
+		// Format errors
+		{
+			name: "too short",
+			code: "10020741",
+			err:  "IDENTITY-01",
+		},
+		{
+			name: "too long",
+			code: "1002074159",
+			err:  "IDENTITY-01",
+		},
+		{
+			name: "not normalized, EE prefix present",
+			code: "EE100207415",
+			err:  "IDENTITY-01",
+		},
+		{
+			name: "contains non-digits",
+			code: "10020741X",
+			err:  "IDENTITY-01",
+		},
+		// Checksum errors
+		{
+			name: "bad checksum, last digit off by one",
+			code: "100207410",
+			err:  "IDENTITY-01",
+		},
+		{
+			name: "bad checksum, sequential digits",
+			code: "123456789",
+			err:  "IDENTITY-01",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tID := &tax.Identity{Country: "EE", Code: tt.code}
+			err := rules.Validate(tID)
+			if tt.err == "" {
+				assert.NoError(t, err)
+			} else {
+				if assert.Error(t, err) {
+					assert.Contains(t, err.Error(), tt.err)
+				}
+			}
+		})
+	}
+}

--- a/regimes/regimes.go
+++ b/regimes/regimes.go
@@ -15,6 +15,7 @@ import (
 	_ "github.com/invopop/gobl/regimes/co"
 	_ "github.com/invopop/gobl/regimes/de"
 	_ "github.com/invopop/gobl/regimes/dk"
+	_ "github.com/invopop/gobl/regimes/ee"
 	_ "github.com/invopop/gobl/regimes/es"
 	_ "github.com/invopop/gobl/regimes/fr"
 	_ "github.com/invopop/gobl/regimes/gb"


### PR DESCRIPTION
## Summary

This PR adds a new tax regime for **Estonia (EE)**. The motivation is the scenario in the assignment: a company already invoicing in one country opens a subsidiary in Estonia, which GOBL did not yet cover.

I used the existing EU regimes (Austria and Ireland) as structural references, since Estonia is an EU member state with a VAT system and the euro.

## What's included

- **VAT category** with four rates:
  - Standard `general` rate — **24%** (current), with historical values kept so past-dated invoices still resolve: **22%** since 2024-01-01 and **20%** since 2009-07-01.
  - `reduced` — **13%** (accommodation services).
  - `super-reduced` — **9%** (books, press publications, certain medicines).
  - `zero` — **0%** (exports, intra-community supply).
- **KMKR VAT identity validation** (`tax_identity.go`): `EE` + 9 digits, validated after the country prefix is stripped during normalization. Includes the mod-10 weighted checksum (weights `[3,7,1,3,7,1,3,7]`).
- **Credit notes** enabled as invoice corrections.
- Regime registered in `regimes/regimes.go`, generated `data/regimes/ee.json`, and a `CHANGELOG.md` entry.

## Tests

- `regimes/ee/tax_identity_test.go` — table tests with real valid KMKR numbers and invalid cases (format, length, un-normalized prefix, bad checksum).
- `regimes/ee/ee_test.go` — sanity check of the regime definition.
- The global `regimes_test.go` validates the new `RegimeDef` automatically.

## Sources

VAT rates and effective dates come from the Estonian Tax and Customs Board (EMTA): https://www.emta.ee/en/business-client/taxes-and-payment/value-added-tax/vat-rates-and-supply-exempt-tax/standard-vat-rate

## Scope — what I deliberately left out

To keep the change focused and reviewable, I limited it to what the law requires for correct invoicing, in line with the "minimum complexity for legal correctness" principle:

- **No e-invoicing addon** (PEPPOL / national CTC). Estonia supports e-invoicing, but that belongs in a separate addon rather than the base regime.
- **No transitional 20% provisions** (cash-accounting / long-term property contracts valid until mid-2025). These depend on time-of-supply rules, not on a standing rate, so modelling them as an active rate would be misleading.
- **No full exemptions catalogue** (financial, insurance, real estate). The global VAT keys (`exempt`, `reverse-charge`, etc.) already cover the common cases.
- **No live VIES/EMTA lookup** for registration status — that's an application-layer concern; the regime validates format and checksum offline, consistent with the other regimes (AT, IE).

Happy to extend any of the above if you'd prefer it in scope.