### PR TITLE
Extract included taxes from rate group sums with currency rounding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 - `tax`: the `currency` rounding rule combined with `prices_include` now determines each rate's tax amount from the sum of the tax-inclusive line totals and shares it back over the lines, so that bases, tax amounts, and document totals always add up, including when other categories such as retained taxes are present.
 
+### Fixed
+
+- `tax`: totals now reset the retained tax sum before recalculating, so repeated calculations over the same totals no longer accumulate stale retained amounts.
+
 ## [v0.502.2] - 2026-07-06
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Changed
+
+- `tax`: the `currency` rounding rule combined with `prices_include` now determines each rate's tax amount from the sum of the tax-inclusive line totals and shares it back over the lines, so that bases, tax amounts, and document totals always add up, including when other categories such as retained taxes are present.
+
 ## [v0.502.2] - 2026-07-06
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Fixed
 
-- `tax`: totals now reset the retained tax sum before recalculating, so repeated calculations over the same totals no longer accumulate stale retained amounts.
+- `tax`: totals now reset the retained tax and category surcharge sums before recalculating, so repeated calculations over the same totals no longer accumulate stale amounts.
 
 ## [v0.502.2] - 2026-07-06
 

--- a/bill/calculator_test.go
+++ b/bill/calculator_test.go
@@ -319,3 +319,75 @@ func TestRemoveIncludedTaxes(t *testing.T) {
 		assert.Equal(t, "8.26", inv.Totals.Charge.String())
 	})
 }
+
+func TestCalculatePricesIncludeCurrencyRounding(t *testing.T) {
+	t.Run("multiple lines", func(t *testing.T) {
+		lines := make([]*bill.Line, 12)
+		for i := range lines {
+			lines[i] = &bill.Line{
+				Quantity: num.MakeAmount(1, 0),
+				Item: &org.Item{
+					Name:  "Room rate",
+					Price: num.NewAmount(12500, 2),
+				},
+				Taxes: tax.Set{
+					{
+						Category: tax.CategoryVAT,
+						Percent:  num.NewPercentage(6, 2),
+					},
+				},
+			}
+		}
+		inv := baseInvoice(t, lines...)
+		inv.Tax.Rounding = tax.RoundingRuleCurrency
+		require.NoError(t, inv.Calculate())
+
+		assert.Equal(t, "1500.00", inv.Totals.Sum.String())
+		assert.Equal(t, "84.91", inv.Totals.TaxIncluded.String())
+		assert.Equal(t, "1415.09", inv.Totals.Total.String())
+		assert.Equal(t, "84.91", inv.Totals.Tax.String())
+		assert.Equal(t, "1500.00", inv.Totals.TotalWithTax.String())
+		assert.Equal(t, "1500.00", inv.Totals.Payable.String())
+		rt := inv.Totals.Taxes.Categories[0].Rates[0]
+		assert.Equal(t, "1415.09", rt.Base.String())
+		assert.Equal(t, "84.91", rt.Amount.String())
+	})
+
+	t.Run("with retained taxes", func(t *testing.T) {
+		lines := make([]*bill.Line, 10)
+		for i := range lines {
+			lines[i] = &bill.Line{
+				Quantity: num.MakeAmount(1, 0),
+				Item: &org.Item{
+					Name:  "Service",
+					Price: num.NewAmount(193, 2),
+				},
+				Taxes: tax.Set{
+					{
+						Category: tax.CategoryVAT,
+						Rate:     tax.RateGeneral,
+					},
+					{
+						Category: es.TaxCategoryIRPF,
+						Rate:     "pro",
+					},
+				},
+			}
+		}
+		inv := baseInvoice(t, lines...)
+		inv.Tax.Rounding = tax.RoundingRuleCurrency
+		require.NoError(t, inv.Calculate())
+
+		assert.Equal(t, "19.30", inv.Totals.Sum.String())
+		assert.Equal(t, "3.35", inv.Totals.TaxIncluded.String())
+		assert.Equal(t, "15.95", inv.Totals.Total.String())
+		assert.Equal(t, "19.30", inv.Totals.TotalWithTax.String())
+		assert.Equal(t, "2.39", inv.Totals.RetainedTax.String())
+		assert.Equal(t, "16.91", inv.Totals.Payable.String())
+		vat := inv.Totals.Taxes.Categories[0].Rates[0]
+		irpf := inv.Totals.Taxes.Categories[1].Rates[0]
+		assert.Equal(t, "15.95", vat.Base.String())
+		assert.Equal(t, "3.35", vat.Amount.String())
+		assert.Equal(t, "15.95", irpf.Base.String())
+	})
+}

--- a/bill/calculator_test.go
+++ b/bill/calculator_test.go
@@ -390,4 +390,42 @@ func TestCalculatePricesIncludeCurrencyRounding(t *testing.T) {
 		assert.Equal(t, "3.35", vat.Amount.String())
 		assert.Equal(t, "15.95", irpf.Base.String())
 	})
+
+	t.Run("multiple lines with retained taxes", func(t *testing.T) {
+		lines := make([]*bill.Line, 12)
+		for i := range lines {
+			lines[i] = &bill.Line{
+				Quantity: num.MakeAmount(1, 0),
+				Item: &org.Item{
+					Name:  "Professional services",
+					Price: num.NewAmount(12500, 2),
+				},
+				Taxes: tax.Set{
+					{
+						Category: tax.CategoryVAT,
+						Rate:     tax.RateGeneral,
+					},
+					{
+						Category: es.TaxCategoryIRPF,
+						Rate:     "pro",
+					},
+				},
+			}
+		}
+		inv := baseInvoice(t, lines...)
+		inv.Tax.Rounding = tax.RoundingRuleCurrency
+		require.NoError(t, inv.Calculate())
+
+		assert.Equal(t, "1500.00", inv.Totals.Sum.String())
+		assert.Equal(t, "260.33", inv.Totals.TaxIncluded.String())
+		assert.Equal(t, "1239.67", inv.Totals.Total.String())
+		assert.Equal(t, "1500.00", inv.Totals.TotalWithTax.String())
+		assert.Equal(t, "185.95", inv.Totals.RetainedTax.String())
+		assert.Equal(t, "1314.05", inv.Totals.Payable.String())
+		vat := inv.Totals.Taxes.Categories[0].Rates[0]
+		irpf := inv.Totals.Taxes.Categories[1].Rates[0]
+		assert.Equal(t, "1239.67", vat.Base.String())
+		assert.Equal(t, "260.33", vat.Amount.String())
+		assert.Equal(t, "1239.67", irpf.Base.String())
+	})
 }

--- a/data/schemas/bill/tax.json
+++ b/data/schemas/bill/tax.json
@@ -21,7 +21,7 @@
             {
               "const": "currency",
               "title": "Currency",
-              "description": "The alternative method of calculating the totals that will first round all the amounts\nto the currency's precision before making the sums. Totals using this approach can always\nbe recalculated using the amounts presented, but can lead to rounding errors in the case\nof pre-payments and when line item prices include tax."
+              "description": "The alternative method of calculating the totals that will first round all the amounts\nto the currency's precision before making the sums. Totals using this approach can always\nbe recalculated using the amounts presented, but can lead to rounding errors in the case\nof pre-payments. When prices include tax, the tax amounts are calculated from each rate's\nsum of tax-inclusive line totals so that the bases and amounts always add up, though\nrecalculating a tax amount from its base alone may occasionally differ by a single\nsubunit of the currency."
             }
           ],
           "title": "Rounding Model",

--- a/examples/es/invoice-es-prices-include.yaml
+++ b/examples/es/invoice-es-prices-include.yaml
@@ -1,0 +1,151 @@
+$schema: "https://gobl.org/draft-0/bill/invoice"
+uuid: "0198f2f1-7f30-7d33-9a63-8a12f4a1c002"
+currency: "EUR"
+issue_date: "2026-07-09"
+series: "SAMPLE"
+code: "024"
+tax:
+  prices_include: "VAT"
+  rounding: "currency"
+supplier:
+  tax_id:
+    country: "ES"
+    code: "B98602642" # random
+  name: "Provide One S.L."
+  emails:
+    - addr: "billing@example.com"
+  addresses:
+    - num: "42"
+      street: "Calle Pradillo"
+      locality: "Madrid"
+      region: "Madrid"
+      code: "28002"
+      country: "ES"
+
+customer:
+  tax_id:
+    country: "ES"
+    code: "54387763P"
+  name: "Sample Consumer"
+
+lines:
+  - quantity: 1
+    item:
+      name: "Professional services"
+      price: "125.00"
+      unit: "h"
+    taxes:
+      - cat: VAT
+        rate: standard
+      - cat: IRPF
+        rate: pro
+  - quantity: 1
+    item:
+      name: "Professional services"
+      price: "125.00"
+      unit: "h"
+    taxes:
+      - cat: VAT
+        rate: standard
+      - cat: IRPF
+        rate: pro
+  - quantity: 1
+    item:
+      name: "Professional services"
+      price: "125.00"
+      unit: "h"
+    taxes:
+      - cat: VAT
+        rate: standard
+      - cat: IRPF
+        rate: pro
+  - quantity: 1
+    item:
+      name: "Professional services"
+      price: "125.00"
+      unit: "h"
+    taxes:
+      - cat: VAT
+        rate: standard
+      - cat: IRPF
+        rate: pro
+  - quantity: 1
+    item:
+      name: "Professional services"
+      price: "125.00"
+      unit: "h"
+    taxes:
+      - cat: VAT
+        rate: standard
+      - cat: IRPF
+        rate: pro
+  - quantity: 1
+    item:
+      name: "Professional services"
+      price: "125.00"
+      unit: "h"
+    taxes:
+      - cat: VAT
+        rate: standard
+      - cat: IRPF
+        rate: pro
+  - quantity: 1
+    item:
+      name: "Professional services"
+      price: "125.00"
+      unit: "h"
+    taxes:
+      - cat: VAT
+        rate: standard
+      - cat: IRPF
+        rate: pro
+  - quantity: 1
+    item:
+      name: "Professional services"
+      price: "125.00"
+      unit: "h"
+    taxes:
+      - cat: VAT
+        rate: standard
+      - cat: IRPF
+        rate: pro
+  - quantity: 1
+    item:
+      name: "Professional services"
+      price: "125.00"
+      unit: "h"
+    taxes:
+      - cat: VAT
+        rate: standard
+      - cat: IRPF
+        rate: pro
+  - quantity: 1
+    item:
+      name: "Professional services"
+      price: "125.00"
+      unit: "h"
+    taxes:
+      - cat: VAT
+        rate: standard
+      - cat: IRPF
+        rate: pro
+  - quantity: 1
+    item:
+      name: "Professional services"
+      price: "125.00"
+      unit: "h"
+    taxes:
+      - cat: VAT
+        rate: standard
+      - cat: IRPF
+        rate: pro
+  - quantity: 1
+    item:
+      name: "Professional services"
+      price: "125.00"
+      unit: "h"
+    taxes:
+      - cat: VAT
+        rate: standard
+      - cat: IRPF
+        rate: pro

