### PR TITLE
Add Cl regime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Added
+
+- `cl`: added the Chilean (CL) tax regime with IVA tax category and RUT tax identity validation.
+
 ## [v0.502.2] - 2026-07-06
 
 ### Changed

--- a/data/regimes/cl.json
+++ b/data/regimes/cl.json
@@ -1,0 +1,119 @@
+{
+  "$schema": "https://gobl.org/draft-0/tax/regime-def",
+  "name": {
+    "en": "Chile",
+    "es": "Chile"
+  },
+  "description": {
+    "en": "Chile's tax system is administered by the Servicio de Impuestos Internos\n(SII). IVA (Impuesto al Valor Agregado), Chile's value-added tax,\napplies at the general rate defined in Decreto Ley 825.\n\nTaxpayers are identified by their RUT (Rol Unico Tributario), which\nincludes a modulo-11 check digit. This regime normalizes and validates\nRUT values when used as Chilean tax identities.\n\nElectronic tax documents (Documentos Tributarios Electronicos, DTE)\ninclude electronic invoices, credit notes, and debit notes. This regime\nprovides the core tax metadata and correction types needed by GOBL;\nDTE XML generation, SII transmission, folio authorization, CAF, and\nelectronic stamps are format-specific concerns left for a future addon."
+  },
+  "sources": [
+    {
+      "title": {
+        "en": "SII - Servicio de Impuestos Internos"
+      },
+      "url": "https://www.sii.cl/"
+    }
+  ],
+  "time_zone": "America/Santiago",
+  "country": "CL",
+  "currency": "CLP",
+  "tax_scheme": "VAT",
+  "corrections": [
+    {
+      "schema": "bill/invoice",
+      "types": [
+        "credit-note",
+        "debit-note"
+      ]
+    }
+  ],
+  "categories": [
+    {
+      "code": "VAT",
+      "name": {
+        "en": "VAT",
+        "es": "IVA"
+      },
+      "title": {
+        "en": "Value Added Tax",
+        "es": "Impuesto al Valor Agregado"
+      },
+      "keys": [
+        {
+          "key": "standard",
+          "name": {
+            "en": "Standard"
+          }
+        },
+        {
+          "key": "zero",
+          "name": {
+            "en": "Zero"
+          }
+        },
+        {
+          "key": "reverse-charge",
+          "name": {
+            "en": "Reverse charge"
+          },
+          "no_percent": true
+        },
+        {
+          "key": "exempt",
+          "name": {
+            "en": "Exempt"
+          },
+          "no_percent": true
+        },
+        {
+          "key": "export",
+          "name": {
+            "en": "Export"
+          },
+          "no_percent": true
+        },
+        {
+          "key": "intra-community",
+          "name": {
+            "en": "Intra-community"
+          },
+          "no_percent": true
+        },
+        {
+          "key": "outside-scope",
+          "name": {
+            "en": "Outside scope"
+          },
+          "no_percent": true
+        }
+      ],
+      "rates": [
+        {
+          "rate": "general",
+          "keys": [
+            "standard"
+          ],
+          "name": {
+            "en": "General Rate",
+            "es": "Tasa General"
+          },
+          "values": [
+            {
+              "since": "2003-10-01",
+              "percent": "19%"
+            }
+          ]
+        }
+      ],
+      "sources": [
+        {
+          "title": {
+            "en": "VAT law - Article 14"
+          },
+          "url": "https://www.bcn.cl/leychile/navegar?idNorma=6369"
+        }
+      ]
+    }
+  ]
+}

