### PR TITLE
Add Slovenia (SI) tax regime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Added
+
+- `si`: added the Slovenian (SI) tax regime.
+
 ## [v0.502.1] - 2026-07-02
 
 ### Removed

--- a/data/regimes/si.json
+++ b/data/regimes/si.json
@@ -1,0 +1,203 @@
+{
+  "$schema": "https://gobl.org/draft-0/tax/regime-def",
+  "name": {
+    "en": "Slovenia",
+    "sl": "Slovenija"
+  },
+  "description": {
+    "en": "Slovenia's tax system is administered by the Financial Administration\nof the Republic of Slovenia (FURS). As an EU member state, Slovenia\nfollows the EU VAT Directive with locally adapted rates.\n\nVAT (davek na dodano vrednost, DDV) applies at a standard rate with a\nreduced rate for specific goods and services such as food, medicines,\npassenger transport and accommodation, and a special reduced rate for\nbooks, newspapers and periodicals in force since 1 January 2020. The\nstandard rate rose from 20% to 22% on 1 July 2013.\n\nTaxpayers are identified by an eight-digit tax number (davčna\nštevilka) whose last digit is a modulo-11 check digit. The VAT\nidentification number is the same number prefixed with the SI\ncountry code (e.g. SI12345678).\n\nSlovenia supports credit notes for invoice corrections."
+  },
+  "sources": [
+    {
+      "title": {
+        "en": "FURS - Entry into the tax register and tax number"
+      },
+      "url": "https://www.fu.gov.si/en/taxes_and_other_duties/work_with_us/entry_into_the_tax_register_and_tax_number"
+    },
+    {
+      "title": {
+        "en": "SPOT - Invoicing"
+      },
+      "url": "https://spot.gov.si/en/info/accountancy/invoicing"
+    }
+  ],
+  "time_zone": "Europe/Ljubljana",
+  "country": "SI",
+  "currency": "EUR",
+  "tax_scheme": "VAT",
+  "identities": [
+    {
+      "code": "MATICNA",
+      "name": {
+        "en": "Registration Number",
+        "sl": "Matična številka"
+      },
+      "sources": [
+        {
+          "title": {
+            "en": "Uredba o vodenju in vzdrževanju Poslovnega registra Slovenije"
+          },
+          "url": "https://pisrs.si/Pis.web/pregledPredpisa?id=URED7599"
+        }
+      ]
+    }
+  ],
+  "scenarios": [
+    {
+      "schema": "bill/invoice",
+      "list": [
+        {
+          "tags": [
+            "reverse-charge"
+          ],
+          "cat": [
+            "VAT"
+          ],
+          "note": {
+            "cat": "VAT",
+            "key": "reverse-charge",
+            "text": "Reverse charge: Customer to account for VAT to the relevant tax authority."
+          }
+        }
+      ]
+    }
+  ],
+  "corrections": [
+    {
+      "schema": "bill/invoice",
+      "types": [
+        "credit-note"
+      ]
+    }
+  ],
+  "categories": [
+    {
+      "code": "VAT",
+      "name": {
+        "en": "VAT",
+        "sl": "DDV"
+      },
+      "title": {
+        "en": "Value Added Tax",
+        "sl": "Davek na dodano vrednost"
+      },
+      "keys": [
+        {
+          "key": "standard",
+          "name": {
+            "en": "Standard"
+          }
+        },
+        {
+          "key": "zero",
+          "name": {
+            "en": "Zero"
+          }
+        },
+        {
+          "key": "reverse-charge",
+          "name": {
+            "en": "Reverse charge"
+          },
+          "no_percent": true
+        },
+        {
+          "key": "exempt",
+          "name": {
+            "en": "Exempt"
+          },
+          "no_percent": true
+        },
+        {
+          "key": "export",
+          "name": {
+            "en": "Export"
+          },
+          "no_percent": true
+        },
+        {
+          "key": "intra-community",
+          "name": {
+            "en": "Intra-community"
+          },
+          "no_percent": true
+        },
+        {
+          "key": "outside-scope",
+          "name": {
+            "en": "Outside scope"
+          },
+          "no_percent": true
+        }
+      ],
+      "rates": [
+        {
+          "rate": "general",
+          "keys": [
+            "standard"
+          ],
+          "name": {
+            "en": "Standard Rate",
+            "sl": "Splošna stopnja"
+          },
+          "values": [
+            {
+              "since": "2013-07-01",
+              "percent": "22.0%"
+            },
+            {
+              "since": "2002-01-01",
+              "percent": "20.0%"
+            }
+          ]
+        },
+        {
+          "rate": "reduced",
+          "keys": [
+            "standard"
+          ],
+          "name": {
+            "en": "Reduced Rate",
+            "sl": "Nižja stopnja"
+          },
+          "values": [
+            {
+              "percent": "9.5%"
+            }
+          ]
+        },
+        {
+          "rate": "super-reduced",
+          "keys": [
+            "standard"
+          ],
+          "name": {
+            "en": "Special Reduced Rate for Publications",
+            "sl": "Posebna nižja stopnja"
+          },
+          "values": [
+            {
+              "percent": "5.0%"
+            }
+          ]
+        }
+      ],
+      "sources": [
+        {
+          "title": {
+            "en": "Financial Administration of the Republic of Slovenia (FURS) - VAT"
+          },
+          "url": "https://www.fu.gov.si/en/taxes_and_other_duties/areas_of_work/value_added_tax_vat",
+          "at": "2026-07-03T00:00:00"
+        },
+        {
+          "title": {
+            "en": "European Commission - VAT rates applied in the Member States of the European Union"
+          },
+          "url": "https://taxation-customs.ec.europa.eu/system/files/2021-06/vat_rates_en.pdf",
+          "at": "2026-07-03T00:00:00"
+        }
+      ]
+    }
+  ]
+}