--- a/examples/es/out/invoice-es-prices-include.json
+++ b/examples/es/out/invoice-es-prices-include.json
@@ -1,0 +1,382 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
+		"dig": {
+			"alg": "sha256",
+			"val": "1f33628bcf4765dba263fa6c76dc423d074cadce57ab0bf1a720dba1e1dae940"
+		}
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"$regime": "ES",
+		"uuid": "0198f2f1-7f30-7d33-9a63-8a12f4a1c002",
+		"type": "standard",
+		"series": "SAMPLE",
+		"code": "024",
+		"issue_date": "2026-07-09",
+		"currency": "EUR",
+		"tax": {
+			"prices_include": "VAT",
+			"rounding": "currency"
+		},
+		"supplier": {
+			"name": "Provide One S.L.",
+			"tax_id": {
+				"country": "ES",
+				"code": "B98602642"
+			},
+			"addresses": [
+				{
+					"num": "42",
+					"street": "Calle Pradillo",
+					"locality": "Madrid",
+					"region": "Madrid",
+					"code": "28002",
+					"country": "ES"
+				}
+			],
+			"emails": [
+				{
+					"addr": "billing@example.com"
+				}
+			]
+		},
+		"customer": {
+			"name": "Sample Consumer",
+			"tax_id": {
+				"country": "ES",
+				"code": "54387763P"
+			}
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "1",
+				"item": {
+					"name": "Professional services",
+					"price": "125.00",
+					"unit": "h"
+				},
+				"sum": "125.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "general",
+						"percent": "21.0%"
+					},
+					{
+						"cat": "IRPF",
+						"rate": "pro",
+						"percent": "15.0%"
+					}
+				],
+				"total": "125.00"
+			},
+			{
+				"i": 2,
+				"quantity": "1",
+				"item": {
+					"name": "Professional services",
+					"price": "125.00",
+					"unit": "h"
+				},
+				"sum": "125.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "general",
+						"percent": "21.0%"
+					},
+					{
+						"cat": "IRPF",
+						"rate": "pro",
+						"percent": "15.0%"
+					}
+				],
+				"total": "125.00"
+			},
+			{
+				"i": 3,
+				"quantity": "1",
+				"item": {
+					"name": "Professional services",
+					"price": "125.00",
+					"unit": "h"
+				},
+				"sum": "125.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "general",
+						"percent": "21.0%"
+					},
+					{
+						"cat": "IRPF",
+						"rate": "pro",
+						"percent": "15.0%"
+					}
+				],
+				"total": "125.00"
+			},
+			{
+				"i": 4,
+				"quantity": "1",
+				"item": {
+					"name": "Professional services",
+					"price": "125.00",
+					"unit": "h"
+				},
+				"sum": "125.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "general",
+						"percent": "21.0%"
+					},
+					{
+						"cat": "IRPF",
+						"rate": "pro",
+						"percent": "15.0%"
+					}
+				],
+				"total": "125.00"
+			},
+			{
+				"i": 5,
+				"quantity": "1",
+				"item": {
+					"name": "Professional services",
+					"price": "125.00",
+					"unit": "h"
+				},
+				"sum": "125.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "general",
+						"percent": "21.0%"
+					},
+					{
+						"cat": "IRPF",
+						"rate": "pro",
+						"percent": "15.0%"
+					}
+				],
+				"total": "125.00"
+			},
+			{
+				"i": 6,
+				"quantity": "1",
+				"item": {
+					"name": "Professional services",
+					"price": "125.00",
+					"unit": "h"
+				},
+				"sum": "125.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "general",
+						"percent": "21.0%"
+					},
+					{
+						"cat": "IRPF",
+						"rate": "pro",
+						"percent": "15.0%"
+					}
+				],
+				"total": "125.00"
+			},
+			{
+				"i": 7,
+				"quantity": "1",
+				"item": {
+					"name": "Professional services",
+					"price": "125.00",
+					"unit": "h"
+				},
+				"sum": "125.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "general",
+						"percent": "21.0%"
+					},
+					{
+						"cat": "IRPF",
+						"rate": "pro",
+						"percent": "15.0%"
+					}
+				],
+				"total": "125.00"
+			},
+			{
+				"i": 8,
+				"quantity": "1",
+				"item": {
+					"name": "Professional services",
+					"price": "125.00",
+					"unit": "h"
+				},
+				"sum": "125.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "general",
+						"percent": "21.0%"
+					},
+					{
+						"cat": "IRPF",
+						"rate": "pro",
+						"percent": "15.0%"
+					}
+				],
+				"total": "125.00"
+			},
+			{
+				"i": 9,
+				"quantity": "1",
+				"item": {
+					"name": "Professional services",
+					"price": "125.00",
+					"unit": "h"
+				},
+				"sum": "125.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "general",
+						"percent": "21.0%"
+					},
+					{
+						"cat": "IRPF",
+						"rate": "pro",
+						"percent": "15.0%"
+					}
+				],
+				"total": "125.00"
+			},
+			{
+				"i": 10,
+				"quantity": "1",
+				"item": {
+					"name": "Professional services",
+					"price": "125.00",
+					"unit": "h"
+				},
+				"sum": "125.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "general",
+						"percent": "21.0%"
+					},
+					{
+						"cat": "IRPF",
+						"rate": "pro",
+						"percent": "15.0%"
+					}
+				],
+				"total": "125.00"
+			},
+			{
+				"i": 11,
+				"quantity": "1",
+				"item": {
+					"name": "Professional services",
+					"price": "125.00",
+					"unit": "h"
+				},
+				"sum": "125.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "general",
+						"percent": "21.0%"
+					},
+					{
+						"cat": "IRPF",
+						"rate": "pro",
+						"percent": "15.0%"
+					}
+				],
+				"total": "125.00"
+			},
+			{
+				"i": 12,
+				"quantity": "1",
+				"item": {
+					"name": "Professional services",
+					"price": "125.00",
+					"unit": "h"
+				},
+				"sum": "125.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "general",
+						"percent": "21.0%"
+					},
+					{
+						"cat": "IRPF",
+						"rate": "pro",
+						"percent": "15.0%"
+					}
+				],
+				"total": "125.00"
+			}
+		],
+		"totals": {
+			"sum": "1500.00",
+			"tax_included": "260.33",
+			"total": "1239.67",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"base": "1239.67",
+								"percent": "21.0%",
+								"amount": "260.33"
+							}
+						],
+						"amount": "260.33"
+					},
+					{
+						"code": "IRPF",
+						"retained": true,
+						"rates": [
+							{
+								"base": "1239.67",
+								"percent": "15.0%",
+								"amount": "185.95"
+							}
+						],
+						"amount": "185.95"
+					}
+				],
+				"sum": "260.33",
+				"retained": "185.95"
+			},
+			"tax": "260.33",
+			"total_with_tax": "1500.00",
+			"retained_tax": "185.95",
+			"payable": "1314.05"
+		}
+	}
+}

--- a/examples/gr/invoice-b2c.yaml
+++ b/examples/gr/invoice-b2c.yaml
@@ -8,7 +8,7 @@ code: "002"
 tax:
   tags:
     - "simplified"
-  # prices_include: "VAT"
+  prices_include: "VAT"
 
 supplier:
   tax_id:

--- a/examples/gr/out/invoice-b2c.json
+++ b/examples/gr/out/invoice-b2c.json
@@ -4,7 +4,7 @@
 		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
 		"dig": {
 			"alg": "sha256",
-			"val": "455d5b988d78e57a6dcf01ad115d797eb34e3e1126374ea4fdd9e8ace6d2e181"
+			"val": "bd732f16f7f31bb9a6ceaf38353a56479d7390012cd7e8d85feec7cfedb45669"
 		}
 	},
 	"doc": {
@@ -23,6 +23,7 @@
 		"issue_date": "2024-08-20",
 		"currency": "EUR",
 		"tax": {
+			"prices_include": "VAT",
 			"ext": {
 				"gr-mydata-invoice-type": "11.3"
 			}
@@ -78,7 +79,7 @@
 					"key": "card",
 					"description": "Prepaid amount",
 					"percent": "100%",
-					"amount": "10.47",
+					"amount": "8.44",
 					"ext": {
 						"gr-mydata-payment-means": "7"
 					}
@@ -93,7 +94,8 @@
 		},
 		"totals": {
 			"sum": "8.44",
-			"total": "8.44",
+			"tax_included": "1.63",
+			"total": "6.81",
 			"taxes": {
 				"categories": [
 					{
@@ -104,20 +106,20 @@
 								"ext": {
 									"gr-mydata-vat-rate": "1"
 								},
-								"base": "8.44",
+								"base": "6.81",
 								"percent": "24%",
-								"amount": "2.03"
+								"amount": "1.63"
 							}
 						],
-						"amount": "2.03"
+						"amount": "1.63"
 					}
 				],
-				"sum": "2.03"
+				"sum": "1.63"
 			},
