### PR TITLE
net: open GET /who, sender endorsements, and signature expiry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 - `org`: new `Attribute` model with `Item.Attributes` for named item features such as color or size (EN 16931 BG-32). Attributes replace the previous practice of mapping `Item.Meta` into output formats — meta is internal-only data. Each attribute is identified by a `key` or `type` and holds exactly one of a `text`, `code`, `amount` (with optional `unit`), or `date` value. Standard keys cover physical properties of the item, dates, nutritional declarations, and CO2e emissions. Item attribute keys must be unique.
 - `org`: `kj` (kilojoule) and `kcal` (kilocalorie) units.
+- `net`: `Client.Who` fetches and verifies a domain's public identity from `GET /.well-known/gobl/who`, and `Client.VerifySender` additionally requires a countersignature from a trusted authority at a minimum scope. New `ErrNoContent` (HTTP 204: the account exists but publishes no identity details) and `ErrScopeInsufficient` sentinel errors.
+- `head`: optional `exp` claim (JWT-standard, RFC 7519 §4.1.4) in the signed payload, set with `head.WithExpiration`, marking the time after which the signature's assertions should no longer be relied upon. `net.VerifyAuthority` rejects countersignatures whose `exp` has passed with the new `ErrSignatureExpired` sentinel; signatures without `exp` do not expire.
 
 ### Changed
 
+- `net`: `/who` is now an open GET returning the domain's self-signed party envelope, replacing the authenticated POST exchange; allow-list support is removed. `Client.VerifyAuthority` takes a minimum scope argument. `Client.VerifyEnvelope` verifies only the first signature, so envelopes carrying authority countersignatures now verify.
 - `tax`: the `currency` rounding rule combined with `prices_include` now determines each rate's tax amount from the sum of the tax-inclusive line totals and shares it back over the lines, so that bases, tax amounts, and document totals always add up, including when other categories such as retained taxes are present.
 - `addons/eu/en16931`: party identities are now validated so that at most one may carry the `legal` scope (BT-30, BT-47) and at most one the `tax` scope (BT-31, BT-48).
 - `addons/it/sdi`: item attribute `type` is validated to be at most 10 characters, matching the FatturaPA `AltriDatiGestionali/TipoDato` (BT-160) field it maps to.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Changed
 
-- `net`: `/who` is now an open GET returning the domain's self-signed party envelope, replacing the authenticated POST exchange; allow-list support is removed. `Client.VerifyAuthority` takes a minimum scope argument. `Client.VerifyEnvelope` verifies only the first signature, so envelopes carrying authority countersignatures now verify.
+- `net`: `/who` is now an open GET returning the domain's self-signed party envelope, replacing the authenticated POST exchange; allow-list support is removed. `Client.VerifyAuthorityWithScope` enforces a minimum scope on top of the `Client.VerifyAuthority` check. `Client.VerifyEnvelope` verifies only the first signature, so envelopes carrying authority countersignatures now verify.
 - `tax`: the `currency` rounding rule combined with `prices_include` now determines each rate's tax amount from the sum of the tax-inclusive line totals and shares it back over the lines, so that bases, tax amounts, and document totals always add up, including when other categories such as retained taxes are present.
 - `addons/eu/en16931`: party identities are now validated so that at most one may carry the `legal` scope (BT-30, BT-47) and at most one the `tax` scope (BT-31, BT-48).
 - `addons/it/sdi`: item attribute `type` is validated to be at most 10 characters, matching the FatturaPA `AltriDatiGestionali/TipoDato` (BT-160) field it maps to.

--- a/head/header.go
+++ b/head/header.go
@@ -168,19 +168,25 @@ func (h *Header) Link(category, key cbc.Key) *Link {
 // Digest identify the document; Iss and Aud are the verifiable origin
 // and audience of *this* signature (as `gobl:` URIs); IssuedAt is the
 // time the signature was produced as a JWT-standard NumericDate (Unix
-// seconds, per RFC 7519 §2). Scope (optional, set via head.WithScope)
-// is the signer's assertion about the level of confidence in the
-// document — e.g. `head.ScopeRegistered` for an address-only check,
-// `head.ScopeVerified` for a KYC-verified countersignature. Header
-// stamps, links, tags, meta, notes and the (unsigned, intent-level)
-// From/To fields can still be modified after signing.
+// seconds, per RFC 7519 §2). ExpiresAt (optional, set via
+// head.WithExpiration) is the JWT-standard `exp` claim (RFC 7519
+// §4.1.4): the time after which the signature's assertions should no
+// longer be relied upon — used by authorities to bound the lifetime
+// of their countersignatures. Scope (optional, set via
+// head.WithScope) is the signer's assertion about the level of
+// confidence in the document — e.g. `head.ScopeRegistered` for an
+// address-only check, `head.ScopeVerified` for a KYC-verified
+// countersignature. Header stamps, links, tags, meta, notes and the
+// (unsigned, intent-level) From/To fields can still be modified
+// after signing.
 type SigningPayload struct {
-	UUID     uuid.UUID    `json:"uuid"`
-	Digest   *dsig.Digest `json:"dig"`
-	Iss      cbc.URI      `json:"iss,omitempty"`
-	Aud      cbc.URI      `json:"aud,omitempty"`
-	IssuedAt int64        `json:"iat,omitempty"`
-	Scope    cbc.Key      `json:"scope,omitempty"`
+	UUID      uuid.UUID    `json:"uuid"`
+	Digest    *dsig.Digest `json:"dig"`
+	Iss       cbc.URI      `json:"iss,omitempty"`
+	Aud       cbc.URI      `json:"aud,omitempty"`
+	IssuedAt  int64        `json:"iat,omitempty"`
+	ExpiresAt int64        `json:"exp,omitempty"`
+	Scope     cbc.Key      `json:"scope,omitempty"`
 }
 
 // Known scope values that an Authority can assert when
@@ -205,6 +211,7 @@ type SignOption func(*signOptions)
 type signOptions struct {
 	iss    cbc.URI
 	aud    cbc.URI
+	exp    int64
 	scope  cbc.Key
 	signer []dsig.SignerOption
 }
@@ -232,20 +239,29 @@ func WithScope(scope cbc.Key) SignOption {
 	return func(o *signOptions) { o.scope = scope }
 }
 
+// WithExpiration sets the JWT-standard `exp` claim in the signed
+// payload: the time after which the signature's assertions should no
+// longer be relied upon. Default (no option) leaves it unset — the
+// signature does not expire.
+func WithExpiration(t time.Time) SignOption {
+	return func(o *signOptions) { o.exp = t.UTC().Unix() }
+}
+
 // WithSignerOption forwards a low-level dsig.SignerOption (e.g.
 // dsig.WithJKU) through to the underlying JWS signer.
 func WithSignerOption(opts ...dsig.SignerOption) SignOption {
 	return func(o *signOptions) { o.signer = append(o.signer, opts...) }
 }
 
-func (h *Header) payload(iss, aud cbc.URI, iat int64, scope cbc.Key) *SigningPayload {
+func (h *Header) payload(iss, aud cbc.URI, iat, exp int64, scope cbc.Key) *SigningPayload {
 	return &SigningPayload{
-		UUID:     h.UUID,
-		Digest:   h.Digest,
-		Iss:      iss,
-		Aud:      aud,
-		IssuedAt: iat,
-		Scope:    scope,
+		UUID:      h.UUID,
+		Digest:    h.Digest,
+		Iss:       iss,
+		Aud:       aud,
+		IssuedAt:  iat,
+		ExpiresAt: exp,
+		Scope:     scope,
 	}
 }
 
@@ -263,7 +279,7 @@ func (h *Header) Sign(key *dsig.PrivateKey, opts ...SignOption) (*dsig.Signature
 		opt(so)
 	}
 	iat := time.Now().UTC().Unix()
-	return dsig.NewSignature(key, h.payload(so.iss, so.aud, iat, so.scope), so.signer...)
+	return dsig.NewSignature(key, h.payload(so.iss, so.aud, iat, so.exp, so.scope), so.signer...)
 }
 
 // Verify checks that the signature covers this header's document

--- a/head/header_test.go
+++ b/head/header_test.go
@@ -2,6 +2,7 @@ package head_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/invopop/gobl/cal"
 	"github.com/invopop/gobl/cbc"
@@ -348,6 +349,31 @@ func TestHeaderSignWithScope(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, head.ScopeVerified, p.Scope)
 	assert.Equal(t, cbc.URI("gobl:authority.example"), p.Iss)
+}
+
+func TestHeaderSignWithExpiration(t *testing.T) {
+	priv := dsig.NewES256Key()
+	h := head.NewHeader()
+	h.UUID = uuid.V7()
+	h.Digest = dsig.NewSHA256Digest([]byte(`{"x":1}`))
+
+	exp := time.Now().Add(90 * 24 * time.Hour)
+	sig, err := h.Sign(priv,
+		head.WithIssuer("gobl:authority.example"),
+		head.WithExpiration(exp))
+	require.NoError(t, err)
+
+	p, err := head.SignedPayload(sig)
+	require.NoError(t, err)
+	assert.Equal(t, exp.UTC().Unix(), p.ExpiresAt)
+	assert.LessOrEqual(t, p.IssuedAt, p.ExpiresAt)
+
+	// Without the option, exp is unset.
+	sig, err = h.Sign(priv, head.WithIssuer("gobl:authority.example"))
+	require.NoError(t, err)
+	p, err = head.SignedPayload(sig)
+	require.NoError(t, err)
+	assert.Zero(t, p.ExpiresAt)
 }
 
 func TestSignedPayloadDecodeError(t *testing.T) {

--- a/net/README.md
+++ b/net/README.md
@@ -22,7 +22,8 @@ documents. It binds a document signature to a fully qualified domain name
 - `/.well-known/gobl/keys/<kid>` — a single public JWK looked up by key
   ID, used to verify signatures.
 - `/.well-known/gobl/who` — a signed GOBL Envelope carrying an
-  `org.Party` document, endorsing the holder's identity.
+  `org.Party` document, endorsing the holder's identity, retrieved
+  with a plain GET.
 - `/.well-known/gobl/inbox` — a write endpoint that accepts signed
   envelopes addressed to the holder.
 
@@ -30,11 +31,18 @@ Trust in an identity is anchored to the TLS certificate for the
 Address's FQDN: a signature's verifiable origin lives in its signed
 `iss`, the verifier fetches the corresponding public key from
 `https://<iss>/.well-known/gobl/keys/<kid>`, and the HTTPS connection
-proves the response really came from that FQDN. KYC vendors
-("Authorities") are an optional endorsement layer on top of that
-anchor — a participant MAY carry a vendor's countersignature, and
-verifiers MAY treat that countersignature as additional evidence;
-neither side is required to.
+proves the response really came from that FQDN. Key discovery is
+unconditional: it works the same for every participant and every
+policy below layers on top of it, never replaces it.
+
+The two roles in an exchange carry asymmetric requirements. *Anyone*
+may provision a receiving address — publishing an inbox requires no
+approval from any third party, and a receive-only participant need
+not even publish identity details (§8.2). *Senders*, by contrast, are
+expected to carry an endorsement: a countersignature on their `/who`
+identity from a KYC vendor ("Authority") that receivers trust.
+Receivers accept or reject incoming documents on the strength of that
+endorsement (§6.4, §8.4).
 
 The protocol layers on top of standards already in use by GOBL:
 
@@ -60,7 +68,12 @@ document are to be interpreted as described in BCP 14 (RFC 2119, RFC 8174).
   optional `valid_from` / `valid_until` extension members) served at
   `/.well-known/gobl/keys/<kid>`.
 - **Party Envelope** — A signed GOBL Envelope whose document is an
-  `org.Party`, exchanged at the who endpoint.
+  `org.Party`, served at the who endpoint. The first signature is the
+  subject's self-signature; Authority countersignatures follow.
+- **Sender / Receiver** — The two roles in a document exchange. A
+  receiver only needs a domain, TLS, and (if it signs) published
+  keys. A sender is additionally expected to carry an Authority
+  endorsement on its who identity (§6.4).
 - **iss / aud** — Fields in a signature's *signed payload* carrying the
   verifiable GOBL Net origin (`iss`) and the address the signature is
   bound to (`aud`), both as `gobl:` `cbc.URI` values. These are the
