### PR TITLE
Item base quantity & line unit of measure (EN 16931 BT-149/150/130)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Added
 
 - `bill`: `PaymentDetails.Payer` party — the party responsible for making payment of the invoice if not the customer, the counterpart of the existing `Payee`.
+- `org`: `Item.BaseQuantity` — the number of units the item's price refers to (e.g. a price per 100 units, EN 16931 BT-149). Line sums are calculated as `price × quantity ÷ base_quantity`.
+- `bill`: `Line.Unit` and `SubLine.Unit` — the unit of measure for the invoiced quantity (EN 16931 BT-130), distinct from the item's price base quantity unit (`Item.Unit`, BT-150). A line-only unit seeds `Item.Unit`, but an item-only unit leaves the line unit empty, so existing documents are unchanged; core EN 16931 permits them to differ (only the PEPPOL layer requires them equal).
 
 ## [v0.501.0] - 2026-06-16
 

--- a/bill/line.go
+++ b/bill/line.go
@@ -18,6 +18,10 @@ type Line struct {
 	Index int `json:"i" jsonschema:"title=Index" jsonschema_extras:"calculated=true"`
 	// Number of items
 	Quantity num.Amount `json:"quantity" jsonschema:"title=Quantity"`
+	// Unit of measure for the invoiced quantity (EN 16931 BT-130). When left
+	// empty it is inferred from the item's unit; set it explicitly when the
+	// invoiced unit differs from the item's price base quantity unit (BT-150).
+	Unit org.Unit `json:"unit,omitempty" jsonschema:"title=Unit"`
 	// Single identifier provided by the supplier for an object on which the
 	// line item is based and is not considered a universal identity. Examples
 	// include a subscription number, telephone number, meter point, etc.
@@ -71,6 +75,10 @@ type SubLine struct {
 	Index int `json:"i" jsonschema:"title=Index" jsonschema_extras:"calculated=true"`
 	// Number of items
 	Quantity num.Amount `json:"quantity" jsonschema:"title=Quantity"`
+	// Unit of measure for the invoiced quantity (EN 16931 BT-130). When left
+	// empty it is inferred from the item's unit; set it explicitly when the
+	// invoiced unit differs from the item's price base quantity unit (BT-150).
+	Unit org.Unit `json:"unit,omitempty" jsonschema:"title=Unit"`
 	// Single identifier provided by the supplier for an object on which the
 	// line item is based and is not considered a universal identity. Examples
 	// include a subscription number, telephone number, meter point, etc.
@@ -181,6 +189,7 @@ func (sl *SubLine) IsEmpty() bool {
 	return sl == nil ||
 		(sl.UUID.IsZero() &&
 			sl.Quantity.IsZero() &&
+			sl.Unit == org.UnitEmpty &&
 			sl.Identifier == nil &&
 			sl.Period == nil &&
 			sl.Order.IsEmpty() &&
@@ -207,6 +216,7 @@ func CleanSubLines(sls []*SubLine) []*SubLine {
 
 func normalizeLine(l *Line) {
 	normalizeLineItemPrice(l)
+	l.Unit = normalizeLineUnit(l.Unit, l.Item)
 	l.Taxes = tax.CleanSet(l.Taxes)
 	l.Discounts = CleanLineDiscounts(l.Discounts)
 	l.Charges = CleanLineCharges(l.Charges)
@@ -215,8 +225,27 @@ func normalizeLine(l *Line) {
 
 func normalizeSubLine(sl *SubLine) {
 	normalizeSubLineItemPrice(sl)
+	sl.Unit = normalizeLineUnit(sl.Unit, sl.Item)
 	sl.Discounts = CleanLineDiscounts(sl.Discounts)
 	sl.Charges = CleanLineCharges(sl.Charges)
+}
+
+// normalizeLineUnit seeds the item's price base quantity unit (BT-150,
+// org.Item.Unit) from the line's invoiced quantity unit (BT-130) when the item
+// has none, so a line that only sets the new unit still carries a base quantity
+// unit. The reverse is intentionally NOT done: an item-only unit leaves the
+// line unit empty, keeping existing documents (and their digests) unchanged.
+// Converters read BT-130 from Line.Unit, falling back to Item.Unit when empty.
+// Core EN 16931 permits BT-130 and BT-150 to differ (only the PEPPOL layer
+// requires them equal), so explicitly divergent units are preserved.
+func normalizeLineUnit(unit org.Unit, item *org.Item) org.Unit {
+	if item == nil {
+		return unit
+	}
+	if unit != org.UnitEmpty && item.Unit == org.UnitEmpty {
+		item.Unit = unit
+	}
+	return unit
 }
 
 func normalizeLineItemPrice(l *Line) {

--- a/bill/line_calculate.go
+++ b/bill/line_calculate.go
@@ -2,6 +2,7 @@ package bill
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/currency"
@@ -101,6 +102,7 @@ func calculateLine(l *Line, cur currency.Code, rates []*currency.ExchangeRate, r
 
 	// Calculate the line sum and total
 	sum := price.Multiply(l.Quantity)
+	sum = applyItemBaseQuantity(sum, l.Item)
 	sum = tax.ApplyRoundingRule(rr, cur, sum)
 	total := sum
 	total = calculateLineDiscounts(l.Discounts, sum, total, cur, rr)
@@ -142,6 +144,7 @@ func calculateSubLine(sl *SubLine, cur currency.Code, rates []*currency.Exchange
 
 	// Calculate the line sum and total
 	sum := price.Multiply(sl.Quantity)
+	sum = applyItemBaseQuantity(sum, sl.Item)
 	sum = tax.ApplyRoundingRule(rr, cur, sum)
 	total := sum
 	total = calculateLineDiscounts(sl.Discounts, sum, total, cur, rr)
@@ -198,6 +201,19 @@ func calculateLineCharges(charges []*LineCharge, quantity, sum, total num.Amount
 		total = total.Add(c.Amount)
 	}
 	return total
+}
+
+// applyItemBaseQuantity divides the sum by the item's base quantity, used
+// when the item's price refers to a number of units other than one. The sum
+// is upscaled to cover the decimal places the division may introduce so
+// that precision is maintained until rounding is applied.
+func applyItemBaseQuantity(sum num.Amount, item *org.Item) num.Amount {
+	bq := item.BaseQuantity
+	if bq == nil || bq.IsZero() {
+		return sum
+	}
+	extra := uint32(len(strconv.FormatInt(bq.Rescale(0).Value(), 10)))
+	return sum.Upscale(extra).Divide(*bq)
 }
 
 // calculateItemPrice will attempt to perform any currency conversion process on

--- a/bill/line_calculate_test.go
+++ b/bill/line_calculate_test.go
@@ -629,3 +629,97 @@ func TestLineCalculate(t *testing.T) {
 		assert.Equal(t, "37.77", lines[0].Total.String())
 	})
 }
+
+func TestLineCalculateBaseQuantity(t *testing.T) {
+	t.Run("exact division", func(t *testing.T) {
+		line := &Line{
+			Quantity: num.MakeAmount(200, 0),
+			Item: &org.Item{
+				Name:         "Screws",
+				Price:        num.NewAmount(123, 2), // 1.23 per 100 units
+				BaseQuantity: num.NewAmount(100, 0),
+			},
+		}
+		err := calculateLine(line, currency.EUR, nil, tax.RoundingRuleCurrency)
+		require.NoError(t, err)
+		assert.Equal(t, "2.46", line.Sum.String())
+		assert.Equal(t, "2.46", line.Total.String())
+	})
+	t.Run("fractional base quantity", func(t *testing.T) {
+		line := &Line{
+			Quantity: num.MakeAmount(5, 0),
+			Item: &org.Item{
+				Name:         "Cable",
+				Price:        num.NewAmount(500, 2), // 5.00 per 2.5 units
+				BaseQuantity: num.NewAmount(25, 1),
+			},
+		}
+		err := calculateLine(line, currency.EUR, nil, tax.RoundingRuleCurrency)
+		require.NoError(t, err)
+		assert.Equal(t, "10.00", line.Sum.String())
+	})
+	t.Run("zero base quantity ignored", func(t *testing.T) {
+		line := &Line{
+			Quantity: num.MakeAmount(2, 0),
+			Item: &org.Item{
+				Name:         "Widget",
+				Price:        num.NewAmount(1000, 2),
+				BaseQuantity: num.NewAmount(0, 0),
+			},
+		}
+		err := calculateLine(line, currency.EUR, nil, tax.RoundingRuleCurrency)
+		require.NoError(t, err)
+		assert.Equal(t, "20.00", line.Sum.String())
+	})
+	t.Run("sub-line base quantity", func(t *testing.T) {
+		sl := &SubLine{
+			Quantity: num.MakeAmount(200, 0),
+			Item: &org.Item{
+				Name:         "Screws",
+				Price:        num.NewAmount(123, 2),
+				BaseQuantity: num.NewAmount(100, 0),
+			},
+		}
+		err := calculateSubLine(sl, currency.EUR, nil, tax.RoundingRuleCurrency)
+		require.NoError(t, err)
+		assert.Equal(t, "2.46", sl.Sum.String())
+	})
+	t.Run("precise rounding keeps division precision", func(t *testing.T) {
+		line := &Line{
+			Quantity: num.MakeAmount(1, 0),
+			Item: &org.Item{
+				Name:         "Bulk item",
+				Price:        num.NewAmount(10000, 2), // 100.00 per 3 units
+				BaseQuantity: num.NewAmount(3, 0),
+			},
+		}
+		err := calculateLine(line, currency.EUR, nil, tax.RoundingRulePrecise)
+		require.NoError(t, err)
+		assert.Equal(t, "33.33333", line.Sum.String())
+	})
+	t.Run("base quantity larger than quantity", func(t *testing.T) {
+		line := &Line{
+			Quantity: num.MakeAmount(50, 0),
+			Item: &org.Item{
+				Name:         "Per-thousand price",
+				Price:        num.NewAmount(2500, 2), // 25.00 per 1000 units
+				BaseQuantity: num.NewAmount(1000, 0),
+			},
+		}
+		err := calculateLine(line, currency.EUR, nil, tax.RoundingRuleCurrency)
+		require.NoError(t, err)
+		assert.Equal(t, "1.25", line.Sum.String())
+	})
+	t.Run("nil base quantity behaves as one", func(t *testing.T) {
+		line := &Line{
+			Quantity: num.MakeAmount(3, 0),
+			Item: &org.Item{
+				Name:  "Plain item",
+				Price: num.NewAmount(1000, 2),
+			},
+		}
+		err := calculateLine(line, currency.EUR, nil, tax.RoundingRuleCurrency)
+		require.NoError(t, err)
+		assert.Equal(t, "30.00", line.Sum.String())
+	})
+}

--- a/bill/line_test.go
+++ b/bill/line_test.go
@@ -497,3 +497,38 @@ func TestLineGetTotal(t *testing.T) {
 		assert.Equal(t, "0", line.GetTotal().String())
 	})
 }
+
+func TestLineUnitNormalization(t *testing.T) {
+	t.Run("item-only unit leaves the line unit empty (no digest churn)", func(t *testing.T) {
+		// Existing documents set the unit on the item; the line unit stays
+		// empty so their serialized output is unchanged. Converters fall back
+		// to Item.Unit for BT-130.
+		line := &Line{
+			Quantity: num.MakeAmount(1, 0),
+			Item:     &org.Item{Name: "Item", Unit: org.UnitKilogram},
+		}
+		norm.Normalize(line)
+		assert.Equal(t, org.UnitEmpty, line.Unit)
+		assert.Equal(t, org.UnitKilogram, line.Item.Unit)
+	})
+	t.Run("a line-only unit seeds the item unit (BT-150 from BT-130)", func(t *testing.T) {
+		line := &Line{
+			Quantity: num.MakeAmount(1, 0),
+			Unit:     org.UnitKilogram,
+			Item:     &org.Item{Name: "Item"},
+		}
+		norm.Normalize(line)
+		assert.Equal(t, org.UnitKilogram, line.Unit)
+		assert.Equal(t, org.UnitKilogram, line.Item.Unit)
+	})
+	t.Run("explicit divergent units are preserved (BT-130 != BT-150)", func(t *testing.T) {
+		line := &Line{
+			Quantity: num.MakeAmount(1, 0),
+			Unit:     org.UnitMetricTon,
+			Item:     &org.Item{Name: "Item", Unit: org.UnitKilogram},
+		}
+		norm.Normalize(line)
+		assert.Equal(t, org.UnitMetricTon, line.Unit)
+		assert.Equal(t, org.UnitKilogram, line.Item.Unit)
+	})
+}

--- a/data/rules/org.json
+++ b/data/rules/org.json
@@ -327,6 +327,21 @@
               ]
             }
           ]
+        },
+        {
+          "field": "base_quantity",
+          "subsets": [
+            {
+              "guard": "present",
+              "assert": [
+                {
+                  "id": "GOBL-ORG-ITEM-03",
+                  "desc": "item base quantity must be positive",
+                  "tests": "min 0"
+                }
+              ]
+            }
+          ]
         }
       ]
     },