-			"tax": "2.03",
-			"total_with_tax": "10.47",
-			"payable": "10.47",
-			"advance": "10.47",
+			"tax": "1.63",
+			"total_with_tax": "8.44",
+			"payable": "8.44",
+			"advance": "8.44",
 			"due": "0.00"
 		}
 	}

--- a/examples/pt/invoice-pt-prices-include-multi.yaml
+++ b/examples/pt/invoice-pt-prices-include-multi.yaml
@@ -1,0 +1,85 @@
+$schema: "https://gobl.org/draft-0/bill/invoice"
+uuid: "0198f2f1-7f30-7d33-9a63-8a12f4a1c003"
+currency: "EUR"
+issue_date: "2026-07-09"
+series: "SAMPLE"
+code: "024"
+tax:
+  prices_include: "VAT"
+  rounding: "currency"
+supplier:
+  tax_id:
+    country: "PT"
+    code: "599999993" # test
+  name: "Hotel Azul Lda."
+  emails:
+    - addr: "billing@example.com"
+  addresses:
+    - street: "Rua das Flores"
+      locality: "Lisboa"
+      code: "3830-000"
+      country: "PT"
+
+customer:
+  tax_id:
+    country: "PT"
+    code: "999999990" # final consumer
+  name: "Sample Guest"
+
+lines:
+  - quantity: 1
+    item:
+      name: "Room rate"
+      price: "125.00"
+      unit: "one"
+    taxes:
+      - cat: VAT
+        rate: reduced
+  - quantity: 1
+    item:
+      name: "Room rate"
+      price: "125.00"
+      unit: "one"
+    taxes:
+      - cat: VAT
+        rate: reduced
+  - quantity: 1
+    item:
+      name: "Breakfast"
+      price: "12.50"
+      unit: "one"
+    taxes:
+      - cat: VAT
+        rate: intermediate
+  - quantity: 1
+    item:
+      name: "Breakfast"
+      price: "12.50"
+      unit: "one"
+    taxes:
+      - cat: VAT
+        rate: intermediate
+  - quantity: 1
+    item:
+      name: "Dinner menu"
+      price: "35.80"
+      unit: "one"
+    taxes:
+      - cat: VAT
+        rate: intermediate
+  - quantity: 1
+    item:
+      name: "Minibar drinks"
+      price: "7.95"
+      unit: "one"
+    taxes:
+      - cat: VAT
+        rate: standard
+  - quantity: 1
+    item:
+      name: "Spa access"
+      price: "45.00"
+      unit: "one"
+    taxes:
+      - cat: VAT
+        rate: standard

--- a/examples/pt/invoice-pt-prices-include.yaml
+++ b/examples/pt/invoice-pt-prices-include.yaml
@@ -1,0 +1,132 @@
+$schema: "https://gobl.org/draft-0/bill/invoice"
+uuid: "0198f2f1-7f30-7d33-9a63-8a12f4a1c001"
+currency: "EUR"
+issue_date: "2026-07-09"
+series: "SAMPLE"
+code: "023"
+tax:
+  prices_include: "VAT"
+  rounding: "currency"
+supplier:
+  tax_id:
+    country: "PT"
+    code: "599999993" # test
+  name: "Hotel Azul Lda."
+  emails:
+    - addr: "billing@example.com"
+  addresses:
+    - street: "Rua das Flores"
+      locality: "Lisboa"
+      code: "3830-000"
+      country: "PT"
+
+customer:
+  tax_id:
+    country: "PT"
+    code: "999999990" # final consumer
+  name: "Sample Guest"
+
+lines:
+  - quantity: 1
+    item:
+      name: "Room rate"
+      price: "125.00"
+      unit: "one"
+    taxes:
+      - cat: VAT
+        rate: reduced
+  - quantity: 1
+    item:
+      name: "Room rate"
+      price: "125.00"
+      unit: "one"
+    taxes:
+      - cat: VAT
+        rate: reduced
+  - quantity: 1
+    item:
+      name: "Room rate"
+      price: "125.00"
+      unit: "one"
+    taxes:
+      - cat: VAT
+        rate: reduced
+  - quantity: 1
+    item:
+      name: "Room rate"
+      price: "125.00"
+      unit: "one"
+    taxes:
+      - cat: VAT
+        rate: reduced
+  - quantity: 1
+    item:
+      name: "Room rate"
+      price: "125.00"
+      unit: "one"
+    taxes:
+      - cat: VAT
+        rate: reduced
+  - quantity: 1
+    item:
+      name: "Room rate"
+      price: "125.00"
+      unit: "one"
+    taxes:
+      - cat: VAT
+        rate: reduced
+  - quantity: 1
+    item:
+      name: "Room rate"
+      price: "125.00"
+      unit: "one"
+    taxes:
+      - cat: VAT
+        rate: reduced
+  - quantity: 1
+    item:
+      name: "Room rate"
+      price: "125.00"
+      unit: "one"
+    taxes:
+      - cat: VAT
+        rate: reduced
+  - quantity: 1
+    item:
+      name: "Room rate"
+      price: "125.00"
+      unit: "one"
+    taxes:
+      - cat: VAT
+        rate: reduced
+  - quantity: 1
+    item:
+      name: "Room rate"
+      price: "125.00"
+      unit: "one"
+    taxes:
+      - cat: VAT
+        rate: reduced
+  - quantity: 1
+    item:
+      name: "Room rate"
+      price: "125.00"
+      unit: "one"
+    taxes:
+      - cat: VAT
+        rate: reduced
+  - quantity: 1
+    item:
+      name: "Room rate"
+      price: "125.00"
+      unit: "one"
+    taxes:
+      - cat: VAT
+        rate: reduced
+
+payment:
+  terms:
+    key: "due-date"
+    due_dates:
+      - date: "2026-07-09"
+        amount: "1500.00"

--- a/examples/pt/out/invoice-pt-prices-include-multi.json
+++ b/examples/pt/out/invoice-pt-prices-include-multi.json
@@ -1,0 +1,253 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
+		"dig": {
+			"alg": "sha256",
+			"val": "afa55df368118e28e7acbc6eeb840c13d99f88bc2f671d660ffa08791ff86543"
+		}
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"$regime": "PT",
+		"uuid": "0198f2f1-7f30-7d33-9a63-8a12f4a1c003",
+		"type": "standard",
+		"series": "SAMPLE",
+		"code": "024",
+		"issue_date": "2026-07-09",
+		"currency": "EUR",
+		"tax": {
+			"prices_include": "VAT",
+			"rounding": "currency"
+		},
+		"supplier": {
+			"name": "Hotel Azul Lda.",
+			"tax_id": {
+				"country": "PT",
+				"code": "599999993"
+			},
+			"addresses": [
+				{
+					"street": "Rua das Flores",
+					"locality": "Lisboa",
+					"code": "3830-000",
+					"country": "PT"
+				}
+			],
+			"emails": [
+				{
+					"addr": "billing@example.com"
+				}
+			]
+		},
+		"customer": {
+			"name": "Sample Guest",
+			"tax_id": {
+				"country": "PT",
+				"code": "999999990"
+			}
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "1",
+				"item": {
+					"name": "Room rate",
+					"price": "125.00",
+					"unit": "one"
+				},
+				"sum": "125.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "reduced",
+						"percent": "6.0%",
+						"ext": {
+							"pt-region": "PT"
+						}
+					}
+				],
+				"total": "125.00"
+			},
+			{
+				"i": 2,
+				"quantity": "1",
+				"item": {
+					"name": "Room rate",
+					"price": "125.00",
+					"unit": "one"
+				},
+				"sum": "125.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "reduced",
+						"percent": "6.0%",
+						"ext": {
+							"pt-region": "PT"
+						}
+					}
+				],
+				"total": "125.00"
+			},
+			{
+				"i": 3,
+				"quantity": "1",
+				"item": {
+					"name": "Breakfast",
+					"price": "12.50",
+					"unit": "one"
+				},
+				"sum": "12.50",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "intermediate",
+						"percent": "13.0%",
+						"ext": {
+							"pt-region": "PT"
+						}
+					}
+				],
+				"total": "12.50"
+			},
+			{
+				"i": 4,
+				"quantity": "1",
+				"item": {
+					"name": "Breakfast",
+					"price": "12.50",
+					"unit": "one"
+				},
+				"sum": "12.50",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "intermediate",
+						"percent": "13.0%",
+						"ext": {
+							"pt-region": "PT"
+						}
+					}
+				],
+				"total": "12.50"
+			},
+			{
+				"i": 5,
+				"quantity": "1",
+				"item": {
+					"name": "Dinner menu",
+					"price": "35.80",
+					"unit": "one"
+				},
+				"sum": "35.80",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "intermediate",
+						"percent": "13.0%",
+						"ext": {
+							"pt-region": "PT"
+						}
+					}
+				],
+				"total": "35.80"
+			},
+			{
+				"i": 6,
+				"quantity": "1",
+				"item": {
+					"name": "Minibar drinks",
+					"price": "7.95",
+					"unit": "one"
+				},
+				"sum": "7.95",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "general",
+						"percent": "23.0%",
+						"ext": {
+							"pt-region": "PT"
+						}
+					}
+				],
+				"total": "7.95"
+			},
+			{
+				"i": 7,
+				"quantity": "1",
+				"item": {
+					"name": "Spa access",
+					"price": "45.00",
+					"unit": "one"
+				},
+				"sum": "45.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "general",
+						"percent": "23.0%",
+						"ext": {
+							"pt-region": "PT"
+						}
+					}
+				],
+				"total": "45.00"
+			}
+		],
+		"totals": {
+			"sum": "363.75",
+			"tax_included": "31.04",
+			"total": "332.71",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"ext": {
+									"pt-region": "PT"
+								},
+								"base": "235.85",
+								"percent": "6.0%",
+								"amount": "14.15"
+							},
+							{
+								"key": "standard",
+								"ext": {
+									"pt-region": "PT"
+								},
+								"base": "53.81",
+								"percent": "13.0%",
+								"amount": "6.99"
+							},
+							{
+								"key": "standard",
+								"ext": {
+									"pt-region": "PT"
+								},
+								"base": "43.05",
+								"percent": "23.0%",
+								"amount": "9.90"
+							}
+						],
+						"amount": "31.04"
+					}
+				],
+				"sum": "31.04"
+			},
+			"tax": "31.04",
+			"total_with_tax": "363.75",
+			"payable": "363.75"
+		}
+	}
+}