@@ -69,8 +82,6 @@ document are to be interpreted as described in BCP 14 (RFC 2119, RFC 8174).
   envelope header expressing *intent/routing* in any scheme
   (`iso6523-actorid-upis:`, `mailto:`, `gobl:`…). Useful for interop
   with other formats; not used for verification.
-- **allow-list** — Optional `<domain>/allow.json` (array of addresses)
-  restricting which callers a domain accepts on `/who` and `/inbox`.
 
 ## 3. Addressing
 
@@ -95,7 +106,7 @@ Inputs that contain a scheme, port, or path MUST be rejected with
 `ErrAddressInvalid`. An empty input MUST be rejected with `ErrAddressEmpty`.
 
 **Canonical form.** Addresses on the wire — in `iss`, `aud`,
-well-known URLs, allow-lists, and identity files — MUST be ASCII
+well-known URLs, and identity files — MUST be ASCII
 A-Labels. Implementations are free to accept U-Label input from
 humans (e.g. CLI flags) but MUST normalise to A-Label before
 signing, fetching, or comparing.
@@ -279,6 +290,12 @@ Each signature signs a payload of `{uuid, dig, iss, aud, iat}`:
   verifiers read it for the per-key validity window check but no
   freshness policy is enforced by default — receivers may apply their
   own max-age window when relevant.
+- `exp` (optional, JWT-standard per RFC 7519 §4.1.4, set with
+  `head.WithExpiration`) is the time after which the signature's
+  assertions should no longer be relied upon. Ordinary transport
+  signatures omit it — archived envelopes must keep verifying
+  indefinitely. Authorities set it on their countersignatures to
+  bound the endorsement's lifetime (§5.3).
 
 Because `iss`/`aud`/`iat` are inside the signed payload, the origin,
 audience, and signing time are all tamper-proof. Multiple parties may
@@ -320,9 +337,22 @@ env.Sign(authorityKey,
 
 Verifiers MAY require a minimum scope per use case (`registered`
 suffices for `/who` discovery; `verified` may be required before
-acting on inbox deliveries from new counterparties). Operators MAY
-define additional scope keys; `registered` and `verified` are the
-baseline values the protocol recognises.
+acting on inbox deliveries from new counterparties). The minimum is
+passed to `Client.VerifyAuthority` / `Client.VerifySender`: an empty
+minimum accepts any authority signature, `registered` is satisfied by
+`registered` or `verified`, and a custom scope key is satisfied only
+by an exact match. Operators MAY define additional scope keys;
+`registered` and `verified` are the baseline values the protocol
+recognises.
+
+An Authority countersignature SHOULD carry an `exp` claim bounding
+the endorsement's lifetime — 90 days is the recommended maximum,
+after which the subject renews its registration (§11.4). Verifiers
+MUST treat an expired countersignature as absent: `VerifyAuthority`
+rejects candidates whose `exp` has passed with
+`ErrSignatureExpired`. A countersignature without `exp` does not
+expire; verifiers MAY apply their own `iat` max-age policy to such
+legacy endorsements.
 
 ### 5.4 X.509 evidence (optional, long-term storage)
 
@@ -341,8 +371,8 @@ Treat `x5c` as supplementary evidence, not as a replacement for §11.1:
 the chain proves that *some* CA-attested entity signed the document,
 but does not bind the signature to a GOBL Net Address. Verifiers MAY
 consult `x5c` for archival proofs, but for live verification of an
-inbox or `/who` exchange the signed `iss` + Web PKI MUST be the
-authoritative chain.
+inbox delivery or `/who` lookup the signed `iss` + Web PKI MUST be
+the authoritative chain.
 
 The library does not stamp `x5c` automatically. Operators with an
 archival need can add it via a future `dsig.WithX5C` option or by
@@ -367,15 +397,29 @@ issuer address:
    within `[valid_from, valid_until]` (each bound optional).
 7. The verified issuer address is returned.
 
-### 6.2 Identity exchange (`/who`)
+### 6.2 Identity lookup (`GET /who`)
 
-`/who` is an authenticated, mutual exchange (see §8.2). The caller POSTs
-a signed envelope (`iss=gobl:caller`, `aud=gobl:target`, document = the
-caller's `org.Party`); the target verifies it, applies its allow-list,
-and responds with its own party envelope signed `iss=gobl:target`,
-`aud=gobl:caller`. A conforming client performs the exchange and
-verifies the response is signed by the target and bound to the
-caller.
+`/who` is an open, unauthenticated GET (see §8.2). The response is
+the target's party envelope: document = the target's `org.Party`,
+first signature = the target's self-signature with `iss=gobl:target`
+and no `aud` (a GET response has no caller to bind to), optionally
+followed by Authority countersignatures.
+
+`Client.Who(ctx, addr)` performs the lookup and verifies it:
+
+1. `GET https://<addr>/.well-known/gobl/who`. A `204` returns
+   `ErrNoContent` — the address exists but publishes no identity
+   details (a receive-only account).
+2. The response envelope's first signature is verified via
+   `VerifyEnvelope` (the signed `iss` resolved to a published key).
+3. The verified issuer MUST equal the fetched address — a valid
+   envelope for a *different* identity served at this URL is
+   rejected.
+4. The document MUST be an `org.Party`, else `ErrPartyMissing`.
+
+Because the response is a static signed document, it is cacheable
+(§8.2). The identity's integrity comes from the self-signature and
+the TLS origin, not from any per-request binding.
 
 ### 6.3 Trusted Authorities
 
@@ -384,21 +428,35 @@ treated as trusted KYC vendors. The default list is empty;
 `net.RegisterAuthority` or the `WithAuthorities` client option add to
 it.
 
-`Client.VerifyAuthority(ctx, env)` returns nil iff the envelope
-carries at least one signature whose signed `iss` is in the client's
-authorities AND that signature cryptographically verifies against
-the authority's published key. It returns `ErrUnknownAuthority` when
-no candidate signature is from a known authority (or none has been
-registered) and `ErrVerifyFailed` when a candidate fails its crypto
+`Client.VerifyAuthority(ctx, env, minScope)` returns nil iff the
+envelope carries at least one signature whose signed `iss` is in the
+client's authorities AND that signature cryptographically verifies
+against the authority's published key AND its signed `exp` claim (if
+any) has not passed AND its signed scope claim satisfies `minScope`
+(§5.3). It returns `ErrUnknownAuthority` when no candidate signature
+is from a known authority (or none has been registered),
+`ErrSignatureExpired` when a verified authority signature has
+expired, `ErrScopeInsufficient` when it falls short of the minimum
+scope, and `ErrVerifyFailed` when a candidate fails its crypto
 check.
 
-The protocol does **not** mandate when callers must invoke
-`VerifyAuthority`. The recommended policy: `/who` consumers SHOULD
-require an authority countersignature by default and only relax it
-for explicitly self-signed lookups (bootstrap, internal discovery).
-The trust anchor in §11.1 — TLS-bound `iss` — does not depend on
-authorities; authorities are an additional, opt-in policy layer on
-top.
+Endorsement requirements attach to the **sending** role. Verifiers
+resolving a *receiver's* identity MUST NOT demand an authority
+countersignature: receiving addresses are self-provisioned and MAY be
+entirely self-signed, or publish nothing at all (204). The trust
+anchor in §11.1 — TLS-bound `iss` — does not depend on authorities;
+authorities are an additional, opt-in policy layer on top.
+
+### 6.4 Sender verification
+
+`Client.VerifySender(ctx, addr, minScope)` combines the two: it
+resolves `addr`'s identity via `Who` and requires an Authority
+countersignature satisfying `minScope` via `VerifyAuthority`,
+returning the endorsed `org.Party`. Receiving inboxes call it with
+the verified issuer of an incoming envelope before accepting the
+delivery (§8.4). A receive-only account (204) or a merely self-signed
+identity fails this check by construction — such addresses can
+receive but cannot act as approved senders.
 
 ## 7. Discovery Transport
 
@@ -413,10 +471,12 @@ The default `HTTPFetcher` enforces:
 | Maximum response size | 1 MiB              |
 | Required `Accept`     | `application/json` |
 | Required scheme       | `https`            |
-| Required status       | `200 OK`           |
+| Required status       | `200 OK` (`204` → `ErrNoContent`) |
 
-Responses larger than 1 MiB are truncated. Any non-200 response causes
-`ErrFetchFailed`.
+Responses larger than 1 MiB are truncated. A `204 No Content`
+response causes `ErrNoContent` — a distinct sentinel because at the
+who endpoint an empty response is meaningful (§8.2). Any other
+non-200 response causes `ErrFetchFailed`.
 
 **SSRF defense.** The fetcher's transport refuses to dial any host
 whose resolved IP is loopback, private (RFC 1918 / RFC 6598),
@@ -445,22 +505,34 @@ the file `<domain>/keys/<kid>.json`, optionally carrying GOBL Net's
 `valid_from` / `valid_until` extension members (see §4). Unknown kid
 returns `404 Not Found`. No bulk endpoint is exposed.
 
-### 8.2 `POST /.well-known/gobl/who`
+### 8.2 `GET /.well-known/gobl/who`
 