--- a/data/rules/cl.json
+++ b/data/rules/cl.json
@@ -17,8 +17,53 @@
                   "assert": [
                     {
                       "id": "GOBL-CL-TAX-IDENTITY-01",
-                      "desc": "invalid Chilean RUT tax identity code",
-                      "tests": "valid"
+                      "desc": "invalid Chilean RUT tax identity code length",
+                      "tests": "valid length"
+                    }
+                  ]
+                },
+                {
+                  "guard": "valid length",
+                  "subsets": [
+                    {
+                      "guard": "present",
+                      "assert": [
+                        {
+                          "id": "GOBL-CL-TAX-IDENTITY-02",
+                          "desc": "Chilean RUT tax identity code body must be numeric",
+                          "tests": "valid body"
+                        }
+                      ]
+                    },
+                    {
+                      "guard": "valid body",
+                      "subsets": [
+                        {
+                          "guard": "present",
+                          "assert": [
+                            {
+                              "id": "GOBL-CL-TAX-IDENTITY-03",
+                              "desc": "invalid Chilean RUT tax identity check digit",
+                              "tests": "valid check digit"
+                            }
+                          ]
+                        },
+                        {
+                          "guard": "valid check digit",
+                          "subsets": [
+                            {
+                              "guard": "present",
+                              "assert": [
+                                {
+                                  "id": "GOBL-CL-TAX-IDENTITY-04",
+                                  "desc": "invalid Chilean RUT tax identity checksum",
+                                  "tests": "valid checksum"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
                     }
                   ]
                 }

--- a/data/rules/cl.json
+++ b/data/rules/cl.json
@@ -1,0 +1,32 @@
+{
+  "id": "GOBL-CL",
+  "package": "cl",
+  "subsets": [
+    {
+      "id": "GOBL-CL-TAX-IDENTITY",
+      "object": "tax.Identity",
+      "subsets": [
+        {
+          "guard": "code in [CL]",
+          "subsets": [
+            {
+              "field": "code",
+              "subsets": [
+                {
+                  "guard": "present",
+                  "assert": [
+                    {
+                      "id": "GOBL-CL-TAX-IDENTITY-01",
+                      "desc": "invalid Chilean RUT tax identity code",
+                      "tests": "valid"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/data/schemas/tax/regime-code.json
+++ b/data/schemas/tax/regime-code.json
@@ -34,6 +34,10 @@
           "title": "Switzerland"
         },
         {
+          "const": "CL",
+          "title": "Chile"
+        },
+        {
           "const": "CO",
           "title": "Colombia"
         },

--- a/examples/cl/invoice-cl-cl.yaml
+++ b/examples/cl/invoice-cl-cl.yaml
@@ -1,0 +1,37 @@
+$schema: "https://gobl.org/draft-0/bill/invoice"
+$regime: "CL"
+uuid: "3aea7b56-59d8-4beb-90bd-f8f280d852a0"
+currency: "CLP"
+issue_date: "2026-01-15"
+series: "CL"
+code: "001"
+
+supplier:
+  tax_id:
+    country: "CL"
+    code: "76.086.428-5"
+  name: "Proveedor Ejemplo SpA"
+  emails:
+    - addr: "facturacion@example.cl"
+  addresses:
+    - street: "Av. Libertador Bernardo O'Higgins 123"
+      locality: "Santiago"
+      region: "Metropolitana"
+      country: "CL"
+
+customer:
+  name: "Cliente Ejemplo Ltda."
+  tax_id:
+    country: "CL"
+    code: "12.531.909-2"
+  emails:
+    - addr: "compras@example.cl"
+
+lines:
+  - quantity: 1
+    item:
+      name: "Servicios profesionales"
+      price: "100000"
+    taxes:
+      - cat: "VAT"
+        rate: "general"

--- a/examples/cl/out/invoice-cl-cl.json
+++ b/examples/cl/out/invoice-cl-cl.json
@@ -1,0 +1,96 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
+		"dig": {
+			"alg": "sha256",
+			"val": "bc60f2e38c7315bc92e12c86fe7ad0d76606ee753d8f2e2b13f40b17c8c79d55"
+		}
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"$regime": "CL",
+		"uuid": "3aea7b56-59d8-4beb-90bd-f8f280d852a0",
+		"type": "standard",
+		"series": "CL",
+		"code": "001",
+		"issue_date": "2026-01-15",
+		"currency": "CLP",
+		"supplier": {
+			"name": "Proveedor Ejemplo SpA",
+			"tax_id": {
+				"country": "CL",
+				"code": "760864285"
+			},
+			"addresses": [
+				{
+					"street": "Av. Libertador Bernardo O'Higgins 123",
+					"locality": "Santiago",
+					"region": "Metropolitana",
+					"country": "CL"
+				}
+			],
+			"emails": [
+				{
+					"addr": "facturacion@example.cl"
+				}
+			]
+		},
+		"customer": {
+			"name": "Cliente Ejemplo Ltda.",
+			"tax_id": {
+				"country": "CL",
+				"code": "125319092"
+			},
+			"emails": [
+				{
+					"addr": "compras@example.cl"
+				}
+			]
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "1",
+				"item": {
+					"name": "Servicios profesionales",
+					"price": "100000"
+				},
+				"sum": "100000",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "general",
+						"percent": "19%"
+					}
+				],
+				"total": "100000"
+			}
+		],
+		"totals": {
+			"sum": "100000",
+			"total": "100000",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"base": "100000",
+								"percent": "19%",
+								"amount": "19000"
+							}
+						],
+						"amount": "19000"
+					}
+				],
+				"sum": "19000"
+			},
+			"tax": "19000",
+			"total_with_tax": "119000",
+			"payable": "119000"
+		}
+	}
+}

--- a/regimes/cl/cl.go
+++ b/regimes/cl/cl.go
@@ -1,0 +1,73 @@
+// Package cl provides the tax region definition for Chile.
+package cl
+
+import (
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/currency"
+	"github.com/invopop/gobl/i18n"
+	"github.com/invopop/gobl/norm"
+	"github.com/invopop/gobl/pkg/here"
+	"github.com/invopop/gobl/rules"
+	"github.com/invopop/gobl/tax"
+)
+
+// CountryCode is the tax country code for Chile.
+const CountryCode = "CL"
+
+func init() {
+	tax.RegisterRegimeDef(New())
+	rules.Register("cl", rules.GOBL.Add(CountryCode),
+		taxIdentityRules(),
+	)
+	norm.Register(
+		norm.When(tax.IdentityIn(CountryCode), norm.For(normalizeTaxIdentity)),
+	)
+}
+
+// New provides the tax region definition for Chile.
+func New() *tax.RegimeDef {
+	return &tax.RegimeDef{
+		Country:   CountryCode,
+		Currency:  currency.CLP,
+		TaxScheme: tax.CategoryVAT,
+		Name: i18n.String{
+			i18n.EN: "Chile",
+			i18n.ES: "Chile",
+		},
+		Description: i18n.String{
+			i18n.EN: here.Doc(`
+				Chile's tax system is administered by the Servicio de Impuestos Internos
+				(SII). IVA (Impuesto al Valor Agregado), Chile's value-added tax,
+				applies at the general rate defined in Decreto Ley 825.
+
+				Taxpayers are identified by their RUT (Rol Unico Tributario), which
+				includes a modulo-11 check digit. This regime normalizes and validates
+				RUT values when used as Chilean tax identities.
+
+				Electronic tax documents (Documentos Tributarios Electronicos, DTE)
+				include electronic invoices, credit notes, and debit notes. This regime
+				provides the core tax metadata and correction types needed by GOBL;
+				DTE XML generation, SII transmission, folio authorization, CAF, and
+				electronic stamps are format-specific concerns left for a future addon.
+			`),
+		},
+		Sources: []*cbc.Source{
+			{
+				Title: i18n.NewString("SII - Servicio de Impuestos Internos"),
+				URL:   "https://www.sii.cl/",
+			},
+		},
+		TimeZone: "America/Santiago",
+		Corrections: []*tax.CorrectionDefinition{
+			{
+				Schema: bill.ShortSchemaInvoice,
+				Types: []cbc.Key{
+					bill.InvoiceTypeCreditNote,
+					bill.InvoiceTypeDebitNote,
+				},
+			},
+		},
+		Categories: taxCategories,
+	}
+}

--- a/regimes/cl/cl_test.go
+++ b/regimes/cl/cl_test.go
@@ -1,0 +1,30 @@
+package cl_test
+
+import (
+	"testing"
+
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/currency"
+	"github.com/invopop/gobl/regimes/cl"
+	"github.com/invopop/gobl/tax"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNew(t *testing.T) {
+	t.Run("should create a new Chile regime", func(t *testing.T) {
+		regime := cl.New()
+		require.NotNil(t, regime)
+
+		assert.Equal(t, "CL", regime.Country.String())
+		assert.Equal(t, currency.CLP, regime.Currency)
+		assert.Equal(t, "America/Santiago", regime.TimeZone)
+		assert.Equal(t, tax.CategoryVAT, regime.TaxScheme)
+		assert.Equal(t, "Chile", regime.Name["en"])
+		assert.NotEmpty(t, regime.Sources)
+		require.Len(t, regime.Corrections, 1)
+		assert.Equal(t, bill.ShortSchemaInvoice, regime.Corrections[0].Schema)
+		assert.Contains(t, regime.Corrections[0].Types, bill.InvoiceTypeCreditNote)
+		assert.Contains(t, regime.Corrections[0].Types, bill.InvoiceTypeDebitNote)
+	})
+}

--- a/regimes/cl/tax_categories.go
+++ b/regimes/cl/tax_categories.go
@@ -1,0 +1,52 @@
+package cl
+
+import (
+	"github.com/invopop/gobl/cal"
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/i18n"
+	"github.com/invopop/gobl/num"
+	"github.com/invopop/gobl/tax"
+)
+
+var taxCategories = []*tax.CategoryDef{
+	//
+	// IVA (Impuesto al Valor Agregado)
+	//
+	{
+		Code: tax.CategoryVAT,
+		Name: i18n.String{
+			i18n.EN: "VAT",
+			i18n.ES: "IVA",
+		},
+		Title: i18n.String{
+			i18n.EN: "Value Added Tax",
+			i18n.ES: "Impuesto al Valor Agregado",
+		},
+		Retained: false,
+		Sources: []*cbc.Source{
+			{
+				Title: i18n.String{
+					i18n.EN: "VAT law - Article 14",
+				},
+				URL: "https://www.bcn.cl/leychile/navegar?idNorma=6369",
+			},
+		},
+		Keys: tax.GlobalVATKeys(),
+		Rates: []*tax.RateDef{
+			{
+				Keys: []cbc.Key{tax.KeyStandard},
+				Rate: tax.RateGeneral,
+				Name: i18n.String{
+					i18n.EN: "General Rate",
+					i18n.ES: "Tasa General",
+				},
+				Values: []*tax.RateValueDef{
+					{
+						Since:   cal.NewDate(2003, 10, 1),
+						Percent: num.MakePercentage(19, 2),
+					},
+				},
+			},
+		},
+	},
+}

--- a/regimes/cl/tax_identity.go
+++ b/regimes/cl/tax_identity.go
@@ -1,0 +1,87 @@
+package cl
+
+import (
+	"errors"
+
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/rules"
+	"github.com/invopop/gobl/rules/is"
+	"github.com/invopop/gobl/tax"
+)
+
+func taxIdentityRules() *rules.Set {
+	return rules.For(new(tax.Identity),
+		rules.When(tax.IdentityIn(CountryCode),
+			rules.Field("code",
+				rules.AssertIfPresent("01", "invalid Chilean RUT tax identity code",
+					is.Func("valid", isValidTaxIdentityCode),
+				),
+			),
+		),
+	)
+}
+
+func normalizeTaxIdentity(tID *tax.Identity) {
+	tax.NormalizeIdentity(tID)
+}
+
+func isValidTaxIdentityCode(value any) bool {
+	code, ok := value.(cbc.Code)
+	if !ok || code == "" {
+		return false
+	}
+	return validateTaxCode(code) == nil
+}
+
+func validateTaxCode(code cbc.Code) error {
+	if code == "" {
+		return nil
+	}
+
+	s := code.String()
+	if len(s) < 8 || len(s) > 9 {
+		return errors.New("invalid length")
+	}
+
+	body := s[:len(s)-1]
+	check := s[len(s)-1]
+	for _, c := range body {
+		if c < '0' || c > '9' {
+			return errors.New("body contains invalid characters")
+		}
+	}
+	if !isValidCheckDigit(check) {
+		return errors.New("invalid check digit")
+	}
+	if expectedRUTCheckDigit(body) != check {
+		return errors.New("checksum mismatch")
+	}
+
+	return nil
+}
+
+func isValidCheckDigit(c byte) bool {
+	return (c >= '0' && c <= '9') || c == 'K'
+}
+
+func expectedRUTCheckDigit(body string) byte {
+	sum := 0
+	factor := 2
+	for i := len(body) - 1; i >= 0; i-- {
+		sum += int(body[i]-'0') * factor
+		factor++
+		if factor > 7 {
+			factor = 2
+		}
+	}
+
+	value := 11 - (sum % 11)
+	switch value {
+	case 11:
+		return '0'
+	case 10:
+		return 'K'
+	default:
+		return byte('0' + value)
+	}
+}

--- a/regimes/cl/tax_identity.go
+++ b/regimes/cl/tax_identity.go
@@ -1,8 +1,6 @@
 package cl
 
 import (
-	"errors"
-
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/rules"
 	"github.com/invopop/gobl/rules/is"
@@ -13,8 +11,23 @@ func taxIdentityRules() *rules.Set {
 	return rules.For(new(tax.Identity),
 		rules.When(tax.IdentityIn(CountryCode),
 			rules.Field("code",
-				rules.AssertIfPresent("01", "invalid Chilean RUT tax identity code",
-					is.Func("valid", isValidTaxIdentityCode),
+				rules.AssertIfPresent("01", "invalid Chilean RUT tax identity code length",
+					is.Func("valid length", isValidTaxIdentityLength),
+				),
+				rules.When(is.Func("valid length", isValidTaxIdentityLength),
+					rules.AssertIfPresent("02", "Chilean RUT tax identity code body must be numeric",
+						is.Func("valid body", isValidTaxIdentityBody),
+					),
+					rules.When(is.Func("valid body", isValidTaxIdentityBody),
+						rules.AssertIfPresent("03", "invalid Chilean RUT tax identity check digit",
+							is.Func("valid check digit", isValidTaxIdentityCheckDigit),
+						),
+						rules.When(is.Func("valid check digit", isValidTaxIdentityCheckDigit),
+							rules.AssertIfPresent("04", "invalid Chilean RUT tax identity checksum",
+								is.Func("valid checksum", isValidTaxIdentityChecksum),
+							),
+						),
+					),
 				),
 			),
 		),
@@ -25,39 +38,56 @@ func normalizeTaxIdentity(tID *tax.Identity) {
 	tax.NormalizeIdentity(tID)
 }
 
-func isValidTaxIdentityCode(value any) bool {
+func isValidTaxIdentityLength(value any) bool {
 	code, ok := value.(cbc.Code)
 	if !ok || code == "" {
 		return false
 	}
-	return validateTaxCode(code) == nil
+	return isValidTaxCodeLength(code)
 }
 
-func validateTaxCode(code cbc.Code) error {
-	if code == "" {
-		return nil
+func isValidTaxIdentityBody(value any) bool {
+	code, ok := value.(cbc.Code)
+	if !ok || code == "" || !isValidTaxCodeLength(code) {
+		return false
 	}
 
 	s := code.String()
-	if len(s) < 8 || len(s) > 9 {
-		return errors.New("invalid length")
-	}
-
 	body := s[:len(s)-1]
-	check := s[len(s)-1]
 	for _, c := range body {
 		if c < '0' || c > '9' {
-			return errors.New("body contains invalid characters")
+			return false
 		}
 	}
-	if !isValidCheckDigit(check) {
-		return errors.New("invalid check digit")
-	}
-	if expectedRUTCheckDigit(body) != check {
-		return errors.New("checksum mismatch")
+
+	return true
+}
+
+func isValidTaxIdentityCheckDigit(value any) bool {
+	code, ok := value.(cbc.Code)
+	if !ok || code == "" || !isValidTaxCodeLength(code) || !isValidTaxIdentityBody(value) {
+		return false
 	}
 
-	return nil
+	s := code.String()
+	return isValidCheckDigit(s[len(s)-1])
+}
+
+func isValidTaxIdentityChecksum(value any) bool {
+	code, ok := value.(cbc.Code)
+	if !ok || code == "" || !isValidTaxCodeLength(code) || !isValidTaxIdentityBody(value) || !isValidTaxIdentityCheckDigit(value) {
+		return false
+	}
+
+	s := code.String()
+	body := s[:len(s)-1]
+	check := s[len(s)-1]
+	return expectedRUTCheckDigit(body) == check
+}
+
+func isValidTaxCodeLength(code cbc.Code) bool {
+	s := code.String()
+	return len(s) >= 8 && len(s) <= 9
 }
 
 func isValidCheckDigit(c byte) bool {

--- a/regimes/cl/tax_identity_test.go
+++ b/regimes/cl/tax_identity_test.go
@@ -63,21 +63,26 @@ func TestTaxIdentityRules(t *testing.T) {
 		{
 			name: "invalid checksum",
 			code: "125319093",
-			err:  "IDENTITY-01",
+			err:  "IDENTITY-04",
 		},
 		{
 			name: "invalid check digit character",
 			code: "12531909X",
-			err:  "IDENTITY-01",
+			err:  "IDENTITY-03",
 		},
 		{
 			name: "invalid body characters",
 			code: "12A319092",
+			err:  "IDENTITY-02",
+		},
+		{
+			name: "too short",
+			code: "1234567",
 			err:  "IDENTITY-01",
 		},
 		{
-			name: "invalid length",
-			code: "1234567",
+			name: "too long",
+			code: "1234567890",
 			err:  "IDENTITY-01",
 		},
 		{

--- a/regimes/cl/tax_identity_test.go
+++ b/regimes/cl/tax_identity_test.go
@@ -1,0 +1,99 @@
+package cl_test
+
+import (
+	"testing"
+
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/norm"
+	"github.com/invopop/gobl/rules"
+	"github.com/invopop/gobl/tax"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizeTaxIdentity(t *testing.T) {
+	tests := []struct {
+		code     cbc.Code
+		expected cbc.Code
+	}{
+		{
+			code:     "76.086.428-5",
+			expected: "760864285",
+		},
+		{
+			code:     "CL 12.531.909-2",
+			expected: "125319092",
+		},
+		{
+			code:     "1.000.005-k",
+			expected: "1000005K",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.code.String(), func(t *testing.T) {
+			tID := &tax.Identity{Country: "CL", Code: tt.code}
+			norm.Normalize(tID)
+			assert.Equal(t, tt.expected, tID.Code)
+		})
+	}
+}
+
+func TestTaxIdentityRules(t *testing.T) {
+	tests := []struct {
+		name string
+		code cbc.Code
+		err  string
+	}{
+		{
+			name: "valid numeric check digit 1",
+			code: "760864285",
+		},
+		{
+			name: "valid numeric check digit 2",
+			code: "125319092",
+		},
+		{
+			name: "valid zero check digit",
+			code: "10000130",
+		},
+		{
+			name: "valid K check digit",
+			code: "1000005K",
+		},
+		{
+			name: "invalid checksum",
+			code: "125319093",
+			err:  "IDENTITY-01",
+		},
+		{
+			name: "invalid check digit character",
+			code: "12531909X",
+			err:  "IDENTITY-01",
+		},
+		{
+			name: "invalid body characters",
+			code: "12A319092",
+			err:  "IDENTITY-01",
+		},
+		{
+			name: "invalid length",
+			code: "1234567",
+			err:  "IDENTITY-01",
+		},
+		{
+			name: "empty code is accepted",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tID := &tax.Identity{Country: "CL", Code: tt.code}
+			err := rules.Validate(tID)
+			if tt.err == "" {
+				assert.NoError(t, err)
+			} else if assert.Error(t, err) {
+				assert.Contains(t, err.Error(), tt.err)
+			}
+		})
+	}
+}

--- a/regimes/regimes.go
+++ b/regimes/regimes.go
@@ -12,6 +12,7 @@ import (
 	_ "github.com/invopop/gobl/regimes/br"
 	_ "github.com/invopop/gobl/regimes/ca"
 	_ "github.com/invopop/gobl/regimes/ch"
+	_ "github.com/invopop/gobl/regimes/cl"
 	_ "github.com/invopop/gobl/regimes/co"
 	_ "github.com/invopop/gobl/regimes/de"
 	_ "github.com/invopop/gobl/regimes/dk"


### PR DESCRIPTION
## Summary

Adds the initial Chile (`CL`) tax regime.

This PR focuses on core GOBL regime support for Chile: country metadata, IVA/VAT, RUT tax identity normalization and validation, invoice correction types, generated data, and a minimal example invoice.

Chile-specific SII/DTE behavior is deliberately left out of scope and would be better handled in a future addon.

## What's included

- `regimes/cl`: initial Chile regime package.
- Chile regime registration via `regimes/regimes.go`.
- Chile regime metadata:
  - `CL` country code
  - `CLP` currency
  - `America/Santiago` timezone
  - VAT as the tax scheme
- IVA (`VAT`) tax category:
  - 19% general rate
  - effective from 2003-10-01
  - sourced from Decreto Ley 825, Article 14, including the Ley 19.888 effective-date note
- Chilean RUT tax identity support:
  - normalization removes separators and optional `CL` prefix
  - lowercase `k` is normalized to `K`
  - validation checks length, numeric body, valid check digit character, and Chilean modulo-11 checksum
- Invoice correction types:
  - credit notes
  - debit notes
- Minimal Chile invoice example under `examples/cl/`.
- Generated regime, rules, schema, and example output data.
- CHANGELOG entry.

## Tests

Adds tests for:

- Chile regime metadata.
- RUT normalization.
- Valid RUTs with numeric, zero, and `K` check digits.
- Invalid RUT checksum.
- Invalid RUT characters.
- Invalid RUT length.
- Empty optional tax identity code behavior.
- Modulo-11 edge cases through public validation behavior.

Focused checks run locally:

```bash
go test ./regimes/cl/... -coverprofile=coverage
go tool cover -func=coverage
golangci-lint run ./regimes/cl/...
```

`go test ./regimes/cl/...` reports 94.7% coverage.

Generated data and example outputs were updated with:

```bash
go generate .
go test --update ./...
```

## Deliberately deferred to a future SII/DTE addon

These are real Chilean e-invoicing concerns, but they are format/platform-specific and do not belong in this initial regime layer:

- DTE XML generation/parsing
- SII transmission, certification, status checks, or API integration
- CAF, folios, TED, electronic stamps, or PDF417 behavior
- Chile-specific DTE document type mapping
- Additional/specific taxes, retentions, and sector-specific taxes
- Chile-specific invoice-level DTE validation rules
- Chile-specific rounding rules beyond existing GOBL/currency behavior

No Chile-specific scenario mappings are added in this initial PR.

## Sources

Official Chilean sources:

- BCN - Decreto Ley 825, Ley sobre Impuesto a las Ventas y Servicios  
  https://www.bcn.cl/leychile/navegar?idNorma=6369

- SII - Formato Documentos Tributarios Electronicos  
  https://www.sii.cl/factura_electronica/formato_dte.pdf

## Pre-Review Checklist

- [x] Opened this PR as a draft
- [x] Read the CONTRIBUTING.md guide.
- [x] Performed a self-review of my code.
- [x] Added thorough tests with at **least** 90% code coverage.
- [x] Modified or created example GOBL documents to show my changes in use, if appropriate.
- [x] Added links to the source of the changes in tax regimes or addons, either structured or in the comments.
- [x] Run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [x] Reviewed and fixed all linter warnings.
- [x] Been obsessive with pointer nil checks to avoid panics.
- [x] Updated the CHANGELOG.md with an overview of my changes.
- [x] Marked this PR as ready for review.

And if you are part of the org:
- [ ] Requested a review from Copilot and fixed or dismissed (with a reason) all the feedback raised.
- [ ] Requested a review from @samlown.