--- a/examples/pt/out/invoice-pt-prices-include.json
+++ b/examples/pt/out/invoice-pt-prices-include.json
@@ -1,0 +1,356 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
+		"dig": {
+			"alg": "sha256",
+			"val": "78e1906209627351ff48694fef48bb9ab3b4df4f27c6d33edd303b61e283c6f0"
+		}
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"$regime": "PT",
+		"uuid": "0198f2f1-7f30-7d33-9a63-8a12f4a1c001",
+		"type": "standard",
+		"series": "SAMPLE",
+		"code": "023",
+		"issue_date": "2026-07-09",
+		"currency": "EUR",
+		"tax": {
+			"prices_include": "VAT",
+			"rounding": "currency"
+		},
+		"supplier": {
+			"name": "Hotel Azul Lda.",
+			"tax_id": {
+				"country": "PT",
+				"code": "599999993"
+			},
+			"addresses": [
+				{
+					"street": "Rua das Flores",
+					"locality": "Lisboa",
+					"code": "3830-000",
+					"country": "PT"
+				}
+			],
+			"emails": [
+				{
+					"addr": "billing@example.com"
+				}
+			]
+		},
+		"customer": {
+			"name": "Sample Guest",
+			"tax_id": {
+				"country": "PT",
+				"code": "999999990"
+			}
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "1",
+				"item": {
+					"name": "Room rate",
+					"price": "125.00",
+					"unit": "one"
+				},
+				"sum": "125.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "reduced",
+						"percent": "6.0%",
+						"ext": {
+							"pt-region": "PT"
+						}
+					}
+				],
+				"total": "125.00"
+			},
+			{
+				"i": 2,
+				"quantity": "1",
+				"item": {
+					"name": "Room rate",
+					"price": "125.00",
+					"unit": "one"
+				},
+				"sum": "125.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "reduced",
+						"percent": "6.0%",
+						"ext": {
+							"pt-region": "PT"
+						}
+					}
+				],
+				"total": "125.00"
+			},
+			{
+				"i": 3,
+				"quantity": "1",
+				"item": {
+					"name": "Room rate",
+					"price": "125.00",
+					"unit": "one"
+				},
+				"sum": "125.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "reduced",
+						"percent": "6.0%",
+						"ext": {
+							"pt-region": "PT"
+						}
+					}
+				],
+				"total": "125.00"
+			},
+			{
+				"i": 4,
+				"quantity": "1",
+				"item": {
+					"name": "Room rate",
+					"price": "125.00",
+					"unit": "one"
+				},
+				"sum": "125.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "reduced",
+						"percent": "6.0%",
+						"ext": {
+							"pt-region": "PT"
+						}
+					}
+				],
+				"total": "125.00"
+			},
+			{
+				"i": 5,
+				"quantity": "1",
+				"item": {
+					"name": "Room rate",
+					"price": "125.00",
+					"unit": "one"
+				},
+				"sum": "125.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "reduced",
+						"percent": "6.0%",
+						"ext": {
+							"pt-region": "PT"
+						}
+					}
+				],
+				"total": "125.00"
+			},
+			{
+				"i": 6,
+				"quantity": "1",
+				"item": {
+					"name": "Room rate",
+					"price": "125.00",
+					"unit": "one"
+				},
+				"sum": "125.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "reduced",
+						"percent": "6.0%",
+						"ext": {
+							"pt-region": "PT"
+						}
+					}
+				],
+				"total": "125.00"
+			},
+			{
+				"i": 7,
+				"quantity": "1",
+				"item": {
+					"name": "Room rate",
+					"price": "125.00",
+					"unit": "one"
+				},
+				"sum": "125.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "reduced",
+						"percent": "6.0%",
+						"ext": {
+							"pt-region": "PT"
+						}
+					}
+				],
+				"total": "125.00"
+			},
+			{
+				"i": 8,
+				"quantity": "1",
+				"item": {
+					"name": "Room rate",
+					"price": "125.00",
+					"unit": "one"
+				},
+				"sum": "125.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "reduced",
+						"percent": "6.0%",
+						"ext": {
+							"pt-region": "PT"
+						}
+					}
+				],
+				"total": "125.00"
+			},
+			{
+				"i": 9,
+				"quantity": "1",
+				"item": {
+					"name": "Room rate",
+					"price": "125.00",
+					"unit": "one"
+				},
+				"sum": "125.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "reduced",
+						"percent": "6.0%",
+						"ext": {
+							"pt-region": "PT"
+						}
+					}
+				],
+				"total": "125.00"
+			},
+			{
+				"i": 10,
+				"quantity": "1",
+				"item": {
+					"name": "Room rate",
+					"price": "125.00",
+					"unit": "one"
+				},
+				"sum": "125.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "reduced",
+						"percent": "6.0%",
+						"ext": {
+							"pt-region": "PT"
+						}
+					}
+				],
+				"total": "125.00"
+			},
+			{
+				"i": 11,
+				"quantity": "1",
+				"item": {
+					"name": "Room rate",
+					"price": "125.00",
+					"unit": "one"
+				},
+				"sum": "125.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "reduced",
+						"percent": "6.0%",
+						"ext": {
+							"pt-region": "PT"
+						}
+					}
+				],
+				"total": "125.00"
+			},
+			{
+				"i": 12,
+				"quantity": "1",
+				"item": {
+					"name": "Room rate",
+					"price": "125.00",
+					"unit": "one"
+				},
+				"sum": "125.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "reduced",
+						"percent": "6.0%",
+						"ext": {
+							"pt-region": "PT"
+						}
+					}
+				],
+				"total": "125.00"
+			}
+		],
+		"payment": {
+			"terms": {
+				"key": "due-date",
+				"due_dates": [
+					{
+						"date": "2026-07-09",
+						"amount": "1500.00"
+					}
+				]
+			}
+		},
+		"totals": {
+			"sum": "1500.00",
+			"tax_included": "84.91",
+			"total": "1415.09",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"ext": {
+									"pt-region": "PT"
+								},
+								"base": "1415.09",
+								"percent": "6.0%",
+								"amount": "84.91"
+							}
+						],
+						"amount": "84.91"
+					}
+				],
+				"sum": "84.91"
+			},
+			"tax": "84.91",
+			"total_with_tax": "1500.00",
+			"payable": "1500.00"
+		}
+	}
+}

--- a/tax/rounding_rules.go
+++ b/tax/rounding_rules.go
@@ -21,9 +21,10 @@ const (
 
 	// RoundingRuleCurrency is the alternative method of performing calculations
 	// whereby the currency's precision or subunits are used to round the amounts
-	// **before** performing the sums. This can lead to rounding errors when converting
-	// to and from prices that include taxes, but is a common approach in other digital
-	// invoicing formats.
+	// **before** performing the sums. This is a common approach in other digital
+	// invoicing formats. When prices include tax, the tax amount is determined
+	// from the sum of each rate's tax-inclusive line totals and shared back over
+	// the lines, so that the resulting bases and amounts always sum precisely.
 	RoundingRuleCurrency cbc.Key = "currency"
 )
 