-Authenticated party exchange. The caller POSTs a signed envelope
-(`iss=gobl:caller`, `aud=gobl:self`, document = the caller's
-`org.Party`). The server verifies the signature against the caller's
-published key (fetched from the caller's per-kid endpoint), requires
-`aud == self`, and applies the allow-list to `iss`. It responds `200`
-with its own party envelope signed
-`iss=gobl:self`, `aud=gobl:caller`.
+Open. Returns the domain's party envelope: an `org.Party` document,
+self-signed with `iss=gobl:self` as the **first** signature (no
+`aud`), optionally carrying Authority countersignatures. The response
+is a static signed document — the same bytes for every caller.
 
-| Status            | Cause                                              |
-|-------------------|----------------------------------------------------|
-| `200 OK`          | Verified; returns the signed party envelope.       |
-| `400 Bad Request` | Body did not decode as an envelope.                |
-| `401 Unauthorized`| Signature/issuer/audience verification failed.     |
-| `403 Forbidden`   | Caller (`iss`) not on the domain's allow-list.     |
+| Status            | Cause                                                |
+|-------------------|------------------------------------------------------|
+| `200 OK`          | Returns the signed party envelope.                   |
+| `204 No Content`  | The account exists but publishes no identity details. A 204 account is receive-only: it cannot pass sender verification (§6.4), but deliveries *to* it are unaffected. |
+| `404 Not Found`   | The address does not participate in GOBL Net.        |
+
+Because the response is static, servers SHOULD set standard HTTP
+caching headers (`Cache-Control`, `ETag`) and clients MAY cache
+accordingly. Keep the TTL modest (minutes to a few hours): a cached
+who bounds how quickly an Authority's revocation of an endorsement is
+observed (§11.4).
+
+Key discovery (§8.1) is independent of who visibility: a participant
+that signs anything MUST serve its published keys regardless of
+whether its who returns 200 or 204.
+
+> **Note.** Earlier drafts specified `/who` as an authenticated POST
+> exchange so the target could pre-approve requesters and log who
+> asked for its details. That negotiated disclosure MAY return in a
+> future revision as an optional POST alongside the GET; the GET is
+> the baseline every participant serves.
 
 ### 8.3 `POST /.well-known/gobl/inbox`
 
@@ -468,15 +540,17 @@ Accepts a signed GOBL Envelope. The signer (`iss`) is verified against
 its published key (fetched from `<iss>/.well-known/gobl/keys/<kid>`);
 the signed `aud` MUST be present and MUST equal this inbox's
 Address — envelopes signed without an audience, or bound to a
-different audience, MUST be rejected. The allow-list (if present) is
-applied to `iss`. Status codes:
+different audience, MUST be rejected. The inbox SHOULD then apply its
+sender-endorsement policy: resolve the sender's who (§6.4) and
+require an Authority countersignature at the operator's minimum
+scope. Status codes:
 
 | Status                       | Cause                                                |
 |------------------------------|------------------------------------------------------|
 | `202 Accepted`               | Envelope parsed, validated, signature verified, persisted. |
 | `400 Bad Request`            | Body could not be read or did not decode as JSON.    |
 | `401 Unauthorized`           | Envelope signature did not verify, or `aud` missing / not equal to this inbox. |
-| `403 Forbidden`              | Caller (`iss`) not on the domain's allow-list.       |
+| `403 Forbidden`              | Sender (`iss`) is not endorsed by an Authority this inbox trusts, or falls short of its minimum scope. |
 | `422 Unprocessable Entity`   | Envelope failed structural validation.               |
 | `500 Internal Server Error`  | Persistence failed.                                  |
 
@@ -491,8 +565,60 @@ receipt. The reference server in
 each accepted envelope to `<config>/<domain>/inbox/<envelope-uuid>.json`;
 that layout is one valid choice, not a protocol requirement.
 
-In this release the server does not return a signed receipt on 202;
-the response body is empty.
+The empty `202 Accepted` body is deliberate: it asserts durable
+persistence by the inbox and nothing more. There are no transport
+receipts in GOBL Net — experience with receipt-bearing networks
+shows they attest to a handoff between intermediaries, not to
+anything the recipient actually did. Business-level processing is
+signalled instead by follow-up documents (e.g. a `bill.Status`
+envelope) sent back through the same inbox mechanism — which, like
+any other sending, requires the responding party to be an endorsed
+sender (§6.4). Receive-only participants do not send status; a
+supplier delivering to consumers should treat delivery as
+fire-and-forget beyond the 202.
+
+Inbox delivery MUST be idempotent on the envelope's identity: a
+re-POST of an envelope with the same `uuid` and `dig` returns `202`
+without creating a duplicate record. Since a status response may
+never come, "retry until 202" is the sender's correct recovery
+strategy, and idempotency is what makes it safe. (The signed `aud`
+already prevents the same envelope being replayed against a
+*different* inbox.)
+
+### 8.4 End-to-end delivery flow
+
+The canonical invoice exchange between a Supplier (sender) and a
+Customer (receiver — a business or an individual consumer):
+
+1. Supplier needs to send an invoice to Customer, whose GOBL Net
+   Address it learned out-of-band (checkout, contract, directory).
+2. *Optionally*, Supplier performs `GET /who` on Customer to fetch
+   complete invoicing details. A `204 No Content` means the account
+   exists but shares nothing — the Supplier proceeds with the details
+   it already holds.
+3. Supplier signs the invoice envelope with `iss=gobl:supplier`,
+   `aud=gobl:customer` and POSTs it to Customer's `/inbox`.
+4. Customer verifies the envelope signature and audience (§6.1), then
+   resolves the Supplier's identity with `GET /who` on the verified
+   issuer (a cached copy MAY be used within its TTL).
+5. Customer accepts iff the Supplier's who carries a countersignature
+   from an Authority the Customer trusts, at the Customer's minimum
+   scope (§6.4) — i.e. the sender is registered/KYC'd.
+6. `202 Accepted` (empty body) confirms reception to the Supplier.
+
+Only step 5 involves any registration requirement, and it applies
+solely to the sending party. The Customer's own address never needs
+Authority approval — steps 1–3 work against any self-provisioned
+endpoint.
+
+Sending is one role, whoever performs it: any follow-up document
+the Customer might send back — a `bill.Status` reporting
+acceptance or payment, a corrective exchange — is itself a
+delivery under this flow and requires the Customer to be an
+endorsed sender. A receive-only Customer sends nothing, and the
+Supplier expects nothing: for B2C, the 202 in step 6 is the end of
+the exchange. Status flows are a feature of exchanges between
+registered participants.
 
 ## 9. Reference Implementation
 
@@ -515,9 +641,12 @@ The package exports the following sentinel errors:
 |------------------------|------------------------------------------------------------------|
 | `ErrAddressEmpty`      | Empty input to `ParseAddress`.                                   |
 | `ErrAddressInvalid`    | Input is not a valid FQDN per §3.1.                              |
-| `ErrFetchFailed`       | Well-known resource fetch failed (network, non-200, malformed).  |
-| `ErrVerifyFailed`      | Envelope verification failed (no signature, non-`gobl:` `iss`, key fetch failed, signature mismatch, `aud` mismatch, `iat` outside the key's validity window). |
+| `ErrFetchFailed`       | Well-known resource fetch failed (network, non-200/204, malformed). |
+| `ErrNoContent`         | The resource exists but has no content (HTTP 204) — a who endpoint that publishes no identity details. |
+| `ErrVerifyFailed`      | Envelope verification failed (no signature, non-`gobl:` `iss`, key fetch failed, signature mismatch, `aud` mismatch, `iat` outside the key's validity window, who issuer/address mismatch). |
 | `ErrUnknownAuthority`  | An endorser on a `/who` envelope is not in `Authorities` (only raised by callers that opt into authority enforcement). |
+| `ErrScopeInsufficient` | An authority countersignature verified but its scope claim falls short of the required minimum. |
+| `ErrSignatureExpired`  | An authority countersignature verified but its `exp` claim has passed. |
 | `ErrPartyMissing`      | A `/who` response did not contain an `org.Party` document.       |
 | `ErrInboxRejected`     | A receiving inbox did not return 202.                            |
 
@@ -540,8 +669,8 @@ produce a signature that verifies against an attacker-controlled key
 served from that host — distinguishable from the expected identity
 at the application layer. Callers that already know the expected
 Address SHOULD pass it as `expectedAud` to `Client.VerifyEnvelope`,
-or compare the returned issuer Address against an allow-list before
-acting on the document.
+or compare the returned issuer Address against the expected sender
+before acting on the document.
 
 ### 11.2 TLS
 
@@ -562,15 +691,26 @@ the strength of that authority's countersignature. Where this hook
 is used, the KYC vendor list MUST be kept short and reviewed
 regularly.
 
-### 11.4 Inbox Authentication
+### 11.4 Inbox Authentication and Sender Endorsement
 
-The inbox endpoint verifies the sender's signature before persisting an
-envelope, but does *not* require the sender to be a known
-KYC-endorsed participant. Operators that need to restrict inbox
-acceptance to known correspondents MUST apply additional filtering —
-typically a per-domain `allow.json` (see §2) gating `iss`, or an
-application-level `/who` exchange against the sender's address before
-acting on the document.
+The inbox endpoint verifies the sender's signature before persisting
+an envelope; the sender-endorsement policy (§6.4, §8.4) is the layer
+that restricts acceptance to Authority-registered participants.
+Operators choose the minimum scope and the trusted Authority list.
+
+Endorsement revocation is bounded by two mechanisms. First, the
+countersignature's own `exp` claim (§5.3): with the recommended
+90-day maximum, a revoked sender's endorsement dies on its own even
+if the stale who keeps being served — and the renewal cycle this
+forces (re-registering before expiry, in the spirit of Let's
+Encrypt certificates) gives the Authority a recurring checkpoint at
+which to decline. Second, who caching: once an Authority stops
+countersigning a sender (or the sender re-publishes its who without
+the countersignature), receivers continue to accept only until
+their cached copy expires. Inboxes enforcing endorsement MUST
+resolve the sender's who with a bounded TTL rather than trusting a
+cached copy indefinitely, and MAY additionally apply a max-age
+policy to the `iat` of countersignatures that carry no `exp`.
 
 ### 11.5 Response Size
 
@@ -595,6 +735,19 @@ checks.
 two visually distinct strings such as `Example.COM.` and `example.com`
 normalize to the same Address. Callers MUST use `ParseAddress` (directly
 or via `Address.Validate`) before comparing addresses for equality.
+
+### 11.8 Identity Privacy
+
+`GET /who` makes the published party details readable by anyone who
+knows the address. Sending participants generally publish business
+details that are public record anyway; individuals and other
+receive-only participants SHOULD respond `204` rather than publish
+personal data. Servers MAY rate-limit the endpoint to slow bulk
+harvesting. Hosted providers offering per-user sub-addresses
+(`alice.inbox.provider.example`) hold the keys and the inbox contents
+for their users; that concentration of trust is a deployment choice
+outside this protocol, but users of such services should understand
+the provider can read anything delivered to them.
 
 ## 12. References
 

--- a/net/README.md
+++ b/net/README.md
@@ -338,10 +338,10 @@ env.Sign(authorityKey,
 Verifiers MAY require a minimum scope per use case (`registered`
 suffices for `/who` discovery; `verified` may be required before
 acting on inbox deliveries from new counterparties). The minimum is
-passed to `Client.VerifyAuthority` / `Client.VerifySender`: an empty
-minimum accepts any authority signature, `registered` is satisfied by
-`registered` or `verified`, and a custom scope key is satisfied only
-by an exact match. Operators MAY define additional scope keys;
+passed to `Client.VerifyAuthorityWithScope` / `Client.VerifySender`:
+`registered` is satisfied by `registered` or `verified`, and a
+custom scope key is satisfied only by an exact match; plain
+`Client.VerifyAuthority` accepts any authority signature. Operators MAY define additional scope keys;
 `registered` and `verified` are the baseline values the protocol
 recognises.
 
@@ -349,10 +349,10 @@ An Authority countersignature SHOULD carry an `exp` claim bounding
 the endorsement's lifetime — 90 days is the recommended maximum,
 after which the subject renews its registration (§11.4). Verifiers
 MUST treat an expired countersignature as absent: `VerifyAuthority`
-rejects candidates whose `exp` has passed with
-`ErrSignatureExpired`. A countersignature without `exp` does not
-expire; verifiers MAY apply their own `iat` max-age policy to such
-legacy endorsements.
+and `VerifyAuthorityWithScope` reject candidates whose `exp` has
+passed with `ErrSignatureExpired`. A countersignature without `exp`
+does not expire; verifiers MAY apply their own `iat` max-age policy
+to such legacy endorsements.
 
 ### 5.4 X.509 evidence (optional, long-term storage)
 
@@ -428,13 +428,14 @@ treated as trusted KYC vendors. The default list is empty;
 `net.RegisterAuthority` or the `WithAuthorities` client option add to
 it.
 
-`Client.VerifyAuthority(ctx, env, minScope)` returns nil iff the
-envelope carries at least one signature whose signed `iss` is in the
-client's authorities AND that signature cryptographically verifies
-against the authority's published key AND its signed `exp` claim (if
-any) has not passed AND its signed scope claim satisfies `minScope`
-(§5.3). It returns `ErrUnknownAuthority` when no candidate signature
-is from a known authority (or none has been registered),
+`Client.VerifyAuthority(ctx, env)` returns nil iff the envelope
+carries at least one signature whose signed `iss` is in the client's
+authorities AND that signature cryptographically verifies against
+the authority's published key AND its signed `exp` claim (if any)
+has not passed. `Client.VerifyAuthorityWithScope(ctx, env, minScope)`
+additionally requires the signed scope claim to satisfy `minScope`
+(§5.3). They return `ErrUnknownAuthority` when no candidate
+signature is from a known authority (or none has been registered),
 `ErrSignatureExpired` when a verified authority signature has
 expired, `ErrScopeInsufficient` when it falls short of the minimum
 scope, and `ErrVerifyFailed` when a candidate fails its crypto
@@ -451,8 +452,8 @@ authorities are an additional, opt-in policy layer on top.
 
 `Client.VerifySender(ctx, addr, minScope)` combines the two: it
 resolves `addr`'s identity via `Who` and requires an Authority
-countersignature satisfying `minScope` via `VerifyAuthority`,
-returning the endorsed `org.Party`. Receiving inboxes call it with
+countersignature satisfying `minScope` via
+`VerifyAuthorityWithScope`, returning the endorsed `org.Party`. Receiving inboxes call it with
 the verified issuer of an incoming envelope before accepting the
 delivery (§8.4). A receive-only account (204) or a merely self-signed
 identity fails this check by construction — such addresses can

--- a/net/address_test.go
+++ b/net/address_test.go
@@ -110,6 +110,12 @@ func TestAddressString(t *testing.T) {
 	assert.Equal(t, "billing.invopop.com", Address("billing.invopop.com").String())
 }
 
+func TestAddressValidate(t *testing.T) {
+	assert.NoError(t, Address("billing.invopop.com").Validate())
+	assert.ErrorIs(t, Address("").Validate(), ErrAddressEmpty)
+	assert.ErrorIs(t, Address("localhost").Validate(), ErrAddressInvalid)
+}
+
 func TestAddressKeyURL(t *testing.T) {
 	a := Address("billing.invopop.com")
 	assert.Equal(t,

--- a/net/authorities.go
+++ b/net/authorities.go
@@ -56,7 +56,9 @@ func (c *Client) VerifyAuthorityWithScope(ctx context.Context, env *gobl.Envelop
 }
 
 func (c *Client) verifyAuthority(ctx context.Context, env *gobl.Envelope, minScope cbc.Key) error {
-	if env == nil || len(env.Signatures) == 0 {
+	// A malformed envelope may carry signatures without a header;
+	// reject rather than let header verification panic.
+	if env == nil || env.Head == nil || len(env.Signatures) == 0 {
 		return fmt.Errorf("%w: envelope is not signed", ErrVerifyFailed)
 	}
 	if len(c.authorities) == 0 {

--- a/net/authorities.go
+++ b/net/authorities.go
@@ -2,7 +2,6 @@ package net
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -30,24 +29,33 @@ func RegisterAuthority(addr Address) {
 // client's known authorities (the package-level Authorities slice
 // plus anything added via WithAuthorities). Each candidate signature
 // is cryptographically verified against the authority's own
-// published key, and its signed scope claim must satisfy minScope:
-// an empty minScope accepts any authority signature, otherwise the
-// claim must be the same key or rank higher (registered < verified).
-// Custom scope keys only satisfy an exact match.
+// published key, and a candidate whose signed exp claim has passed
+// is rejected: expired endorsements are not evidence.
 //
-// A candidate whose signed exp claim has passed is rejected: expired
-// endorsements are not evidence.
-//
-// Returns nil on the first authority signature that verifies at
-// minScope. If no signature is from a known authority, returns
-// ErrUnknownAuthority. If a verified authority signature has expired,
-// returns ErrSignatureExpired; if it falls short of minScope, returns
-// ErrScopeInsufficient. If all candidates fail crypto verification,
+// Returns nil on the first authority signature that verifies. If no
+// signature is from a known authority, returns ErrUnknownAuthority.
+// If a verified authority signature has expired, returns
+// ErrSignatureExpired. If all candidates fail crypto verification,
 // returns ErrVerifyFailed wrapping the last error.
 //
 // Callers that want to accept self-signed (no-authority) envelopes
-// should skip this call rather than ignore its error.
-func (c *Client) VerifyAuthority(ctx context.Context, env *gobl.Envelope, minScope cbc.Key) error {
+// should skip this call rather than ignore its error. Callers with
+// a minimum scope requirement use VerifyAuthorityWithScope.
+func (c *Client) VerifyAuthority(ctx context.Context, env *gobl.Envelope) error {
+	return c.verifyAuthority(ctx, env, "")
+}
+
+// VerifyAuthorityWithScope performs the VerifyAuthority check and
+// additionally requires the countersignature's signed scope claim to
+// satisfy minScope: the claim must be the same key or rank higher
+// (registered < verified); custom scope keys only satisfy an exact
+// match. A verified authority signature falling short of the minimum
+// returns ErrScopeInsufficient.
+func (c *Client) VerifyAuthorityWithScope(ctx context.Context, env *gobl.Envelope, minScope cbc.Key) error {
+	return c.verifyAuthority(ctx, env, minScope)
+}
+
+func (c *Client) verifyAuthority(ctx context.Context, env *gobl.Envelope, minScope cbc.Key) error {
 	if env == nil || len(env.Signatures) == 0 {
 		return fmt.Errorf("%w: envelope is not signed", ErrVerifyFailed)
 	}
@@ -59,7 +67,10 @@ func (c *Client) VerifyAuthority(ctx context.Context, env *gobl.Envelope, minSco
 		auths[a] = true
 	}
 
-	var lastErr error
+	// claimErr records a candidate that verified cryptographically but
+	// failed a claim check (expired or insufficient scope); it takes
+	// precedence over crypto failures from other candidates.
+	var lastErr, claimErr error
 	for _, sig := range env.Signatures {
 		p, err := head.SignedPayload(sig)
 		if err != nil {
@@ -85,22 +96,23 @@ func (c *Client) VerifyAuthority(ctx context.Context, env *gobl.Envelope, minSco
 			lastErr = err
 			continue
 		}
-		// Claims are only trusted after the signature verifies.
-		if p.ExpiresAt > 0 && time.Now().UTC().Unix() > p.ExpiresAt {
-			lastErr = fmt.Errorf("%w: exp %s has passed", ErrSignatureExpired,
+		// Claims are only trusted after the signature verifies. Per
+		// RFC 7519, the current time must be strictly before exp.
+		if p.ExpiresAt > 0 && time.Now().UTC().Unix() >= p.ExpiresAt {
+			claimErr = fmt.Errorf("%w: exp %s has passed", ErrSignatureExpired,
 				time.Unix(p.ExpiresAt, 0).UTC().Format(time.RFC3339))
 			continue
 		}
 		if !scopeSatisfies(p.Scope, minScope) {
-			lastErr = fmt.Errorf("%w: %q does not meet minimum %q", ErrScopeInsufficient, p.Scope, minScope)
+			claimErr = fmt.Errorf("%w: %q does not meet minimum %q", ErrScopeInsufficient, p.Scope, minScope)
 			continue
 		}
 		return nil
 	}
+	if claimErr != nil {
+		return claimErr
+	}
 	if lastErr != nil {
-		if errors.Is(lastErr, ErrScopeInsufficient) || errors.Is(lastErr, ErrSignatureExpired) {
-			return lastErr
-		}
 		return fmt.Errorf("%w: %v", ErrVerifyFailed, lastErr)
 	}
 	return ErrUnknownAuthority

--- a/net/authorities.go
+++ b/net/authorities.go
@@ -2,9 +2,12 @@ package net
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"time"
 
 	"github.com/invopop/gobl"
+	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/head"
 )
 
@@ -27,16 +30,24 @@ func RegisterAuthority(addr Address) {
 // client's known authorities (the package-level Authorities slice
 // plus anything added via WithAuthorities). Each candidate signature
 // is cryptographically verified against the authority's own
-// published key.
+// published key, and its signed scope claim must satisfy minScope:
+// an empty minScope accepts any authority signature, otherwise the
+// claim must be the same key or rank higher (registered < verified).
+// Custom scope keys only satisfy an exact match.
 //
-// Returns nil on the first authority signature that verifies. If no
-// signature is from a known authority, returns ErrUnknownAuthority.
-// If all candidates fail crypto verification, returns
-// ErrVerifyFailed wrapping the last error.
+// A candidate whose signed exp claim has passed is rejected: expired
+// endorsements are not evidence.
+//
+// Returns nil on the first authority signature that verifies at
+// minScope. If no signature is from a known authority, returns
+// ErrUnknownAuthority. If a verified authority signature has expired,
+// returns ErrSignatureExpired; if it falls short of minScope, returns
+// ErrScopeInsufficient. If all candidates fail crypto verification,
+// returns ErrVerifyFailed wrapping the last error.
 //
 // Callers that want to accept self-signed (no-authority) envelopes
 // should skip this call rather than ignore its error.
-func (c *Client) VerifyAuthority(ctx context.Context, env *gobl.Envelope) error {
+func (c *Client) VerifyAuthority(ctx context.Context, env *gobl.Envelope, minScope cbc.Key) error {
 	if env == nil || len(env.Signatures) == 0 {
 		return fmt.Errorf("%w: envelope is not signed", ErrVerifyFailed)
 	}
@@ -74,10 +85,47 @@ func (c *Client) VerifyAuthority(ctx context.Context, env *gobl.Envelope) error 
 			lastErr = err
 			continue
 		}
+		// Claims are only trusted after the signature verifies.
+		if p.ExpiresAt > 0 && time.Now().UTC().Unix() > p.ExpiresAt {
+			lastErr = fmt.Errorf("%w: exp %s has passed", ErrSignatureExpired,
+				time.Unix(p.ExpiresAt, 0).UTC().Format(time.RFC3339))
+			continue
+		}
+		if !scopeSatisfies(p.Scope, minScope) {
+			lastErr = fmt.Errorf("%w: %q does not meet minimum %q", ErrScopeInsufficient, p.Scope, minScope)
+			continue
+		}
 		return nil
 	}
 	if lastErr != nil {
+		if errors.Is(lastErr, ErrScopeInsufficient) || errors.Is(lastErr, ErrSignatureExpired) {
+			return lastErr
+		}
 		return fmt.Errorf("%w: %v", ErrVerifyFailed, lastErr)
 	}
 	return ErrUnknownAuthority
+}
+
+// scopeRank orders the baseline scope keys: none < registered <
+// verified. Unrecognised keys rank 0.
+func scopeRank(scope cbc.Key) int {
+	switch scope {
+	case head.ScopeRegistered:
+		return 1
+	case head.ScopeVerified:
+		return 2
+	}
+	return 0
+}
+
+// scopeSatisfies reports whether a signed scope claim meets the
+// required minimum: any claim satisfies an empty minimum, an exact
+// match always satisfies, and baseline keys satisfy lower-ranked
+// baseline minimums.
+func scopeSatisfies(got, minScope cbc.Key) bool {
+	if minScope == "" || got == minScope {
+		return true
+	}
+	r := scopeRank(minScope)
+	return r > 0 && scopeRank(got) >= r
 }

--- a/net/authorities.go
+++ b/net/authorities.go
@@ -62,9 +62,13 @@ func (c *Client) verifyAuthority(ctx context.Context, env *gobl.Envelope, minSco
 	if len(c.authorities) == 0 {
 		return fmt.Errorf("%w: no authorities registered on this client", ErrUnknownAuthority)
 	}
+	// Both sides of the lookup are canonicalized so U-Label or
+	// trailing-dot forms — configured or signed — compare equal.
 	auths := make(map[Address]bool, len(c.authorities))
 	for _, a := range c.authorities {
-		auths[a] = true
+		if canon, err := ParseAddress(string(a)); err == nil {
+			auths[canon] = true
+		}
 	}
 
 	// claimErr records a candidate that verified cryptographically but
@@ -79,8 +83,8 @@ func (c *Client) verifyAuthority(ctx context.Context, env *gobl.Envelope, minSco
 		if p.Iss.Scheme() != Scheme {
 			continue
 		}
-		issuer := Address(p.Iss.Opaque())
-		if err := issuer.Validate(); err != nil {
+		issuer, err := ParseAddress(p.Iss.Opaque())
+		if err != nil {
 			continue
 		}
 		if !auths[issuer] {

--- a/net/authorities.go
+++ b/net/authorities.go
@@ -97,8 +97,10 @@ func (c *Client) verifyAuthority(ctx context.Context, env *gobl.Envelope, minSco
 			continue
 		}
 		// Claims are only trusted after the signature verifies. Per
-		// RFC 7519, the current time must be strictly before exp.
-		if p.ExpiresAt > 0 && time.Now().UTC().Unix() >= p.ExpiresAt {
+		// RFC 7519, the current time must be strictly before exp. Zero
+		// means the claim is absent (the JSON zero value); any other
+		// value — including a pre-1970 NumericDate — is enforced.
+		if p.ExpiresAt != 0 && time.Now().UTC().Unix() >= p.ExpiresAt {
 			claimErr = fmt.Errorf("%w: exp %s has passed", ErrSignatureExpired,
 				time.Unix(p.ExpiresAt, 0).UTC().Format(time.RFC3339))
 			continue

--- a/net/authorities_test.go
+++ b/net/authorities_test.go
@@ -309,6 +309,84 @@ func TestVerifyAuthority(t *testing.T) {
 		assert.True(t, errors.Is(err, ErrUnknownAuthority))
 	})
 
+	t.Run("skips undecodable signature payloads", func(t *testing.T) {
+		msg := &note.Message{Content: "party doc"}
+		msg.SetUUID(uuid.V7())
+		env, err := gobl.Envelop(msg)
+		require.NoError(t, err)
+		require.NoError(t, env.Sign(authKey,
+			head.WithIssuer(authorityAddr.URI()),
+			head.WithScope(head.ScopeVerified)))
+		// Prepend a signature whose payload does not decode; it must be
+		// stepped past, not fail the whole check.
+		bad, err := dsig.NewSignature(authKey, "not-an-object")
+		require.NoError(t, err)
+		env.Signatures = append([]*dsig.Signature{bad}, env.Signatures...)
+
+		c := NewClient(
+			WithAuthorities(authorityAddr),
+			WithFetcher(&mapFetcher{data: map[string][]byte{
+				authorityAddr.KeyURL(authKey.ID()): jwkOf(authKey),
+			}}),
+		)
+		assert.NoError(t, c.VerifyAuthority(ctx, env))
+	})
+
+	t.Run("skips an invalid iss FQDN", func(t *testing.T) {
+		msg := &note.Message{Content: "party doc"}
+		msg.SetUUID(uuid.V7())
+		env, err := gobl.Envelop(msg)
+		require.NoError(t, err)
+		require.NoError(t, env.Sign(authKey, head.WithIssuer(cbc.URI("gobl:localhost"))))
+
+		c := NewClient(WithAuthorities(authorityAddr))
+		err = c.VerifyAuthority(ctx, env)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrUnknownAuthority))
+	})
+
+	t.Run("rejects a tampered envelope", func(t *testing.T) {
+		// The countersignature fetches its key fine but no longer
+		// matches the (mutated) header digest.
+		msg := &note.Message{Content: "party doc"}
+		msg.SetUUID(uuid.V7())
+		env, err := gobl.Envelop(msg)
+		require.NoError(t, err)
+		require.NoError(t, env.Sign(authKey, head.WithIssuer(authorityAddr.URI())))
+		env.Head.Digest = dsig.NewSHA256Digest([]byte("tampered"))
+
+		c := NewClient(
+			WithAuthorities(authorityAddr),
+			WithFetcher(&mapFetcher{data: map[string][]byte{
+				authorityAddr.KeyURL(authKey.ID()): jwkOf(authKey),
+			}}),
+		)
+		err = c.VerifyAuthority(ctx, env)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrVerifyFailed))
+	})
+
+	t.Run("rejects signatures without a header", func(t *testing.T) {
+		// A malformed envelope carrying signatures but no head must be
+		// rejected, not panic.
+		msg := &note.Message{Content: "party doc"}
+		msg.SetUUID(uuid.V7())
+		env, err := gobl.Envelop(msg)
+		require.NoError(t, err)
+		require.NoError(t, env.Sign(authKey, head.WithIssuer(authorityAddr.URI())))
+		env.Head = nil
+
+		c := NewClient(
+			WithAuthorities(authorityAddr),
+			WithFetcher(&mapFetcher{data: map[string][]byte{
+				authorityAddr.KeyURL(authKey.ID()): jwkOf(authKey),
+			}}),
+		)
+		err = c.VerifyAuthority(ctx, env)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrVerifyFailed))
+	})
+
 	t.Run("rejects an envelope with no signatures at all", func(t *testing.T) {
 		msg := &note.Message{Content: "x"}
 		msg.SetUUID(uuid.V7())

--- a/net/authorities_test.go
+++ b/net/authorities_test.go
@@ -203,6 +203,29 @@ func TestVerifyAuthority(t *testing.T) {
 		assert.True(t, errors.Is(err, ErrSignatureExpired))
 	})
 
+	t.Run("rejects a pre-epoch expiry", func(t *testing.T) {
+		// A negative exp is a valid NumericDate before 1970 and must be
+		// enforced, not treated as an absent claim.
+		msg := &note.Message{Content: "party doc"}
+		msg.SetUUID(uuid.V7())
+		env, err := gobl.Envelop(msg)
+		require.NoError(t, err)
+		require.NoError(t, env.Sign(authKey,
+			head.WithIssuer(authorityAddr.URI()),
+			head.WithScope(head.ScopeVerified),
+			head.WithExpiration(time.Unix(-1000, 0))))
+
+		c := NewClient(
+			WithAuthorities(authorityAddr),
+			WithFetcher(&mapFetcher{data: map[string][]byte{
+				authorityAddr.KeyURL(authKey.ID()): jwkOf(authKey),
+			}}),
+		)
+		err = c.VerifyAuthority(ctx, env)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrSignatureExpired))
+	})
+
 	t.Run("expiry outlives later candidate failures", func(t *testing.T) {
 		// An expired countersignature followed by a candidate whose key
 		// cannot be fetched must still surface ErrSignatureExpired, not

--- a/net/authorities_test.go
+++ b/net/authorities_test.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/invopop/gobl"
+	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/dsig"
 	"github.com/invopop/gobl/head"
 	"github.com/invopop/gobl/note"
@@ -94,7 +96,130 @@ func TestVerifyAuthority(t *testing.T) {
 				authorityAddr.KeyURL(authKey.ID()): jwkOf(authKey),
 			}}),
 		)
-		assert.NoError(t, c.VerifyAuthority(ctx, env))
+		assert.NoError(t, c.VerifyAuthority(ctx, env, ""))
+	})
+
+	t.Run("enforces a minimum scope", func(t *testing.T) {
+		msg := &note.Message{Content: "party doc"}
+		msg.SetUUID(uuid.V7())
+		env, err := gobl.Envelop(msg)
+		require.NoError(t, err)
+		require.NoError(t, env.Sign(subjKey, head.WithIssuer(subjectAddr.URI())))
+		require.NoError(t, env.Sign(authKey,
+			head.WithIssuer(authorityAddr.URI()),
+			head.WithAudience(subjectAddr.URI()),
+			head.WithScope(head.ScopeRegistered)))
+
+		c := NewClient(
+			WithAuthorities(authorityAddr),
+			WithFetcher(&mapFetcher{data: map[string][]byte{
+				authorityAddr.KeyURL(authKey.ID()): jwkOf(authKey),
+			}}),
+		)
+		// registered satisfies registered but not verified.
+		assert.NoError(t, c.VerifyAuthority(ctx, env, head.ScopeRegistered))
+		err = c.VerifyAuthority(ctx, env, head.ScopeVerified)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrScopeInsufficient))
+	})
+
+	t.Run("verified satisfies a registered minimum", func(t *testing.T) {
+		msg := &note.Message{Content: "party doc"}
+		msg.SetUUID(uuid.V7())
+		env, err := gobl.Envelop(msg)
+		require.NoError(t, err)
+		require.NoError(t, env.Sign(authKey,
+			head.WithIssuer(authorityAddr.URI()),
+			head.WithScope(head.ScopeVerified)))
+
+		c := NewClient(
+			WithAuthorities(authorityAddr),
+			WithFetcher(&mapFetcher{data: map[string][]byte{
+				authorityAddr.KeyURL(authKey.ID()): jwkOf(authKey),
+			}}),
+		)
+		assert.NoError(t, c.VerifyAuthority(ctx, env, head.ScopeRegistered))
+	})
+
+	t.Run("scopeless authority signature fails any named minimum", func(t *testing.T) {
+		msg := &note.Message{Content: "party doc"}
+		msg.SetUUID(uuid.V7())
+		env, err := gobl.Envelop(msg)
+		require.NoError(t, err)
+		require.NoError(t, env.Sign(authKey, head.WithIssuer(authorityAddr.URI())))
+
+		c := NewClient(
+			WithAuthorities(authorityAddr),
+			WithFetcher(&mapFetcher{data: map[string][]byte{
+				authorityAddr.KeyURL(authKey.ID()): jwkOf(authKey),
+			}}),
+		)
+		assert.NoError(t, c.VerifyAuthority(ctx, env, ""))
+		err = c.VerifyAuthority(ctx, env, head.ScopeRegistered)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrScopeInsufficient))
+	})
+
+	t.Run("custom scope requires an exact match", func(t *testing.T) {
+		custom := cbc.Key("premium")
+		msg := &note.Message{Content: "party doc"}
+		msg.SetUUID(uuid.V7())
+		env, err := gobl.Envelop(msg)
+		require.NoError(t, err)
+		require.NoError(t, env.Sign(authKey,
+			head.WithIssuer(authorityAddr.URI()),
+			head.WithScope(custom)))
+
+		c := NewClient(
+			WithAuthorities(authorityAddr),
+			WithFetcher(&mapFetcher{data: map[string][]byte{
+				authorityAddr.KeyURL(authKey.ID()): jwkOf(authKey),
+			}}),
+		)
+		assert.NoError(t, c.VerifyAuthority(ctx, env, custom))
+		err = c.VerifyAuthority(ctx, env, head.ScopeRegistered)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrScopeInsufficient))
+	})
+
+	t.Run("rejects an expired countersignature", func(t *testing.T) {
+		msg := &note.Message{Content: "party doc"}
+		msg.SetUUID(uuid.V7())
+		env, err := gobl.Envelop(msg)
+		require.NoError(t, err)
+		require.NoError(t, env.Sign(authKey,
+			head.WithIssuer(authorityAddr.URI()),
+			head.WithScope(head.ScopeVerified),
+			head.WithExpiration(time.Now().Add(-time.Hour))))
+
+		c := NewClient(
+			WithAuthorities(authorityAddr),
+			WithFetcher(&mapFetcher{data: map[string][]byte{
+				authorityAddr.KeyURL(authKey.ID()): jwkOf(authKey),
+			}}),
+		)
+		err = c.VerifyAuthority(ctx, env, "")
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrSignatureExpired))
+	})
+
+	t.Run("accepts a countersignature within its exp window", func(t *testing.T) {
+		msg := &note.Message{Content: "party doc"}
+		msg.SetUUID(uuid.V7())
+		env, err := gobl.Envelop(msg)
+		require.NoError(t, err)
+		require.NoError(t, env.Sign(authKey,
+			head.WithIssuer(authorityAddr.URI()),
+			head.WithScope(head.ScopeVerified),
+			head.WithExpiration(time.Now().Add(90*24*time.Hour))))
+
+		c := NewClient(
+			WithAuthorities(authorityAddr),
+			WithFetcher(&mapFetcher{data: map[string][]byte{
+				authorityAddr.KeyURL(authKey.ID()): jwkOf(authKey),
+			}}),
+		)
+		assert.NoError(t, c.VerifyAuthority(ctx, env, head.ScopeVerified))
 	})
 
 	t.Run("rejects an envelope with only a self-signature", func(t *testing.T) {
@@ -108,7 +233,7 @@ func TestVerifyAuthority(t *testing.T) {
 			WithAuthorities(authorityAddr),
 			WithFetcher(&mapFetcher{data: map[string][]byte{}}),
 		)
-		err = c.VerifyAuthority(ctx, env)
+		err = c.VerifyAuthority(ctx, env, "")
 		require.Error(t, err)
 		assert.True(t, errors.Is(err, ErrUnknownAuthority))
 	})
