### PR TITLE
Release 0.502.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+## [v0.502.1] - 2026-07-02
+
+### Removed
+
+- `dk-oioubl-v2`: removed from the approved external addons list. The [`github.com/invopop/gobl.dk.oioubl`](https://github.com/invopop/gobl.dk.oioubl) module is not yet ready for release; it was approved prematurely in v0.502.0. It will be re-added once the module ships a stable release.
+
 ## [v0.502.0] - 2026-07-02
 
 ### Fixed

--- a/addons/external.go
+++ b/addons/external.go
@@ -59,14 +59,6 @@ func init() {
 	})
 
 	tax.RegisterApprovedAddon(&tax.ExternalAddon{
-		Key: "dk-oioubl-v2",
-		Name: i18n.String{
-			i18n.EN: "Danish OIOUBL 2.1",
-			i18n.DA: "Dansk OIOUBL 2.1",
-		},
-		Module: "github.com/invopop/gobl.dk.oioubl",
-	})
-	tax.RegisterApprovedAddon(&tax.ExternalAddon{
 		Key: "pt-saft-v1",
 		Name: i18n.String{
 			i18n.EN: "Portugal SAF-T",

--- a/addons/external_test.go
+++ b/addons/external_test.go
@@ -66,16 +66,3 @@ func TestApprovedAddons(t *testing.T) {
 		})
 	}
 }
-
-func TestApprovedDKOIOUBLAddon(t *testing.T) {
-	byKey := make(map[cbc.Key]*tax.ExternalAddon)
-	for _, ea := range tax.ApprovedAddons() {
-		byKey[ea.Key] = ea
-	}
-
-	ea, ok := byKey["dk-oioubl-v2"]
-	require.True(t, ok, "expected dk-oioubl-v2 on the approved list")
-	assert.Equal(t, "github.com/invopop/gobl.dk.oioubl", ea.Module)
-	assert.NotEmpty(t, ea.Name.String())
-	assert.Nil(t, tax.AddonForKey("dk-oioubl-v2"), "dk-oioubl-v2 should not be registered in core")
-}

--- a/data/schemas/tax/addon-list.json
+++ b/data/schemas/tax/addon-list.json
@@ -32,10 +32,6 @@
             "title": "German ZUGFeRD 2.X"
           },
           {
-            "const": "dk-oioubl-v2",
-            "title": "Danish OIOUBL 2.1"
-          },
-          {
             "const": "es-facturae-v3",
             "title": "Spain FacturaE"
           },

--- a/version.go
+++ b/version.go
@@ -8,7 +8,7 @@ import (
 type Version string
 
 // VERSION is the current version of the GOBL library
-const VERSION Version = "v0.502.0"
+const VERSION Version = "v0.502.1"
 
 // Semver parses and returns semver
 func (v Version) Semver() *semver.Version {


### PR DESCRIPTION
## Summary

Removes the `dk-oioubl-v2` external addon that was approved prematurely in v0.502.0. The [`gobl.dk.oioubl`](https://github.com/invopop/gobl.dk.oioubl) module is not yet ready for release, so the key should not be advertised on the approved-addons list yet.

## Changes

- `addons/external.go`: drop the `dk-oioubl-v2` `RegisterApprovedAddon` entry.
- `addons/external_test.go`: remove `TestApprovedDKOIOUBLAddon`.
- `data/schemas/tax/addon-list.json`: regenerated — `dk-oioubl-v2` removed from the `$addons` enum.
- `version.go`: bump to `v0.502.1`.
- `CHANGELOG.md`: add a v0.502.1 section documenting the removal.

It will be re-added once the module ships a stable release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)