@@ -52,7 +53,10 @@ var RoundingRules = []*cbc.Definition{
 				The alternative method of calculating the totals that will first round all the amounts
 				to the currency's precision before making the sums. Totals using this approach can always
 				be recalculated using the amounts presented, but can lead to rounding errors in the case
-				of pre-payments and when line item prices include tax.
+				of pre-payments. When prices include tax, the tax amounts are calculated from each rate's
+				sum of tax-inclusive line totals so that the bases and amounts always add up, though
+				recalculating a tax amount from its base alone may occasionally differ by a single
+				subunit of the currency.
 			`),
 		},
 	},

--- a/tax/totals.go
+++ b/tax/totals.go
@@ -357,6 +357,7 @@ func (t *Total) Calculate(cur currency.Code, rr cbc.Key) {
 func (t *Total) calculateFinalSum(zero num.Amount, rr cbc.Key) {
 	// Now go through each category to apply the percentage and calculate the final sums
 	t.Sum = zero
+	t.Retained = nil
 	for _, ct := range t.Categories {
 		t.calculateBaseCategoryTotal(ct, zero, rr)
 

--- a/tax/totals.go
+++ b/tax/totals.go
@@ -344,81 +344,22 @@ func (t *Total) Exchange(rate *currency.ExchangeRate, rr cbc.Key) {
 	t.Calculate(rate.To, rr)
 }
 
-// Calculate will go through all the categories and rates to calculate the final
-// sum of the taxes. The rounding rule will be applied to the final sums.
+// Calculate will go through all the categories and rates to recalculate the
+// final tax amounts and sums from the accumulated bases according to the
+// rounding rule. When source lines are available, use the TotalCalculator
+// instead; recalculations from the bases alone cannot take into account any
+// taxes included in prices.
 func (t *Total) Calculate(cur currency.Code, rr cbc.Key) {
 	if t == nil {
 		return
 	}
 	zero := cur.Def().Zero()
-	t.calculateFinalSum(zero, rr)
-}
-
-func (t *Total) calculateFinalSum(zero num.Amount, rr cbc.Key) {
-	// Now go through each category to apply the percentage and calculate the final sums
-	t.Sum = zero
-	t.Retained = nil
-	for _, ct := range t.Categories {
-		t.calculateBaseCategoryTotal(ct, zero, rr)
-
-		if ct.Informative {
-			// Informative taxes don't affect Sum or Retained
-			continue
-		}
-		if ct.Retained {
-			if t.Retained == nil {
-				t.Retained = &zero
-			}
-			tr := *t.Retained
-			tr = matchRoundingPrecision(rr, tr, ct.Amount)
-			tr = tr.Add(ct.Amount)
-			if ct.Surcharge != nil {
-				tr = tr.Add(*ct.Surcharge)
-			}
-			t.Retained = &tr
-		} else {
-			t.Sum = matchRoundingPrecision(rr, t.Sum, ct.Amount)
-			t.Sum = t.Sum.Add(ct.Amount)
-			if ct.Surcharge != nil {
-				t.Sum = t.Sum.Add(*ct.Surcharge)
-			}
-		}
-	}
-}
-
-func (t *Total) calculateBaseCategoryTotal(ct *CategoryTotal, zero num.Amount, rr cbc.Key) {
-	ct.Amount = zero
-	for _, rt := range ct.Rates {
-		if rt.Percent == nil {
-			rt.Amount = zero
-			continue // exempt, nothing else to do
-		}
-		base := rt.Base
-		rt.Amount = rt.Percent.Of(rt.Base)
-		ct.Amount = matchRoundingPrecision(rr, ct.Amount, rt.Amount)
-		ct.Amount = ct.Amount.Add(rt.Amount)
-		if rt.Surcharge != nil {
-			rt.Surcharge.Amount = rt.Surcharge.Percent.Of(base)
-			if ct.Surcharge == nil {
-				ct.Surcharge = &zero
-			}
-			a := rt.Surcharge.Amount
-			x := *ct.Surcharge
-			x = matchRoundingPrecision(rr, x, a)
-			x = x.Add(a)
-			ct.Surcharge = &x
-		}
-	}
-}
-
-// matchPrecision will decide what precision to maintain on the amount based on
-// the rounding rule.
-func matchRoundingPrecision(rr cbc.Key, a, b num.Amount) num.Amount {
 	switch rr {
 	case RoundingRuleCurrency:
-		return a // maintain original precision
+		t.calculateCurrencyFinalSums(zero, cbc.CodeEmpty)
+	default:
+		t.calculatePreciseFinalSums(zero)
 	}
-	return a.MatchPrecision(b)
 }
 
 // Round will go through all the values generated and round them to the currency's

--- a/tax/totals_calculator.go
+++ b/tax/totals_calculator.go
@@ -28,7 +28,9 @@ type TaxableLine interface {
 	GetTotal() num.Amount
 }
 
-// Calculate the totals
+// Calculate the totals according to the rounding rule, either using the
+// currency's precision for every step, or maintaining precision until
+// the final sums.
 func (tc *TotalCalculator) Calculate(t *Total) error {
 	tc.zero = tc.Currency.Def().Zero()
 
@@ -38,68 +40,39 @@ func (tc *TotalCalculator) Calculate(t *Total) error {
 
 	// get simplified list of lines
 	taxLines := mapTaxLines(tc.Lines)
-	if err := tc.prepareLines(taxLines); err != nil {
+	if err := tc.prepareCombos(taxLines); err != nil {
 		return err
 	}
 
-	// Remove included taxes
-	if err := tc.removeIncludedTaxes(taxLines); err != nil {
-		return err
+	if tc.Rounding == RoundingRuleCurrency {
+		return tc.calculateCurrencyTotals(t, taxLines)
 	}
-
-	tc.calculateBaseRateTotals(taxLines, t)
-	t.Calculate(tc.Currency, tc.Rounding)
-
-	return nil
+	return tc.calculatePreciseTotals(t, taxLines)
 }
 
-func (tc *TotalCalculator) prepareLines(taxLines []*taxLine) error {
-	// First, prepare all tax combos using the country and date
+// prepareCombos ensures the tax combos of every line have been calculated
+// using the country and date.
+func (tc *TotalCalculator) prepareCombos(taxLines []*taxLine) error {
 	for _, tl := range taxLines {
 		for _, combo := range tl.taxes {
 			if err := combo.calculate(tc.Country, tc.Date); err != nil {
 				return err
 			}
-			// always add 2 decimal places for all tax calculations
-			tl.total = tl.total.RescaleUp(tc.zero.Exp() + 2)
 		}
 	}
 	return nil
 }
 
-func (tc *TotalCalculator) removeIncludedTaxes(taxLines []*taxLine) error {
-	// If prices include a tax, perform a pre-loop to update all the line prices with
-	// the price minus the defined tax.
-	if tc.Includes.IsEmpty() {
-		return nil
+// checkIncludedCombo ensures the combo's category can be used for
+// taxes included in prices.
+func (tc *TotalCalculator) checkIncludedCombo(c *Combo) error {
+	if c.retained {
+		return ErrInvalidPricesInclude.WithMessage("cannot include retained category '%s'", tc.Includes.String())
 	}
-	for _, tl := range taxLines {
-		if c := tl.taxes.Get(tc.Includes); c != nil {
-			if c.retained {
-				return ErrInvalidPricesInclude.WithMessage("cannot include retained category '%s'", tc.Includes.String())
-			}
-			if c.informative {
-				return ErrInvalidPricesInclude.WithMessage("cannot include informative category '%s'", tc.Includes.String())
-			}
-			if c.Percent == nil {
-				// no taxes, skip
-				continue
-			}
-			tl.total = tl.total.Remove(*c.Percent)
-		}
+	if c.informative {
+		return ErrInvalidPricesInclude.WithMessage("cannot include informative category '%s'", tc.Includes.String())
 	}
 	return nil
-}
-
-func (tc *TotalCalculator) calculateBaseRateTotals(taxLines []*taxLine, t *Total) {
-	// Go through each line and add the total to the base of each tax
-	for _, tl := range taxLines {
-		for _, c := range tl.taxes {
-			rt := t.rateTotalFor(c, tc.zero)
-			rt.Base = matchRoundingPrecision(tc.Rounding, rt.Base, tl.total)
-			rt.Base = rt.Base.Add(tl.total)
-		}
-	}
 }
 
 // taxLine is used to replace

--- a/tax/totals_calculator.go
+++ b/tax/totals_calculator.go
@@ -37,6 +37,7 @@ func (tc *TotalCalculator) Calculate(t *Total) error {
 	// reset
 	t.Categories = make([]*CategoryTotal, 0)
 	t.Sum = tc.zero
+	t.Retained = nil
 
 	// get simplified list of lines
 	taxLines := mapTaxLines(tc.Lines)

--- a/tax/totals_calculator_currency.go
+++ b/tax/totals_calculator_currency.go
@@ -1,0 +1,111 @@
+package tax
+
+// calculateCurrencyTotals performs all calculations using the currency's
+// precision, rounding each line's amounts before adding them to the sums,
+// so that the results can always be recalculated from the data presented.
+func (tc *TotalCalculator) calculateCurrencyTotals(t *Total, taxLines []*taxLine) error {
+	if err := tc.extractIncludedTaxes(t, taxLines); err != nil {
+		return err
+	}
+
+	// Go through each line and add the total to the base of each tax,
+	// rounded to the currency's precision.
+	for _, tl := range taxLines {
+		for _, c := range tl.taxes {
+			if c.Category == tc.Includes && c.Percent != nil {
+				// base already accumulated during extraction
+				continue
+			}
+			rt := t.rateTotalFor(c, tc.zero)
+			rt.Base = rt.Base.Add(tl.total)
+		}
+	}
+
+	tc.calculateFinalSums(t)
+	return nil
+}
+
+// extractIncludedTaxes removes the included tax from each line's total.
+// The tax is calculated over the accumulated sum of the rate's tax-inclusive
+// line totals, with each line assuming the increment, so that the resulting
+// bases and tax amounts will always add up to the sum of the original totals.
+func (tc *TotalCalculator) extractIncludedTaxes(t *Total, taxLines []*taxLine) error {
+	if tc.Includes.IsEmpty() {
+		return nil
+	}
+	for _, tl := range taxLines {
+		c := tl.taxes.Get(tc.Includes)
+		if c == nil {
+			continue
+		}
+		if err := tc.checkIncludedCombo(c); err != nil {
+			return err
+		}
+		if c.Percent == nil {
+			// no taxes, skip
+			continue
+		}
+		// use the rate total to accumulate the running sums of the
+		// tax-inclusive totals and their taxes
+		rt := t.rateTotalFor(c, tc.zero)
+		rt.Base = rt.Base.MatchPrecision(tl.total).Add(tl.total)
+		tax := c.Percent.From(rt.Base.Upscale(4)).Rescale(tc.zero.Exp())
+		tl.total = tl.total.Subtract(tax.Subtract(rt.Amount))
+		rt.Amount = tax
+	}
+
+	// swap the accumulated tax-inclusive totals for the final bases
+	if ct := t.Category(tc.Includes); ct != nil {
+		for _, rt := range ct.Rates {
+			rt.Base = rt.Base.Subtract(rt.Amount)
+		}
+	}
+	return nil
+}
+
+// calculateFinalSums provides the final category and document sums, keeping
+// any tax amounts already extracted from tax-inclusive totals.
+func (tc *TotalCalculator) calculateFinalSums(t *Total) {
+	t.Sum = tc.zero
+	for _, ct := range t.Categories {
+		ct.Amount = tc.zero
+		for _, rt := range ct.Rates {
+			if rt.Percent == nil {
+				rt.Amount = tc.zero
+				continue // exempt, nothing else to do
+			}
+			if ct.Code != tc.Includes {
+				rt.Amount = rt.Percent.Of(rt.Base)
+			}
+			ct.Amount = ct.Amount.Add(rt.Amount)
+			if rt.Surcharge != nil {
+				rt.Surcharge.Amount = rt.Surcharge.Percent.Of(rt.Base)
+				s := tc.zero
+				if ct.Surcharge != nil {
+					s = *ct.Surcharge
+				}
+				s = s.Add(rt.Surcharge.Amount)
+				ct.Surcharge = &s
+			}
+		}
+
+		if ct.Informative {
+			// Informative taxes don't affect Sum or Retained
+			continue
+		}
+		a := ct.Amount
+		if ct.Surcharge != nil {
+			a = a.Add(*ct.Surcharge)
+		}
+		if ct.Retained {
+			r := tc.zero
+			if t.Retained != nil {
+				r = *t.Retained
+			}
+			r = r.Add(a)
+			t.Retained = &r
+		} else {
+			t.Sum = t.Sum.Add(a)
+		}
+	}
+}

--- a/tax/totals_calculator_currency.go
+++ b/tax/totals_calculator_currency.go
@@ -1,5 +1,10 @@
 package tax
 
+import (
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/num"
+)
+
 // calculateCurrencyTotals performs all calculations using the currency's
 // precision, rounding each line's amounts before adding them to the sums,
 // so that the results can always be recalculated from the data presented.
@@ -26,7 +31,7 @@ func (tc *TotalCalculator) calculateCurrencyTotals(t *Total, taxLines []*taxLine
 		}
 	}
 
-	tc.calculateFinalSums(t)
+	t.calculateCurrencyFinalSums(tc.zero, tc.Includes)
 	return nil
 }
 
@@ -70,25 +75,28 @@ func (tc *TotalCalculator) extractIncludedTaxes(t *Total, taxLines []*taxLine) e
 	return nil
 }
 
-// calculateFinalSums provides the final category and document sums, keeping
-// any tax amounts already extracted from tax-inclusive totals.
-func (tc *TotalCalculator) calculateFinalSums(t *Total) {
-	t.Sum = tc.zero
+// calculateCurrencyFinalSums provides the final category and document sums
+// from the accumulated bases at the currency's precision, keeping any tax
+// amounts already extracted from the tax-inclusive totals of the included
+// category.
+func (t *Total) calculateCurrencyFinalSums(zero num.Amount, includes cbc.Code) {
+	t.Sum = zero
 	t.Retained = nil
 	for _, ct := range t.Categories {
-		ct.Amount = tc.zero
+		ct.Amount = zero
+		ct.Surcharge = nil
 		for _, rt := range ct.Rates {
 			if rt.Percent == nil {
-				rt.Amount = tc.zero
+				rt.Amount = zero
 				continue // exempt, nothing else to do
 			}
-			if ct.Code != tc.Includes {
+			if ct.Code != includes {
 				rt.Amount = rt.Percent.Of(rt.Base)
 			}
 			ct.Amount = ct.Amount.Add(rt.Amount)
 			if rt.Surcharge != nil {
 				rt.Surcharge.Amount = rt.Surcharge.Percent.Of(rt.Base)
-				s := tc.zero
+				s := zero
 				if ct.Surcharge != nil {
 					s = *ct.Surcharge
 				}
@@ -106,7 +114,7 @@ func (tc *TotalCalculator) calculateFinalSums(t *Total) {
 			a = a.Add(*ct.Surcharge)
 		}
 		if ct.Retained {
-			r := tc.zero
+			r := zero
 			if t.Retained != nil {
 				r = *t.Retained
 			}

--- a/tax/totals_calculator_currency.go
+++ b/tax/totals_calculator_currency.go
@@ -4,6 +4,11 @@ package tax
 // precision, rounding each line's amounts before adding them to the sums,
 // so that the results can always be recalculated from the data presented.
 func (tc *TotalCalculator) calculateCurrencyTotals(t *Total, taxLines []*taxLine) error {
+	// round all the line totals to the currency's precision
+	for _, tl := range taxLines {
+		tl.total = tl.total.Rescale(tc.zero.Exp())
+	}
+
 	if err := tc.extractIncludedTaxes(t, taxLines); err != nil {
 		return err
 	}
@@ -46,9 +51,11 @@ func (tc *TotalCalculator) extractIncludedTaxes(t *Total, taxLines []*taxLine) e
 			continue
 		}
 		// use the rate total to accumulate the running sums of the
-		// tax-inclusive totals and their taxes
+		// tax-inclusive totals and their taxes, with four extra decimal
+		// places of precision to avoid double-rounding errors close to
+		// the currency's rounding boundaries
 		rt := t.rateTotalFor(c, tc.zero)
-		rt.Base = rt.Base.MatchPrecision(tl.total).Add(tl.total)
+		rt.Base = rt.Base.Add(tl.total)
 		tax := c.Percent.From(rt.Base.Upscale(4)).Rescale(tc.zero.Exp())
 		tl.total = tl.total.Subtract(tax.Subtract(rt.Amount))
 		rt.Amount = tax
@@ -67,6 +74,7 @@ func (tc *TotalCalculator) extractIncludedTaxes(t *Total, taxLines []*taxLine) e
 // any tax amounts already extracted from tax-inclusive totals.
 func (tc *TotalCalculator) calculateFinalSums(t *Total) {
 	t.Sum = tc.zero
+	t.Retained = nil
 	for _, ct := range t.Categories {
 		ct.Amount = tc.zero
 		for _, rt := range ct.Rates {

--- a/tax/totals_calculator_precise.go
+++ b/tax/totals_calculator_precise.go
@@ -1,0 +1,48 @@
+package tax
+
+// calculatePreciseTotals accumulates the rate bases with at least two extra
+// decimal places of precision above the currency's own, providing the most
+// accurate results possible when rounding the final sums.
+func (tc *TotalCalculator) calculatePreciseTotals(t *Total, taxLines []*taxLine) error {
+	// always add 2 decimal places for all tax calculations
+	for _, tl := range taxLines {
+		tl.total = tl.total.RescaleUp(tc.zero.Exp() + 2)
+	}
+
+	if err := tc.removeIncludedTaxes(taxLines); err != nil {
+		return err
+	}
+
+	// Go through each line and add the total to the base of each tax
+	for _, tl := range taxLines {
+		for _, c := range tl.taxes {
+			rt := t.rateTotalFor(c, tc.zero)
+			rt.Base = rt.Base.MatchPrecision(tl.total)
+			rt.Base = rt.Base.Add(tl.total)
+		}
+	}
+
+	t.Calculate(tc.Currency, RoundingRulePrecise)
+	return nil
+}
+
+// removeIncludedTaxes performs a pre-loop to update all the line totals
+// with the total minus the included tax.
+func (tc *TotalCalculator) removeIncludedTaxes(taxLines []*taxLine) error {
+	if tc.Includes.IsEmpty() {
+		return nil
+	}
+	for _, tl := range taxLines {
+		if c := tl.taxes.Get(tc.Includes); c != nil {
+			if err := tc.checkIncludedCombo(c); err != nil {
+				return err
+			}
+			if c.Percent == nil {
+				// no taxes, skip
+				continue
+			}
+			tl.total = tl.total.Remove(*c.Percent)
+		}
+	}
+	return nil
+}

--- a/tax/totals_calculator_precise.go
+++ b/tax/totals_calculator_precise.go
@@ -1,5 +1,9 @@
 package tax
 
+import (
+	"github.com/invopop/gobl/num"
+)
+
 // calculatePreciseTotals accumulates the rate bases with at least two extra
 // decimal places of precision above the currency's own, providing the most
 // accurate results possible when rounding the final sums.
@@ -22,7 +26,7 @@ func (tc *TotalCalculator) calculatePreciseTotals(t *Total, taxLines []*taxLine)
 		}
 	}
 
-	t.Calculate(tc.Currency, RoundingRulePrecise)
+	t.calculatePreciseFinalSums(tc.zero)
 	return nil
 }
 
@@ -45,4 +49,58 @@ func (tc *TotalCalculator) removeIncludedTaxes(taxLines []*taxLine) error {
 		}
 	}
 	return nil
+}
+
+// calculatePreciseFinalSums provides the final category and document sums
+// from the accumulated bases, maintaining their precision until the totals
+// are rounded to the currency later.
+func (t *Total) calculatePreciseFinalSums(zero num.Amount) {
+	t.Sum = zero
+	t.Retained = nil
+	for _, ct := range t.Categories {
+		ct.Amount = zero
+		ct.Surcharge = nil
+		for _, rt := range ct.Rates {
+			if rt.Percent == nil {
+				rt.Amount = zero
+				continue // exempt, nothing else to do
+			}
+			rt.Amount = rt.Percent.Of(rt.Base)
+			ct.Amount = ct.Amount.MatchPrecision(rt.Amount)
+			ct.Amount = ct.Amount.Add(rt.Amount)
+			if rt.Surcharge != nil {
+				rt.Surcharge.Amount = rt.Surcharge.Percent.Of(rt.Base)
+				s := zero
+				if ct.Surcharge != nil {
+					s = *ct.Surcharge
+				}
+				s = s.MatchPrecision(rt.Surcharge.Amount)
+				s = s.Add(rt.Surcharge.Amount)
+				ct.Surcharge = &s
+			}
+		}
+
+		if ct.Informative {
+			// Informative taxes don't affect Sum or Retained
+			continue
+		}
+		if ct.Retained {
+			r := zero
+			if t.Retained != nil {
+				r = *t.Retained
+			}
+			r = r.MatchPrecision(ct.Amount)
+			r = r.Add(ct.Amount)
+			if ct.Surcharge != nil {
+				r = r.Add(*ct.Surcharge)
+			}
+			t.Retained = &r
+		} else {
+			t.Sum = t.Sum.MatchPrecision(ct.Amount)
+			t.Sum = t.Sum.Add(ct.Amount)
+			if ct.Surcharge != nil {
+				t.Sum = t.Sum.Add(*ct.Surcharge)
+			}
+		}
+	}
 }

--- a/tax/totals_calculator_test.go
+++ b/tax/totals_calculator_test.go
@@ -1499,3 +1499,195 @@ func TestTotalCalculatorCurrencyRoundingIncludedTaxes(t *testing.T) {
 		assert.Equal(t, "0.00", exempt.Amount.String())
 	})
 }
+
+func TestTotalCalculatorCurrencyRounding(t *testing.T) {
+	date := cal.MakeDate(2026, 7, 9)
+	zero := currency.EUR.Def().Zero()
+	calculate := func(t *testing.T, country l10n.TaxCountryCode, includes cbc.Code, lines ...tax.TaxableLine) (*tax.Total, error) {
+		t.Helper()
+		tc := &tax.TotalCalculator{
+			Country:  country,
+			Currency: currency.EUR,
+			Rounding: tax.RoundingRuleCurrency,
+			Date:     date,
+			Lines:    lines,
+			Includes: includes,
+		}
+		tot := new(tax.Total)
+		err := tc.Calculate(tot)
+		tot.Round(zero)
+		return tot, err
+	}
+
+	t.Run("with surcharges", func(t *testing.T) {
+		lines := make([]tax.TaxableLine, 2)
+		for i := range lines {
+			lines[i] = &taxableLine{
+				taxes: tax.Set{{
+					Category:  tax.CategoryVAT,
+					Percent:   num.NewPercentage(21, 2),
+					Surcharge: num.NewPercentage(52, 3),
+				}},
+				amount: num.MakeAmount(10000, 2),
+			}
+		}
+		lines = append(lines, &taxableLine{
+			taxes: tax.Set{{
+				Category:  tax.CategoryVAT,
+				Percent:   num.NewPercentage(10, 2),
+				Surcharge: num.NewPercentage(14, 3),
+			}},
+			amount: num.MakeAmount(10000, 2),
+		})
+		tot, err := calculate(t, "ES", "", lines...)
+		require.NoError(t, err)
+		ct := tot.Categories[0]
+		rt := ct.Rates[0]
+		assert.Equal(t, "200.00", rt.Base.String())
+		assert.Equal(t, "42.00", rt.Amount.String())
+		assert.Equal(t, "10.40", rt.Surcharge.Amount.String())
+		assert.Equal(t, "11.80", ct.Surcharge.String())
+		assert.Equal(t, "63.80", tot.Sum.String())
+	})
+
+	t.Run("included taxes with surcharges", func(t *testing.T) {
+		lines := make([]tax.TaxableLine, 2)
+		for i := range lines {
+			lines[i] = &taxableLine{
+				taxes: tax.Set{{
+					Category:  tax.CategoryVAT,
+					Percent:   num.NewPercentage(21, 2),
+					Surcharge: num.NewPercentage(52, 3),
+				}},
+				amount: num.MakeAmount(12100, 2),
+			}
+		}
+		tot, err := calculate(t, "ES", tax.CategoryVAT, lines...)
+		require.NoError(t, err)
+		rt := tot.Categories[0].Rates[0]
+		assert.Equal(t, "200.00", rt.Base.String())
+		assert.Equal(t, "42.00", rt.Amount.String())
+		assert.Equal(t, "10.40", rt.Surcharge.Amount.String())
+		assert.Equal(t, "52.40", tot.Sum.String())
+	})
+
+	t.Run("with informative categories", func(t *testing.T) {
+		tot, err := calculate(t, "BR", "",
+			&taxableLine{
+				taxes: tax.Set{{
+					Category: br.TaxCategoryISS,
+					Percent:  num.NewPercentage(5, 2),
+				}},
+				amount: num.MakeAmount(20000, 2),
+			},
+		)
+		require.NoError(t, err)
+		ct := tot.Categories[0]
+		assert.True(t, ct.Informative)
+		assert.Equal(t, "10.00", ct.Amount.String())
+		assert.Equal(t, "0.00", tot.Sum.String())
+		assert.Nil(t, tot.Retained)
+	})
+
+	t.Run("with multiple retained categories", func(t *testing.T) {
+		tot, err := calculate(t, "BR", "",
+			&taxableLine{
+				taxes: tax.Set{
+					{
+						Category: br.TaxCategoryPISRet,
+						Percent:  num.NewPercentage(65, 4),
+					},
+					{
+						Category: br.TaxCategoryCOFINSRet,
+						Percent:  num.NewPercentage(3, 2),
+					},
+				},
+				amount: num.MakeAmount(100000, 2),
+			},
+		)
+		require.NoError(t, err)
+		require.NotNil(t, tot.Retained)
+		assert.Equal(t, "36.50", tot.Retained.String())
+		assert.Equal(t, "0.00", tot.Sum.String())
+	})
+
+	t.Run("error including retained category", func(t *testing.T) {
+		_, err := calculate(t, "ES", "IRPF",
+			&taxableLine{
+				taxes:  tax.Set{{Category: "IRPF", Percent: num.NewPercentage(15, 2)}},
+				amount: num.MakeAmount(10000, 2),
+			},
+		)
+		require.ErrorContains(t, err, "cannot include retained category 'IRPF'")
+	})
+
+	t.Run("error including informative category", func(t *testing.T) {
+		_, err := calculate(t, "BR", br.TaxCategoryISS,
+			&taxableLine{
+				taxes: tax.Set{{
+					Category: br.TaxCategoryISS,
+					Percent:  num.NewPercentage(5, 2),
+				}},
+				amount: num.MakeAmount(10000, 2),
+			},
+		)
+		require.ErrorContains(t, err, "cannot include informative category 'ISS'")
+	})
+
+	t.Run("lines without the included category", func(t *testing.T) {
+		tot, err := calculate(t, "ES", tax.CategoryVAT,
+			&taxableLine{
+				taxes:  tax.Set{{Category: tax.CategoryVAT, Rate: tax.RateGeneral}},
+				amount: num.MakeAmount(193, 2),
+			},
+			&taxableLine{
+				taxes:  tax.Set{{Category: es.TaxCategoryIRPF, Percent: num.NewPercentage(15, 2)}},
+				amount: num.MakeAmount(1000, 2),
+			},
+		)
+		require.NoError(t, err)
+		vat := tot.Categories[0].Rates[0]
+		irpf := tot.Categories[1].Rates[0]
+		assert.Equal(t, "1.60", vat.Base.String())
+		assert.Equal(t, "0.33", vat.Amount.String())
+		assert.Equal(t, "10.00", irpf.Base.String())
+		assert.Equal(t, "1.50", irpf.Amount.String())
+	})
+
+	t.Run("line totals with extra precision", func(t *testing.T) {
+		tot, err := calculate(t, "ES", "",
+			&taxableLine{
+				taxes:  tax.Set{{Category: tax.CategoryVAT, Rate: tax.RateGeneral}},
+				amount: num.MakeAmount(1000049, 4), // 100.0049
+			},
+		)
+		require.NoError(t, err)
+		rt := tot.Categories[0].Rates[0]
+		assert.Equal(t, "100.00", rt.Base.String())
+		assert.Equal(t, "21.00", rt.Amount.String())
+	})
+
+	t.Run("repeated calculations", func(t *testing.T) {
+		tc := &tax.TotalCalculator{
+			Country:  "ES",
+			Currency: currency.EUR,
+			Rounding: tax.RoundingRuleCurrency,
+			Date:     date,
+			Lines: []tax.TaxableLine{
+				&taxableLine{
+					taxes: tax.Set{
+						{Category: tax.CategoryVAT, Rate: tax.RateGeneral},
+						{Category: es.TaxCategoryIRPF, Rate: "pro"},
+					},
+					amount: num.MakeAmount(10000, 2),
+				},
+			},
+		}
+		tot := new(tax.Total)
+		require.NoError(t, tc.Calculate(tot))
+		require.NoError(t, tc.Calculate(tot))
+		require.NotNil(t, tot.Retained)
+		assert.Equal(t, "15.00", tot.Retained.String())
+		assert.Equal(t, "21.00", tot.Sum.String())
+	})
+}

--- a/tax/totals_calculator_test.go
+++ b/tax/totals_calculator_test.go
@@ -1370,3 +1370,132 @@ func TestTotalBySumCalculate(t *testing.T) {
 	}
 
 }
+
+func TestTotalCalculatorCurrencyRoundingIncludedTaxes(t *testing.T) {
+	date := cal.MakeDate(2026, 7, 9)
+	zero := currency.EUR.Def().Zero()
+	calculate := func(t *testing.T, country l10n.TaxCountryCode, lines ...tax.TaxableLine) *tax.Total {
+		t.Helper()
+		tc := &tax.TotalCalculator{
+			Country:  country,
+			Currency: currency.EUR,
+			Rounding: tax.RoundingRuleCurrency,
+			Date:     date,
+			Lines:    lines,
+			Includes: tax.CategoryVAT,
+		}
+		tot := new(tax.Total)
+		require.NoError(t, tc.Calculate(tot))
+		tot.Round(zero)
+		return tot
+	}
+
+	t.Run("single rate over multiple lines", func(t *testing.T) {
+		// 12 lines of 125.00 with 6% VAT included
+		lines := make([]tax.TaxableLine, 12)
+		for i := range lines {
+			lines[i] = &taxableLine{
+				taxes:  tax.Set{{Category: tax.CategoryVAT, Rate: tax.RateReduced}},
+				amount: num.MakeAmount(12500, 2),
+			}
+		}
+		tot := calculate(t, "PT", lines...)
+		rt := tot.Categories[0].Rates[0]
+		assert.Equal(t, "1415.09", rt.Base.String())
+		assert.Equal(t, "84.91", rt.Amount.String())
+		assert.Equal(t, "84.91", tot.Sum.String())
+		// the base and amount add up to the original tax-inclusive sum
+		assert.Equal(t, "1500.00", rt.Base.Add(rt.Amount).String())
+	})
+
+	t.Run("lines with individual rounding errors", func(t *testing.T) {
+		// each line's price of 1.93 with 21% VAT included has a base of
+		// 1.5950 that individually rounds up to 1.60
+		lines := make([]tax.TaxableLine, 10)
+		for i := range lines {
+			lines[i] = &taxableLine{
+				taxes:  tax.Set{{Category: tax.CategoryVAT, Rate: tax.RateGeneral}},
+				amount: num.MakeAmount(193, 2),
+			}
+		}
+		tot := calculate(t, "ES", lines...)
+		rt := tot.Categories[0].Rates[0]
+		assert.Equal(t, "15.95", rt.Base.String())
+		assert.Equal(t, "3.35", rt.Amount.String())
+		assert.Equal(t, "19.30", rt.Base.Add(rt.Amount).String())
+	})
+
+	t.Run("with retained taxes", func(t *testing.T) {
+		lines := make([]tax.TaxableLine, 10)
+		for i := range lines {
+			lines[i] = &taxableLine{
+				taxes: tax.Set{
+					{Category: tax.CategoryVAT, Rate: tax.RateGeneral},
+					{Category: es.TaxCategoryIRPF, Rate: "pro"},
+				},
+				amount: num.MakeAmount(193, 2),
+			}
+		}
+		tot := calculate(t, "ES", lines...)
+		vat := tot.Categories[0].Rates[0]
+		irpf := tot.Categories[1].Rates[0]
+		// the retained tax base matches the VAT base exactly
+		assert.Equal(t, "15.95", vat.Base.String())
+		assert.Equal(t, "15.95", irpf.Base.String())
+		assert.Equal(t, "2.39", irpf.Amount.String())
+		assert.Equal(t, "3.35", tot.Sum.String())
+		assert.Equal(t, "2.39", tot.Retained.String())
+	})
+
+	t.Run("retained tax over multiple rate groups", func(t *testing.T) {
+		mk := func(cents int64, rate cbc.Key) tax.TaxableLine {
+			return &taxableLine{
+				taxes: tax.Set{
+					{Category: tax.CategoryVAT, Rate: rate},
+					{Category: es.TaxCategoryIRPF, Rate: "pro"},
+				},
+				amount: num.MakeAmount(cents, 2),
+			}
+		}
+		tot := calculate(t, "ES",
+			mk(193, tax.RateGeneral),
+			mk(314, tax.RateGeneral),
+			mk(677, tax.RateGeneral),
+			mk(187, tax.RateReduced),
+			mk(407, tax.RateReduced),
+			mk(297, tax.RateReduced),
+		)
+		general := tot.Categories[0].Rates[0]
+		reduced := tot.Categories[0].Rates[1]
+		irpf := tot.Categories[1].Rates[0]
+		// each rate group's base and amount add up to its tax-inclusive sum,
+		// with the amount maintained from the group total even when it
+		// differs from a recalculation over the rounded base
+		assert.Equal(t, "9.79", general.Base.String())
+		assert.Equal(t, "2.05", general.Amount.String())
+		assert.Equal(t, "8.10", reduced.Base.String())
+		assert.Equal(t, "0.81", reduced.Amount.String())
+		// the retained base spans both groups without rounding drift
+		assert.Equal(t, "17.89", irpf.Base.String())
+		assert.Equal(t, "2.68", irpf.Amount.String())
+	})
+
+	t.Run("with exempt lines", func(t *testing.T) {
+		tot := calculate(t, "ES",
+			&taxableLine{
+				taxes:  tax.Set{{Category: tax.CategoryVAT, Rate: tax.RateGeneral}},
+				amount: num.MakeAmount(193, 2),
+			},
+			&taxableLine{
+				taxes:  tax.Set{{Category: tax.CategoryVAT, Key: tax.KeyExempt}},
+				amount: num.MakeAmount(1000, 2),
+			},
+		)
+		general := tot.Categories[0].Rates[0]
+		exempt := tot.Categories[0].Rates[1]
+		assert.Equal(t, "1.60", general.Base.String())
+		assert.Equal(t, "0.33", general.Amount.String())
+		assert.Equal(t, "10.00", exempt.Base.String())
+		assert.Equal(t, "0.00", exempt.Amount.String())
+	})
+}

--- a/tax/totals_test.go
+++ b/tax/totals_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/currency"
 	"github.com/invopop/gobl/num"
 	"github.com/invopop/gobl/tax"
@@ -688,4 +689,64 @@ func TestTotalCalculate(t *testing.T) {
 		assert.Equal(t, "5.00", tt.Category("ISS").Rates[0].Amount.String())
 		assert.Equal(t, "3.00", tt.Category("ISS").Rates[1].Amount.String())
 	})
+}
+
+func TestTotalCalculateRepeated(t *testing.T) {
+	build := func() *tax.Total {
+		return &tax.Total{
+			Categories: []*tax.CategoryTotal{
+				{
+					Code: tax.CategoryVAT,
+					Rates: []*tax.RateTotal{
+						{
+							Base:    num.MakeAmount(10000, 2),
+							Percent: num.NewPercentage(21, 2),
+							Surcharge: &tax.RateTotalSurcharge{
+								Percent: *num.NewPercentage(52, 3),
+							},
+						},
+						{
+							Base:    num.MakeAmount(10000, 2),
+							Percent: num.NewPercentage(10, 2),
+							Surcharge: &tax.RateTotalSurcharge{
+								Percent: *num.NewPercentage(14, 3),
+							},
+						},
+					},
+				},
+				{
+					Code:     "IRPF",
+					Retained: true,
+					Rates: []*tax.RateTotal{
+						{
+							Base:    num.MakeAmount(10000, 2),
+							Percent: num.NewPercentage(15, 2),
+						},
+					},
+				},
+				{
+					Code:     "RET",
+					Retained: true,
+					Rates: []*tax.RateTotal{
+						{
+							Base:    num.MakeAmount(10000, 2),
+							Percent: num.NewPercentage(2, 2),
+						},
+					},
+				},
+			},
+		}
+	}
+	for _, rr := range []cbc.Key{tax.RoundingRulePrecise, tax.RoundingRuleCurrency} {
+		t.Run(rr.String(), func(t *testing.T) {
+			tot := build()
+			tot.Calculate(currency.EUR, rr)
+			tot.Calculate(currency.EUR, rr)
+			assert.Equal(t, "21.00", tot.Categories[0].Rates[0].Amount.String())
+			assert.Equal(t, "6.60", tot.Categories[0].Surcharge.String())
+			assert.Equal(t, "37.60", tot.Sum.String())
+			require.NotNil(t, tot.Retained)
+			assert.Equal(t, "17.00", tot.Retained.String())
+		})
+	}
 }


### PR DESCRIPTION
## Summary

Fixes tax calculations when combining `prices_include` with the `currency` rounding rule. Previously each line's base was extracted and rounded individually, so with multiple lines the accumulated rounding drift meant the tax total's base plus amount no longer matched the document totals (e.g. 10 lines of 1.93 € at 21% VAT produced a base of 36.00 against a net total of 35.94).

With the currency rounding rule, included taxes are now determined from the sum of each rate group's tax-inclusive line totals, and shared back over the lines using cumulative rounding, so that:

- each rate's `base + amount` equals the sum of its original tax-inclusive line totals,
- `totals.total` equals the sum of the rate bases, and
- other categories — including retained taxes such as IRPF — accumulate their bases from the exact extracted line totals, without drift, even when spanning multiple rate groups.

The `precise` and `currency` rounding rules now have completely independent total calculators (`totals_calculator_precise.go` and `totals_calculator_currency.go`) so it is clear how each treats the data. The `precise` path is unchanged.

The Greek B2C example re-enables `prices_include`, which was commented out when the `round-then-sum` rule was originally introduced.

Note: a recalculation of a tax amount from its rounded base alone may occasionally differ by a single currency subunit from the amount derived from the tax-inclusive sums; this is inherent to any tax-inclusive scheme and is now mentioned in the rounding rule description.

## Testing

- New `tax` package tests covering multiple lines with a single rate, per-line rounding drift, retained taxes, retained taxes spanning multiple rate groups, and exempt lines.
- New `bill` package tests asserting full invoice totals with included VAT under currency rounding, with and without retained taxes.
- New PT example invoice (`examples/pt/invoice-pt-prices-include.yaml`) based on an anonymised customer document: 12 lines of 125.00 € with 6% VAT included and currency rounding, producing `base 1415.09 + tax 84.91 = 1500.00`.
- Regenerated Greek B2C example output: `base 6.81 + tax 1.63 = 8.44`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)