@@ -120,7 +245,7 @@ func TestVerifyAuthority(t *testing.T) {
 		require.NoError(t, err)
 
 		c := NewClient(WithAuthorities(authorityAddr))
-		err = c.VerifyAuthority(ctx, env)
+		err = c.VerifyAuthority(ctx, env, "")
 		require.Error(t, err)
 		assert.True(t, errors.Is(err, ErrVerifyFailed))
 	})
@@ -133,7 +258,7 @@ func TestVerifyAuthority(t *testing.T) {
 		require.NoError(t, env.Sign(authKey, head.WithIssuer(authorityAddr.URI())))
 
 		c := NewClient() // empty authorities
-		err = c.VerifyAuthority(ctx, env)
+		err = c.VerifyAuthority(ctx, env, "")
 		require.Error(t, err)
 		assert.True(t, errors.Is(err, ErrUnknownAuthority))
 	})
@@ -156,7 +281,7 @@ func TestVerifyAuthority(t *testing.T) {
 				authorityAddr.KeyURL(authKey.ID()): jwkOf(other),
 			}}),
 		)
-		err = c.VerifyAuthority(ctx, env)
+		err = c.VerifyAuthority(ctx, env, "")
 		require.Error(t, err)
 		assert.True(t, errors.Is(err, ErrVerifyFailed))
 	})
