### PR TITLE
Add Iceland (IS) tax regime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - `regimes/br`: Party address country is now inferred automatically from tax ID or identities.
 - `addons/br/nfe`: Allow foreign customers to provide an identity (e.g. a passport) alternatively to a tax ID.
 - `addons/br/nfe`: Supplier and customer addresses now require the `country` field, as mandated by the NF-e spec.
+- `regimes/is`: New tax regime for Iceland (VSK/VAT with 24% standard and 11% reduced rates, kennitala tax ID and organization identity validation with MOD-11 checksum, and an example invoice).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Added
+
+- `regimes/is`: New tax regime for Iceland (VSK/VAT with 24% standard and 11% reduced rates, kennitala tax ID and organization identity validation with MOD-11 checksum, and an example invoice).
+
 ## [v0.502.1] - 2026-07-02
 
 ### Removed
@@ -44,7 +48,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - `regimes/br`: Party address country is now inferred automatically from tax ID or identities.
 - `addons/br/nfe`: Allow foreign customers to provide an identity (e.g. a passport) alternatively to a tax ID.
 - `addons/br/nfe`: Supplier and customer addresses now require the `country` field, as mandated by the NF-e spec.
-- `regimes/is`: New tax regime for Iceland (VSK/VAT with 24% standard and 11% reduced rates, kennitala tax ID and organization identity validation with MOD-11 checksum, and an example invoice).
+
 
 ### Changed
 

--- a/data/regimes/is.json
+++ b/data/regimes/is.json
@@ -1,0 +1,185 @@
+{
+  "$schema": "https://gobl.org/draft-0/tax/regime-def",
+  "name": {
+    "en": "Iceland",
+    "is": "Ísland"
+  },
+  "description": {
+    "en": "Iceland's tax system is administered by the Directorate of Internal\nRevenue (Skatturinn). Although Iceland is not an EU member state, it is\npart of the European Economic Area (EEA) and operates a value added tax\nbroadly aligned with European practice.\n\nVSK (Virðisaukaskattur) applies at a standard and a reduced rate. \nExports are zero-rated. Health, education, public transport, real \nestate leasing, sports and financial services are exempt under Article \n12 of the VAT Act.\n\nBusinesses and individuals alike are identified by their kennitala, a\n10-digit national identification number issued by Registers Iceland\n(Þjóðskrá Íslands). The same number serves as the VAT identifier; for\ninternational use it is prefixed with \"IS\". The kennitala encodes a date\n(birth date for individuals, registration date for companies) followed by \ntwo random digits, a MOD-11 checksum digit, and a final century indicator.\n\nE-invoicing is mandatory for all B2G transactions since 2020 under\nRegulation 44/2019, using the Peppol BIS Billing 3.0 format together with\nthe national CIUS TS-236. The Peppol Authority is Fjársýsla ríkisins\n(FJS). B2B and B2C e-invoicing is voluntary but widely adopted."
+  },
+  "sources": [
+    {
+      "title": {
+        "en": "Registers Iceland - ID numbers (kennitala)"
+      },
+      "url": "https://www.skra.is/english/people/my-registration/id-numbers/"
+    },
+    {
+      "title": {
+        "en": "Skatturinn - Value Added Tax (VSK)"
+      },
+      "url": "https://www.skatturinn.is/english/companies/value-added-tax/"
+    },
+    {
+      "title": {
+        "en": "European Commission - eInvoicing in Iceland"
+      },
+      "url": "https://ec.europa.eu/digital-building-blocks/sites/display/DIGITAL/eInvoicing+in+Iceland"
+    },
+    {
+      "title": {
+        "en": "Ecosio - E-invoicing in Iceland"
+      },
+      "url": "https://ecosio.com/en/compliance/iceland/e-invoicing/"
+    }
+  ],
+  "time_zone": "Atlantic/Reykjavik",
+  "country": "IS",
+  "currency": "ISK",
+  "tax_scheme": "VAT",
+  "identities": [
+    {
+      "code": "KT",
+      "name": {
+        "en": "Kennitala",
+        "is": "Kennitala"
+      },
+      "desc": {
+        "en": "Icelandic national identification number for persons and companies.",
+        "is": "Íslensk kennitala fyrir einstaklinga og fyrirtæki."
+      }
+    }
+  ],
+  "scenarios": [
+    {
+      "schema": "bill/invoice",
+      "list": [
+        {
+          "tags": [
+            "reverse-charge"
+          ],
+          "cat": [
+            "VAT"
+          ],
+          "note": {
+            "cat": "VAT",
+            "key": "reverse-charge",
+            "text": "Reverse charge: Customer to account for VAT to the relevant tax authority."
+          }
+        }
+      ]
+    }
+  ],
+  "categories": [
+    {
+      "code": "VAT",
+      "name": {
+        "en": "VAT",
+        "is": "VSK"
+      },
+      "title": {
+        "en": "Value Added Tax",
+        "is": "Virðisaukaskattur"
+      },
+      "keys": [
+        {
+          "key": "standard",
+          "name": {
+            "en": "Standard"
+          }
+        },
+        {
+          "key": "zero",
+          "name": {
+            "en": "Zero"
+          }
+        },
+        {
+          "key": "reverse-charge",
+          "name": {
+            "en": "Reverse charge"
+          },
+          "no_percent": true
+        },
+        {
+          "key": "exempt",
+          "name": {
+            "en": "Exempt"
+          },
+          "no_percent": true
+        },
+        {
+          "key": "export",
+          "name": {
+            "en": "Export"
+          },
+          "no_percent": true
+        },
+        {
+          "key": "intra-community",
+          "name": {
+            "en": "Intra-community"
+          },
+          "no_percent": true
+        },
+        {
+          "key": "outside-scope",
+          "name": {
+            "en": "Outside scope"
+          },
+          "no_percent": true
+        }
+      ],
+      "rates": [
+        {
+          "rate": "general",
+          "keys": [
+            "standard"
+          ],
+          "name": {
+            "en": "Standard Rate",
+            "is": "Almennt skatthlutfall"
+          },
+          "values": [
+            {
+              "since": "2015-01-01",
+              "percent": "24.0%"
+            }
+          ]
+        },
+        {
+          "rate": "reduced",
+          "keys": [
+            "standard"
+          ],
+          "name": {
+            "en": "Reduced Rate",
+            "is": "Lægra skatthlutfall"
+          },
+          "values": [
+            {
+              "since": "2015-01-01",
+              "percent": "11.0%"
+            }
+          ]
+        }
+      ],
+      "sources": [
+        {
+          "title": {
+            "en": "Skatturinn - Value Added Tax (VSK)"
+          },
+          "url": "https://www.skatturinn.is/english/companies/value-added-tax/",
+          "at": "2026-06-30T00:00:00"
+        },
+        {
+          "title": {
+            "en": "KPMG - Icelandic Tax Facts 2025"
+          },
+          "url": "https://assets.kpmg.com/content/dam/kpmg/is/pdf/2025/01/Icelandic-Tax-Facts-2025.pdf",
+          "at": "2026-06-30T00:00:00"
+        }
+      ]
+    }
+  ]
+}

