### PR TITLE
Increase cbc.Code max length to 128

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Changed
+
+- `cbc.Code`: maximum length increased from 64 to 128 characters.
+
 ## [v0.502.1] - 2026-07-02
 
 ### Removed

--- a/cbc/code.go
+++ b/cbc/code.go
@@ -26,7 +26,7 @@ const (
 // systems and formats can be preserved as-is: normalization applies Unicode NFC,
 // removes control and other non-printable characters, and trims surrounding
 // whitespace (see NormalizeCode), while validation only requires that the code
-// be no longer than 64 characters and contain no control characters or leading
+// be no longer than 128 characters and contain no control characters or leading
 // or trailing whitespace.
 //
 // Fields that need a stricter, canonical format (letters, numbers, and single
@@ -46,7 +46,7 @@ var (
 	CodePattern              = `^[` + CodeDigits + `]+([` + CodeSeparators + `]?[` + CodeDigits + `]+)*$`
 	CodePatternRegexp        = regexp.MustCompile(CodePattern)
 	CodeMinLength     uint64 = 1
-	CodeMaxLength     uint64 = 64
+	CodeMaxLength     uint64 = 128
 
 	// CodePatternLenient is the default code validation pattern. It rejects
 	// leading or trailing whitespace and any control character (C0, DEL, and
@@ -218,7 +218,7 @@ func (Code) JSONSchema() *jsonschema.Schema {
 		MinLength: &CodeMinLength,
 		MaxLength: &CodeMaxLength,
 		Description: here.Doc(`
-			Text identifier with a limit of 64 characters, no control characters, and
+			Text identifier with a limit of 128 characters, no control characters, and
 			no leading or trailing whitespace.
 		`),
 	}

--- a/cbc/code_test.go
+++ b/cbc/code_test.go
@@ -423,7 +423,7 @@ func TestCode_Rules(t *testing.T) {
 		},
 		{
 			name: "almost too long",
-			code: cbc.Code("123456789012345678901234567890AB"),
+			code: cbc.Code("123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890ABCDEFGH"),
 		},
 		{
 			name: "dot at start",
@@ -471,7 +471,7 @@ func TestCode_Rules(t *testing.T) {
 		},
 		{
 			name:     "too long",
-			code:     cbc.Code("123456789012345678901234567890ABC123456789012345678901234567890ABC"),
+			code:     cbc.Code("123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890ABCDEFGHI"),
 			wantCode: "GOBL-CBC-CODE-01",
 		},
 	}
@@ -541,7 +541,7 @@ func TestCode_Validate(t *testing.T) {
 		},
 		{
 			name: "almost too long",
-			code: cbc.Code("123456789012345678901234567890AB"),
+			code: cbc.Code("123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890ABCDEFGH"),
 		},
 		{
 			name: "dot at start",
@@ -589,7 +589,7 @@ func TestCode_Validate(t *testing.T) {
 		},
 		{
 			name:    "too long",
-			code:    cbc.Code("123456789012345678901234567890ABC123456789012345678901234567890ABC"),
+			code:    cbc.Code("123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890ABCDEFGHI"),
 			wantErr: "codes must be no longer than",
 		},
 	}
@@ -749,7 +749,7 @@ func TestCodeJSONSchema(t *testing.T) {
 	assert.Equal(t, "string", s.Type)
 	assert.Equal(t, "Code", s.Title)
 	assert.Equal(t, uint64(1), *s.MinLength)
-	assert.Equal(t, uint64(64), *s.MaxLength)
+	assert.Equal(t, uint64(128), *s.MaxLength)
 }
 
 func TestCodeMapJSONSchemaExtend(t *testing.T) {

--- a/data/rules/cbc.json
+++ b/data/rules/cbc.json
@@ -8,8 +8,8 @@
       "assert": [
         {
           "id": "GOBL-CBC-CODE-01",
-          "desc": "codes must be no longer than 64 characters",
-          "tests": "length between 0 and 64"
+          "desc": "codes must be no longer than 128 characters",
+          "tests": "length between 0 and 128"
         },
         {
           "id": "GOBL-CBC-CODE-02",

--- a/data/schemas/cbc/code.json
+++ b/data/schemas/cbc/code.json
@@ -5,11 +5,11 @@
   "$defs": {
     "cbc.Code": {
       "type": "string",
-      "maxLength": 64,
+      "maxLength": 128,
       "minLength": 1,
       "pattern": "^[^\\s\\x00-\\x1f\\x7f-\\x9f]([^\\x00-\\x1f\\x7f-\\x9f]*[^\\s\\x00-\\x1f\\x7f-\\x9f])?$",
       "title": "Code",
-      "description": "Text identifier with a limit of 64 characters, no control characters, and\nno leading or trailing whitespace."
+      "description": "Text identifier with a limit of 128 characters, no control characters, and\nno leading or trailing whitespace."
     }
   }
 }


### PR DESCRIPTION
## Summary

Increases the `cbc.Code` maximum length limit from 64 to 128 characters. Some customers require codes longer than the previous limit.

## Changes

- `cbc/code.go`: `CodeMaxLength` bumped from 64 to 128, with doc comment and JSON schema description updated to match.
- `cbc/code_test.go`: boundary test cases ("almost too long" / "too long") updated to exercise the new 128-character limit.
- Regenerated `data/schemas/cbc/code.json` and `data/rules/cbc.json` via `go generate`.

## Testing

- `go test ./cbc/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)