@@ -171,7 +296,7 @@ func TestVerifyAuthority(t *testing.T) {
 		require.NoError(t, env.Sign(subjKey, head.WithIssuer("mailto:a@b")))
 
 		c := NewClient(WithAuthorities(authorityAddr))
-		err = c.VerifyAuthority(ctx, env)
+		err = c.VerifyAuthority(ctx, env, "")
 		require.Error(t, err)
 		assert.True(t, errors.Is(err, ErrUnknownAuthority))
 	})

--- a/net/authorities_test.go
+++ b/net/authorities_test.go
@@ -96,7 +96,7 @@ func TestVerifyAuthority(t *testing.T) {
 				authorityAddr.KeyURL(authKey.ID()): jwkOf(authKey),
 			}}),
 		)
-		assert.NoError(t, c.VerifyAuthority(ctx, env, ""))
+		assert.NoError(t, c.VerifyAuthority(ctx, env))
 	})
 
 	t.Run("enforces a minimum scope", func(t *testing.T) {
@@ -117,8 +117,8 @@ func TestVerifyAuthority(t *testing.T) {
 			}}),
 		)
 		// registered satisfies registered but not verified.
-		assert.NoError(t, c.VerifyAuthority(ctx, env, head.ScopeRegistered))
-		err = c.VerifyAuthority(ctx, env, head.ScopeVerified)
+		assert.NoError(t, c.VerifyAuthorityWithScope(ctx, env, head.ScopeRegistered))
+		err = c.VerifyAuthorityWithScope(ctx, env, head.ScopeVerified)
 		require.Error(t, err)
 		assert.True(t, errors.Is(err, ErrScopeInsufficient))
 	})