--- a/data/regimes/is.json
+++ b/data/regimes/is.json
@@ -25,12 +25,6 @@
         "en": "European Commission - eInvoicing in Iceland"
       },
       "url": "https://ec.europa.eu/digital-building-blocks/sites/display/DIGITAL/eInvoicing+in+Iceland"
-    },
-    {
-      "title": {
-        "en": "Ecosio - E-invoicing in Iceland"
-      },
-      "url": "https://ecosio.com/en/compliance/iceland/e-invoicing/"
     }
   ],
   "time_zone": "Atlantic/Reykjavik",
@@ -174,10 +168,11 @@
         },
         {
           "title": {
-            "en": "KPMG - Icelandic Tax Facts 2025"
+            "en": "Act No. 50/1988 on Value Added Tax (Alþingi)",
+            "is": "Lög nr. 50/1988 um virðisaukaskatt (Alþingi)"
           },
-          "url": "https://assets.kpmg.com/content/dam/kpmg/is/pdf/2025/01/Icelandic-Tax-Facts-2025.pdf",
-          "at": "2026-06-30T00:00:00"
+          "url": "https://www.althingi.is/lagas/nuna/1988050.html",
+          "at": "2026-07-01T00:00:00"
         }
       ]
     }

--- a/data/rules/is.json
+++ b/data/rules/is.json
@@ -1,0 +1,103 @@
+{
+  "id": "GOBL-IS",
+  "package": "is",
+  "subsets": [
+    {
+      "id": "GOBL-IS-TAX-IDENTITY",
+      "object": "tax.Identity",
+      "subsets": [
+        {
+          "guard": "code in [IS]",
+          "subsets": [
+            {
+              "field": "code",
+              "subsets": [
+                {
+                  "guard": "present",
+                  "assert": [
+                    {
+                      "id": "GOBL-IS-TAX-IDENTITY-01",
+                      "desc": "invalid kennitala format",
+                      "tests": "numeric"
+                    }
+                  ]
+                },
+                {
+                  "guard": "present",
+                  "assert": [
+                    {
+                      "id": "GOBL-IS-TAX-IDENTITY-02",
+                      "desc": "invalid kennitala length",
+                      "tests": "length"
+                    }
+                  ]
+                },
+                {
+                  "guard": "present",
+                  "assert": [
+                    {
+                      "id": "GOBL-IS-TAX-IDENTITY-03",
+                      "desc": "invalid checksum for kennitala",
+                      "tests": "checksum"
+                    }
+                  ]
+                },
+                {
+                  "guard": "present",
+                  "assert": [
+                    {
+                      "id": "GOBL-IS-TAX-IDENTITY-04",
+                      "desc": "person kennitala is not valid for VAT",
+                      "tests": "not person"
+                    }
+                  ]
+                },
+                {
+                  "guard": "present",
+                  "assert": [
+                    {
+                      "id": "GOBL-IS-TAX-IDENTITY-05",
+                      "desc": "temporary kennitala is not valid for VAT",
+                      "tests": "not temporary"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "GOBL-IS-ORG-IDENTITY",
+      "object": "org.Identity",
+      "subsets": [
+        {
+          "guard": "context: regime in [IS]",
+          "subsets": [
+            {
+              "guard": "type in [KT]",
+              "subsets": [
+                {
+                  "field": "code",
+                  "assert": [
+                    {
+                      "id": "GOBL-IS-ORG-IDENTITY-01",
+                      "desc": "invalid kennitala format",
+                      "tests": "well-formed"
+                    },
+                    {
+                      "id": "GOBL-IS-ORG-IDENTITY-02",
+                      "desc": "invalid checksum for kennitala",
+                      "tests": "checksum"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/data/schemas/tax/regime-code.json
+++ b/data/schemas/tax/regime-code.json
@@ -74,6 +74,10 @@
           "title": "India"
         },
         {
+          "const": "IS",
+          "title": "Iceland"
+        },
+        {
           "const": "IT",
           "title": "Italy"
         },

--- a/examples/is/invoice-is-is.yaml
+++ b/examples/is/invoice-is-is.yaml
@@ -1,0 +1,38 @@
+$schema: https://gobl.org/draft-0/bill/invoice
+$regime: IS
+uuid: 35c8070e-689e-47ed-bb56-8f92f0b5d493
+currency: ISK
+series: "2026"
+code: "0001"
+issue_date: "2026-09-15"
+
+supplier:
+  name: Norðurljós Software ehf.
+  tax_id:
+    country: IS
+    code: "5012031220"
+  addresses:
+    - street: Laugavegur 22
+      locality: Reykjavík
+      country: IS
+      code: "101"
+
+customer:
+  name: Bláfjall Ráðgjöf ehf.
+  tax_id:
+    country: IS
+    code: "6012843160"
+  addresses:
+    - street: Borgartún 35
+      locality: Reykjavík
+      country: IS
+      code: "105"
+
+lines:
+  - quantity: "2"
+    item:
+      name: Software Engineering Services
+      price: "150000"
+    taxes:
+      - cat: VAT
+        rate: standard

--- a/examples/is/out/invoice-is-is.json
+++ b/examples/is/out/invoice-is-is.json
@@ -1,0 +1,94 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
+		"dig": {
+			"alg": "sha256",
+			"val": "813644ea77144cea8d2e40541dacc2afb27dc4b5a314fdbea3bcc458f6bb317c"
+		}
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"$regime": "IS",
+		"uuid": "35c8070e-689e-47ed-bb56-8f92f0b5d493",
+		"type": "standard",
+		"series": "2026",
+		"code": "0001",
+		"issue_date": "2026-09-15",
+		"currency": "ISK",
+		"supplier": {
+			"name": "Norðurljós Software ehf.",
+			"tax_id": {
+				"country": "IS",
+				"code": "5012031220"
+			},
+			"addresses": [
+				{
+					"street": "Laugavegur 22",
+					"locality": "Reykjavík",
+					"code": "101",
+					"country": "IS"
+				}
+			]
+		},
+		"customer": {
+			"name": "Bláfjall Ráðgjöf ehf.",
+			"tax_id": {
+				"country": "IS",
+				"code": "6012843160"
+			},
+			"addresses": [
+				{
+					"street": "Borgartún 35",
+					"locality": "Reykjavík",
+					"code": "105",
+					"country": "IS"
+				}
+			]
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "2",
+				"item": {
+					"name": "Software Engineering Services",
+					"price": "150000"
+				},
+				"sum": "300000",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "general",
+						"percent": "24.0%"
+					}
+				],
+				"total": "300000"
+			}
+		],
+		"totals": {
+			"sum": "300000",
+			"total": "300000",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"base": "300000",
+								"percent": "24.0%",
+								"amount": "72000"
+							}
+						],
+						"amount": "72000"
+					}
+				],
+				"sum": "72000"
+			},
+			"tax": "72000",
+			"total_with_tax": "372000",
+			"payable": "372000"
+		}
+	}
+}

--- a/regimes/is/is.go
+++ b/regimes/is/is.go
@@ -1,0 +1,91 @@
+// Package is provides the tax regime definition for Iceland.
+package is
+
+import (
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/currency"
+	"github.com/invopop/gobl/i18n"
+	"github.com/invopop/gobl/l10n"
+	"github.com/invopop/gobl/norm"
+	"github.com/invopop/gobl/pkg/here"
+	"github.com/invopop/gobl/rules"
+	rulesis "github.com/invopop/gobl/rules/is"
+	"github.com/invopop/gobl/tax"
+)
+
+// CountryCode is the tax country code for Iceland.
+const CountryCode = "IS"
+
+func init() {
+	tax.RegisterRegimeDef(New())
+	rules.Register("is", rules.GOBL.Add(CountryCode), taxIdentityRules(), orgIdentityRules())
+	norm.Register(
+		norm.When(tax.IdentityIn(CountryCode), norm.For(func(id *tax.Identity) { tax.NormalizeIdentity(id) })),
+	)
+	norm.RegisterWithGuard(rulesis.InContext(tax.RegimeIn(CountryCode)),
+		norm.For(normalizeOrgIdentity),
+	)
+}
+
+// New instantiates a new Icelandic tax regime.
+func New() *tax.RegimeDef {
+	return &tax.RegimeDef{
+		Country:   l10n.IS.Tax(),
+		Currency:  currency.ISK,
+		TaxScheme: tax.CategoryVAT,
+		Name: i18n.String{
+			i18n.EN: "Iceland",
+			i18n.IS: "Ísland",
+		},
+		Description: i18n.String{
+			i18n.EN: here.Doc(`
+				Iceland's tax system is administered by the Directorate of Internal
+				Revenue (Skatturinn). Although Iceland is not an EU member state, it is
+				part of the European Economic Area (EEA) and operates a value added tax
+				broadly aligned with European practice.
+
+				VSK (Virðisaukaskattur) applies at a standard and a reduced rate. 
+				Exports are zero-rated. Health, education, public transport, real 
+				estate leasing, sports and financial services are exempt under Article 
+				12 of the VAT Act.
+
+				Businesses and individuals alike are identified by their kennitala, a
+				10-digit national identification number issued by Registers Iceland
+				(Þjóðskrá Íslands). The same number serves as the VAT identifier; for
+				international use it is prefixed with "IS". The kennitala encodes a date
+				(birth date for individuals, registration date for companies) followed by 
+				two random digits, a MOD-11 checksum digit, and a final century indicator.
+
+				E-invoicing is mandatory for all B2G transactions since 2020 under
+				Regulation 44/2019, using the Peppol BIS Billing 3.0 format together with
+				the national CIUS TS-236. The Peppol Authority is Fjársýsla ríkisins
+				(FJS). B2B and B2C e-invoicing is voluntary but widely adopted.
+			`),
+		},
+		Sources: []*cbc.Source{
+			{
+				Title: i18n.NewString("Registers Iceland - ID numbers (kennitala)"),
+				URL:   "https://www.skra.is/english/people/my-registration/id-numbers/",
+			},
+			{
+				Title: i18n.NewString("Skatturinn - Value Added Tax (VSK)"),
+				URL:   "https://www.skatturinn.is/english/companies/value-added-tax/",
+			},
+			{
+				Title: i18n.NewString("European Commission - eInvoicing in Iceland"),
+				URL:   "https://ec.europa.eu/digital-building-blocks/sites/display/DIGITAL/eInvoicing+in+Iceland",
+			},
+			{
+				Title: i18n.NewString("Ecosio - E-invoicing in Iceland"),
+				URL:   "https://ecosio.com/en/compliance/iceland/e-invoicing/",
+			},
+		},
+		TimeZone:   "Atlantic/Reykjavik",
+		Identities: identityTypeDefinitions,
+		Categories: taxCategories,
+		Scenarios: []*tax.ScenarioSet{
+			bill.InvoiceScenarios(),
+		},
+	}
+}

--- a/regimes/is/is.go
+++ b/regimes/is/is.go
@@ -76,10 +76,6 @@ func New() *tax.RegimeDef {
 				Title: i18n.NewString("European Commission - eInvoicing in Iceland"),
 				URL:   "https://ec.europa.eu/digital-building-blocks/sites/display/DIGITAL/eInvoicing+in+Iceland",
 			},
-			{
-				Title: i18n.NewString("Ecosio - E-invoicing in Iceland"),
-				URL:   "https://ecosio.com/en/compliance/iceland/e-invoicing/",
-			},
 		},
 		TimeZone:   "Atlantic/Reykjavik",
 		Identities: identityTypeDefinitions,

--- a/regimes/is/org_identities.go
+++ b/regimes/is/org_identities.go
@@ -1,0 +1,75 @@
+package is
+
+import (
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/i18n"
+	"github.com/invopop/gobl/org"
+	"github.com/invopop/gobl/rules"
+	rulesis "github.com/invopop/gobl/rules/is" // aliased: rules/is collides with this package's name
+	"github.com/invopop/gobl/tax"
+)
+
+// IdentityTypeKennitala identifies the Icelandic national identification number
+// (kennitala), issued by Registers Iceland (Þjóðskrá Íslands) to both natural
+// persons and companies.
+const IdentityTypeKennitala cbc.Code = "KT"
+
+var identityTypeDefinitions = []*cbc.Definition{
+	{
+		Code: IdentityTypeKennitala,
+		Name: i18n.String{
+			i18n.EN: "Kennitala",
+			i18n.IS: "Kennitala",
+		},
+		Desc: i18n.String{
+			i18n.EN: "Icelandic national identification number for persons and companies.",
+			i18n.IS: "Íslensk kennitala fyrir einstaklinga og fyrirtæki.",
+		},
+	},
+}
+
+// normalizeOrgIdentity strips separators and whitespace from a kennitala, leaving
+// the bare 10-digit form. If the result is not 10 digits it leaves the value
+// untouched, so validation can report the original malformed code.
+func normalizeOrgIdentity(id *org.Identity) {
+	if id == nil || id.Type != IdentityTypeKennitala {
+		return
+	}
+	code := cbc.NormalizeNumericalCode(id.Code)
+	if len(code) != kennitalaLength {
+		return
+	}
+	id.Code = code
+}
+
+func orgIdentityRules() *rules.Set {
+	return rules.For(new(org.Identity),
+		rules.When(
+			rulesis.InContext(tax.RegimeIn(CountryCode)),
+			rules.When(
+				org.IdentityTypeIn(IdentityTypeKennitala),
+				rules.Field("code",
+					rules.Assert("01", "invalid kennitala format",
+						rulesis.Func("well-formed", orgKennitalaWellFormed),
+					),
+					rules.Assert("02", "invalid checksum for kennitala",
+						rulesis.Func("checksum", orgKennitalaChecksumValid),
+					),
+				),
+			),
+		),
+	)
+}
+
+func orgKennitalaWellFormed(value any) bool {
+	code, ok := value.(cbc.Code)
+	return ok && isCanonicalKennitala(code)
+}
+
+func orgKennitalaChecksumValid(value any) bool {
+	code, ok := value.(cbc.Code)
+	if !ok || !isCanonicalKennitala(code) {
+		return true // skip if not well-formed; the format assertion reports that
+	}
+	return ValidKennitala(code)
+}

--- a/regimes/is/org_identities_test.go
+++ b/regimes/is/org_identities_test.go
@@ -1,0 +1,76 @@
+package is_test
+
+import (
+	"testing"
+
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/norm"
+	"github.com/invopop/gobl/org"
+	"github.com/invopop/gobl/regimes/is"
+	"github.com/invopop/gobl/rules"
+	"github.com/invopop/gobl/tax"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOrgIdentityNormalize(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		typeCode cbc.Code
+		input    cbc.Code
+		expected cbc.Code
+	}{
+		{name: "already normalized", typeCode: is.IdentityTypeKennitala, input: "5012031220", expected: "5012031220"},
+		{name: "with hyphen", typeCode: is.IdentityTypeKennitala, input: "090286-2349", expected: "0902862349"},
+		{name: "with spaces", typeCode: is.IdentityTypeKennitala, input: "  5012031220  ", expected: "5012031220"},
+		{name: "non-numeric left untouched", typeCode: is.IdentityTypeKennitala, input: "ABCDEFGHIJK", expected: "ABCDEFGHIJK"},
+		{name: "empty left untouched", typeCode: is.IdentityTypeKennitala, input: "", expected: ""},
+		{name: "other type left untouched", typeCode: "unknown", input: "090286-2349", expected: "090286-2349"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			id := &org.Identity{Type: tt.typeCode, Code: tt.input}
+			norm.Normalize(id, tax.RegimeContext("IS"))
+			assert.Equal(t, tt.expected, id.Code)
+		})
+	}
+}
+
+func TestOrgIdentityValidate(t *testing.T) {
+	tests := []struct {
+		name     string
+		typeCode cbc.Code
+		input    cbc.Code
+		err      string
+	}{
+		// Valid: person, company, and temporary kennitalas are all valid national IDs.
+		{name: "valid company kennitala", typeCode: is.IdentityTypeKennitala, input: "5012031220"},
+		{name: "valid person kennitala", typeCode: is.IdentityTypeKennitala, input: "0902862349"},
+		{name: "valid temporary kennitala", typeCode: is.IdentityTypeKennitala, input: "8101850150"},
+		{name: "unknown identity type", typeCode: "unknown", input: "1234567890"},
+
+		// Invalid.
+		{name: "too short", typeCode: is.IdentityTypeKennitala, input: "501203122", err: "[GOBL-IS-ORG-IDENTITY-01]"},
+		{name: "too long", typeCode: is.IdentityTypeKennitala, input: "50120312201", err: "[GOBL-IS-ORG-IDENTITY-01]"},
+		{name: "with letters", typeCode: is.IdentityTypeKennitala, input: "501203122A", err: "[GOBL-IS-ORG-IDENTITY-01]"},
+		{name: "invalid checksum", typeCode: is.IdentityTypeKennitala, input: "5012031230", err: "[GOBL-IS-ORG-IDENTITY-02]"},
+	}
+
+	opts := []rules.WithContext{
+		tax.RegimeContext(is.CountryCode),
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			id := &org.Identity{Type: tt.typeCode, Code: tt.input}
+			err := rules.Validate(id, opts...)
+			if tt.err == "" {
+				assert.NoError(t, err)
+			} else if assert.Error(t, err) {
+				assert.Contains(t, err.Error(), tt.err)
+			}
+		})
+	}
+}

--- a/regimes/is/tax_categories.go
+++ b/regimes/is/tax_categories.go
@@ -1,0 +1,71 @@
+package is
+
+import (
+	"github.com/invopop/gobl/cal"
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/i18n"
+	"github.com/invopop/gobl/num"
+	"github.com/invopop/gobl/tax"
+)
+
+var taxCategories = []*tax.CategoryDef{
+	{
+		Code: tax.CategoryVAT,
+		Name: i18n.String{
+			i18n.EN: "VAT",
+			i18n.IS: "VSK",
+		},
+		Title: i18n.String{
+			i18n.EN: "Value Added Tax",
+			i18n.IS: "Virðisaukaskattur",
+		},
+		Retained: false,
+		Keys:     tax.GlobalVATKeys(),
+		Rates: []*tax.RateDef{
+			{
+				Keys: []cbc.Key{tax.KeyStandard},
+				Rate: tax.RateGeneral,
+				Name: i18n.String{
+					i18n.EN: "Standard Rate",
+					i18n.IS: "Almennt skatthlutfall",
+				},
+				Values: []*tax.RateValueDef{
+					{
+						Percent: num.MakePercentage(240, 3),
+						Since:   cal.NewDate(2015, 1, 1),
+					},
+				},
+			},
+			{
+				Keys: []cbc.Key{tax.KeyStandard},
+				Rate: tax.RateReduced,
+				Name: i18n.String{
+					i18n.EN: "Reduced Rate",
+					i18n.IS: "Lægra skatthlutfall",
+				},
+				Values: []*tax.RateValueDef{
+					{
+						Percent: num.MakePercentage(110, 3),
+						Since:   cal.NewDate(2015, 1, 1),
+					},
+				},
+			},
+		},
+		Sources: []*cbc.Source{
+			{
+				Title: i18n.String{
+					i18n.EN: "Skatturinn - Value Added Tax (VSK)",
+				},
+				URL: "https://www.skatturinn.is/english/companies/value-added-tax/",
+				At:  cal.NewDateTime(2026, 6, 30, 0, 0, 0),
+			},
+			{
+				Title: i18n.String{
+					i18n.EN: "KPMG - Icelandic Tax Facts 2025",
+				},
+				URL: "https://assets.kpmg.com/content/dam/kpmg/is/pdf/2025/01/Icelandic-Tax-Facts-2025.pdf",
+				At:  cal.NewDateTime(2026, 6, 30, 0, 0, 0),
+			},
+		},
+	},
+}

--- a/regimes/is/tax_categories.go
+++ b/regimes/is/tax_categories.go
@@ -61,10 +61,11 @@ var taxCategories = []*tax.CategoryDef{
 			},
 			{
 				Title: i18n.String{
-					i18n.EN: "KPMG - Icelandic Tax Facts 2025",
+					i18n.EN: "Act No. 50/1988 on Value Added Tax (Alþingi)",
+					i18n.IS: "Lög nr. 50/1988 um virðisaukaskatt (Alþingi)",
 				},
-				URL: "https://assets.kpmg.com/content/dam/kpmg/is/pdf/2025/01/Icelandic-Tax-Facts-2025.pdf",
-				At:  cal.NewDateTime(2026, 6, 30, 0, 0, 0),
+				URL: "https://www.althingi.is/lagas/nuna/1988050.html",
+				At:  cal.NewDateTime(2026, 7, 1, 0, 0, 0),
 			},
 		},
 	},

--- a/regimes/is/tax_identity.go
+++ b/regimes/is/tax_identity.go
@@ -1,0 +1,168 @@
+package is
+
+import (
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/rules"
+	rulesis "github.com/invopop/gobl/rules/is" // aliased: rules/is collides with this package's name
+	"github.com/invopop/gobl/tax"
+)
+
+const (
+	// kennitalaLength is the number of digits in a normalized kennitala (DDMMYY-RRCV).
+	kennitalaLength = 10
+	// kennitalaWeightedDigits is the count of leading digits (positions 1–8) that
+	// feed into the MOD-11 check-digit calculation.
+	kennitalaWeightedDigits = 8
+	// kennitalaCheckDigitIndex is the 0-based index of the check digit (position 9).
+	kennitalaCheckDigitIndex = 8
+	// kennitalaModulus is the modulus of the MOD-11 check-digit algorithm.
+	kennitalaModulus = 11
+	// kennitalaNoCheckDigitRemainder is the (S mod 11) remainder for which the check
+	// digit would be 10 — not representable as a single digit, so Registers Iceland
+	// never issues such numbers and they must be rejected.
+	kennitalaNoCheckDigitRemainder = 1
+
+	// A company kennitala encodes its day-of-month offset by 40, so the day field is
+	// 41–71 and the first digit is 4–7. A natural person's day is 01–31 (first digit
+	// 0–3); temporary "kerfiskennitala" numbers use a first digit of 8 or 9.
+	companyFirstDigitMin   = 4
+	companyFirstDigitMax   = 7
+	personFirstDigitMin    = 0
+	personFirstDigitMax    = 3
+	temporaryFirstDigitMin = 8
+	temporaryFirstDigitMax = 9
+)
+
+// kennitalaWeights are the multipliers applied to digits 1–8 when computing the
+// MOD-11 check digit. It is a var, not a const, because Go constants cannot hold
+// composite types such as arrays.
+var kennitalaWeights = [kennitalaWeightedDigits]int{3, 2, 7, 6, 5, 4, 3, 2}
+
+// ValidKennitala reports whether code is a structurally valid kennitala: exactly
+// ten digits whose ninth digit matches the MOD-11 check digit computed from the
+// first eight. It does not distinguish persons from companies — use
+// Company or Person for that. The tenth digit (century
+// indicator) is intentionally excluded from the checksum.
+func ValidKennitala(code cbc.Code) bool {
+	s := code.String()
+	if len(s) != kennitalaLength || !isAllDigits(s) {
+		return false
+	}
+	sum := 0
+	for i := 0; i < kennitalaWeightedDigits; i++ {
+		sum += int(s[i]-'0') * kennitalaWeights[i]
+	}
+	remainder := sum % kennitalaModulus
+	if remainder == kennitalaNoCheckDigitRemainder {
+		return false
+	}
+	check := (kennitalaModulus - remainder) % kennitalaModulus
+	return int(s[kennitalaCheckDigitIndex]-'0') == check
+}
+
+// Company reports whether code's first digit (4–7) identifies a company
+// rather than a person or a temporary number. It does not validate the checksum.
+func Company(code cbc.Code) bool {
+	d, ok := firstDigit(code)
+	return ok && d >= companyFirstDigitMin && d <= companyFirstDigitMax
+}
+
+// Person reports whether code's first digit (0–3) identifies a natural
+// person. It does not validate the checksum.
+func Person(code cbc.Code) bool {
+	d, ok := firstDigit(code)
+	return ok && d >= personFirstDigitMin && d <= personFirstDigitMax
+}
+
+func isTemporaryKennitala(code cbc.Code) bool {
+	d, ok := firstDigit(code)
+	return ok && d >= temporaryFirstDigitMin && d <= temporaryFirstDigitMax
+}
+
+func firstDigit(code cbc.Code) (int, bool) {
+	s := code.String()
+	if len(s) == 0 || s[0] < '0' || s[0] > '9' {
+		return 0, false
+	}
+	return int(s[0] - '0'), true
+}
+
+func isAllDigits(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// isCanonicalKennitala reports whether code is a 10-digit numeric string — the
+// precondition for the checksum and classification checks. It lets each downstream
+// assertion skip cleanly, so a malformed code is reported only by the format or
+// length assertion.
+func isCanonicalKennitala(code cbc.Code) bool {
+	s := code.String()
+	return isAllDigits(s) && len(s) == kennitalaLength
+}
+
+func taxIdentityRules() *rules.Set {
+	return rules.For(new(tax.Identity),
+		rules.When(tax.IdentityIn(CountryCode),
+			rules.Field("code",
+				rules.AssertIfPresent("01", "invalid kennitala format",
+					rulesis.Func("numeric", kennitalaFormatValid),
+				),
+				rules.AssertIfPresent("02", "invalid kennitala length",
+					rulesis.Func("length", kennitalaLengthValid),
+				),
+				rules.AssertIfPresent("03", "invalid checksum for kennitala",
+					rulesis.Func("checksum", kennitalaChecksumValid),
+				),
+				rules.AssertIfPresent("04", "person kennitala is not valid for VAT",
+					rulesis.Func("not person", kennitalaNotPerson),
+				),
+				rules.AssertIfPresent("05", "temporary kennitala is not valid for VAT",
+					rulesis.Func("not temporary", kennitalaNotTemporary),
+				),
+			),
+		),
+	)
+}
+
+func kennitalaFormatValid(value any) bool {
+	code, ok := value.(cbc.Code)
+	return ok && isAllDigits(code.String())
+}
+
+func kennitalaLengthValid(value any) bool {
+	code, _ := value.(cbc.Code)
+	s := code.String()
+	if !isAllDigits(s) {
+		return true // not numeric: the format assertion reports this
+	}
+	return len(s) == kennitalaLength
+}
+
+func kennitalaChecksumValid(value any) bool {
+	code, _ := value.(cbc.Code)
+	if !isCanonicalKennitala(code) {
+		return true // format/length assertions report these
+	}
+	return ValidKennitala(code)
+}
+
+func kennitalaNotPerson(value any) bool {
+	code, _ := value.(cbc.Code)
+	if !isCanonicalKennitala(code) {
+		return true
+	}
+	return !Person(code)
+}
+
+func kennitalaNotTemporary(value any) bool {
+	code, _ := value.(cbc.Code)
+	if !isCanonicalKennitala(code) {
+		return true
+	}
+	return !isTemporaryKennitala(code)
+}

--- a/regimes/is/tax_identity.go
+++ b/regimes/is/tax_identity.go
@@ -10,11 +10,6 @@ import (
 const (
 	// kennitalaLength is the number of digits in a normalized kennitala (DDMMYY-RRCV).
 	kennitalaLength = 10
-	// kennitalaWeightedDigits is the count of leading digits (positions 1–8) that
-	// feed into the MOD-11 check-digit calculation.
-	kennitalaWeightedDigits = 8
-	// kennitalaCheckDigitIndex is the 0-based index of the check digit (position 9).
-	kennitalaCheckDigitIndex = 8
 	// kennitalaModulus is the modulus of the MOD-11 check-digit algorithm.
 	kennitalaModulus = 11
 	// kennitalaNoCheckDigitRemainder is the (S mod 11) remainder for which the check
@@ -22,21 +17,19 @@ const (
 	// never issues such numbers and they must be rejected.
 	kennitalaNoCheckDigitRemainder = 1
 
-	// A company kennitala encodes its day-of-month offset by 40, so the day field is
-	// 41–71 and the first digit is 4–7. A natural person's day is 01–31 (first digit
-	// 0–3); temporary "kerfiskennitala" numbers use a first digit of 8 or 9.
-	companyFirstDigitMin   = 4
-	companyFirstDigitMax   = 7
-	personFirstDigitMin    = 0
-	personFirstDigitMax    = 3
-	temporaryFirstDigitMin = 8
-	temporaryFirstDigitMax = 9
+	// companyFirstDigitMin and companyFirstDigitMax bound the first digit of a company
+	// kennitala, whose day-of-month is offset by 40 (day field 41–71, first digit 4–7).
+	// Natural persons fall below this range (first digit 0–3) and temporary
+	// "kerfiskennitala" numbers above it (first digit 8–9).
+	companyFirstDigitMin = 4
+	companyFirstDigitMax = 7
 )
 
-// kennitalaWeights are the multipliers applied to digits 1–8 when computing the
-// MOD-11 check digit. It is a var, not a const, because Go constants cannot hold
-// composite types such as arrays.
-var kennitalaWeights = [kennitalaWeightedDigits]int{3, 2, 7, 6, 5, 4, 3, 2}
+// kennitalaWeights are the multipliers applied to the leading digits when computing
+// the MOD-11 check digit; its length also defines how many digits are weighted and
+// the index of the check digit that follows them. It is a var, not a const, because
+// Go constants cannot hold composite types such as arrays.
+var kennitalaWeights = [...]int{3, 2, 7, 6, 5, 4, 3, 2}
 
 // ValidKennitala reports whether code is a structurally valid kennitala: exactly
 // ten digits whose ninth digit matches the MOD-11 check digit computed from the
@@ -49,7 +42,7 @@ func ValidKennitala(code cbc.Code) bool {
 		return false
 	}
 	sum := 0
-	for i := 0; i < kennitalaWeightedDigits; i++ {
+	for i := 0; i < len(kennitalaWeights); i++ {
 		sum += int(s[i]-'0') * kennitalaWeights[i]
 	}
 	remainder := sum % kennitalaModulus
@@ -57,7 +50,7 @@ func ValidKennitala(code cbc.Code) bool {
 		return false
 	}
 	check := (kennitalaModulus - remainder) % kennitalaModulus
-	return int(s[kennitalaCheckDigitIndex]-'0') == check
+	return int(s[len(kennitalaWeights)]-'0') == check
 }
 
 // Company reports whether code's first digit (4–7) identifies a company
@@ -67,16 +60,16 @@ func Company(code cbc.Code) bool {
 	return ok && d >= companyFirstDigitMin && d <= companyFirstDigitMax
 }
 
-// Person reports whether code's first digit (0–3) identifies a natural
-// person. It does not validate the checksum.
+// Person reports whether code's first digit (0–3, i.e. below the company range)
+// identifies a natural person. It does not validate the checksum.
 func Person(code cbc.Code) bool {
 	d, ok := firstDigit(code)
-	return ok && d >= personFirstDigitMin && d <= personFirstDigitMax
+	return ok && d < companyFirstDigitMin
 }
 
 func isTemporaryKennitala(code cbc.Code) bool {
 	d, ok := firstDigit(code)
-	return ok && d >= temporaryFirstDigitMin && d <= temporaryFirstDigitMax
+	return ok && d > companyFirstDigitMax
 }
 
 func firstDigit(code cbc.Code) (int, bool) {

--- a/regimes/is/tax_identity_test.go
+++ b/regimes/is/tax_identity_test.go
@@ -1,0 +1,86 @@
+package is_test
+
+import (
+	"testing"
+
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/norm"
+	"github.com/invopop/gobl/regimes/is"
+	"github.com/invopop/gobl/rules"
+	"github.com/invopop/gobl/tax"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizeTaxIdentity(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		input    cbc.Code
+		expected cbc.Code
+	}{
+		{name: "already normalized", input: "5012031220", expected: "5012031220"},
+		{name: "lowercase prefix", input: "is5012031220", expected: "5012031220"},
+		{name: "uppercase prefix", input: "IS5012031220", expected: "5012031220"},
+		{name: "hyphenated with prefix", input: "IS-1234567890", expected: "1234567890"},
+		{name: "spaces and prefix", input: "  IS 1234567890  ", expected: "1234567890"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tID := &tax.Identity{Country: "IS", Code: tt.input}
+			norm.Normalize(tID)
+			assert.Equal(t, tt.expected, tID.Code)
+		})
+	}
+}
+
+func TestTaxIdentityRules(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		code cbc.Code
+		err  string
+	}{
+		{name: "valid company kennitala", code: "5012031220"},
+		{name: "empty code", code: ""},
+		{name: "valid person kennitala rejected for VAT", code: "0902862349", err: "person kennitala is not valid for VAT"},
+		{name: "temporary kennitala starting with 8", code: "8101850150", err: "temporary kennitala is not valid for VAT"},
+		{name: "wrong checksum", code: "5012031230", err: "invalid checksum for kennitala"},
+		{name: "wrong length", code: "501203122", err: "invalid kennitala length"},
+		{name: "non-numeric characters", code: "501203122A", err: "invalid kennitala format"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tID := &tax.Identity{Country: "IS", Code: tt.code}
+			err := rules.Validate(tID)
+			if tt.err == "" {
+				assert.NoError(t, err)
+			} else if assert.Error(t, err) {
+				assert.Contains(t, err.Error(), tt.err)
+			}
+		})
+	}
+}
+
+// TestKennitalaChecksum covers the verification anchor from both angles: its
+// checksum is valid, yet it is a person kennitala and so must fail VAT-ID checks.
+func TestKennitalaChecksum(t *testing.T) {
+	t.Parallel()
+
+	// Anchor: 0902862349 — valid checksum, but a PERSON (first digit 0).
+	assert.True(t, is.ValidKennitala("0902862349"), "anchor checksum should be valid")
+	assert.True(t, is.Person("0902862349"))
+	assert.False(t, is.Company("0902862349"))
+
+	// Valid company kennitala.
+	assert.True(t, is.ValidKennitala("5012031220"))
+	assert.True(t, is.Company("5012031220"))
+
+	// Same number, tampered check digit -> invalid checksum.
+	assert.False(t, is.ValidKennitala("5012031230"))
+
+	// Temporary kennitala (first digit 8) is neither person nor company form.
+	assert.False(t, is.Company("8101850150"))
+	assert.False(t, is.Person("8101850150"))
+}

--- a/regimes/is/tax_identity_test.go
+++ b/regimes/is/tax_identity_test.go
@@ -83,4 +83,14 @@ func TestKennitalaChecksum(t *testing.T) {
 	// Temporary kennitala (first digit 8) is neither person nor company form.
 	assert.False(t, is.Company("8101850150"))
 	assert.False(t, is.Person("8101850150"))
+
+	// Non-canonical input (wrong length) is rejected before the checksum runs.
+	assert.False(t, is.ValidKennitala("123"))
+
+	// Checksum with S mod 11 == 1 → check digit would be 10 (impossible): rejected.
+	assert.False(t, is.ValidKennitala("6012031200"))
+
+	// firstDigit guard: empty and non-numeric first char are not classified.
+	assert.False(t, is.Company(""))
+	assert.False(t, is.Person("X902862349"))
 }

--- a/regimes/regimes.go
+++ b/regimes/regimes.go
@@ -22,6 +22,7 @@ import (
 	_ "github.com/invopop/gobl/regimes/gr"
 	_ "github.com/invopop/gobl/regimes/ie"
 	_ "github.com/invopop/gobl/regimes/in"
+	_ "github.com/invopop/gobl/regimes/is"
 	_ "github.com/invopop/gobl/regimes/it"
 	_ "github.com/invopop/gobl/regimes/mx"
 	_ "github.com/invopop/gobl/regimes/nl"


### PR DESCRIPTION
## Summary

Adds Iceland (`IS`) as a new tax regime. Completes Nordic coverage alongside `dk`, `se` and `no`.

## Changes

- `regimes/is/` — regime, VSK category (24% / 11%, since 2015), kennitala validation, `IdentityTypeKennitala`.
- Tests at 95.5% coverage; example invoice in `examples/is/`.
- changelog entry, regenerated schemas.

## Design decisions

- **Single kennitala model.** Iceland uses one national identifier for persons and companies; the distinction is the first digit (`0–3` person, `4–7` company, `8–9` temporary). Modeled as one type with `IsCompany` / `IsPerson` helpers rather than mirroring Sweden's split.
- **VAT-ID restricted to company-form.** Person and temporary kennitalas rejected — only companies hold VSK numbers.
- **Current rates only.** Modeled post-2015 rates; pre-2015 (25.5% / 7%) omitted to keep the MVP focused, can be backfilled symmetrically.

## Out of scope

- **TS-236 addon.** Iceland's B2G Peppol BIS 3.0 CIUS. Natural follow-up under `addons/is/ts236/`. Left out here because it requires reading the full spec and ideally a domain-expert review.
- Custom scenarios beyond `bill.InvoiceScenarios()`.

## Sources

- [Registers Iceland — kennitala](https://www.skra.is/english/people/my-registration/id-numbers/)
- [Skatturinn — VSK](https://www.skatturinn.is/english/companies/value-added-tax/)
- [OECD — Iceland TIN](https://www.oecd.org/content/dam/oecd/en/topics/policy-issue-focus/aeoi/iceland-tin.pdf)
- [EC — eInvoicing in Iceland](https://ec.europa.eu/digital-building-blocks/sites/display/DIGITAL/eInvoicing+in+Iceland)

## Pre-Review Checklist

- [x] Opened this PR as a draft
- [x] Read the CONTRIBUTING.md guide.
- [x] Performed a self-review of my code.
- [x] Added thorough tests with at **least** 90% code coverage.
- [x] Modified or created example GOBL documents to show my changes in use, if appropriate.
- [x] Added links to the source of the changes in tax regimes or addons, either structured or in the comments.
- [x] Run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [x] Reviewed and fixed all linter warnings.
- [x] Been obsessive with pointer nil checks to avoid panics.
- [x] Updated the CHANGELOG.md with an overview of my changes.
- [x] Marked this PR as ready for review.

And if you are part of the org:
- [ ] Requested a review from Copilot and fixed or dismissed (with a reason) all the feedback raised.
- [ ] Requested a review from @samlown.
