### PR TITLE
it-sdi: validate item attribute type length (FatturaPA TipoDato)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 - `tax`: the `currency` rounding rule combined with `prices_include` now determines each rate's tax amount from the sum of the tax-inclusive line totals and shares it back over the lines, so that bases, tax amounts, and document totals always add up, including when other categories such as retained taxes are present.
 - `addons/eu/en16931`: party identities are now validated so that at most one may carry the `legal` scope (BT-30, BT-47) and at most one the `tax` scope (BT-31, BT-48).
+- `addons/it/sdi`: item attribute `type` is validated to be at most 10 characters, matching the FatturaPA `AltriDatiGestionali/TipoDato` (BT-160) field it maps to.
 
 ### Fixed
 

--- a/addons/it/sdi/org.go
+++ b/addons/it/sdi/org.go
@@ -46,7 +46,7 @@ func orgAttributeRules() *rules.Set {
 	return rules.For(new(org.Attribute),
 		rules.Field("type",
 			rules.Assert("01", "attribute type cannot be longer than 10 characters (TipoDato)",
-				is.RuneLength(0, 10),
+				is.Length(0, 10),
 			),
 		),
 	)

--- a/addons/it/sdi/org.go
+++ b/addons/it/sdi/org.go
@@ -39,6 +39,19 @@ func orgAddressRules() *rules.Set {
 	)
 }
 