@@ -138,7 +138,7 @@ func TestVerifyAuthority(t *testing.T) {
 				authorityAddr.KeyURL(authKey.ID()): jwkOf(authKey),
 			}}),
 		)
-		assert.NoError(t, c.VerifyAuthority(ctx, env, head.ScopeRegistered))
+		assert.NoError(t, c.VerifyAuthorityWithScope(ctx, env, head.ScopeRegistered))
 	})
 
 	t.Run("scopeless authority signature fails any named minimum", func(t *testing.T) {
@@ -154,8 +154,8 @@ func TestVerifyAuthority(t *testing.T) {
 				authorityAddr.KeyURL(authKey.ID()): jwkOf(authKey),
 			}}),
 		)
-		assert.NoError(t, c.VerifyAuthority(ctx, env, ""))
-		err = c.VerifyAuthority(ctx, env, head.ScopeRegistered)
+		assert.NoError(t, c.VerifyAuthority(ctx, env))
+		err = c.VerifyAuthorityWithScope(ctx, env, head.ScopeRegistered)
 		require.Error(t, err)
 		assert.True(t, errors.Is(err, ErrScopeInsufficient))
 	})
@@ -176,8 +176,8 @@ func TestVerifyAuthority(t *testing.T) {
 				authorityAddr.KeyURL(authKey.ID()): jwkOf(authKey),
 			}}),
 		)
-		assert.NoError(t, c.VerifyAuthority(ctx, env, custom))
-		err = c.VerifyAuthority(ctx, env, head.ScopeRegistered)
+		assert.NoError(t, c.VerifyAuthorityWithScope(ctx, env, custom))
+		err = c.VerifyAuthorityWithScope(ctx, env, head.ScopeRegistered)
 		require.Error(t, err)
 		assert.True(t, errors.Is(err, ErrScopeInsufficient))
 	})
@@ -198,7 +198,35 @@ func TestVerifyAuthority(t *testing.T) {
 				authorityAddr.KeyURL(authKey.ID()): jwkOf(authKey),
 			}}),
 		)
-		err = c.VerifyAuthority(ctx, env, "")
+		err = c.VerifyAuthority(ctx, env)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrSignatureExpired))
+	})
+
+	t.Run("expiry outlives later candidate failures", func(t *testing.T) {
+		// An expired countersignature followed by a candidate whose key
+		// cannot be fetched must still surface ErrSignatureExpired, not
+		// the generic ErrVerifyFailed from the later failure.
+		otherAuth := Address("auth.example.org")
+		otherKey := dsig.NewES256Key()
+		msg := &note.Message{Content: "party doc"}
+		msg.SetUUID(uuid.V7())
+		env, err := gobl.Envelop(msg)
+		require.NoError(t, err)
+		require.NoError(t, env.Sign(authKey,
+			head.WithIssuer(authorityAddr.URI()),
+			head.WithScope(head.ScopeVerified),
+			head.WithExpiration(time.Now().Add(-time.Hour))))
+		require.NoError(t, env.Sign(otherKey, head.WithIssuer(otherAuth.URI())))
+
+		c := NewClient(
+			WithAuthorities(authorityAddr, otherAuth),
+			WithFetcher(&mapFetcher{data: map[string][]byte{
+				// Only the first authority's key resolves.
+				authorityAddr.KeyURL(authKey.ID()): jwkOf(authKey),
+			}}),
+		)
+		err = c.VerifyAuthority(ctx, env)
 		require.Error(t, err)
 		assert.True(t, errors.Is(err, ErrSignatureExpired))
 	})
@@ -219,7 +247,7 @@ func TestVerifyAuthority(t *testing.T) {
 				authorityAddr.KeyURL(authKey.ID()): jwkOf(authKey),
 			}}),
 		)
-		assert.NoError(t, c.VerifyAuthority(ctx, env, head.ScopeVerified))
+		assert.NoError(t, c.VerifyAuthorityWithScope(ctx, env, head.ScopeVerified))
 	})
 
 	t.Run("rejects an envelope with only a self-signature", func(t *testing.T) {
@@ -233,7 +261,7 @@ func TestVerifyAuthority(t *testing.T) {
 			WithAuthorities(authorityAddr),
 			WithFetcher(&mapFetcher{data: map[string][]byte{}}),
 		)
-		err = c.VerifyAuthority(ctx, env, "")
+		err = c.VerifyAuthority(ctx, env)
 		require.Error(t, err)
 		assert.True(t, errors.Is(err, ErrUnknownAuthority))
 	})
@@ -245,7 +273,7 @@ func TestVerifyAuthority(t *testing.T) {
 		require.NoError(t, err)
 
 		c := NewClient(WithAuthorities(authorityAddr))
-		err = c.VerifyAuthority(ctx, env, "")
+		err = c.VerifyAuthority(ctx, env)
 		require.Error(t, err)
 		assert.True(t, errors.Is(err, ErrVerifyFailed))
 	})
@@ -258,7 +286,7 @@ func TestVerifyAuthority(t *testing.T) {
 		require.NoError(t, env.Sign(authKey, head.WithIssuer(authorityAddr.URI())))
 
 		c := NewClient() // empty authorities
-		err = c.VerifyAuthority(ctx, env, "")
+		err = c.VerifyAuthority(ctx, env)
 		require.Error(t, err)
 		assert.True(t, errors.Is(err, ErrUnknownAuthority))
 	})
@@ -281,7 +309,7 @@ func TestVerifyAuthority(t *testing.T) {
 				authorityAddr.KeyURL(authKey.ID()): jwkOf(other),
 			}}),
 		)
-		err = c.VerifyAuthority(ctx, env, "")
+		err = c.VerifyAuthority(ctx, env)
 		require.Error(t, err)
 		assert.True(t, errors.Is(err, ErrVerifyFailed))
 	})
@@ -296,7 +324,7 @@ func TestVerifyAuthority(t *testing.T) {
 		require.NoError(t, env.Sign(subjKey, head.WithIssuer("mailto:a@b")))
 
 		c := NewClient(WithAuthorities(authorityAddr))
-		err = c.VerifyAuthority(ctx, env, "")
+		err = c.VerifyAuthority(ctx, env)
 		require.Error(t, err)
 		assert.True(t, errors.Is(err, ErrUnknownAuthority))
 	})

--- a/net/authorities_test.go
+++ b/net/authorities_test.go
@@ -203,6 +203,26 @@ func TestVerifyAuthority(t *testing.T) {
 		assert.True(t, errors.Is(err, ErrSignatureExpired))
 	})
 
