### PR TITLE
Normalize IT SDI customer to a single destination inbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - `tax`: the `currency` rounding rule combined with `prices_include` now determines each rate's tax amount from the sum of the tax-inclusive line totals and shares it back over the lines, so that bases, tax amounts, and document totals always add up, including when other categories such as retained taxes are present.
 - `addons/eu/en16931`: party identities are now validated so that at most one may carry the `legal` scope (BT-30, BT-47) and at most one the `tax` scope (BT-31, BT-48).
 - `addons/it/sdi`: item attribute `type` is validated to be at most 10 characters, matching the FatturaPA `AltriDatiGestionali/TipoDato` (BT-160) field it maps to.
+- `addons/it/sdi`: invoice customers may no longer carry both an `it-sdi-code` and an `it-sdi-pec` inbox. FatturaPA allows `PECDestinatario` only alongside the `0000000` recipient code, so a document with both can never be delivered.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - `tax`: the `currency` rounding rule combined with `prices_include` now determines each rate's tax amount from the sum of the tax-inclusive line totals and shares it back over the lines, so that bases, tax amounts, and document totals always add up, including when other categories such as retained taxes are present.
 - `addons/eu/en16931`: party identities are now validated so that at most one may carry the `legal` scope (BT-30, BT-47) and at most one the `tax` scope (BT-31, BT-48).
 - `addons/it/sdi`: item attribute `type` is validated to be at most 10 characters, matching the FatturaPA `AltriDatiGestionali/TipoDato` (BT-160) field it maps to.
-- `addons/it/sdi`: invoice customers may no longer carry both an `it-sdi-code` and an `it-sdi-pec` inbox. FatturaPA allows `PECDestinatario` only alongside the `0000000` recipient code, so a document with both can never be delivered.
+- `addons/it/sdi`: when an invoice customer carries both an `it-sdi-code` and an `it-sdi-pec` inbox, normalization now removes the PEC and keeps the code. FatturaPA allows `PECDestinatario` only alongside the `0000000` recipient code, so a document with both can never be delivered.
 
 ### Fixed
 