+// orgAttributeRules validates item attributes against the constraints of the
+// FatturaPA AltriDatiGestionali block they map to. The attribute's type is
+// mapped to the TipoDato field, which is limited to 10 characters.
+func orgAttributeRules() *rules.Set {
+	return rules.For(new(org.Attribute),
+		rules.Field("type",
+			rules.Assert("01", "attribute type cannot be longer than 10 characters (TipoDato)",
+				is.RuneLength(0, 10),
+			),
+		),
+	)
+}
+
 func addressHasStreetOrPostBox(val any) bool {
 	a, ok := val.(*org.Address)
 	if !ok || a == nil {

--- a/addons/it/sdi/org_test.go
+++ b/addons/it/sdi/org_test.go
@@ -1,0 +1,42 @@
+package sdi_test
+
+import (
+	"testing"
+
+	"github.com/invopop/gobl/addons/it/sdi"
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/org"
+	"github.com/invopop/gobl/rules"
+	"github.com/invopop/gobl/tax"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateOrgAttribute(t *testing.T) {
+	t.Run("type within 10 characters is valid", func(t *testing.T) {
+		attr := &org.Attribute{
+			Type: cbc.Code("TARGA"),
+			Text: "AB123CD",
+		}
+		err := rules.Validate(attr, tax.AddonContext(sdi.V1))
+		require.NoError(t, err)
+	})
+
+	t.Run("type longer than 10 characters is rejected", func(t *testing.T) {
+		attr := &org.Attribute{
+			Type: cbc.Code("TOOLONGVALUE"), // 12 characters
+			Text: "x",
+		}
+		err := rules.Validate(attr, tax.AddonContext(sdi.V1))
+		assert.ErrorContains(t, err, "type cannot be longer than 10 characters")
+	})
+
+	t.Run("key-based attribute is not constrained by TipoDato length", func(t *testing.T) {
+		attr := &org.Attribute{
+			Key:  org.AttributeKeyColor,
+			Text: "red",
+		}
+		err := rules.Validate(attr, tax.AddonContext(sdi.V1))
+		require.NoError(t, err)
+	})
+}

--- a/addons/it/sdi/sdi.go
+++ b/addons/it/sdi/sdi.go
@@ -35,6 +35,7 @@ func init() {
 		billInvoiceRules(),
 		billChargeRules(),
 		orgAddressRules(),
+		orgAttributeRules(),
 		taxComboRules(),
 		payInstructionsRules(),
 		payAdvanceRules(),

--- a/data/rules/it-sdi.json
+++ b/data/rules/it-sdi.json
@@ -441,7 +441,7 @@
             {
               "id": "GOBL-IT-SDI-ORG-ATTRIBUTE-01",
               "desc": "attribute type cannot be longer than 10 characters (TipoDato)",
-              "tests": "rune length between 0 and 10"
+              "tests": "length between 0 and 10"
             }
           ]
         }

--- a/data/rules/it-sdi.json
+++ b/data/rules/it-sdi.json
@@ -432,6 +432,22 @@
       ]
     },
     {
+      "id": "GOBL-IT-SDI-ORG-ATTRIBUTE",
+      "object": "org.Attribute",
+      "subsets": [
+        {
+          "field": "type",
+          "assert": [
+            {
+              "id": "GOBL-IT-SDI-ORG-ATTRIBUTE-01",
+              "desc": "attribute type cannot be longer than 10 characters (TipoDato)",
+              "tests": "rune length between 0 and 10"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "id": "GOBL-IT-SDI-TAX-COMBO",
       "object": "tax.Combo",
       "subsets": [

--- a/examples/it/item-attributes.yaml
+++ b/examples/it/item-attributes.yaml
@@ -43,11 +43,6 @@ lines:
     item:
       name: Mattoni Rossi
       price: "0.50"
-      # Named item features (EN 16931 BG-32). In FatturaPA these map to the
-      # AltriDatiGestionali block, where the attribute `type` becomes the
-      # TipoDato (limited to 10 characters by the it-sdi addon) and the value
-      # is routed by kind: text/code to RiferimentoTesto, amount to
-      # RiferimentoNumero, and date to RiferimentoData.
       attributes:
         - type: LOTTO
           text: "MR-2025-08"

--- a/examples/it/item-attributes.yaml
+++ b/examples/it/item-attributes.yaml
@@ -1,0 +1,71 @@
+$schema: "https://gobl.org/draft-0/bill/invoice"
+$addons: ["it-sdi-v1"]
+uuid: "0194b2c0-1a2b-7c3d-8e4f-5a6b7c8d9e0f"
+series: SAMPLE
+code: "003"
+currency: EUR
+issue_date: "2024-02-15"
+type: standard
+supplier:
+  tax_id:
+    country: IT
+    code: "12345678903"
+  name: Mattoni e Cementi S.r.l.
+  registration:
+    capital: "50000.00"
+    currency: EUR
+    entry: "123456"
+    office: RM
+  addresses:
+    - num: "102"
+      street: Via dei Mattoni
+      locality: Roma
+      region: RM
+      code: "00100"
+      country: IT
+customer:
+  tax_id:
+    country: IT
+    code: "13029381004"
+  name: Edilizia Firenze S.r.l.
+  inboxes:
+    - key: it-sdi-code
+      code: M5UXCR5
+  addresses:
+    - num: "23"
+      street: Via dei Mille
+      locality: Firenze
+      region: FI
+      code: "50100"
+      country: IT
+lines:
+  - quantity: "1000"
+    item:
+      name: Mattoni Rossi
+      price: "0.50"
+      # Named item features (EN 16931 BG-32). In FatturaPA these map to the
+      # AltriDatiGestionali block, where the attribute `type` becomes the
+      # TipoDato (limited to 10 characters by the it-sdi addon) and the value
+      # is routed by kind: text/code to RiferimentoTesto, amount to
+      # RiferimentoNumero, and date to RiferimentoData.
+      attributes:
+        - type: LOTTO
+          text: "MR-2025-08"
+        - type: PRODUZIONE
+          date: "2025-08-01"
+    taxes:
+      - cat: VAT
+        rate: standard
+  - quantity: "50"
+    item:
+      name: Sacchi di Cemento 25kg
+      price: "6.00"
+      attributes:
+        - type: LOTTO
+          text: "CEM-2025-07"
+        - type: PESO
+          amount: "25"
+          unit: kg
+    taxes:
+      - cat: VAT
+        rate: standard

--- a/examples/it/item-attributes.yaml
+++ b/examples/it/item-attributes.yaml
@@ -50,7 +50,7 @@ lines:
           date: "2025-08-01"
     taxes:
       - cat: VAT
-        rate: standard
+        rate: general
   - quantity: "50"
     item:
       name: Sacchi di Cemento 25kg
@@ -63,4 +63,4 @@ lines:
           unit: kg
     taxes:
       - cat: VAT
-        rate: standard
+        rate: general

--- a/examples/it/out/item-attributes.json
+++ b/examples/it/out/item-attributes.json
@@ -1,0 +1,161 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
+		"dig": {
+			"alg": "sha256",
+			"val": "608e4e292919a326a06de907292603fe005b8d090f6bdbd2fbd14db6393b18d7"
+		}
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"$regime": "IT",
+		"$addons": [
+			"it-sdi-v1"
+		],
+		"uuid": "0194b2c0-1a2b-7c3d-8e4f-5a6b7c8d9e0f",
+		"type": "standard",
+		"series": "SAMPLE",
+		"code": "003",
+		"issue_date": "2024-02-15",
+		"currency": "EUR",
+		"tax": {
+			"ext": {
+				"it-sdi-document-type": "TD01",
+				"it-sdi-format": "FPR12"
+			}
+		},
+		"supplier": {
+			"name": "Mattoni e Cementi S.r.l.",
+			"tax_id": {
+				"country": "IT",
+				"code": "12345678903"
+			},
+			"addresses": [
+				{
+					"num": "102",
+					"street": "Via dei Mattoni",
+					"locality": "Roma",
+					"region": "RM",
+					"code": "00100",
+					"country": "IT"
+				}
+			],
+			"registration": {
+				"capital": "50000.00",
+				"currency": "EUR",
+				"office": "RM",
+				"entry": "123456"
+			},
+			"ext": {
+				"it-sdi-fiscal-regime": "RF01"
+			}
+		},
+		"customer": {
+			"name": "Edilizia Firenze S.r.l.",
+			"tax_id": {
+				"country": "IT",
+				"code": "13029381004"
+			},
+			"inboxes": [
+				{
+					"key": "it-sdi-code",
+					"code": "M5UXCR5"
+				}
+			],
+			"addresses": [
+				{
+					"num": "23",
+					"street": "Via dei Mille",
+					"locality": "Firenze",
+					"region": "FI",
+					"code": "50100",
+					"country": "IT"
+				}
+			]
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "1000",
+				"item": {
+					"name": "Mattoni Rossi",
+					"attributes": [
+						{
+							"type": "LOTTO",
+							"text": "MR-2025-08"
+						},
+						{
+							"type": "PRODUZIONE",
+							"date": "2025-08-01"
+						}
+					],
+					"price": "0.50"
+				},
+				"sum": "500.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "general",
+						"percent": "22.0%"
+					}
+				],
+				"total": "500.00"
+			},
+			{
+				"i": 2,
+				"quantity": "50",
+				"item": {
+					"name": "Sacchi di Cemento 25kg",
+					"attributes": [
+						{
+							"type": "LOTTO",
+							"text": "CEM-2025-07"
+						},
+						{
+							"type": "PESO",
+							"amount": "25",
+							"unit": "kg"
+						}
+					],
+					"price": "6.00"
+				},
+				"sum": "300.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "general",
+						"percent": "22.0%"
+					}
+				],
+				"total": "300.00"
+			}
+		],
+		"totals": {
+			"sum": "800.00",
+			"total": "800.00",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"base": "800.00",
+								"percent": "22.0%",
+								"amount": "176.00"
+							}
+						],
+						"amount": "176.00"
+					}
+				],
+				"sum": "176.00"
+			},
+			"tax": "176.00",
+			"total_with_tax": "976.00",
+			"payable": "976.00"
+		}
+	}
+}