+	t.Run("canonicalizes a non-canonical authority iss", func(t *testing.T) {
+		// The countersignature names the authority in mixed case with a
+		// trailing dot; it must still match the registered authority.
+		msg := &note.Message{Content: "party doc"}
+		msg.SetUUID(uuid.V7())
+		env, err := gobl.Envelop(msg)
+		require.NoError(t, err)
+		require.NoError(t, env.Sign(authKey,
+			head.WithIssuer(cbc.URI("gobl:KYC.Example.COM.")),
+			head.WithScope(head.ScopeVerified)))
+
+		c := NewClient(
+			WithAuthorities(authorityAddr),
+			WithFetcher(&mapFetcher{data: map[string][]byte{
+				authorityAddr.KeyURL(authKey.ID()): jwkOf(authKey),
+			}}),
+		)
+		assert.NoError(t, c.VerifyAuthority(ctx, env))
+	})
+
 	t.Run("rejects a pre-epoch expiry", func(t *testing.T) {
 		// A negative exp is a valid NumericDate before 1970 and must be
 		// enforced, not treated as an absent claim.

--- a/net/client.go
+++ b/net/client.go
@@ -178,7 +178,10 @@ func NewClient(opts ...ClientOption) *Client {
 // augmented with the `valid_from` / `valid_until` extension members
 // understood by dsig.PublicKey.
 func (c *Client) FetchKey(ctx context.Context, addr Address, kid string) (*dsig.PublicKey, error) {
-	if err := addr.Validate(); err != nil {
+	// Canonicalize so the per-key URL uses the ASCII form regardless
+	// of how the address was written.
+	addr, err := ParseAddress(string(addr))
+	if err != nil {
 		return nil, err
 	}
 	if kid == "" {

--- a/net/client.go
+++ b/net/client.go
@@ -121,6 +121,9 @@ func (f *HTTPFetcher) Fetch(ctx context.Context, url string) ([]byte, error) {
 	}
 	defer resp.Body.Close() // nolint:errcheck
 
+	if resp.StatusCode == http.StatusNoContent {
+		return nil, fmt.Errorf("%w: %s", ErrNoContent, url)
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("%w: HTTP %d from %s", ErrFetchFailed, resp.StatusCode, url)
 	}

--- a/net/client_test.go
+++ b/net/client_test.go
@@ -116,6 +116,17 @@ func TestHTTPFetcherFetch(t *testing.T) {
 		assert.Equal(t, `{"ok":true}`, string(body))
 	})
 
+	t.Run("204 returns ErrNoContent", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		defer srv.Close()
+
+		_, err := newHTTPFetcher(true).Fetch(context.Background(), srv.URL)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrNoContent))
+	})
+
 	t.Run("non-200", func(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			http.Error(w, "nope", http.StatusNotFound)

--- a/net/client_test.go
+++ b/net/client_test.go
@@ -195,6 +195,29 @@ func TestHTTPFetcherRejectsNonPublicAddresses(t *testing.T) {
 	assert.Contains(t, err.Error(), "refusing to dial non-public address")
 }
 
+func TestSafeDialContext(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("address without a port", func(t *testing.T) {
+		_, err := safeDialContext(ctx, "tcp", "example.com")
+		require.Error(t, err)
+	})
+
+	t.Run("unresolvable host", func(t *testing.T) {
+		// .invalid is reserved (RFC 2606) and never resolves.
+		_, err := safeDialContext(ctx, "tcp", "does-not-exist.invalid:443")
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrFetchFailed))
+	})
+
+	t.Run("non-public address", func(t *testing.T) {
+		_, err := safeDialContext(ctx, "tcp", "127.0.0.1:443")
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrFetchFailed))
+		assert.Contains(t, err.Error(), "refusing to dial non-public address")
+	})
+}
+
 func TestIsPublicIP(t *testing.T) {
 	tests := []struct {
 		ip   string

--- a/net/errors.go
+++ b/net/errors.go
@@ -9,11 +9,21 @@ var (
 	ErrAddressInvalid = errors.New("net: invalid address")
 	// ErrFetchFailed is returned when a well-known resource could not be fetched.
 	ErrFetchFailed = errors.New("net: failed to fetch resource")
+	// ErrNoContent is returned when a well-known resource exists but has no
+	// content to share (HTTP 204), e.g. a /who endpoint whose owner does not
+	// publish identity details.
+	ErrNoContent = errors.New("net: no content")
 	// ErrVerifyFailed is returned when verification fails.
 	ErrVerifyFailed = errors.New("net: verification failed")
 	// ErrUnknownAuthority is returned when a /who envelope is signed by an
 	// address not in the Authorities list.
 	ErrUnknownAuthority = errors.New("net: endorser is not a recognised authority")
+	// ErrScopeInsufficient is returned when an authority countersignature
+	// verifies but its scope claim does not meet the required minimum.
+	ErrScopeInsufficient = errors.New("net: authority scope insufficient")
+	// ErrSignatureExpired is returned when an authority countersignature
+	// verifies but its exp claim is in the past.
+	ErrSignatureExpired = errors.New("net: signature expired")
 	// ErrPartyMissing is returned when a /who response does not contain an
 	// org.Party document.
 	ErrPartyMissing = errors.New("net: /who response did not contain a party document")

--- a/net/verify.go
+++ b/net/verify.go
@@ -12,9 +12,10 @@ import (
 // VerifyEnvelope performs remote verification of a signed GOBL envelope.
 // It reads the signer's GOBL Net identity (iss) from the first
 // signature's signed payload, fetches that address's public keys, and
-// verifies the signature. When expectedAud is non-empty, the signature's
+// verifies that signature. When expectedAud is non-empty, the signature's
 // signed audience (aud) must equal it. The verified issuer address is
-// returned.
+// returned. Additional signatures (e.g. authority countersignatures) are
+// not checked here; use VerifyAuthority for those.
 func (c *Client) VerifyEnvelope(ctx context.Context, env *gobl.Envelope, expectedAud cbc.URI) (Address, error) {
 	if !env.Signed() {
 		return "", fmt.Errorf("%w: envelope is not signed", ErrVerifyFailed)
@@ -45,9 +46,9 @@ func (c *Client) VerifyEnvelope(ctx context.Context, env *gobl.Envelope, expecte
 	if err != nil {
 		return "", fmt.Errorf("%w: %v", ErrVerifyFailed, err)
 	}
-	// env.Verify enforces the key's validity window against the signed
-	// `ts` via head.Header.Verify.
-	if err := env.Verify(pubKey); err != nil {
+	// VerifySignature enforces the key's validity window against the
+	// signed `iat` via head.Header.Verify.
+	if err := env.VerifySignature(sig, pubKey); err != nil {
 		return "", fmt.Errorf("%w: %v", ErrVerifyFailed, err)
 	}
 

--- a/net/verify.go
+++ b/net/verify.go
@@ -32,8 +32,10 @@ func (c *Client) VerifyEnvelope(ctx context.Context, env *gobl.Envelope, expecte
 	if p.Iss.Scheme() != Scheme {
 		return "", fmt.Errorf("%w: iss %q is not a gobl address", ErrVerifyFailed, p.Iss)
 	}
-	issuer := Address(p.Iss.Opaque())
-	if err := issuer.Validate(); err != nil {
+	// Canonicalize the issuer so key-fetch URLs and comparisons use
+	// the ASCII form regardless of how the iss was written.
+	issuer, err := ParseAddress(p.Iss.Opaque())
+	if err != nil {
 		return "", fmt.Errorf("%w: %v", ErrVerifyFailed, err)
 	}
 

--- a/net/verify.go
+++ b/net/verify.go
@@ -17,7 +17,9 @@ import (
 // returned. Additional signatures (e.g. authority countersignatures) are
 // not checked here; use VerifyAuthority for those.
 func (c *Client) VerifyEnvelope(ctx context.Context, env *gobl.Envelope, expectedAud cbc.URI) (Address, error) {
-	if !env.Signed() {
+	// A malformed envelope may carry signatures without a header;
+	// reject rather than let header verification panic.
+	if env == nil || env.Head == nil || !env.Signed() {
 		return "", fmt.Errorf("%w: envelope is not signed", ErrVerifyFailed)
 	}
 

--- a/net/verify_test.go
+++ b/net/verify_test.go
@@ -62,6 +62,35 @@ func TestVerifyEnvelope(t *testing.T) {
 		assert.Equal(t, addr.KeyURL(key.ID()), mock.url)
 	})
 
+	t.Run("countersignatures do not block verification", func(t *testing.T) {
+		// Only the first (transport) signature is verified; additional
+		// signatures — e.g. an authority countersignature whose key is
+		// not fetchable here — must not fail the envelope.
+		key := dsig.NewES256Key()
+		env := buildTestEnvelope(t, key, addr.URI(), "")
+		other := dsig.NewES256Key()
+		require.NoError(t, env.Sign(other, head.WithIssuer(Address("kyc.example.com").URI())))
+
+		c := NewClient(WithFetcher(&mockFetcher{data: jwkFromKey(t, key)}))
+		issuer, err := c.VerifyEnvelope(ctx, env, "")
+		require.NoError(t, err)
+		assert.Equal(t, addr, issuer)
+	})
+
+	t.Run("non-canonical iss is canonicalized", func(t *testing.T) {
+		// A U-Label / mixed-case iss must resolve to the same ASCII
+		// address for key fetching and the returned issuer.
+		key := dsig.NewES256Key()
+		env := buildTestEnvelope(t, key, cbc.URI("gobl:Billing.Invopop.COM."), "")
+
+		mock := &mockFetcher{data: jwkFromKey(t, key)}
+		c := NewClient(WithFetcher(mock))
+		issuer, err := c.VerifyEnvelope(ctx, env, "")
+		require.NoError(t, err)
+		assert.Equal(t, addr, issuer)
+		assert.Equal(t, addr.KeyURL(key.ID()), mock.url, "key URL uses the canonical form")
+	})
+
 	t.Run("audience match", func(t *testing.T) {
 		key := dsig.NewES256Key()
 		aud := Address("recipient.example.com")

--- a/net/verify_test.go
+++ b/net/verify_test.go
@@ -119,6 +119,32 @@ func TestVerifyEnvelope(t *testing.T) {
 		assert.True(t, errors.Is(err, ErrVerifyFailed))
 	})
 
+	t.Run("undecodable signature payload", func(t *testing.T) {
+		key := dsig.NewES256Key()
+		env := buildTestEnvelope(t, key, addr.URI(), "")
+		bad, err := dsig.NewSignature(key, "not-an-object")
+		require.NoError(t, err)
+		env.Signatures[0] = bad
+
+		c := NewClient(WithFetcher(&mockFetcher{data: jwkFromKey(t, key)}))
+		_, err = c.VerifyEnvelope(ctx, env, "")
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrVerifyFailed))
+	})
+
+	t.Run("signatures without a header", func(t *testing.T) {
+		// A malformed envelope carrying signatures but no head must be
+		// rejected, not panic.
+		key := dsig.NewES256Key()
+		env := buildTestEnvelope(t, key, addr.URI(), "")
+		env.Head = nil
+
+		c := NewClient(WithFetcher(&mockFetcher{data: jwkFromKey(t, key)}))
+		_, err := c.VerifyEnvelope(ctx, env, "")
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrVerifyFailed))
+	})
+
 	t.Run("no iss", func(t *testing.T) {
 		key := dsig.NewES256Key()
 		env := buildTestEnvelope(t, key, "", "") // signed without an iss

--- a/net/who.go
+++ b/net/who.go
@@ -22,7 +22,10 @@ import (
 // A 204 response returns ErrNoContent: the address exists but does not
 // publish identity details (a receive-only account).
 func (c *Client) Who(ctx context.Context, addr Address) (*gobl.Envelope, error) {
-	if err := addr.Validate(); err != nil {
+	// Canonicalize so well-known URLs and the issuer comparison use
+	// the ASCII form regardless of how the address was written.
+	addr, err := ParseAddress(string(addr))
+	if err != nil {
 		return nil, err
 	}
 	data, err := c.fetcher.Fetch(ctx, addr.WhoURL())

--- a/net/who.go
+++ b/net/who.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/invopop/gobl"
 	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/head"
 	"github.com/invopop/gobl/org"
 )
 
@@ -39,6 +40,16 @@ func (c *Client) Who(ctx context.Context, addr Address) (*gobl.Envelope, error) 
 	if issuer != addr {
 		return nil, fmt.Errorf("%w: who issuer %q does not match address %q", ErrVerifyFailed, issuer, addr)
 	}
+	// A who response is a public document: a caller-bound (aud-carrying)
+	// envelope is not a conforming identity and must not be treated as
+	// one.
+	p, err := head.SignedPayload(env.Signatures[0])
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrVerifyFailed, err)
+	}
+	if p.Aud != "" {
+		return nil, fmt.Errorf("%w: who response must not be audience-bound (aud %q)", ErrVerifyFailed, p.Aud)
+	}
 	if _, ok := env.Extract().(*org.Party); !ok {
 		return nil, ErrPartyMissing
 	}
@@ -56,7 +67,7 @@ func (c *Client) VerifySender(ctx context.Context, addr Address, minScope cbc.Ke
 	if err != nil {
 		return nil, err
 	}
-	if err := c.VerifyAuthority(ctx, env, minScope); err != nil {
+	if err := c.VerifyAuthorityWithScope(ctx, env, minScope); err != nil {
 		return nil, err
 	}
 	return env.Extract().(*org.Party), nil

--- a/net/who.go
+++ b/net/who.go
@@ -1,0 +1,63 @@
+package net
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/invopop/gobl"
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/org"
+)
+
+// Who fetches the public identity for the given address with a GET on
+// its well-known who endpoint and verifies it. The response envelope's
+// first signature must be the subject's self-signature: its signed
+// `iss` is resolved to a published key and must name the fetched
+// address. The document must be an org.Party. Authority
+// countersignatures, if any, are preserved on the returned envelope
+// for VerifyAuthority.
+//
+// A 204 response returns ErrNoContent: the address exists but does not
+// publish identity details (a receive-only account).
+func (c *Client) Who(ctx context.Context, addr Address) (*gobl.Envelope, error) {
+	if err := addr.Validate(); err != nil {
+		return nil, err
+	}
+	data, err := c.fetcher.Fetch(ctx, addr.WhoURL())
+	if err != nil {
+		return nil, err
+	}
+	env := new(gobl.Envelope)
+	if err := json.Unmarshal(data, env); err != nil {
+		return nil, fmt.Errorf("%w: invalid who envelope: %v", ErrFetchFailed, err)
+	}
+	issuer, err := c.VerifyEnvelope(ctx, env, "")
+	if err != nil {
+		return nil, err
+	}
+	if issuer != addr {
+		return nil, fmt.Errorf("%w: who issuer %q does not match address %q", ErrVerifyFailed, issuer, addr)
+	}
+	if _, ok := env.Extract().(*org.Party); !ok {
+		return nil, ErrPartyMissing
+	}
+	return env, nil
+}
+
+// VerifySender confirms that the given address is approved to send
+// documents: its who identity must verify (see Who) and carry a
+// countersignature from one of the client's trusted authorities
+// satisfying minScope. Returns the sender's endorsed party on
+// success. Receiving inboxes call this with the verified issuer of an
+// incoming envelope before accepting it.
+func (c *Client) VerifySender(ctx context.Context, addr Address, minScope cbc.Key) (*org.Party, error) {
+	env, err := c.Who(ctx, addr)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.VerifyAuthority(ctx, env, minScope); err != nil {
+		return nil, err
+	}
+	return env.Extract().(*org.Party), nil
+}

--- a/net/who_test.go
+++ b/net/who_test.go
@@ -127,6 +127,13 @@ func TestWho(t *testing.T) {
 		assert.True(t, errors.Is(err, ErrPartyMissing))
 	})
 
+	t.Run("rejects an invalid address", func(t *testing.T) {
+		c := NewClient()
+		_, err := c.Who(ctx, Address("localhost"))
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrAddressInvalid))
+	})
+
 	t.Run("propagates a no-content response", func(t *testing.T) {
 		c := NewClient(WithFetcher(&mockFetcher{err: ErrNoContent}))
 		_, err := c.Who(ctx, subject)

--- a/net/who_test.go
+++ b/net/who_test.go
@@ -1,0 +1,194 @@
+package net
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/invopop/gobl"
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/dsig"
+	"github.com/invopop/gobl/head"
+	"github.com/invopop/gobl/note"
+	"github.com/invopop/gobl/org"
+	"github.com/invopop/gobl/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// buildPartyEnvelope returns the JSON of a party envelope self-signed
+// by subject, optionally countersigned by an authority at scope.
+func buildPartyEnvelope(t *testing.T, subjKey *dsig.PrivateKey, subject Address, authKey *dsig.PrivateKey, authority Address, scope cbc.Key) []byte {
+	t.Helper()
+	party := &org.Party{Name: "Test Subject"}
+	party.SetUUID(uuid.V7())
+	env, err := gobl.Envelop(party)
+	require.NoError(t, err)
+	require.NoError(t, env.Sign(subjKey, head.WithIssuer(subject.URI())))
+	if authKey != nil {
+		require.NoError(t, env.Sign(authKey,
+			head.WithIssuer(authority.URI()),
+			head.WithAudience(subject.URI()),
+			head.WithScope(scope)))
+	}
+	data, err := json.Marshal(env)
+	require.NoError(t, err)
+	return data
+}
+
+func TestWho(t *testing.T) {
+	ctx := context.Background()
+	subject := Address("supplier.example.com")
+	subjKey := dsig.NewES256Key()
+
+	jwkOf := func(k *dsig.PrivateKey) []byte {
+		t.Helper()
+		out, err := json.Marshal(k.Public())
+		require.NoError(t, err)
+		return out
+	}
+
+	t.Run("fetches and verifies a self-signed identity", func(t *testing.T) {
+		c := NewClient(WithFetcher(&mapFetcher{data: map[string][]byte{
+			subject.WhoURL():             buildPartyEnvelope(t, subjKey, subject, nil, "", ""),
+			subject.KeyURL(subjKey.ID()): jwkOf(subjKey),
+		}}))
+		env, err := c.Who(ctx, subject)
+		require.NoError(t, err)
+		party, ok := env.Extract().(*org.Party)
+		require.True(t, ok)
+		assert.Equal(t, "Test Subject", party.Name)
+	})
+
+	t.Run("rejects an issuer that does not match the address", func(t *testing.T) {
+		other := Address("other.example.com")
+		c := NewClient(WithFetcher(&mapFetcher{data: map[string][]byte{
+			// Served from subject's who URL, but signed as other.
+			subject.WhoURL():           buildPartyEnvelope(t, subjKey, other, nil, "", ""),
+			other.KeyURL(subjKey.ID()): jwkOf(subjKey),
+		}}))
+		_, err := c.Who(ctx, subject)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrVerifyFailed))
+		assert.Contains(t, err.Error(), "does not match address")
+	})
+
+	t.Run("rejects a non-party document", func(t *testing.T) {
+		msg := &note.Message{Content: "not a party"}
+		msg.SetUUID(uuid.V7())
+		env, err := gobl.Envelop(msg)
+		require.NoError(t, err)
+		require.NoError(t, env.Sign(subjKey, head.WithIssuer(subject.URI())))
+		data, err := json.Marshal(env)
+		require.NoError(t, err)
+
+		c := NewClient(WithFetcher(&mapFetcher{data: map[string][]byte{
+			subject.WhoURL():             data,
+			subject.KeyURL(subjKey.ID()): jwkOf(subjKey),
+		}}))
+		_, err = c.Who(ctx, subject)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrPartyMissing))
+	})
+
+	t.Run("propagates a no-content response", func(t *testing.T) {
+		c := NewClient(WithFetcher(&mockFetcher{err: ErrNoContent}))
+		_, err := c.Who(ctx, subject)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrNoContent))
+	})
+
+	t.Run("rejects an unsigned envelope", func(t *testing.T) {
+		party := &org.Party{Name: "Unsigned"}
+		party.SetUUID(uuid.V7())
+		env, err := gobl.Envelop(party)
+		require.NoError(t, err)
+		data, err := json.Marshal(env)
+		require.NoError(t, err)
+
+		c := NewClient(WithFetcher(&mapFetcher{data: map[string][]byte{
+			subject.WhoURL(): data,
+		}}))
+		_, err = c.Who(ctx, subject)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrVerifyFailed))
+	})
+
+	t.Run("rejects a body that is not an envelope", func(t *testing.T) {
+		c := NewClient(WithFetcher(&mapFetcher{data: map[string][]byte{
+			subject.WhoURL(): []byte("not json"),
+		}}))
+		_, err := c.Who(ctx, subject)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrFetchFailed))
+	})
+}
+
+func TestVerifySender(t *testing.T) {
+	ctx := context.Background()
+	subject := Address("supplier.example.com")
+	authority := Address("kyc.example.com")
+	subjKey := dsig.NewES256Key()
+	authKey := dsig.NewES256Key()
+
+	jwkOf := func(k *dsig.PrivateKey) []byte {
+		t.Helper()
+		out, err := json.Marshal(k.Public())
+		require.NoError(t, err)
+		return out
+	}
+
+	endorsed := map[string][]byte{
+		subject.WhoURL():               buildPartyEnvelope(t, subjKey, subject, authKey, authority, head.ScopeVerified),
+		subject.KeyURL(subjKey.ID()):   jwkOf(subjKey),
+		authority.KeyURL(authKey.ID()): jwkOf(authKey),
+	}
+
+	t.Run("accepts an authority-endorsed sender", func(t *testing.T) {
+		c := NewClient(
+			WithAuthorities(authority),
+			WithFetcher(&mapFetcher{data: endorsed}),
+		)
+		party, err := c.VerifySender(ctx, subject, head.ScopeVerified)
+		require.NoError(t, err)
+		assert.Equal(t, "Test Subject", party.Name)
+	})
+
+	t.Run("rejects a self-signed sender", func(t *testing.T) {
+		c := NewClient(
+			WithAuthorities(authority),
+			WithFetcher(&mapFetcher{data: map[string][]byte{
+				subject.WhoURL():             buildPartyEnvelope(t, subjKey, subject, nil, "", ""),
+				subject.KeyURL(subjKey.ID()): jwkOf(subjKey),
+			}}),
+		)
+		_, err := c.VerifySender(ctx, subject, "")
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrUnknownAuthority))
+	})
+
+	t.Run("rejects an endorsement below the minimum scope", func(t *testing.T) {
+		c := NewClient(
+			WithAuthorities(authority),
+			WithFetcher(&mapFetcher{data: map[string][]byte{
+				subject.WhoURL():               buildPartyEnvelope(t, subjKey, subject, authKey, authority, head.ScopeRegistered),
+				subject.KeyURL(subjKey.ID()):   jwkOf(subjKey),
+				authority.KeyURL(authKey.ID()): jwkOf(authKey),
+			}}),
+		)
+		_, err := c.VerifySender(ctx, subject, head.ScopeVerified)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrScopeInsufficient))
+	})
+
+	t.Run("rejects a receive-only account", func(t *testing.T) {
+		c := NewClient(
+			WithAuthorities(authority),
+			WithFetcher(&mockFetcher{err: ErrNoContent}),
+		)
+		_, err := c.VerifySender(ctx, subject, head.ScopeVerified)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrNoContent))
+	})
+}

