### PR TITLE
Add an extensions field to the tax identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Added
+
+- `tax`: `Identity` now includes `ext` for addon- or format-specific information, mirroring `org.Identity`.
+
 ## [v0.501.0] - 2026-06-16
 
 ### Added

--- a/data/schemas/tax/identity.json
+++ b/data/schemas/tax/identity.json
@@ -25,6 +25,11 @@
           "$ref": "https://gobl.org/draft-0/cbc/key",
           "title": "Type",
           "description": "Type is set according to the requirements of each regime, some have a single\ntax document type code, others require a choice to be made.\n\nDeprecated: Tax Identities should only be used for VAT or similar codes\nfor companies. Use the identities array for other types of identification."
+        },
+        "ext": {
+          "$ref": "https://gobl.org/draft-0/tax/extensions",
+          "title": "Extensions",
+          "description": "Ext provides a way to add additional information to the tax identity,\ntypically required by a specific addon or electronic format (for example a\nUBL or CII scheme identifier)."
         }
       },
       "type": "object",

--- a/tax/identity.go
+++ b/tax/identity.go
@@ -41,6 +41,11 @@ type Identity struct {
 	// Deprecated: Tax Identities should only be used for VAT or similar codes
 	// for companies. Use the identities array for other types of identification.
 	Type cbc.Key `json:"type,omitempty" jsonschema:"title=Type"`
+
+	// Ext provides a way to add additional information to the tax identity,
+	// typically required by a specific addon or electronic format (for example a
+	// UBL or CII scheme identifier).
+	Ext Extensions `json:"ext,omitzero" jsonschema:"title=Extensions"`
 }
 
 var (


### PR DESCRIPTION
- Adds an `ext` field to `tax.Identity`, mirroring `org.Identity`, so addons and electronic formats can attach identity-specific information (e.g. a UBL/CII scheme identifier on the tax CompanyID).

## Pre-Review Checklist

- [x] Opened this PR as a draft
- [x] Read the CONTRIBUTING.md guide.
- [x] Performed a self-review of my code.
- [x] Added thorough tests with at **least** 90% code coverage. 
- [x] Modified or created example GOBL documents to show my changes in use, if appropriate.
- [x] Added links to the source of the changes in tax regimes or addons, either structured or in the comments.
- [x] Run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [x] Reviewed and fixed all linter warnings.
- [x] Been obsessive with pointer nil checks to avoid panics.
- [x] Updated the CHANGELOG.md with an overview of my changes.
- [x] Marked this PR as ready for review.

And if you are part of the org:
- [ ] Requested a review from Copilot and fixed or dismissed (with a reason) all the feedback raised.
- [ ] Requested a review from @samlown.