### PR DESCRIPTION
## Summary

PR #859 introduced `org.Attribute` / `Item.Attributes` (EN 16931 BG-32). In FatturaPA these map to the `DettaglioLinee/AltriDatiGestionali` block, where the attribute's `type` becomes the `TipoDato` field — a `String10` (max 10 characters).

This adds an `it-sdi` validation rule asserting that an item attribute's `type` is at most 10 characters, so invalid data is caught up-front rather than being rejected downstream by the SDI XSD. Attributes identified by a `key` (rather than a `type`) are unaffected.

## Changes

- `addons/it/sdi/org.go`: new `orgAttributeRules()` → `GOBL-IT-SDI-ORG-ATTRIBUTE-01`.
- `addons/it/sdi/sdi.go`: registered under the addon guard.
- `data/rules/it-sdi.json`: regenerated via `go generate`.
- `addons/it/sdi/org_test.go`: tests for the new rule.
- `examples/it/item-attributes.yaml` (+ golden): Italian goods invoice demonstrating attribute usage across text/amount/date values.
- `CHANGELOG.md`: entry.

## Related

The actual `Item.Attributes` ↔ `AltriDatiGestionali` mapping (both directions) lives in the companion **gobl.fatturapa** PR (invopop/gobl.fatturapa#76). That PR is self-contained and does not block on this one; once released, gobl.fatturapa's dependency can be bumped to activate this validation.

## Pre-Review Checklist

- [x] Opened this PR as a draft
- [x] Read the CONTRIBUTING.md guide.
- [x] Performed a self-review of my code.
- [x] Added thorough tests with at **least** 90% code coverage.
- [x] Modified or created example GOBL documents to show my changes in use, if appropriate.
- [x] Added links to the source of the changes in tax regimes or addons, either structured or in the comments.
- [x] Run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [x] Reviewed and fixed all linter warnings.
- [x] Been obsessive with pointer nil checks to avoid panics.
- [x] Updated the CHANGELOG.md with an overview of my changes.
- [x] Marked this PR as ready for review.

And if you are part of the org:
- [ ] Requested a review from Copilot and fixed or dismissed (with a reason) all the feedback raised.
- [ ] Requested a review from @samlown.
