### PR TITLE
Add income tax withholdings to Portugal regime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Added
+
+- `regimes/pt`: `IRS` and `IRC` retained tax categories for Portugal income tax withholdings (*retenção na fonte*).
+
 ### Changed
 
 - `addons/pt/saft`: **breaking**: the Portuguese SAF-T addon moved to the standalone [`github.com/invopop/gobl.pt.saft`](https://github.com/invopop/gobl.pt.saft) module. Add a blank import of `gobl.pt.saft/addon` to keep using the `pt-saft-v1` addon key.

--- a/data/regimes/pt.json
+++ b/data/regimes/pt.json
@@ -1726,6 +1726,38 @@
           }
         }
       ]
+    },
+    {
+      "code": "IRS",
+      "name": {
+        "en": "IRS",
+        "pt": "IRS"
+      },
+      "title": {
+        "en": "Personal income tax",
+        "pt": "Imposto sobre o Rendimento das Pessoas Singulares"
+      },
+      "desc": {
+        "en": "Personal income tax withheld at source from payments made to individuals\nand self-employed workers. The Portuguese payer retains the tax on each\npayment and remits it to the AT on behalf of the recipient.",
+        "pt": "Imposto sobre o rendimento retido na fonte sobre pagamentos efetuados a\npessoas singulares e trabalhadores independentes. O pagador português retém\no imposto em cada pagamento e entrega-o à AT por conta do titular do\nrendimento."
+      },
+      "retained": true
+    },
+    {
+      "code": "IRC",
+      "name": {
+        "en": "IRC",
+        "pt": "IRC"
+      },
+      "title": {
+        "en": "Corporate income tax",
+        "pt": "Imposto sobre o Rendimento das Pessoas Coletivas"
+      },
+      "desc": {
+        "en": "Corporate income tax withheld at source from payments made to legal\npersons. The Portuguese payer retains the tax on each payment and remits it\nto the AT on behalf of the recipient.",
+        "pt": "Imposto sobre o rendimento retido na fonte sobre pagamentos efetuados a\npessoas coletivas. O pagador português retém o imposto em cada pagamento e\nentrega-o à AT por conta do titular do rendimento."
+      },
+      "retained": true
     }
   ]
 }

--- a/regimes/pt/tax_categories.go
+++ b/regimes/pt/tax_categories.go
@@ -5,11 +5,20 @@ import (
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/i18n"
 	"github.com/invopop/gobl/num"
+	"github.com/invopop/gobl/pkg/here"
 	"github.com/invopop/gobl/tax"
 )
 
+// Local tax category definitions which are not considered standard.
+const (
+	TaxCategoryIRS cbc.Code = "IRS" // Imposto sobre o Rendimento das Pessoas Singulares
+	TaxCategoryIRC cbc.Code = "IRC" // Imposto sobre o Rendimento das Pessoas Coletivas
+)
+
 var taxCategories = []*tax.CategoryDef{
+	//
 	// VAT
+	//
 	{
 		Code: tax.CategoryVAT,
 		Name: i18n.String{
@@ -124,6 +133,63 @@ var taxCategories = []*tax.CategoryDef{
 				},
 				Values: []*tax.RateValueDef{},
 			},
+		},
+	},
+
+	//
+	// IRS
+	//
+	{
+		Code:     TaxCategoryIRS,
+		Retained: true,
+		Name: i18n.String{
+			i18n.EN: "IRS",
+			i18n.PT: "IRS",
+		},
+		Title: i18n.String{
+			i18n.EN: "Personal income tax",
+			i18n.PT: "Imposto sobre o Rendimento das Pessoas Singulares",
+		},
+		Description: &i18n.String{
+			i18n.EN: here.Doc(`
+				Personal income tax withheld at source from payments made to individuals
+				and self-employed workers. The Portuguese payer retains the tax on each
+				payment and remits it to the AT on behalf of the recipient.
+			`),
+			i18n.PT: here.Doc(`
+				Imposto sobre o rendimento retido na fonte sobre pagamentos efetuados a
+				pessoas singulares e trabalhadores independentes. O pagador português retém
+				o imposto em cada pagamento e entrega-o à AT por conta do titular do
+				rendimento.
+			`),
+		},
+	},
+
+	//
+	// IRC
+	//
+	{
+		Code:     TaxCategoryIRC,
+		Retained: true,
+		Name: i18n.String{
+			i18n.EN: "IRC",
+			i18n.PT: "IRC",
+		},
+		Title: i18n.String{
+			i18n.EN: "Corporate income tax",
+			i18n.PT: "Imposto sobre o Rendimento das Pessoas Coletivas",
+		},
+		Description: &i18n.String{
+			i18n.EN: here.Doc(`
+				Corporate income tax withheld at source from payments made to legal
+				persons. The Portuguese payer retains the tax on each payment and remits it
+				to the AT on behalf of the recipient.
+			`),
+			i18n.PT: here.Doc(`
+				Imposto sobre o rendimento retido na fonte sobre pagamentos efetuados a
+				pessoas coletivas. O pagador português retém o imposto em cada pagamento e
+				entrega-o à AT por conta do titular do rendimento.
+			`),
 		},
 	},
 }

--- a/regimes/pt/tax_categories_test.go
+++ b/regimes/pt/tax_categories_test.go
@@ -1,0 +1,24 @@
+package pt_test
+
+import (
+	"testing"
+
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/regimes/pt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithholdingTaxCategories(t *testing.T) {
+	r := pt.New()
+
+	for _, code := range []cbc.Code{"IRS", "IRC"} {
+		t.Run(code.String(), func(t *testing.T) {
+			cat := r.CategoryDef(code)
+			require.NotNil(t, cat, "category %s should be defined in the PT regime", code)
+			assert.Equal(t, code, cat.Code)
+			assert.True(t, cat.Retained, "category %s should be retained", code)
+			assert.Empty(t, cat.Rates, "category %s should be rate-less", code)
+		})
+	}
+}


### PR DESCRIPTION
- Adds `IRS` and `IRC` retained tax categories for Portugal's income tax withholdings

## Pre-Review Checklist

- [x] Opened this PR as a draft
- [x] Read the CONTRIBUTING.md guide.
- [x] Performed a self-review of my code.
- [x] Added thorough tests with at **least** 90% code coverage.
- [x] Modified or created example GOBL documents to show my changes in use, if appropriate.
- [x] Added links to the source of the changes in tax regimes or addons, either structured or in the comments.
- [x] Run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [x] Reviewed and fixed all linter warnings.
- [x] Been obsessive with pointer nil checks to avoid panics.
- [x] Updated the CHANGELOG.md with an overview of my changes.
- [x] Marked this PR as ready for review.

And if you are part of the org:
- [x] Requested a review from Copilot and fixed or dismissed (with a reason) all the feedback raised.
- [x] Requested a review from @samlown.