--- a/data/regimes/si.json
+++ b/data/regimes/si.json
@@ -5,7 +5,7 @@
     "sl": "Slovenija"
   },
   "description": {
-    "en": "Slovenia's tax system is administered by the Financial Administration\nof the Republic of Slovenia (FURS). As an EU member state, Slovenia\nfollows the EU VAT Directive with locally adapted rates.\n\nVAT (davek na dodano vrednost, DDV) applies at a standard rate with a\nreduced rate for specific goods and services such as food, medicines,\npassenger transport and accommodation, and a special reduced rate for\nbooks, newspapers and periodicals in force since 1 January 2020. The\nstandard rate rose from 20% to 22% on 1 July 2013.\n\nTaxpayers are identified by an eight-digit tax number (davčna\nštevilka) whose last digit is a modulo-11 check digit. The VAT\nidentification number is the same number prefixed with the SI\ncountry code (e.g. SI12345678).\n\nSlovenia supports credit notes for invoice corrections."
+    "en": "Slovenia's tax system is administered by the Financial Administration\nof the Republic of Slovenia (FURS). As an EU member state, Slovenia\nfollows the EU VAT Directive with locally adapted rates.\n\nVAT (davek na dodano vrednost, DDV) applies at a standard rate with a\nreduced rate for specific goods and services such as food, medicines,\npassenger transport and accommodation, and a special reduced rate for\nbooks, newspapers and periodicals in force since 1 January 2020. The\nstandard rate rose from 20% to 22% on 1 July 2013.\n\nTaxpayers are identified by an eight-digit tax number (davčna\nštevilka) whose last digit is a modulo-11 check digit. The VAT\nidentification number is the same number prefixed with the SI\ncountry code (e.g. SI12345678).\n\nCompanies are additionally identified in the Slovenian Business\nRegister (Poslovni register Slovenije) by a ten-digit\nregistration number (matična številka), also protected by a\nmodulo-11 check digit.\n\nSlovenia supports credit notes for invoice corrections."
   },
   "sources": [
     {
@@ -27,7 +27,7 @@
   "tax_scheme": "VAT",
   "identities": [
     {
-      "code": "MATICNA",
+      "code": "MŠ",
       "name": {
         "en": "Registration Number",
         "sl": "Matična številka"
@@ -35,7 +35,8 @@
       "sources": [
         {
           "title": {
-            "en": "Uredba o vodenju in vzdrževanju Poslovnega registra Slovenije"
+            "en": "Decree on the keeping and maintenance of the Slovenian Business Register",
+            "sl": "Uredba o vodenju in vzdrževanju Poslovnega registra Slovenije"
           },
           "url": "https://pisrs.si/Pis.web/pregledPredpisa?id=URED7599"
         }

--- a/data/rules/si.json
+++ b/data/rules/si.json
@@ -11,11 +11,28 @@
           "subsets": [
             {
               "field": "supplier",
-              "assert": [
+              "subsets": [
                 {
-                  "id": "GOBL-SI-BILL-INVOICE-01",
-                  "desc": "invoice SI supplier must have a tax ID code",
-                  "tests": "has tax ID code"
+                  "field": "tax_id",
+                  "assert": [
+                    {
+                      "id": "GOBL-SI-BILL-INVOICE-01",
+                      "desc": "invoice SI supplier must have a tax ID",
+                      "tests": "present"
+                    }
+                  ],
+                  "subsets": [
+                    {
+                      "field": "code",
+                      "assert": [
+                        {
+                          "id": "GOBL-SI-BILL-INVOICE-02",
+                          "desc": "invoice SI supplier tax ID must have a code",
+                          "tests": "present"
+                        }
+                      ]
+                    }
+                  ]
                 }
               ]
             }
@@ -31,15 +48,37 @@
           "guard": "context: regime in [SI]",
           "subsets": [
             {
-              "guard": "type in [MATICNA]",
+              "guard": "type in [MŠ]",
               "subsets": [
                 {
                   "field": "code",
                   "assert": [
                     {
                       "id": "GOBL-SI-ORG-IDENTITY-01",
-                      "desc": "identity code for type MATICNA must be valid",
-                      "tests": "valid"
+                      "desc": "Slovenian registration number is required",
+                      "tests": "present"
+                    }
+                  ],
+                  "subsets": [
+                    {
+                      "guard": "present",
+                      "assert": [
+                        {
+                          "id": "GOBL-SI-ORG-IDENTITY-02",
+                          "desc": "invalid Slovenian registration number format",
+                          "tests": "matches ^\\d{10}$"
+                        }
+                      ]
+                    },
+                    {
+                      "guard": "present",
+                      "assert": [
+                        {
+                          "id": "GOBL-SI-ORG-IDENTITY-03",
+                          "desc": "invalid Slovenian registration number check digit",
+                          "tests": "checksum"
+                        }
+                      ]
                     }
                   ]
                 }
@@ -64,8 +103,18 @@
                   "assert": [
                     {
                       "id": "GOBL-SI-TAX-IDENTITY-01",
-                      "desc": "invalid Slovenian VAT identity code",
-                      "tests": "valid"
+                      "desc": "invalid Slovenian VAT identity format",
+                      "tests": "matches ^[1-9]\\d{7}$"
+                    }
+                  ]
+                },
+                {
+                  "guard": "present",
+                  "assert": [
+                    {
+                      "id": "GOBL-SI-TAX-IDENTITY-02",
+                      "desc": "invalid Slovenian VAT identity check digit",
+                      "tests": "checksum"
                     }
                   ]
                 }

--- a/data/rules/si.json
+++ b/data/rules/si.json
@@ -1,0 +1,79 @@
+{
+  "id": "GOBL-SI",
+  "package": "si",
+  "subsets": [
+    {
+      "id": "GOBL-SI-BILL-INVOICE",
+      "object": "bill.Invoice",
+      "subsets": [
+        {
+          "guard": "context: regime in [SI]",
+          "subsets": [
+            {
+              "field": "supplier",
+              "assert": [
+                {
+                  "id": "GOBL-SI-BILL-INVOICE-01",
+                  "desc": "invoice SI supplier must have a tax ID code",
+                  "tests": "has tax ID code"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "GOBL-SI-ORG-IDENTITY",
+      "object": "org.Identity",
+      "subsets": [
+        {
+          "guard": "context: regime in [SI]",
+          "subsets": [
+            {
+              "guard": "type in [MATICNA]",
+              "subsets": [
+                {
+                  "field": "code",
+                  "assert": [
+                    {
+                      "id": "GOBL-SI-ORG-IDENTITY-01",
+                      "desc": "identity code for type MATICNA must be valid",
+                      "tests": "valid"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "GOBL-SI-TAX-IDENTITY",
+      "object": "tax.Identity",
+      "subsets": [
+        {
+          "guard": "code in [SI]",
+          "subsets": [
+            {
+              "field": "code",
+              "subsets": [
+                {
+                  "guard": "present",
+                  "assert": [
+                    {
+                      "id": "GOBL-SI-TAX-IDENTITY-01",
+                      "desc": "invalid Slovenian VAT identity code",
+                      "tests": "valid"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/data/schemas/tax/regime-code.json
+++ b/data/schemas/tax/regime-code.json
@@ -110,6 +110,10 @@
           "title": "Singapore"
         },
         {
+          "const": "SI",
+          "title": "Slovenia"
+        },
+        {
           "const": "US",
           "title": "United States of America"
         }

--- a/examples/si/invoice-si-si.yaml
+++ b/examples/si/invoice-si-si.yaml
@@ -1,0 +1,48 @@
+$schema: "https://gobl.org/draft-0/bill/invoice"
+uuid: "5b1e9c7a-2d4f-4a8b-9c3e-6f7a8b9c0d1e"
+series: "SAMPLE"
+code: "001"
+issue_date: "2026-03-01"
+
+supplier:
+  name: "Primer d.o.o."
+  tax_id:
+    country: "SI"
+    code: "12345679"
+  addresses:
+    - num: "10"
+      street: "Slovenska cesta"
+      locality: "Ljubljana"
+      code: "1000"
+      country: "SI"
+  emails:
+    - addr: "billing@example.si"
+
+customer:
+  name: "Stranka d.o.o."
+  tax_id:
+    country: "SI"
+    code: "87654326"
+  addresses:
+    - num: "5"
+      street: "Dunajska cesta"
+      locality: "Ljubljana"
+      code: "1000"
+      country: "SI"
+
+lines:
+  - quantity: "10"
+    item:
+      name: "Software development services"
+      price: "120.00"
+      unit: "h"
+    taxes:
+      - cat: VAT
+        rate: "standard"
+  - quantity: "5"
+    item:
+      name: "Printed book"
+      price: "20.00"
+    taxes:
+      - cat: VAT
+        rate: "super-reduced"

--- a/examples/si/out/invoice-si-si.json
+++ b/examples/si/out/invoice-si-si.json
@@ -1,0 +1,126 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
+		"dig": {
+			"alg": "sha256",
+			"val": "4bba7b8cea83a24866df33fa0bcf624672df504b595f552370bc9ba9f519c8ba"
+		}
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"$regime": "SI",
+		"uuid": "5b1e9c7a-2d4f-4a8b-9c3e-6f7a8b9c0d1e",
+		"type": "standard",
+		"series": "SAMPLE",
+		"code": "001",
+		"issue_date": "2026-03-01",
+		"currency": "EUR",
+		"supplier": {
+			"name": "Primer d.o.o.",
+			"tax_id": {
+				"country": "SI",
+				"code": "12345679"
+			},
+			"addresses": [
+				{
+					"num": "10",
+					"street": "Slovenska cesta",
+					"locality": "Ljubljana",
+					"code": "1000",
+					"country": "SI"
+				}
+			],
+			"emails": [
+				{
+					"addr": "billing@example.si"
+				}
+			]
+		},
+		"customer": {
+			"name": "Stranka d.o.o.",
+			"tax_id": {
+				"country": "SI",
+				"code": "87654326"
+			},
+			"addresses": [
+				{
+					"num": "5",
+					"street": "Dunajska cesta",
+					"locality": "Ljubljana",
+					"code": "1000",
+					"country": "SI"
+				}
+			]
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "10",
+				"item": {
+					"name": "Software development services",
+					"price": "120.00",
+					"unit": "h"
+				},
+				"sum": "1200.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "general",
+						"percent": "22.0%"
+					}
+				],
+				"total": "1200.00"
+			},
+			{
+				"i": 2,
+				"quantity": "5",
+				"item": {
+					"name": "Printed book",
+					"price": "20.00"
+				},
+				"sum": "100.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "super-reduced",
+						"percent": "5.0%"
+					}
+				],
+				"total": "100.00"
+			}
+		],
+		"totals": {
+			"sum": "1300.00",
+			"total": "1300.00",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"base": "1200.00",
+								"percent": "22.0%",
+								"amount": "264.00"
+							},
+							{
+								"key": "standard",
+								"base": "100.00",
+								"percent": "5.0%",
+								"amount": "5.00"
+							}
+						],
+						"amount": "269.00"
+					}
+				],
+				"sum": "269.00"
+			},
+			"tax": "269.00",
+			"total_with_tax": "1569.00",
+			"payable": "1569.00"
+		}
+	}
+}

--- a/regimes/regimes.go
+++ b/regimes/regimes.go
@@ -31,5 +31,6 @@ import (
 	_ "github.com/invopop/gobl/regimes/sa"
 	_ "github.com/invopop/gobl/regimes/se"
 	_ "github.com/invopop/gobl/regimes/sg"
+	_ "github.com/invopop/gobl/regimes/si"
 	_ "github.com/invopop/gobl/regimes/us"
 )

--- a/regimes/si/bill_invoices.go
+++ b/regimes/si/bill_invoices.go
@@ -2,7 +2,6 @@ package si
 
 import (
 	"github.com/invopop/gobl/bill"
-	"github.com/invopop/gobl/org"
 	"github.com/invopop/gobl/rules"
 	"github.com/invopop/gobl/rules/is"
 	"github.com/invopop/gobl/tax"
@@ -17,15 +16,13 @@ func billInvoiceRules() *rules.Set {
 		rules.When(
 			is.InContext(tax.RegimeIn(CountryCode)),
 			rules.Field("supplier",
-				rules.Assert("01", "invoice SI supplier must have a tax ID code",
-					is.Func("has tax ID code", hasSupplierTaxIDCode),
+				rules.Field("tax_id",
+					rules.Assert("01", "invoice SI supplier must have a tax ID", is.Present),
+					rules.Field("code",
+						rules.Assert("02", "invoice SI supplier tax ID must have a code", is.Present),
+					),
 				),
 			),
 		),
 	)
-}
-
-func hasSupplierTaxIDCode(value any) bool {
-	party, _ := value.(*org.Party)
-	return party != nil && party.TaxID != nil && party.TaxID.Code != ""
 }

--- a/regimes/si/bill_invoices.go
+++ b/regimes/si/bill_invoices.go
@@ -1,0 +1,31 @@
+package si
+
+import (
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/org"
+	"github.com/invopop/gobl/rules"
+	"github.com/invopop/gobl/rules/is"
+	"github.com/invopop/gobl/tax"
+)
+
+// Article 82 of the Slovenian VAT Act (ZDDV-1) requires invoices to state
+// the VAT identification number under which the taxable person supplied
+// the goods or services.
+// Source: https://spot.gov.si/en/info/accountancy/invoicing
+func billInvoiceRules() *rules.Set {
+	return rules.For(new(bill.Invoice),
+		rules.When(
+			is.InContext(tax.RegimeIn(CountryCode)),
+			rules.Field("supplier",
+				rules.Assert("01", "invoice SI supplier must have a tax ID code",
+					is.Func("has tax ID code", hasSupplierTaxIDCode),
+				),
+			),
+		),
+	)
+}
+
+func hasSupplierTaxIDCode(value any) bool {
+	party, _ := value.(*org.Party)
+	return party != nil && party.TaxID != nil && party.TaxID.Code != ""
+}

--- a/regimes/si/bill_invoices_test.go
+++ b/regimes/si/bill_invoices_test.go
@@ -62,7 +62,7 @@ func TestInvoiceValidation(t *testing.T) {
 		inv := validInvoice()
 		inv.Supplier.TaxID.Code = ""
 		require.NoError(t, inv.Calculate())
-		assert.ErrorContains(t, rules.Validate(inv), "[GOBL-SI-BILL-INVOICE-01] ($.supplier) invoice SI supplier must have a tax ID code")
+		assert.ErrorContains(t, rules.Validate(inv), "[GOBL-SI-BILL-INVOICE-02] ($.supplier.tax_id.code) invoice SI supplier tax ID must have a code")
 	})
 
 	t.Run("supplier with nil tax ID", func(t *testing.T) {

--- a/regimes/si/bill_invoices_test.go
+++ b/regimes/si/bill_invoices_test.go
@@ -1,0 +1,90 @@
+package si_test
+
+import (
+	"testing"
+
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/num"
+	"github.com/invopop/gobl/org"
+	"github.com/invopop/gobl/regimes/si"
+	"github.com/invopop/gobl/rules"
+	"github.com/invopop/gobl/tax"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func validInvoice() *bill.Invoice {
+	return &bill.Invoice{
+		Regime: tax.WithRegime("SI"),
+		Series: "TEST",
+		Code:   "0002",
+		Supplier: &org.Party{
+			Name: "Test Supplier",
+			TaxID: &tax.Identity{
+				Country: "SI",
+				Code:    "82646716",
+			},
+		},
+		Customer: &org.Party{
+			Name: "Test Customer",
+			TaxID: &tax.Identity{
+				Country: "SI",
+				Code:    "12345679",
+			},
+		},
+		Lines: []*bill.Line{
+			{
+				Quantity: num.MakeAmount(1, 0),
+				Item: &org.Item{
+					Name:  "bogus",
+					Price: num.NewAmount(10000, 2),
+					Unit:  org.UnitPackage,
+				},
+				Taxes: tax.Set{
+					{
+						Category: "VAT",
+						Rate:     "general",
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestInvoiceValidation(t *testing.T) {
+	t.Run("valid invoice with tax ID", func(t *testing.T) {
+		inv := validInvoice()
+		require.NoError(t, inv.Calculate())
+		assert.NoError(t, rules.Validate(inv))
+	})
+
+	t.Run("missing supplier tax ID code", func(t *testing.T) {
+		inv := validInvoice()
+		inv.Supplier.TaxID.Code = ""
+		require.NoError(t, inv.Calculate())
+		assert.ErrorContains(t, rules.Validate(inv), "[GOBL-SI-BILL-INVOICE-01] ($.supplier) invoice SI supplier must have a tax ID code")
+	})
+
+	t.Run("supplier with nil tax ID", func(t *testing.T) {
+		inv := validInvoice()
+		inv.Supplier.TaxID = nil
+		require.NoError(t, inv.Calculate())
+		assert.ErrorContains(t, rules.Validate(inv), "GOBL-SI-BILL-INVOICE-01")
+	})
+
+	t.Run("supplier with registration number but no tax ID", func(t *testing.T) {
+		// A valid registration number (matična številka) is not a
+		// substitute for the VAT number: the invoice must still be
+		// rejected when the supplier has no tax ID code.
+		inv := validInvoice()
+		inv.Supplier.TaxID = nil
+		inv.Supplier.Identities = []*org.Identity{
+			{
+				Type: si.IdentityTypeMaticna,
+				Code: "5043611000",
+			},
+		}
+		require.NoError(t, inv.Calculate())
+		assert.ErrorContains(t, rules.Validate(inv), "GOBL-SI-BILL-INVOICE-01")
+	})
+}

--- a/regimes/si/org_identities.go
+++ b/regimes/si/org_identities.go
@@ -13,13 +13,13 @@ const (
 	// IdentityTypeMaticna represents the Slovenian registration number
 	// (matična številka) assigned by AJPES to every entity entered in
 	// the Slovenian Business Register (e.g. "5043611000").
-	IdentityTypeMaticna cbc.Code = "MATICNA"
+	IdentityTypeMaticna cbc.Code = "MŠ"
 )
 
-// registrationNumberLen is the length of a registration number: six
-// digits, a modulo-11 check digit, and a three-digit suffix identifying
-// the business unit ("000" for the head office).
-const registrationNumberLen = 10
+// registrationNumberPattern matches a registration number (matična
+// številka): six base digits, a modulo-11 check digit, and a three-digit
+// suffix identifying the business unit ("000" for the head office).
+const registrationNumberPattern = `^\d{10}$`
 
 // registrationNumberMultipliers are the weights applied to the first six
 // digits of the registration number to calculate the check digit.
@@ -38,8 +38,11 @@ var identityDefinitions = []*cbc.Definition{
 		},
 		Sources: []*cbc.Source{
 			{
-				Title: i18n.NewString("Uredba o vodenju in vzdrževanju Poslovnega registra Slovenije"),
-				URL:   "https://pisrs.si/Pis.web/pregledPredpisa?id=URED7599",
+				Title: i18n.String{
+					i18n.EN: "Decree on the keeping and maintenance of the Slovenian Business Register",
+					i18n.SL: "Uredba o vodenju in vzdrževanju Poslovnega registra Slovenije",
+				},
+				URL: "https://pisrs.si/Pis.web/pregledPredpisa?id=URED7599",
 			},
 		},
 	},
@@ -52,8 +55,14 @@ func orgIdentityRules() *rules.Set {
 			rules.When(
 				org.IdentityTypeIn(IdentityTypeMaticna),
 				rules.Field("code",
-					rules.Assert("01", "identity code for type MATICNA must be valid",
-						is.Func("valid", isValidRegistrationNumber),
+					rules.Assert("01", "Slovenian registration number is required",
+						is.Present,
+					),
+					rules.AssertIfPresent("02", "invalid Slovenian registration number format",
+						is.Matches(registrationNumberPattern),
+					),
+					rules.AssertIfPresent("03", "invalid Slovenian registration number check digit",
+						is.StringFunc("checksum", registrationNumberChecksumValid),
 					),
 				),
 			),
@@ -61,19 +70,14 @@ func orgIdentityRules() *rules.Set {
 	)
 }
 
-// isValidRegistrationNumber expects a registration number in its full
-// ten-digit form and validates the modulo-11 check digit that follows
-// the six base digits. The business unit suffix carries no checksum of
-// its own.
-func isValidRegistrationNumber(value any) bool {
-	code, ok := value.(cbc.Code)
-	if !ok || len(code) != registrationNumberLen {
+// registrationNumberChecksumValid reports whether the registration number's
+// seventh digit is a valid modulo-11 check digit of the first six. The
+// three-digit business-unit suffix carries no checksum of its own and is
+// only validated for being numeric by the format rule. It guards its length
+// so it is safe to call before the format rule has run.
+func registrationNumberChecksumValid(code string) bool {
+	if len(code) < 7 {
 		return false
 	}
-	for i := 7; i < registrationNumberLen; i++ {
-		if code[i] < '0' || code[i] > '9' {
-			return false
-		}
-	}
-	return validateMod11(code[:7], registrationNumberMultipliers) == nil
+	return validMod11(code[:7], registrationNumberMultipliers)
 }

--- a/regimes/si/org_identities.go
+++ b/regimes/si/org_identities.go
@@ -1,0 +1,79 @@
+package si
+
+import (
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/i18n"
+	"github.com/invopop/gobl/org"
+	"github.com/invopop/gobl/rules"
+	"github.com/invopop/gobl/rules/is"
+	"github.com/invopop/gobl/tax"
+)
+
+const (
+	// IdentityTypeMaticna represents the Slovenian registration number
+	// (matična številka) assigned by AJPES to every entity entered in
+	// the Slovenian Business Register (e.g. "5043611000").
+	IdentityTypeMaticna cbc.Code = "MATICNA"
+)
+
+// registrationNumberLen is the length of a registration number: six
+// digits, a modulo-11 check digit, and a three-digit suffix identifying
+// the business unit ("000" for the head office).
+const registrationNumberLen = 10
+
+// registrationNumberMultipliers are the weights applied to the first six
+// digits of the registration number to calculate the check digit.
+//
+// Algorithm source: Article 11 of the Slovenian Business Register decree
+// (Uredba o vodenju in vzdrževanju Poslovnega registra Slovenije).
+// https://pisrs.si/Pis.web/pregledPredpisa?id=URED7599
+var registrationNumberMultipliers = []int{7, 6, 5, 4, 3, 2}
+
+var identityDefinitions = []*cbc.Definition{
+	{
+		Code: IdentityTypeMaticna,
+		Name: i18n.String{
+			i18n.EN: "Registration Number",
+			i18n.SL: "Matična številka",
+		},
+		Sources: []*cbc.Source{
+			{
+				Title: i18n.NewString("Uredba o vodenju in vzdrževanju Poslovnega registra Slovenije"),
+				URL:   "https://pisrs.si/Pis.web/pregledPredpisa?id=URED7599",
+			},
+		},
+	},
+}
+
+func orgIdentityRules() *rules.Set {
+	return rules.For(new(org.Identity),
+		rules.When(
+			is.InContext(tax.RegimeIn(CountryCode)),
+			rules.When(
+				org.IdentityTypeIn(IdentityTypeMaticna),
+				rules.Field("code",
+					rules.Assert("01", "identity code for type MATICNA must be valid",
+						is.Func("valid", isValidRegistrationNumber),
+					),
+				),
+			),
+		),
+	)
+}
+
+// isValidRegistrationNumber expects a registration number in its full
+// ten-digit form and validates the modulo-11 check digit that follows
+// the six base digits. The business unit suffix carries no checksum of
+// its own.
+func isValidRegistrationNumber(value any) bool {
+	code, ok := value.(cbc.Code)
+	if !ok || len(code) != registrationNumberLen {
+		return false
+	}
+	for i := 7; i < registrationNumberLen; i++ {
+		if code[i] < '0' || code[i] > '9' {
+			return false
+		}
+	}
+	return validateMod11(code[:7], registrationNumberMultipliers) == nil
+}

--- a/regimes/si/org_identities_test.go
+++ b/regimes/si/org_identities_test.go
@@ -45,7 +45,7 @@ func TestValidateOrgIdentity(t *testing.T) {
 				Type: si.IdentityTypeMaticna,
 				Code: "5043611",
 			},
-			err: "ORG-IDENTITY-01",
+			err: "ORG-IDENTITY-02",
 		},
 		{
 			name: "non numeric suffix",
@@ -53,7 +53,7 @@ func TestValidateOrgIdentity(t *testing.T) {
 				Type: si.IdentityTypeMaticna,
 				Code: "1234579A00",
 			},
-			err: "ORG-IDENTITY-01",
+			err: "ORG-IDENTITY-02",
 		},
 		{
 			name: "checksum mismatch",
@@ -61,7 +61,7 @@ func TestValidateOrgIdentity(t *testing.T) {
 				Type: si.IdentityTypeMaticna,
 				Code: "1234571000",
 			},
-			err: "ORG-IDENTITY-01",
+			err: "ORG-IDENTITY-03",
 		},
 		{
 			// The weighted sum leaves a remainder of 0, which is never
@@ -71,7 +71,7 @@ func TestValidateOrgIdentity(t *testing.T) {
 				Type: si.IdentityTypeMaticna,
 				Code: "1234567000",
 			},
-			err: "ORG-IDENTITY-01",
+			err: "ORG-IDENTITY-03",
 		},
 		{
 			name: "empty code",

--- a/regimes/si/org_identities_test.go
+++ b/regimes/si/org_identities_test.go
@@ -1,0 +1,108 @@
+package si_test
+
+import (
+	"testing"
+
+	"github.com/invopop/gobl/org"
+	"github.com/invopop/gobl/regimes/si"
+	"github.com/invopop/gobl/rules"
+	"github.com/invopop/gobl/tax"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateOrgIdentity(t *testing.T) {
+	tests := []struct {
+		name     string
+		identity *org.Identity
+		err      string
+	}{
+		{
+			// Krka d.d., Novo mesto's publicly listed registration number.
+			name: "valid",
+			identity: &org.Identity{
+				Type: si.IdentityTypeMaticna,
+				Code: "5043611000",
+			},
+		},
+		{
+			name: "valid 2",
+			identity: &org.Identity{
+				Type: si.IdentityTypeMaticna,
+				Code: "1234579000",
+			},
+		},
+		{
+			// Weighted sum leaves a remainder of 1, so the check digit is 0.
+			name: "valid with zero check digit",
+			identity: &org.Identity{
+				Type: si.IdentityTypeMaticna,
+				Code: "1234510000",
+			},
+		},
+		{
+			name: "too short",
+			identity: &org.Identity{
+				Type: si.IdentityTypeMaticna,
+				Code: "5043611",
+			},
+			err: "ORG-IDENTITY-01",
+		},
+		{
+			name: "non numeric suffix",
+			identity: &org.Identity{
+				Type: si.IdentityTypeMaticna,
+				Code: "1234579A00",
+			},
+			err: "ORG-IDENTITY-01",
+		},
+		{
+			name: "checksum mismatch",
+			identity: &org.Identity{
+				Type: si.IdentityTypeMaticna,
+				Code: "1234571000",
+			},
+			err: "ORG-IDENTITY-01",
+		},
+		{
+			// The weighted sum leaves a remainder of 0, which is never
+			// assigned: no valid registration number produces it.
+			name: "remainder zero",
+			identity: &org.Identity{
+				Type: si.IdentityTypeMaticna,
+				Code: "1234567000",
+			},
+			err: "ORG-IDENTITY-01",
+		},
+		{
+			name: "empty code",
+			identity: &org.Identity{
+				Type: si.IdentityTypeMaticna,
+				Code: "",
+			},
+			err: "ORG-IDENTITY-01",
+		},
+		{
+			name: "other identity type",
+			identity: &org.Identity{
+				Type: "OTHER",
+				Code: "not checked",
+			},
+		},
+	}
+
+	opts := []rules.WithContext{
+		tax.RegimeContext(si.CountryCode),
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := rules.Validate(tt.identity, opts...)
+			if tt.err == "" {
+				assert.NoError(t, err)
+			} else {
+				if assert.Error(t, err) {
+					assert.Contains(t, err.Error(), tt.err)
+				}
+			}
+		})
+	}
+}

--- a/regimes/si/si.go
+++ b/regimes/si/si.go
@@ -1,0 +1,93 @@
+// Package si provides the tax region definition for Slovenia.
+package si
+
+import (
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/currency"
+	"github.com/invopop/gobl/i18n"
+	"github.com/invopop/gobl/norm"
+	"github.com/invopop/gobl/pkg/here"
+	"github.com/invopop/gobl/rules"
+	"github.com/invopop/gobl/tax"
+)
+
+// CountryCode is the tax country code for Slovenia.
+const CountryCode = "SI"
+
+// init registers the Slovenian regime, its validation rules and its
+// normalization with GOBL so that they become available as soon as this
+// package is imported.
+func init() {
+	tax.RegisterRegimeDef(New())
+	rules.Register("si", rules.GOBL.Add(CountryCode),
+		billInvoiceRules(),
+		orgIdentityRules(),
+		taxIdentityRules(),
+	)
+	norm.Register(
+		norm.When(tax.IdentityIn(CountryCode), norm.For(func(id *tax.Identity) { tax.NormalizeIdentity(id) })),
+	)
+}
+
+// New provides the tax region definition for Slovenia.
+func New() *tax.RegimeDef {
+	return &tax.RegimeDef{
+		Country:   CountryCode,
+		Currency:  currency.EUR,
+		TaxScheme: tax.CategoryVAT,
+		Name: i18n.String{
+			i18n.EN: "Slovenia",
+			i18n.SL: "Slovenija",
+		},
+		Description: i18n.String{
+			i18n.EN: here.Doc(`
+				Slovenia's tax system is administered by the Financial Administration
+				of the Republic of Slovenia (FURS). As an EU member state, Slovenia
+				follows the EU VAT Directive with locally adapted rates.
+
+				VAT (davek na dodano vrednost, DDV) applies at a standard rate with a
+				reduced rate for specific goods and services such as food, medicines,
+				passenger transport and accommodation, and a special reduced rate for
+				books, newspapers and periodicals in force since 1 January 2020. The
+				standard rate rose from 20% to 22% on 1 July 2013.
+
+				Taxpayers are identified by an eight-digit tax number (davčna
+				številka) whose last digit is a modulo-11 check digit. The VAT
+				identification number is the same number prefixed with the SI
+				country code (e.g. SI12345678).
+
+				Companies are additionally identified in the Slovenian Business
+				Register (Poslovni register Slovenije) by a ten-digit
+				registration number (matična številka), also protected by a
+				modulo-11 check digit.
+
+				Slovenia supports credit notes for invoice corrections.
+			`),
+		},
+		Sources: []*cbc.Source{
+			{
+				Title: i18n.NewString("FURS - Entry into the tax register and tax number"),
+				URL:   "https://www.fu.gov.si/en/taxes_and_other_duties/work_with_us/entry_into_the_tax_register_and_tax_number",
+			},
+			{
+				Title: i18n.NewString("SPOT - Invoicing"),
+				URL:   "https://spot.gov.si/en/info/accountancy/invoicing",
+			},
+		},
+		TimeZone:   "Europe/Ljubljana",
+		Identities: identityDefinitions,
+		Scenarios: []*tax.ScenarioSet{
+			bill.InvoiceScenarios(),
+		},
+		Corrections: []*tax.CorrectionDefinition{
+			{
+				Schema: bill.ShortSchemaInvoice,
+				Types: []cbc.Key{
+					bill.InvoiceTypeCreditNote,
+				},
+			},
+		},
+		Categories: taxCategories,
+	}
+}

--- a/regimes/si/si_test.go
+++ b/regimes/si/si_test.go
@@ -1,0 +1,15 @@
+package si_test
+
+import (
+	"testing"
+
+	"github.com/invopop/gobl/regimes/si"
+	"github.com/invopop/gobl/rules"
+)
+
+func TestTaxRegion(t *testing.T) {
+	tr := si.New()
+	if err := rules.Validate(tr); err != nil {
+		t.Errorf("Validation on tax def failed: %v", err.Error())
+	}
+}

--- a/regimes/si/tax_categories.go
+++ b/regimes/si/tax_categories.go
@@ -1,0 +1,91 @@
+package si
+
+import (
+	"github.com/invopop/gobl/cal"
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/i18n"
+	"github.com/invopop/gobl/num"
+	"github.com/invopop/gobl/tax"
+)
+
+var taxCategories = []*tax.CategoryDef{
+	{
+		Code: tax.CategoryVAT,
+		Name: i18n.String{
+			i18n.EN: "VAT",
+			i18n.SL: "DDV",
+		},
+		Title: i18n.String{
+			i18n.EN: "Value Added Tax",
+			i18n.SL: "Davek na dodano vrednost",
+		},
+		Retained: false,
+		Keys:     tax.GlobalVATKeys(),
+		Rates: []*tax.RateDef{
+			{
+				Keys: []cbc.Key{tax.KeyStandard},
+				Rate: tax.RateGeneral,
+				Name: i18n.String{
+					i18n.EN: "Standard Rate",
+					i18n.SL: "Splošna stopnja",
+				},
+				Values: []*tax.RateValueDef{
+					{
+						Since:   cal.NewDate(2013, 7, 1),
+						Percent: num.MakePercentage(220, 3),
+					},
+					{
+						Since:   cal.NewDate(2002, 1, 1),
+						Percent: num.MakePercentage(200, 3),
+					},
+				},
+			},
+			{
+				Keys: []cbc.Key{tax.KeyStandard},
+				Rate: tax.RateReduced,
+				Name: i18n.String{
+					i18n.EN: "Reduced Rate",
+					i18n.SL: "Nižja stopnja",
+				},
+				// Food, medicines, passenger transport, accommodation, and
+				// other goods and services listed in Annex I to the VAT Act.
+				Values: []*tax.RateValueDef{
+					{
+						Percent: num.MakePercentage(95, 3),
+					},
+				},
+			},
+			{
+				Keys: []cbc.Key{tax.KeyStandard},
+				Rate: tax.RateSuperReduced,
+				Name: i18n.String{
+					i18n.EN: "Special Reduced Rate for Publications",
+					i18n.SL: "Posebna nižja stopnja",
+				},
+				// Books, newspapers and periodicals, in print or electronic
+				// form, in force since 1 January 2020.
+				Values: []*tax.RateValueDef{
+					{
+						Percent: num.MakePercentage(50, 3),
+					},
+				},
+			},
+		},
+		Sources: []*cbc.Source{
+			{
+				Title: i18n.String{
+					i18n.EN: "Financial Administration of the Republic of Slovenia (FURS) - VAT",
+				},
+				URL: "https://www.fu.gov.si/en/taxes_and_other_duties/areas_of_work/value_added_tax_vat",
+				At:  cal.NewDateTime(2026, 7, 3, 0, 0, 0),
+			},
+			{
+				Title: i18n.String{
+					i18n.EN: "European Commission - VAT rates applied in the Member States of the European Union",
+				},
+				URL: "https://taxation-customs.ec.europa.eu/system/files/2021-06/vat_rates_en.pdf",
+				At:  cal.NewDateTime(2026, 7, 3, 0, 0, 0),
+			},
+		},
+	},
+}

--- a/regimes/si/tax_identity.go
+++ b/regimes/si/tax_identity.go
@@ -1,94 +1,78 @@
 package si
 
 import (
-	"errors"
-
-	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/rules"
 	"github.com/invopop/gobl/rules/is"
 	"github.com/invopop/gobl/tax"
 )
 
-// taxCodeLen is the expected length of a Slovenian tax number (davčna
-// številka): seven digits followed by a modulo-11 check digit. The first
-// digit is never zero.
-const taxCodeLen = 8
-
-// taxCodeMultipliers are the weights applied to the first seven digits of
-// the tax number to calculate the check digit.
+// taxCodePattern matches a Slovenian tax number (davčna številka): eight
+// digits, the first of which is never zero, followed by a modulo-11 check
+// digit.
 //
 // The official register documents the format and the modulo-11 control,
 // but not the formula itself.
 // Format source: https://www.fu.gov.si/en/taxes_and_other_duties/work_with_us/entry_into_the_tax_register_and_tax_number
 // Algorithm reference: https://github.com/arthurdejong/python-stdnum (stdnum/si/ddv.py)
+const taxCodePattern = `^[1-9]\d{7}$`
+
+// taxCodeMultipliers are the weights applied to the first seven digits of
+// the tax number to calculate the check digit.
 var taxCodeMultipliers = []int{8, 7, 6, 5, 4, 3, 2}
 
 func taxIdentityRules() *rules.Set {
 	return rules.For(new(tax.Identity),
 		rules.When(tax.IdentityIn(CountryCode),
 			rules.Field("code",
-				rules.AssertIfPresent("01", "invalid Slovenian VAT identity code",
-					is.Func("valid", isValidTaxIdentityCode),
+				rules.AssertIfPresent("01", "invalid Slovenian VAT identity format",
+					is.Matches(taxCodePattern),
+				),
+				rules.AssertIfPresent("02", "invalid Slovenian VAT identity check digit",
+					is.StringFunc("checksum", taxCodeChecksumValid),
 				),
 			),
 		),
 	)
 }
 
-func isValidTaxIdentityCode(value any) bool {
-	code, ok := value.(cbc.Code)
-	if !ok || code == "" {
-		return false
-	}
-	return validateTaxCode(code) == nil
+// taxCodeChecksumValid reports whether the tax number's final digit is a
+// valid modulo-11 check digit. It runs alongside the format rule, so it
+// guards against malformed input rather than assuming it.
+func taxCodeChecksumValid(code string) bool {
+	return validMod11(code, taxCodeMultipliers)
 }
 
-func validateTaxCode(code cbc.Code) error {
-	if code == "" {
-		return nil
-	}
-	if len(code) != taxCodeLen {
-		return errors.New("invalid length")
-	}
-	if code[0] == '0' {
-		return errors.New("invalid format")
-	}
-	return validateMod11(code, taxCodeMultipliers)
-}
-
-// validateMod11 checks that code is made up of digits and that its last
-// digit is the modulo-11 check digit of the preceding ones, weighted with
-// the given multipliers. It expects exactly len(weights)+1 characters.
+// validMod11 reports whether the last digit of code is the modulo-11 check
+// digit of the preceding ones, weighted with the given multipliers. It
+// expects exactly len(weights)+1 numeric characters and returns false for
+// anything else, so it is safe to call before the format rule has run.
 //
 // Both Slovenian identifiers (the tax number and the registration number)
 // share this scheme with different weights: a remainder of 0 is never
 // assigned (no valid number produces it), a remainder of 1 means a check
 // digit of 0, and any other remainder means a check digit of 11 minus the
 // remainder.
-func validateMod11(code cbc.Code, weights []int) error {
+func validMod11(code string, weights []int) bool {
+	if len(code) != len(weights)+1 {
+		return false
+	}
 	sum := 0
 	for i, w := range weights {
-		c := code[i]
-		if c < '0' || c > '9' {
-			return errors.New("invalid characters")
+		if code[i] < '0' || code[i] > '9' {
+			return false
 		}
-		sum += int(c-'0') * w
+		sum += int(code[i]-'0') * w
 	}
 	check := code[len(weights)]
 	if check < '0' || check > '9' {
-		return errors.New("invalid characters")
+		return false
 	}
 	switch r := sum % 11; r {
 	case 0:
-		return errors.New("invalid checksum")
+		return false
 	case 1:
-		if check != '0' {
-			return errors.New("checksum mismatch")
-		}
+		return check == '0'
 	default:
-		if int(check-'0') != 11-r {
-			return errors.New("checksum mismatch")
-		}
+		return int(check-'0') == 11-r
 	}
-	return nil
 }

--- a/regimes/si/tax_identity.go
+++ b/regimes/si/tax_identity.go
@@ -1,0 +1,94 @@
+package si
+
+import (
+	"errors"
+
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/rules"
+	"github.com/invopop/gobl/rules/is"
+	"github.com/invopop/gobl/tax"
+)
+
+// taxCodeLen is the expected length of a Slovenian tax number (davčna
+// številka): seven digits followed by a modulo-11 check digit. The first
+// digit is never zero.
+const taxCodeLen = 8
+
+// taxCodeMultipliers are the weights applied to the first seven digits of
+// the tax number to calculate the check digit.
+//
+// The official register documents the format and the modulo-11 control,
+// but not the formula itself.
+// Format source: https://www.fu.gov.si/en/taxes_and_other_duties/work_with_us/entry_into_the_tax_register_and_tax_number
+// Algorithm reference: https://github.com/arthurdejong/python-stdnum (stdnum/si/ddv.py)
+var taxCodeMultipliers = []int{8, 7, 6, 5, 4, 3, 2}
+
+func taxIdentityRules() *rules.Set {
+	return rules.For(new(tax.Identity),
+		rules.When(tax.IdentityIn(CountryCode),
+			rules.Field("code",
+				rules.AssertIfPresent("01", "invalid Slovenian VAT identity code",
+					is.Func("valid", isValidTaxIdentityCode),
+				),
+			),
+		),
+	)
+}
+
+func isValidTaxIdentityCode(value any) bool {
+	code, ok := value.(cbc.Code)
+	if !ok || code == "" {
+		return false
+	}
+	return validateTaxCode(code) == nil
+}
+
+func validateTaxCode(code cbc.Code) error {
+	if code == "" {
+		return nil
+	}
+	if len(code) != taxCodeLen {
+		return errors.New("invalid length")
+	}
+	if code[0] == '0' {
+		return errors.New("invalid format")
+	}
+	return validateMod11(code, taxCodeMultipliers)
+}
+
+// validateMod11 checks that code is made up of digits and that its last
+// digit is the modulo-11 check digit of the preceding ones, weighted with
+// the given multipliers. It expects exactly len(weights)+1 characters.
+//
+// Both Slovenian identifiers (the tax number and the registration number)
+// share this scheme with different weights: a remainder of 0 is never
+// assigned (no valid number produces it), a remainder of 1 means a check
+// digit of 0, and any other remainder means a check digit of 11 minus the
+// remainder.
+func validateMod11(code cbc.Code, weights []int) error {
+	sum := 0
+	for i, w := range weights {
+		c := code[i]
+		if c < '0' || c > '9' {
+			return errors.New("invalid characters")
+		}
+		sum += int(c-'0') * w
+	}
+	check := code[len(weights)]
+	if check < '0' || check > '9' {
+		return errors.New("invalid characters")
+	}
+	switch r := sum % 11; r {
+	case 0:
+		return errors.New("invalid checksum")
+	case 1:
+		if check != '0' {
+			return errors.New("checksum mismatch")
+		}
+	default:
+		if int(check-'0') != 11-r {
+			return errors.New("checksum mismatch")
+		}
+	}
+	return nil
+}

--- a/regimes/si/tax_identity_test.go
+++ b/regimes/si/tax_identity_test.go
@@ -91,14 +91,14 @@ func TestTaxIdentityRules(t *testing.T) {
 		{
 			name: "checksum mismatch",
 			code: "12345678",
-			err:  "IDENTITY-01",
+			err:  "IDENTITY-02",
 		},
 		{
 			// The weighted sum leaves a remainder of 0, which is never
 			// assigned: no valid tax number produces it.
 			name: "remainder zero",
 			code: "10000100",
-			err:  "IDENTITY-01",
+			err:  "IDENTITY-02",
 		},
 	}
 

--- a/regimes/si/tax_identity_test.go
+++ b/regimes/si/tax_identity_test.go
@@ -1,0 +1,118 @@
+package si_test
+
+import (
+	"testing"
+
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/norm"
+	"github.com/invopop/gobl/rules"
+	"github.com/invopop/gobl/tax"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizeTaxIdentity(t *testing.T) {
+	tests := []struct {
+		Code     cbc.Code
+		Expected cbc.Code
+	}{
+		{
+			Code:     "82646716",
+			Expected: "82646716",
+		},
+		{
+			Code:     "SI82646716",
+			Expected: "82646716",
+		},
+		{
+			Code:     "si 82646716",
+			Expected: "82646716",
+		},
+		{
+			Code:     " 12345679 ",
+			Expected: "12345679",
+		},
+	}
+	for _, ts := range tests {
+		tID := &tax.Identity{Country: "SI", Code: ts.Code}
+		norm.Normalize(tID)
+		assert.Equal(t, ts.Expected, tID.Code)
+	}
+}
+
+func TestTaxIdentityRules(t *testing.T) {
+	tests := []struct {
+		name string
+		code cbc.Code
+		err  string
+	}{
+		{
+			name: "empty",
+			code: "",
+		},
+		{
+			// Krka d.d., Novo mesto's publicly listed VAT number.
+			name: "valid",
+			code: "82646716",
+		},
+		{
+			name: "valid 2",
+			code: "12345679",
+		},
+		{
+			// Weighted sum leaves a remainder of 1, so the check digit is 0.
+			name: "valid with zero check digit",
+			code: "10001000",
+		},
+		{
+			name: "too short",
+			code: "1234567",
+			err:  "IDENTITY-01",
+		},
+		{
+			name: "too long",
+			code: "123456789",
+			err:  "IDENTITY-01",
+		},
+		{
+			name: "leading zero",
+			code: "02345679",
+			err:  "IDENTITY-01",
+		},
+		{
+			name: "non numeric",
+			code: "123456A9",
+			err:  "IDENTITY-01",
+		},
+		{
+			name: "non numeric check digit",
+			code: "1234567A",
+			err:  "IDENTITY-01",
+		},
+		{
+			name: "checksum mismatch",
+			code: "12345678",
+			err:  "IDENTITY-01",
+		},
+		{
+			// The weighted sum leaves a remainder of 0, which is never
+			// assigned: no valid tax number produces it.
+			name: "remainder zero",
+			code: "10000100",
+			err:  "IDENTITY-01",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tID := &tax.Identity{Country: "SI", Code: tt.code}
+			err := rules.Validate(tID)
+			if tt.err == "" {
+				assert.NoError(t, err)
+			} else {
+				if assert.Error(t, err) {
+					assert.Contains(t, err.Error(), tt.err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds Slovenia (SI) as a new tax regime.

I picked Slovenia because it wasn't supported yet and fits GOBL's model well: an EU member
state using EUR, with tax identifiers that carry real modulo-11 check digits, so the regime
can do genuine validation rather than only format checks. I used the Netherlands (`nl`)
regime as a structural reference, since it's close to Slovenia: EU member, EUR, and a VAT
identity with a checksum.

## What's included

- **Base regime:** EUR, `Europe/Ljubljana`, the standard invoice scenarios, and credit notes for corrections.
- **VAT rates:** the standard rate with its history (20% since 2002, 22% from 1 July 2013), plus the current reduced rate (9.5%) and the special reduced rate of 5% for books, newspapers and periodicals.
- **Tax ID validation:** the modulo-11 check-digit algorithm, applied to two identifiers — the VAT number / davčna številka (8 digits) and the domestic registration number / matična številka (10 digits).
- **Invoice rule:** the supplier must carry a tax ID code. The registration number identifies a company but is not a substitute for the VAT number on an invoice, so the rule checks specifically for the tax ID (ZDDV-1, Article 82).

## Scope and design notes

A few things I decided deliberately, with the reasoning in case it helps the review:

- I modelled the full date history only for the standard rate, to exercise the `Since` mechanism. The reduced rates have been stable for years, so I kept only their current values rather than pad the base regime with historical data — happy to add the full history if you'd prefer.
- The modulo-11 logic lives in one place (`tax_identity.go`) and takes the weights as a parameter, since the two identifiers share the same scheme with different weights. The registration-number check strips its three-digit branch suffix (which has no check digit of its own) and reuses it.
- One Slovenian detail worth flagging: a remainder of 0 is never assigned (no valid number produces it), so the shared validator rejects it explicitly.
- I kept the scope to tax and identity rules — Slovenia's own e-invoicing formats and networks are a separate kind of extension in GOBL, so I left those out.

## Testing

- Table-driven tests across the package: 5 test functions, 29 sub-cases, covering valid and invalid inputs.
- The official sources publish the number formats but not the check-digit formulas, so I verified each checksum against a real, public identifier from the same company (Krka d.d.: VAT number `SI82646716` and registration number `5043611000`) and exercised every branch of both algorithms, including the `remainder == 0` case that can never yield a valid number.
- `gofmt`, `go vet` and `golangci-lint` are clean.

## Sources

- VAT rates — Financial Administration of the Republic of Slovenia (FURS), and the European Commission rates table
  https://www.fu.gov.si/en/taxes_and_other_duties/areas_of_work/value_added_tax_vat
  https://taxation-customs.ec.europa.eu/system/files/2021-06/vat_rates_en.pdf
- Invoice requirements — SPOT business portal (ZDDV-1, Article 82)
  https://spot.gov.si/en/info/accountancy/invoicing
- Tax number format — FURS
  https://www.fu.gov.si/en/taxes_and_other_duties/work_with_us/entry_into_the_tax_register_and_tax_number
- Registration number (matična številka) format — PISRS, Article 11 of the Business Register decree
  https://pisrs.si/Pis.web/pregledPredpisa?id=URED7599
- Checksum algorithms — the official registers document the formats but not the formulas, so I
  based them on a widely used open-source implementation (python-stdnum) and verified them
  against the public identifiers above:
  https://github.com/arthurdejong/python-stdnum


## Pre-Review Checklist
- [x] Opened this PR as a draft
- [x] Read the CONTRIBUTING.md guide.
- [x] Performed a self-review of my code.
- [x] Added thorough tests with at **least** 90% code coverage.
- [x] Modified or created example GOBL documents to show my changes in use, if appropriate.
- [x] Added links to the source of the changes in tax regimes or addons, either structured or in the comments.
- [x] Run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [x] Reviewed and fixed all linter warnings.
- [x] Been obsessive with pointer nil checks to avoid panics.
- [x] Updated the CHANGELOG.md with an overview of my changes.
- [x] Marked this PR as ready for review.