--- a/data/schemas/bill/line.json
+++ b/data/schemas/bill/line.json
@@ -22,6 +22,11 @@
           "title": "Quantity",
           "description": "Number of items"
         },
+        "unit": {
+          "$ref": "https://gobl.org/draft-0/org/unit",
+          "title": "Unit",
+          "description": "Unit of measure for the invoiced quantity (EN 16931 BT-130). When left\nempty it is inferred from the item's unit; set it explicitly when the\ninvoiced unit differs from the item's price base quantity unit (BT-150)."
+        },
         "identifier": {
           "$ref": "https://gobl.org/draft-0/org/identity",
           "title": "Identifier",
@@ -358,6 +363,11 @@
           "$ref": "https://gobl.org/draft-0/num/amount",
           "title": "Quantity",
           "description": "Number of items"
+        },
+        "unit": {
+          "$ref": "https://gobl.org/draft-0/org/unit",
+          "title": "Unit",
+          "description": "Unit of measure for the invoiced quantity (EN 16931 BT-130). When left\nempty it is inferred from the item's unit; set it explicitly when the\ninvoiced unit differs from the item's price base quantity unit (BT-150)."
         },
         "identifier": {
           "$ref": "https://gobl.org/draft-0/org/identity",

--- a/data/schemas/org/item.json
+++ b/data/schemas/org/item.json
@@ -79,10 +79,15 @@
           "title": "Alternative Prices",
           "description": "AltPrices defines a list of prices with their currencies that may be used\nas an alternative to the item's base price."
         },