--- a/addons/it/sdi/bill.go
+++ b/addons/it/sdi/bill.go
@@ -105,6 +105,12 @@ func billInvoiceRules() *rules.Set {
 			rules.Field("addresses",
 				rules.Assert("12", "customer addresses are required", is.Present),
 			),
+			rules.Field("inboxes",
+				rules.Assert("23",
+					fmt.Sprintf("customer cannot have both '%s' and '%s' inboxes", KeyInboxCode, KeyInboxPEC),
+					is.Func("single SDI inbox", inboxesNotBothCodeAndPEC),
+				),
+			),
 		),
 		// Customer name required when tax_id code is present or people is nil
 		rules.Assert("13", "customer name is required",
@@ -255,6 +261,26 @@ func invoiceCustomerHasFiscalCodeIdentity(val any) bool {
 		return false
 	}
 	return org.IdentityForKey(ids, it.IdentityKeyFiscalCode) != nil
+}
+
+func inboxesNotBothCodeAndPEC(val any) bool {
+	ins, ok := val.([]*org.Inbox)
+	if !ok {
+		return true
+	}
+	var code, pec bool
+	for _, in := range ins {
+		if in == nil {
+			continue
+		}
+		switch in.Key {
+		case KeyInboxCode:
+			code = true
+		case KeyInboxPEC:
+			pec = true
+		}
+	}
+	return !code || !pec
 }
 
 func invoiceHasDeferredTag(val any) bool {

--- a/addons/it/sdi/bill.go
+++ b/addons/it/sdi/bill.go
@@ -15,6 +15,34 @@ import (
 
 func normalizeInvoice(inv *bill.Invoice) {
 	normalizeSupplier(inv.Supplier)
+	normalizeCustomer(inv.Customer)
+}
+
+func normalizeCustomer(party *org.Party) {
+	if party == nil {
+		return
+	}
+	// FatturaPA only allows a PEC destination alongside the "0000000"
+	// recipient code, so when an SDI code is also present the code takes
+	// precedence and the PEC inbox is removed.
+	var code, pec bool
+	for _, in := range party.Inboxes {
+		switch in.Key {
+		case KeyInboxCode:
+			code = true
+		case KeyInboxPEC:
+			pec = true
+		}
+	}
+	if code && pec {
+		ins := make([]*org.Inbox, 0, len(party.Inboxes)-1)
+		for _, in := range party.Inboxes {
+			if in.Key != KeyInboxPEC {
+				ins = append(ins, in)
+			}
+		}
+		party.Inboxes = ins
+	}
 }
 
 func normalizeSupplier(party *org.Party) {
@@ -104,12 +132,6 @@ func billInvoiceRules() *rules.Set {
 			),
 			rules.Field("addresses",
 				rules.Assert("12", "customer addresses are required", is.Present),
-			),
-			rules.Field("inboxes",
-				rules.Assert("23",
-					fmt.Sprintf("customer cannot have both '%s' and '%s' inboxes", KeyInboxCode, KeyInboxPEC),
-					is.Func("single SDI inbox", inboxesNotBothCodeAndPEC),
-				),
 			),
 		),
 		// Customer name required when tax_id code is present or people is nil
@@ -261,20 +283,6 @@ func invoiceCustomerHasFiscalCodeIdentity(val any) bool {
 		return false
 	}
 	return org.IdentityForKey(ids, it.IdentityKeyFiscalCode) != nil
-}
-
-func inboxesNotBothCodeAndPEC(val any) bool {
-	ins, _ := val.([]*org.Inbox)
-	var code, pec bool
-	for _, in := range ins {
-		switch in.Key {
-		case KeyInboxCode:
-			code = true
-		case KeyInboxPEC:
-			pec = true
-		}
-	}
-	return !code || !pec
 }
 
 func invoiceHasDeferredTag(val any) bool {

--- a/addons/it/sdi/bill.go
+++ b/addons/it/sdi/bill.go
@@ -264,15 +264,9 @@ func invoiceCustomerHasFiscalCodeIdentity(val any) bool {
 }
 
 func inboxesNotBothCodeAndPEC(val any) bool {
-	ins, ok := val.([]*org.Inbox)
-	if !ok {
-		return true
-	}
+	ins, _ := val.([]*org.Inbox)
 	var code, pec bool
 	for _, in := range ins {
-		if in == nil {
-			continue
-		}
 		switch in.Key {
 		case KeyInboxCode:
 			code = true

--- a/addons/it/sdi/bill_test.go
+++ b/addons/it/sdi/bill_test.go
@@ -339,6 +339,34 @@ func TestCustomerValidation(t *testing.T) {
 		assert.ErrorContains(t, err, "customer people are required when name is empty")
 	})
 
+	t.Run("customer with code inbox", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Customer.Inboxes = []*org.Inbox{
+			{Key: sdi.KeyInboxCode, Code: "ABC1234"},
+		}
+		require.NoError(t, inv.Calculate())
+		assert.NoError(t, rules.Validate(inv))
+	})
+
+	t.Run("customer with PEC inbox", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Customer.Inboxes = []*org.Inbox{
+			{Key: sdi.KeyInboxPEC, Email: "customer@pec.it"},
+		}
+		require.NoError(t, inv.Calculate())
+		assert.NoError(t, rules.Validate(inv))
+	})
+
+	t.Run("customer with both code and PEC inboxes", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Customer.Inboxes = []*org.Inbox{
+			{Key: sdi.KeyInboxCode, Code: "ABC1234"},
+			{Key: sdi.KeyInboxPEC, Email: "customer@pec.it"},
+		}
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, fmt.Sprintf("customer cannot have both '%s' and '%s' inboxes", sdi.KeyInboxCode, sdi.KeyInboxPEC))
+	})
 }
 
 func TestSupplierTelephoneValidation(t *testing.T) {

--- a/addons/it/sdi/bill_test.go
+++ b/addons/it/sdi/bill_test.go
@@ -357,15 +357,16 @@ func TestCustomerValidation(t *testing.T) {
 		assert.NoError(t, rules.Validate(inv))
 	})
 