--- a/net/who_test.go
+++ b/net/who_test.go
@@ -61,6 +61,18 @@ func TestWho(t *testing.T) {
 		assert.Equal(t, "Test Subject", party.Name)
 	})
 
+	t.Run("canonicalizes a non-canonical address", func(t *testing.T) {
+		// Mixed case and a trailing dot must resolve to the same
+		// canonical who URL and match the signed issuer.
+		c := NewClient(WithFetcher(&mapFetcher{data: map[string][]byte{
+			subject.WhoURL():             buildPartyEnvelope(t, subjKey, subject, nil, "", ""),
+			subject.KeyURL(subjKey.ID()): jwkOf(subjKey),
+		}}))
+		env, err := c.Who(ctx, Address("SUPPLIER.Example.COM."))
+		require.NoError(t, err)
+		assert.NotNil(t, env)
+	})
+
 	t.Run("rejects an issuer that does not match the address", func(t *testing.T) {
 		other := Address("other.example.com")
 		c := NewClient(WithFetcher(&mapFetcher{data: map[string][]byte{

--- a/net/who_test.go
+++ b/net/who_test.go
@@ -74,6 +74,29 @@ func TestWho(t *testing.T) {
 		assert.Contains(t, err.Error(), "does not match address")
 	})
 
+	t.Run("rejects an audience-bound response", func(t *testing.T) {
+		// A who response is a public document; an envelope signed with
+		// an aud is caller-bound and non-conforming.
+		party := &org.Party{Name: "Bound"}
+		party.SetUUID(uuid.V7())
+		env, err := gobl.Envelop(party)
+		require.NoError(t, err)
+		require.NoError(t, env.Sign(subjKey,
+			head.WithIssuer(subject.URI()),
+			head.WithAudience(Address("caller.example.com").URI())))
+		data, err := json.Marshal(env)
+		require.NoError(t, err)
+
+		c := NewClient(WithFetcher(&mapFetcher{data: map[string][]byte{
+			subject.WhoURL():             data,
+			subject.KeyURL(subjKey.ID()): jwkOf(subjKey),
+		}}))
+		_, err = c.Who(ctx, subject)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrVerifyFailed))
+		assert.Contains(t, err.Error(), "audience-bound")
+	})
+
 	t.Run("rejects a non-party document", func(t *testing.T) {
 		msg := &note.Message{Content: "not a party"}
 		msg.SetUUID(uuid.V7())


### PR DESCRIPTION
Refocuses GOBL Net on the B2C model: anyone may self-provision a receiving address without approval, while senders must carry an authority (KYC) endorsement on their public identity.

## Protocol (net/README.md)

- `/who` is now an **open GET** returning the domain's self-signed party envelope — `200` with the envelope, `204 No Content` for accounts that publish nothing (receive-only), `404` for non-participants. The authenticated POST exchange and allow-list support are removed; a negotiated-disclosure POST may return later as an optional addition.
- Endorsement requirements attach to the **sending role only**: receivers may be entirely self-signed or private. New §8.4 documents the end-to-end Supplier → Customer delivery flow.
- The empty `202 Accepted` inbox response is documented as deliberate (durability only, no transport receipts); processing is signalled by follow-up documents such as `bill.Status`, which themselves require an endorsed sender. Inbox delivery MUST be idempotent on `uuid`+`dig`, making "retry until 202" safe.
- Authority countersignatures SHOULD carry the new `exp` claim (90 days recommended), forcing a Let's Encrypt-style renewal cycle that bounds revocation exposure.

## Library

- `head`: optional JWT-standard `exp` claim in the signed payload via `head.WithExpiration`.
- `net.Client.Who(ctx, addr)`: fetch + verify a public identity (issuer must match the fetched address, the response must not be audience-bound, document must be an `org.Party`; `ErrNoContent` on 204).
- `net.Client.VerifySender(ctx, addr, minScope)`: `Who` + authority countersignature at a minimum scope — the one call a receiving inbox makes before accepting a delivery.
- `net.Client.VerifyAuthority(ctx, env)` keeps its basic contract (any authority countersignature, expiry enforced); the new `net.Client.VerifyAuthorityWithScope(ctx, env, minScope)` adds the minimum-scope requirement (`registered` < `verified`, custom keys need an exact match). Claims are only evaluated after the signature cryptographically verifies; failures surface as `ErrSignatureExpired` / `ErrScopeInsufficient`.
- `net.Client.VerifyEnvelope` verifies only the first signature, fixing verification of countersigned envelopes.
- Addresses are canonicalized (via `ParseAddress`) at every client entry point — `Who`, `VerifyEnvelope`, `FetchKey`, and authority lookups — so U-Label, mixed-case, or trailing-dot forms behave identically to the ASCII canonical form.
- `HTTPFetcher` maps HTTP 204 to the new `ErrNoContent` sentinel.

The `net` package is experimental, so the breaking API changes (`/who` semantics, error surface) ship without deprecation. Companion changes to `gobl.lookup` and `gobl-net` are ready and depend on this landing in a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)