+        "base_quantity": {
+          "$ref": "https://gobl.org/draft-0/num/amount",
+          "title": "Base Quantity",
+          "description": "Number of units the price refers to, e.g. a price per 100 units\n(EN 16931 BT-149). Assumed to be 1 when left empty. The base quantity is\nexpressed in the item's unit of measure (BT-150)."
+        },
         "unit": {
           "$ref": "https://gobl.org/draft-0/org/unit",
           "title": "Unit",
-          "description": "Unit of measure."
+          "description": "Unit of measure the item's price refers to (EN 16931 BT-150). The line's\ninvoiced quantity may use a different unit (BT-130)."
         },
         "origin": {
           "$ref": "https://gobl.org/draft-0/l10n/iso-country-code",

--- a/examples/gb/invoice-base-quantity.yaml
+++ b/examples/gb/invoice-base-quantity.yaml
@@ -1,0 +1,43 @@
+$schema: "https://gobl.org/draft-0/bill/invoice"
+uuid: "019035bd-4524-73ab-bf44-6037841ce5d9"
+issue_date: "2024-07-31"
+series: "SAMPLE"
+code: "003"
+
+supplier:
+  tax_id:
+    country: "GB"
+    code: "000472631"
+  name: "Test Company Ltd."
+  addresses:
+    - num: "12"
+      street: "Main Street"
+      locality: "Hull"
+      code: "HU17 7PQ"
+      country: "GB"
+
+customer:
+  tax_id:
+    country: "GB"
+    code: "350983637"
+  name: "Random Company Ltd."
+  addresses:
+    - num: "45"
+      street: "Some Street"
+      locality: "London"
+      code: "SW1A 1AA"
+      country: "GB"
+
+lines:
+  # 250 kg invoiced (BT-129/BT-130) at a price quoted per 100 kg
+  # (BT-149 base quantity, BT-150 unit). Sum = 120.00 × 250 ÷ 100 = 300.00.
+  - quantity: 250
+    unit: "kg"
+    item:
+      name: "Bulk coffee beans"
+      price: "120.00"
+      base_quantity: 100
+      unit: "kg"
+    taxes:
+      - cat: VAT
+        rate: "standard"

--- a/examples/gb/out/invoice-base-quantity.json
+++ b/examples/gb/out/invoice-base-quantity.json
@@ -1,0 +1,99 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
+		"dig": {
+			"alg": "sha256",
+			"val": "60e2a077acccaf2e81d54996dddd9f4b96237c454e871a55df618c21baccb166"
+		}
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"$regime": "GB",
+		"uuid": "019035bd-4524-73ab-bf44-6037841ce5d9",
+		"type": "standard",
+		"series": "SAMPLE",
+		"code": "003",
+		"issue_date": "2024-07-31",
+		"currency": "GBP",
+		"supplier": {
+			"name": "Test Company Ltd.",
+			"tax_id": {
+				"country": "GB",
+				"code": "000472631"
+			},
+			"addresses": [
+				{
+					"num": "12",
+					"street": "Main Street",
+					"locality": "Hull",
+					"code": "HU17 7PQ",
+					"country": "GB"
+				}
+			]
+		},
+		"customer": {
+			"name": "Random Company Ltd.",
+			"tax_id": {
+				"country": "GB",
+				"code": "350983637"
+			},
+			"addresses": [
+				{
+					"num": "45",
+					"street": "Some Street",
+					"locality": "London",
+					"code": "SW1A 1AA",
+					"country": "GB"
+				}
+			]
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "250",
+				"unit": "kg",
+				"item": {
+					"name": "Bulk coffee beans",
+					"price": "120.00",
+					"base_quantity": "100",
+					"unit": "kg"
+				},
+				"sum": "300.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "general",
+						"percent": "20.0%"
+					}
+				],
+				"total": "300.00"
+			}
+		],
+		"totals": {
+			"sum": "300.00",
+			"total": "300.00",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"base": "300.00",
+								"percent": "20.0%",
+								"amount": "60.00"
+							}
+						],
+						"amount": "60.00"
+					}
+				],
+				"sum": "60.00"
+			},
+			"tax": "60.00",
+			"total_with_tax": "360.00",
+			"payable": "360.00"
+		}
+	}
+}