-	t.Run("customer with both code and PEC inboxes", func(t *testing.T) {
+	t.Run("customer with both code and PEC inboxes keeps only the code", func(t *testing.T) {
 		inv := testInvoiceStandard(t)
 		inv.Customer.Inboxes = []*org.Inbox{
 			{Key: sdi.KeyInboxCode, Code: "ABC1234"},
 			{Key: sdi.KeyInboxPEC, Email: "customer@pec.it"},
 		}
 		require.NoError(t, inv.Calculate())
-		err := rules.Validate(inv)
-		assert.ErrorContains(t, err, fmt.Sprintf("customer cannot have both '%s' and '%s' inboxes", sdi.KeyInboxCode, sdi.KeyInboxPEC))
+		assert.NoError(t, rules.Validate(inv))
+		require.Len(t, inv.Customer.Inboxes, 1)
+		assert.Equal(t, sdi.KeyInboxCode, inv.Customer.Inboxes[0].Key)
 	})
 }
 

--- a/examples/it/hotel-b2g.json
+++ b/examples/it/hotel-b2g.json
@@ -44,10 +44,6 @@
       {
         "key": "it-sdi-code",
         "code": "M5UXCR5"
-      },
-      {
-        "key": "it-sdi-pec",
-        "code": "inbox@example.com"
       }
     ],
     "addresses": [

--- a/examples/it/hotel-custom.yaml
+++ b/examples/it/hotel-custom.yaml
@@ -36,8 +36,6 @@ customer:
   inboxes:
     - key: it-sdi-code
       code: M5UXCR5
-    - key: it-sdi-pec
-      email: "inbox@example.com"
   addresses:
     - num: "23"
       street: Via dei Mille

--- a/examples/it/out/hotel-b2g.json
+++ b/examples/it/out/hotel-b2g.json
@@ -4,7 +4,7 @@
 		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
 		"dig": {
 			"alg": "sha256",
-			"val": "b3d4afc24c0692feaac973288122c66afb1002ef47c4408bc42a8b3de1f3c4e5"
+			"val": "49cecdb856503ea29b45a5e472db3ed52b2a7a8b13be1de18906de7d7d4b975a"
 		}
 	},
 	"doc": {
@@ -65,10 +65,6 @@
 				{
 					"key": "it-sdi-code",
 					"code": "M5UXCR5"
-				},
-				{
-					"key": "it-sdi-pec",
-					"email": "inbox@example.com"
 				}
 			],
 			"addresses": [

--- a/examples/it/out/hotel-custom.json
+++ b/examples/it/out/hotel-custom.json
@@ -4,7 +4,7 @@
 		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
 		"dig": {
 			"alg": "sha256",
-			"val": "b3d4afc24c0692feaac973288122c66afb1002ef47c4408bc42a8b3de1f3c4e5"
+			"val": "49cecdb856503ea29b45a5e472db3ed52b2a7a8b13be1de18906de7d7d4b975a"
 		}
 	},
 	"doc": {
@@ -65,10 +65,6 @@
 				{
 					"key": "it-sdi-code",
 					"code": "M5UXCR5"
-				},
-				{
-					"key": "it-sdi-pec",
-					"email": "inbox@example.com"
 				}
 			],
 			"addresses": [


### PR DESCRIPTION
## Context

FatturaPA's `DatiTrasmissione` block allows a single routing destination: per the specification, `PECDestinatario` may only be populated when `CodiceDestinatario` is the placeholder `0000000`. A GOBL customer carrying both an `it-sdi-code` and an `it-sdi-pec` inbox therefore describes a transmission that can never be expressed in valid FatturaPA — there is no correct way for a converter to write both.

## Changes

- When an invoice customer carries both inboxes, `it-sdi-v1` normalization now removes the PEC and keeps the code, so the document builds into deliverable FatturaPA. The code wins because it's the stronger routing signal — a PEC is only meaningful without one.
- Normalization was chosen over a validation error so that documents that build today keep building, and already-signed documents (which can't be re-normalized) don't start failing re-validation.
- The two IT examples that paired a code with a PEC now keep only the code, with golden outputs regenerated.

## Next

Nothing pending on this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDvrXj44FqsDPV4VSroccF