--- a/org/item.go
+++ b/org/item.go
@@ -49,7 +49,12 @@ type Item struct {
 	// AltPrices defines a list of prices with their currencies that may be used
 	// as an alternative to the item's base price.
 	AltPrices []*currency.Amount `json:"alt_prices,omitempty" jsonschema:"title=Alternative Prices"`
-	// Unit of measure.
+	// Number of units the price refers to, e.g. a price per 100 units
+	// (EN 16931 BT-149). Assumed to be 1 when left empty. The base quantity is
+	// expressed in the item's unit of measure (BT-150).
+	BaseQuantity *num.Amount `json:"base_quantity,omitempty" jsonschema:"title=Base Quantity"`
+	// Unit of measure the item's price refers to (EN 16931 BT-150). The line's
+	// invoiced quantity may use a different unit (BT-130).
 	Unit Unit `json:"unit,omitempty" jsonschema:"title=Unit"`
 	// Country code of where this item was from originally.
 	Origin l10n.ISOCountryCode `json:"origin,omitempty" jsonschema:"title=Country of Origin"`
@@ -66,6 +71,9 @@ func itemRules() *rules.Set {
 		),
 		rules.Field("price",
 			rules.AssertIfPresent("02", "item price must be zero or positive", num.ZeroOrPositive),
+		),
+		rules.Field("base_quantity",
+			rules.AssertIfPresent("03", "item base quantity must be positive", num.Positive),
 		),
 	)
 }

--- a/org/item_test.go
+++ b/org/item_test.go
@@ -104,3 +104,30 @@ func TestItemJSONSchema(t *testing.T) {
 	assert.Equal(t, org.ItemKeyServices, prop.AnyOf[1].Const)
 	assert.Equal(t, "Services", prop.AnyOf[1].Title)
 }
+
+func TestItemBaseQuantity(t *testing.T) {
+	t.Run("positive", func(t *testing.T) {
+		i := &org.Item{
+			Name:         "test item",
+			Price:        num.NewAmount(123, 2),
+			BaseQuantity: num.NewAmount(100, 0),
+		}
+		assert.NoError(t, rules.Validate(i))
+	})
+	t.Run("zero", func(t *testing.T) {
+		i := &org.Item{
+			Name:         "test item",
+			Price:        num.NewAmount(123, 2),
+			BaseQuantity: num.NewAmount(0, 0),
+		}
+		assert.ErrorContains(t, rules.Validate(i), "item base quantity must be positive")
+	})
+	t.Run("negative", func(t *testing.T) {
+		i := &org.Item{
+			Name:         "test item",
+			Price:        num.NewAmount(123, 2),
+			BaseQuantity: num.NewAmount(-100, 0),
+		}
+		assert.ErrorContains(t, rules.Validate(i), "item base quantity must be positive")
+	})
+}


### PR DESCRIPTION
Adds the item price base quantity and a line-level unit of measure for EN 16931.

> Part of splitting the original combined item-details PR. Sibling PRs: item attributes (#859), and item identities & buyer item reference.

## Changes

- **`org`: base quantity (BT-149)** — `Item.BaseQuantity`, the number of units the item's price refers to (e.g. a price per 100 units). Line sums are calculated as `price × quantity ÷ base_quantity`. Validated as positive.
- **`bill`: invoiced quantity unit (BT-130)** — `Line.Unit` / `SubLine.Unit`, distinct from the item's price base quantity unit (`Item.Unit`, BT-150). Core EN 16931 permits the two to differ (e.g. priced per bushel, invoiced in tonnes); only the PEPPOL layer requires them equal.
- **Normalization is lazy by design** — a line-only unit seeds `Item.Unit` (BT-150), but an item-only unit does **not** populate the line. Existing documents are byte-for-byte unchanged (no digest churn); divergent units are preserved when set explicitly.
- Adds a GB example (`examples/gb/invoice-base-quantity.yaml`): 250 kg invoiced, priced per 100 kg → sum 300.00.

## Converter follow-up (gobl.ubl / gobl.cii)

The `@unitCode` on the invoiced quantity (BT-130) is mandatory in both UBL and CII, so the converter mapping is:

- **BT-130** → `InvoicedQuantity/@unitCode` (UBL) / `BilledQuantity/@unitCode` (CII) = `Line.Unit` if set, else fall back to `Item.Unit`.
- **BT-150** → `Price/BaseQuantity/@unitCode` (UBL) / `BasisQuantity/@unitCode` (CII) = `Item.Unit`, emitted only when a base quantity is present.

A future `addons/peppol` should enforce `PEPPOL-EN16931-R130` (BT-150 == BT-130); core EN 16931 has no such rule.

## Pre-Review Checklist

- [ ] Opened this PR as a draft
- [ ] Read the CONTRIBUTING.md guide.
- [ ] Performed a self-review of my code.
- [ ] Added thorough tests with at **least** 90% code coverage.
- [ ] Modified or created example GOBL documents to show my changes in use, if appropriate.
- [ ] Added links to the source of the changes in tax regimes or addons, either structured or in the comments.
- [ ] Run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [ ] Reviewed and fixed all linter warnings.
- [ ] Been obsessive with pointer nil checks to avoid panics.
- [ ] Updated the CHANGELOG.md with an overview of my changes.
- [ ] Marked this PR as ready for review.

And if you are part of the org:
- [ ] Requested a review from Copilot and fixed or dismissed (with a reason) all the feedback raised.
- [ ] Requested a review from @samlown.
