### PR TITLE
Peppol PINT base addon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Added
 
+- `addons/peppol/pint`: New base addon for the Peppol International (PINT) billing model. Builds on EN 16931 and re-maps the UNTDID 5305 tax category code from the tax key so that non-VAT schemes such as GST are reported correctly (e.g. standard-rated GST as `S` instead of `O`). Also adds the PINT business rules not already covered by GOBL core or EN 16931 — a mandatory Buyer (ibr-007), Seller and Buyer electronic addresses (ibr-080/081), and an identifiable Seller (ibr-co-26). Intended as the shared layer for country-specific PINT sub-addons.
 - `regimes/au`: New tax regime for Australia — GST and ABN tax identity validation (weighted modulus-89 checksum).
 - `regimes/nz`: New tax regime for New Zealand — GST, IRD number validation (weighted modulus-11 checksum), and te reo Māori (`mi`) translations.
 - `bill`: `PaymentDetails.Payer` party — the party responsible for making payment of the invoice if not the customer, the counterpart of the existing `Payee`.

--- a/addons/addons.go
+++ b/addons/addons.go
@@ -26,6 +26,7 @@ import (
 	_ "github.com/invopop/gobl/addons/it/sdi"
 	_ "github.com/invopop/gobl/addons/it/ticket"
 	_ "github.com/invopop/gobl/addons/mx/cfdi"
+	_ "github.com/invopop/gobl/addons/peppol/pint"
 	_ "github.com/invopop/gobl/addons/pl/favat"
 	_ "github.com/invopop/gobl/addons/pt/saft"
 )

--- a/addons/eu/en16931/bill.go
+++ b/addons/eu/en16931/bill.go
@@ -60,11 +60,11 @@ func normalizeTaxNote(n *tax.Note) {
 
 	// Reverse: if ext is present but no key, derive the key
 	if n.Key.IsEmpty() {
-		n.Key = vatKeyMap.Lookup(n.Ext.Get(untdid.ExtKeyTaxCategory))
+		n.Key = TaxCategoryMap.Lookup(n.Ext.Get(untdid.ExtKeyTaxCategory))
 	}
 
 	// Forward: if key is present, ensure the ext is set
-	if code := vatKeyMap.Get(n.Key); !code.IsEmpty() {
+	if code := TaxCategoryMap.Get(n.Key); !code.IsEmpty() {
 		n.Ext = n.Ext.Merge(tax.ExtensionsOf(cbc.CodeMap{
 			untdid.ExtKeyTaxCategory: code,
 		}))

--- a/addons/eu/en16931/tax_combo.go
+++ b/addons/eu/en16931/tax_combo.go
@@ -30,8 +30,9 @@ var exemptTaxCategories = []cbc.Code{
 	TaxCategoryExport, TaxCategoryOutsideScope,
 }
 
-// VAT key mapping from GOBL tax keys to UNTDID 5305 codes.
-var vatKeyMap = tax.ExtensionsOf(cbc.CodeMap{
+// TaxCategoryMap maps GOBL tax keys to their UNTDID 5305 duty/tax/fee category
+// codes.
+var TaxCategoryMap = tax.ExtensionsOf(cbc.CodeMap{
 	tax.KeyStandard:       TaxCategoryStandard,
 	tax.KeyZero:           TaxCategoryZero,
 	tax.KeyExempt:         TaxCategoryExempt,
@@ -49,13 +50,13 @@ func NormalizeTaxCombo(tc *tax.Combo) {
 	case tax.CategoryVAT:
 		if tc.Key.IsEmpty() {
 			// Try doing a reverse map of the VAT category key
-			k := vatKeyMap.Lookup(tc.Ext.Get(untdid.ExtKeyTaxCategory))
+			k := TaxCategoryMap.Lookup(tc.Ext.Get(untdid.ExtKeyTaxCategory))
 			if k.IsEmpty() {
 				k = tax.KeyStandard
 			}
 			tc.Key = k
 		}
-		tc.Ext = tc.Ext.Set(untdid.ExtKeyTaxCategory, vatKeyMap.Get(tc.Key))
+		tc.Ext = tc.Ext.Set(untdid.ExtKeyTaxCategory, TaxCategoryMap.Get(tc.Key))
 	case es.TaxCategoryIGIC:
 		tc.Ext = tc.Ext.Set(untdid.ExtKeyTaxCategory, TaxCategoryIGIC)
 	case es.TaxCategoryIPSI:
@@ -76,7 +77,7 @@ func taxComboRules() *rules.Set {
 		rules.When(is.Func("is VAT", taxComboIsVAT),
 			rules.Field("ext",
 				rules.Assert("02", "VAT category code must be valid",
-					tax.ExtensionsHasCodes(untdid.ExtKeyTaxCategory, vatKeyMap.Values()...),
+					tax.ExtensionsHasCodes(untdid.ExtKeyTaxCategory, TaxCategoryMap.Values()...),
 				),
 			),
 		),

--- a/addons/peppol/pint/bill.go
+++ b/addons/peppol/pint/bill.go
@@ -1,0 +1,40 @@
+package pint
+
+import (
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/org"
+	"github.com/invopop/gobl/rules"
+	"github.com/invopop/gobl/rules/is"
+)
+
+func billInvoiceRules() *rules.Set {
+	return rules.For(new(bill.Invoice),
+		rules.Field("supplier",
+			rules.Assert("01", "invoice supplier must have a tax ID or identity (IBR-CO-26)",
+				is.Func("has identifier", partyHasIdentifier),
+			),
+			rules.Field("inboxes",
+				rules.Assert("02", "invoice supplier electronic address is required (IBR-081)", is.Present),
+			),
+		),
+		rules.Field("customer",
+			rules.Assert("03", "invoice customer is required (IBR-007)", is.Present),
+			rules.Field("inboxes",
+				rules.Assert("04", "invoice customer electronic address is required (IBR-080)", is.Present),
+			),
+		),
+	)
+}
+
+// partyHasIdentifier reports whether the party can be identified through a tax
+// identity code or at least one organisation identity.
+func partyHasIdentifier(val any) bool {
+	p, ok := val.(*org.Party)
+	if !ok || p == nil {
+		return true // presence of the party is asserted elsewhere
+	}
+	if p.TaxID != nil && p.TaxID.Code != "" {
+		return true
+	}
+	return len(p.Identities) > 0
+}

--- a/addons/peppol/pint/bill_test.go
+++ b/addons/peppol/pint/bill_test.go
@@ -1,0 +1,78 @@
+package pint_test
+
+import (
+	"testing"
+
+	"github.com/invopop/gobl/addons/peppol/pint"
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/org"
+	"github.com/invopop/gobl/rules"
+	"github.com/invopop/gobl/tax"
+	"github.com/stretchr/testify/assert"
+)
+
+func validInbox() []*org.Inbox {
+	return []*org.Inbox{{Key: "peppol", Scheme: "0151", Code: "51824753556"}}
+}
+
+func baseInvoice() *bill.Invoice {
+	return &bill.Invoice{
+		Supplier: &org.Party{
+			Name:    "Seller Pty Ltd",
+			TaxID:   &tax.Identity{Country: "AU", Code: "51824753556"},
+			Inboxes: validInbox(),
+		},
+		Customer: &org.Party{
+			Name:    "Buyer Pty Ltd",
+			TaxID:   &tax.Identity{Country: "AU", Code: "53004085616"},
+			Inboxes: []*org.Inbox{{Key: "peppol", Scheme: "0151", Code: "53004085616"}},
+		},
+	}
+}
+
+func TestBillInvoiceRules(t *testing.T) {
+	validate := func(inv *bill.Invoice) error {
+		return rules.Validate(inv, tax.AddonContext(pint.V1))
+	}
+
+	t.Run("valid parties raise no PINT party faults", func(t *testing.T) {
+		// The skeleton invoice trips unrelated core rules; assert only that
+		// none of the PINT party rules fired. The full happy path is covered
+		// by the golden example invoices.
+		err := validate(baseInvoice())
+		if err != nil {
+			assert.NotContains(t, err.Error(), "customer is required")
+			assert.NotContains(t, err.Error(), "electronic address is required")
+			assert.NotContains(t, err.Error(), "tax ID or identity")
+		}
+	})
+
+	t.Run("customer is required (ibr-007)", func(t *testing.T) {
+		inv := baseInvoice()
+		inv.Customer = nil
+		err := validate(inv)
+		assert.ErrorContains(t, err, "customer is required")
+	})
+
+	t.Run("supplier electronic address is required (ibr-081)", func(t *testing.T) {
+		inv := baseInvoice()
+		inv.Supplier.Inboxes = nil
+		err := validate(inv)
+		assert.ErrorContains(t, err, "supplier electronic address is required")
+	})
+
+	t.Run("customer electronic address is required (ibr-080)", func(t *testing.T) {
+		inv := baseInvoice()
+		inv.Customer.Inboxes = nil
+		err := validate(inv)
+		assert.ErrorContains(t, err, "customer electronic address is required")
+	})
+
+	t.Run("supplier must be identifiable (ibr-co-26)", func(t *testing.T) {
+		inv := baseInvoice()
+		inv.Supplier.TaxID = nil
+		inv.Supplier.Identities = nil
+		err := validate(inv)
+		assert.ErrorContains(t, err, "supplier must have a tax ID or identity")
+	})
+}

--- a/addons/peppol/pint/pint.go
+++ b/addons/peppol/pint/pint.go
@@ -1,0 +1,73 @@
+// Package pint provides the base addon for the Peppol International (PINT)
+// billing model.
+package pint
+
+import (
+	"github.com/invopop/gobl/addons/eu/en16931"
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/i18n"
+	"github.com/invopop/gobl/norm"
+	"github.com/invopop/gobl/pkg/here"
+	"github.com/invopop/gobl/rules"
+	"github.com/invopop/gobl/rules/is"
+	"github.com/invopop/gobl/tax"
+)
+
+const (
+	// Namespace is the rules namespace for the Peppol PINT addon.
+	Namespace rules.Code = "PEPPOL-PINT"
+
+	// Key identifies the Peppol PINT addon family.
+	Key cbc.Key = "peppol-pint"
+
+	// V1 is the first version of the Peppol PINT addon.
+	V1 cbc.Key = Key + "-v1"
+)
+
+func init() {
+	tax.RegisterAddonDef(newV1Addon())
+	rules.RegisterWithGuard(
+		Key.String(),
+		rules.GOBL.Add(Namespace),
+		is.InContext(tax.AddonIn(V1)),
+		billInvoiceRules(),
+		taxComboRules(),
+	)
+	norm.RegisterWithGuard(
+		is.InContext(tax.AddonIn(V1)),
+		norm.For(normalizeTaxCombo),
+	)
+}
+
+func newV1Addon() *tax.AddonDef {
+	return &tax.AddonDef{
+		Key: V1,
+		Name: i18n.String{
+			i18n.EN: "Peppol PINT",
+		},
+		Requires: []cbc.Key{
+			en16931.V2017,
+		},
+		Description: i18n.String{
+			i18n.EN: here.Doc(`
+				Support for the Peppol International (PINT) billing model, the common
+				layer shared by the country-specific PINT specifications.
+
+				PINT builds on EN 16931 but, unlike the EU CIUS, recognises indirect
+				tax schemes beyond VAT. This addon re-maps the
+				UNTDID 5305 tax category code from the GOBL tax key so that, for
+				example, standard-rated GST is reported as "S" (standard rated) instead
+				of the EN 16931 default of "O" (outside scope).
+
+				Country-specific requirements are layered on top by dedicated sub-addons
+				that require this one.
+			`),
+		},
+		Sources: []*cbc.Source{
+			{
+				Title: i18n.NewString("Peppol PINT specifications"),
+				URL:   "https://docs.peppol.eu/poac/pint/",
+			},
+		},
+	}
+}

--- a/addons/peppol/pint/tax_combo.go
+++ b/addons/peppol/pint/tax_combo.go
@@ -1,0 +1,35 @@
+package pint
+
+import (
+	"github.com/invopop/gobl/addons/eu/en16931"
+	"github.com/invopop/gobl/catalogues/untdid"
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/rules"
+	"github.com/invopop/gobl/tax"
+)
+
+// normalizeTaxCombo re-maps the UNTDID tax category code from the tax combo's
+// key, reusing EN 16931's key-to-code mapping.
+func normalizeTaxCombo(tc *tax.Combo) {
+	if tc == nil || tc.Key.IsEmpty() {
+		return
+	}
+	if code := en16931.TaxCategoryMap.Get(tc.Key); code != cbc.CodeEmpty {
+		tc.Ext = tc.Ext.Set(untdid.ExtKeyTaxCategory, code)
+	}
+}
+
+func taxComboRules() *rules.Set {
+	return rules.For(new(tax.Combo),
+		// PINT recognises GST (and other non-VAT schemes) as standard, zero or
+		// exempt rated, so the EN 16931 rule that forces every non-VAT category
+		// to outside scope must not apply here.
+		rules.Ignore("GOBL-EU-EN16931-TAX-COMBO-05"),
+
+		rules.Field("ext",
+			rules.Assert("01", "invoice line tax category code must be a recognised PINT UNTDID 5305 code",
+				tax.ExtensionsHasCodes(untdid.ExtKeyTaxCategory, en16931.TaxCategoryMap.Values()...),
+			),
+		),
+	)
+}

--- a/addons/peppol/pint/tax_combo_test.go
+++ b/addons/peppol/pint/tax_combo_test.go
@@ -1,0 +1,61 @@
+package pint_test
+
+import (
+	"testing"
+
+	"github.com/invopop/gobl/addons/eu/en16931"
+	"github.com/invopop/gobl/addons/peppol/pint"
+	"github.com/invopop/gobl/catalogues/untdid"
+	"github.com/invopop/gobl/norm"
+	"github.com/invopop/gobl/num"
+	"github.com/invopop/gobl/tax"
+	"github.com/stretchr/testify/assert"
+)
+
+// Both en16931 (required by PINT) and the PINT addon are applied, mirroring how
+// they resolve on a real document, so we can confirm PINT's normalizer runs
+// after en16931's and wins.
+
+func TestTaxComboNormalization(t *testing.T) {
+	t.Run("standard GST rate maps to S (not O)", func(t *testing.T) {
+		p := num.MakePercentage(10, 2)
+		c := &tax.Combo{
+			Category: tax.CategoryGST,
+			Key:      tax.KeyStandard,
+			Percent:  &p,
+		}
+		norm.Normalize(c, tax.AddonContext(en16931.V2017, pint.V1))
+		assert.Equal(t, "S", c.Ext.Get(untdid.ExtKeyTaxCategory).String())
+	})
+
+	t.Run("zero-rated GST maps to Z", func(t *testing.T) {
+		p := num.MakePercentage(0, 2)
+		c := &tax.Combo{
+			Category: tax.CategoryGST,
+			Key:      tax.KeyZero,
+			Percent:  &p,
+		}
+		norm.Normalize(c, tax.AddonContext(en16931.V2017, pint.V1))
+		assert.Equal(t, "Z", c.Ext.Get(untdid.ExtKeyTaxCategory).String())
+	})
+
+	t.Run("exempt GST maps to E", func(t *testing.T) {
+		c := &tax.Combo{
+			Category: tax.CategoryGST,
+			Key:      tax.KeyExempt,
+		}
+		norm.Normalize(c, tax.AddonContext(en16931.V2017, pint.V1))
+		assert.Equal(t, "E", c.Ext.Get(untdid.ExtKeyTaxCategory).String())
+	})
+
+	t.Run("standard VAT still maps to S", func(t *testing.T) {
+		p := num.MakePercentage(20, 2)
+		c := &tax.Combo{
+			Category: tax.CategoryVAT,
+			Key:      tax.KeyStandard,
+			Percent:  &p,
+		}
+		norm.Normalize(c, tax.AddonContext(en16931.V2017, pint.V1))
+		assert.Equal(t, "S", c.Ext.Get(untdid.ExtKeyTaxCategory).String())
+	})
+}

--- a/data/addons/peppol-pint-v1.json
+++ b/data/addons/peppol-pint-v1.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://gobl.org/draft-0/tax/addon-def",
+  "key": "peppol-pint-v1",
+  "requires": [
+    "eu-en16931-v2017"
+  ],
+  "name": {
+    "en": "Peppol PINT"
+  },
+  "description": {
+    "en": "Support for the Peppol International (PINT) billing model, the common\nlayer shared by the country-specific PINT specifications.\n\nPINT builds on EN 16931 but, unlike the EU CIUS, recognises indirect\ntax schemes beyond VAT. This addon re-maps the\nUNTDID 5305 tax category code from the GOBL tax key so that, for\nexample, standard-rated GST is reported as \"S\" (standard rated) instead\nof the EN 16931 default of \"O\" (outside scope).\n\nCountry-specific requirements are layered on top by dedicated sub-addons\nthat require this one."
+  },
+  "sources": [
+    {
+      "title": {
+        "en": "Peppol PINT specifications"
+      },
+      "url": "https://docs.peppol.eu/poac/pint/"
+    }
+  ],
+  "extensions": null,
+  "scenarios": null,
+  "corrections": null
+}

--- a/data/rules/peppol-pint.json
+++ b/data/rules/peppol-pint.json
@@ -1,0 +1,73 @@
+{
+  "id": "GOBL-PEPPOL-PINT",
+  "package": "peppol-pint",
+  "guard": "context: addon in [peppol-pint-v1]",
+  "subsets": [
+    {
+      "id": "GOBL-PEPPOL-PINT-BILL-INVOICE",
+      "object": "bill.Invoice",
+      "subsets": [
+        {
+          "field": "supplier",
+          "assert": [
+            {
+              "id": "GOBL-PEPPOL-PINT-BILL-INVOICE-01",
+              "desc": "invoice supplier must have a tax ID or identity (IBR-CO-26)",
+              "tests": "has identifier"
+            }
+          ],
+          "subsets": [
+            {
+              "field": "inboxes",
+              "assert": [
+                {
+                  "id": "GOBL-PEPPOL-PINT-BILL-INVOICE-02",
+                  "desc": "invoice supplier electronic address is required (IBR-081)",
+                  "tests": "present"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "field": "customer",
+          "assert": [
+            {
+              "id": "GOBL-PEPPOL-PINT-BILL-INVOICE-03",
+              "desc": "invoice customer is required (IBR-007)",
+              "tests": "present"
+            }
+          ],
+          "subsets": [
+            {
+              "field": "inboxes",
+              "assert": [
+                {
+                  "id": "GOBL-PEPPOL-PINT-BILL-INVOICE-04",
+                  "desc": "invoice customer electronic address is required (IBR-080)",
+                  "tests": "present"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "GOBL-PEPPOL-PINT-TAX-COMBO",
+      "object": "tax.Combo",
+      "subsets": [
+        {
+          "field": "ext",
+          "assert": [
+            {
+              "id": "GOBL-PEPPOL-PINT-TAX-COMBO-01",
+              "desc": "invoice line tax category code must be a recognised PINT UNTDID 5305 code",
+              "tests": "ext 'untdid-tax-category' in [AE, E, G, K, O, S, Z]"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/data/schemas/tax/addon-list.json
+++ b/data/schemas/tax/addon-list.json
@@ -92,6 +92,10 @@
             "title": "Mexican SAT CFDI v4.X"
           },
           {
+            "const": "peppol-pint-v1",
+            "title": "Peppol PINT"
+          },
+          {
             "const": "pl-favat-v3",
             "title": "Polish KSeF FA_VAT FA(3)"
           },

--- a/examples/au/invoice-au-pint.yaml
+++ b/examples/au/invoice-au-pint.yaml
@@ -1,0 +1,66 @@
+$schema: "https://gobl.org/draft-0/bill/invoice"
+$addons: ["peppol-pint-v1"]
+uuid: "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2"
+regime: "AU"
+type: "standard"
+series: "SAMPLE"
+code: "001"
+issue_date: "2024-05-15"
+currency: "AUD"
+
+supplier:
+  name: "Provide One Pty Ltd"
+  tax_id:
+    country: "AU"
+    code: "51824753556"
+  inboxes:
+    - key: "peppol"
+      scheme: "0151"
+      code: "51824753556"
+  addresses:
+    - num: "100"
+      street: "Queen Street"
+      locality: "Melbourne"
+      region: "VIC"
+      code: "3000"
+      country: "AU"
+
+customer:
+  name: "Sample Customer Pty Ltd"
+  tax_id:
+    country: "AU"
+    code: "53004085616"
+  inboxes:
+    - key: "peppol"
+      scheme: "0151"
+      code: "53004085616"
+  addresses:
+    - num: "1"
+      street: "Martin Place"
+      locality: "Sydney"
+      region: "NSW"
+      code: "2000"
+      country: "AU"
+
+lines:
+  - quantity: "10"
+    item:
+      name: "Consulting services"
+      price: "100.00"
+      unit: "h"
+    taxes:
+      - cat: "GST"
+        key: "standard"
+        rate: "general"
+
+payment:
+  terms:
+    key: "due-date"
+    due_dates:
+      - date: "2024-06-15"
+        percent: "100%"
+  instructions:
+    key: "credit-transfer"
+    credit_transfer:
+      - number: "123456789"
+        name: "Provide One Pty Ltd"

--- a/examples/au/out/invoice-au-pint.json
+++ b/examples/au/out/invoice-au-pint.json
@@ -1,0 +1,164 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
+		"dig": {
+			"alg": "sha256",
+			"val": "773a6a1d1212d96781c231d49e1ebbf7494756a33194fde3a084aae217f765f2"
+		},
+		"from": "iso6523-actorid-upis::0151:51824753556",
+		"to": "iso6523-actorid-upis::0151:53004085616"
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"$regime": "AU",
+		"$addons": [
+			"eu-en16931-v2017",
+			"peppol-pint-v1"
+		],
+		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
+		"type": "standard",
+		"series": "SAMPLE",
+		"code": "001",
+		"issue_date": "2024-05-15",
+		"currency": "AUD",
+		"tax": {
+			"ext": {
+				"untdid-document-type": "380"
+			}
+		},
+		"supplier": {
+			"name": "Provide One Pty Ltd",
+			"tax_id": {
+				"country": "AU",
+				"code": "51824753556"
+			},
+			"endpoints": [
+				{
+					"uri": "iso6523-actorid-upis::0151:51824753556"
+				}
+			],
+			"inboxes": [
+				{
+					"key": "peppol",
+					"scheme": "0151",
+					"code": "51824753556"
+				}
+			],
+			"addresses": [
+				{
+					"num": "100",
+					"street": "Queen Street",
+					"locality": "Melbourne",
+					"region": "VIC",
+					"code": "3000",
+					"country": "AU"
+				}
+			]
+		},
+		"customer": {
+			"name": "Sample Customer Pty Ltd",
+			"tax_id": {
+				"country": "AU",
+				"code": "53004085616"
+			},
+			"endpoints": [
+				{
+					"uri": "iso6523-actorid-upis::0151:53004085616"
+				}
+			],
+			"inboxes": [
+				{
+					"key": "peppol",
+					"scheme": "0151",
+					"code": "53004085616"
+				}
+			],
+			"addresses": [
+				{
+					"num": "1",
+					"street": "Martin Place",
+					"locality": "Sydney",
+					"region": "NSW",
+					"code": "2000",
+					"country": "AU"
+				}
+			]
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "10",
+				"item": {
+					"name": "Consulting services",
+					"price": "100.00",
+					"unit": "h"
+				},
+				"sum": "1000.00",
+				"taxes": [
+					{
+						"cat": "GST",
+						"key": "standard",
+						"rate": "general",
+						"percent": "10.0%",
+						"ext": {
+							"untdid-tax-category": "S"
+						}
+					}
+				],
+				"total": "1000.00"
+			}
+		],
+		"payment": {
+			"terms": {
+				"key": "due-date",
+				"due_dates": [
+					{
+						"date": "2024-06-15",
+						"amount": "1100.00",
+						"percent": "100%"
+					}
+				]
+			},
+			"instructions": {
+				"key": "credit-transfer",
+				"credit_transfer": [
+					{
+						"number": "123456789",
+						"name": "Provide One Pty Ltd"
+					}
+				],
+				"ext": {
+					"untdid-payment-means": "30"
+				}
+			}
+		},
+		"totals": {
+			"sum": "1000.00",
+			"total": "1000.00",
+			"taxes": {
+				"categories": [
+					{
+						"code": "GST",
+						"rates": [
+							{
+								"key": "standard",
+								"ext": {
+									"untdid-tax-category": "S"
+								},
+								"base": "1000.00",
+								"percent": "10.0%",
+								"amount": "100.00"
+							}
+						],
+						"amount": "100.00"
+					}
+				],
+				"sum": "100.00"
+			},
+			"tax": "100.00",
+			"total_with_tax": "1100.00",
+			"payable": "1100.00"
+		}
+	}
+}

--- a/examples/nz/invoice-nz-pint.yaml
+++ b/examples/nz/invoice-nz-pint.yaml
@@ -1,0 +1,64 @@
+$schema: "https://gobl.org/draft-0/bill/invoice"
+$addons: ["peppol-pint-v1"]
+uuid: "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2"
+regime: "NZ"
+type: "standard"
+series: "SAMPLE"
+code: "001"
+issue_date: "2024-05-15"
+currency: "NZD"
+
+supplier:
+  name: "Provide One Limited"
+  tax_id:
+    country: "NZ"
+    code: "49091850"
+  inboxes:
+    - key: "peppol"
+      scheme: "0088"
+      code: "9429000000008"
+  addresses:
+    - num: "1"
+      street: "Queen Street"
+      locality: "Auckland"
+      code: "1010"
+      country: "NZ"
+
+customer:
+  name: "Sample Customer Limited"
+  tax_id:
+    country: "NZ"
+    code: "136410132"
+  inboxes:
+    - key: "peppol"
+      scheme: "0088"
+      code: "9429000000015"
+  addresses:
+    - num: "10"
+      street: "Lambton Quay"
+      locality: "Wellington"
+      code: "6011"
+      country: "NZ"
+
+lines:
+  - quantity: "10"
+    item:
+      name: "Consulting services"
+      price: "100.00"
+      unit: "h"
+    taxes:
+      - cat: "GST"
+        key: "standard"
+        rate: "general"
+
+payment:
+  terms:
+    key: "due-date"
+    due_dates:
+      - date: "2024-06-15"
+        percent: "100%"
+  instructions:
+    key: "credit-transfer"
+    credit_transfer:
+      - number: "0100000000000"
+        name: "Provide One Limited"

--- a/examples/nz/invoice-nz-zero-rated.yaml
+++ b/examples/nz/invoice-nz-zero-rated.yaml
@@ -1,0 +1,64 @@
+$schema: "https://gobl.org/draft-0/bill/invoice"
+$addons: ["peppol-pint-v1"]
+uuid: "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2"
+regime: "NZ"
+type: "standard"
+series: "SAMPLE"
+code: "002"
+issue_date: "2024-05-15"
+currency: "NZD"
+
+supplier:
+  name: "Provide One Limited"
+  tax_id:
+    country: "NZ"
+    code: "49091850"
+  inboxes:
+    - key: "peppol"
+      scheme: "0088"
+      code: "9429000000008"
+  addresses:
+    - num: "1"
+      street: "Queen Street"
+      locality: "Auckland"
+      code: "1010"
+      country: "NZ"
+
+customer:
+  name: "Sample Customer Limited"
+  tax_id:
+    country: "NZ"
+    code: "136410132"
+  inboxes:
+    - key: "peppol"
+      scheme: "0088"
+      code: "9429000000015"
+  addresses:
+    - num: "10"
+      street: "Lambton Quay"
+      locality: "Wellington"
+      code: "6011"
+      country: "NZ"
+
+lines:
+  - quantity: "10"
+    item:
+      name: "Exported goods"
+      price: "100.00"
+      unit: "h"
+    taxes:
+      - cat: "GST"
+        key: "zero"
+        percent: "0%"
+
+payment:
+  terms:
+    key: "due-date"
+    due_dates:
+      - date: "2024-06-15"
+        percent: "100%"
+  instructions:
+    key: "credit-transfer"
+    credit_transfer:
+      - number: "0100000000000"
+        name: "Provide One Limited"

--- a/examples/nz/out/invoice-nz-pint.json
+++ b/examples/nz/out/invoice-nz-pint.json
@@ -1,0 +1,162 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
+		"dig": {
+			"alg": "sha256",
+			"val": "d94e83564051a054d8acc05dabf6376b9728b84e37e5cc63168a7ee0a50f3daa"
+		},
+		"from": "iso6523-actorid-upis::0088:9429000000008",
+		"to": "iso6523-actorid-upis::0088:9429000000015"
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"$regime": "NZ",
+		"$addons": [
+			"eu-en16931-v2017",
+			"peppol-pint-v1"
+		],
+		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
+		"type": "standard",
+		"series": "SAMPLE",
+		"code": "001",
+		"issue_date": "2024-05-15",
+		"currency": "NZD",
+		"tax": {
+			"ext": {
+				"untdid-document-type": "380"
+			}
+		},
+		"supplier": {
+			"name": "Provide One Limited",
+			"tax_id": {
+				"country": "NZ",
+				"code": "49091850"
+			},
+			"endpoints": [
+				{
+					"uri": "iso6523-actorid-upis::0088:9429000000008"
+				}
+			],
+			"inboxes": [
+				{
+					"key": "peppol",
+					"scheme": "0088",
+					"code": "9429000000008"
+				}
+			],
+			"addresses": [
+				{
+					"num": "1",
+					"street": "Queen Street",
+					"locality": "Auckland",
+					"code": "1010",
+					"country": "NZ"
+				}
+			]
+		},
+		"customer": {
+			"name": "Sample Customer Limited",
+			"tax_id": {
+				"country": "NZ",
+				"code": "136410132"
+			},
+			"endpoints": [
+				{
+					"uri": "iso6523-actorid-upis::0088:9429000000015"
+				}
+			],
+			"inboxes": [
+				{
+					"key": "peppol",
+					"scheme": "0088",
+					"code": "9429000000015"
+				}
+			],
+			"addresses": [
+				{
+					"num": "10",
+					"street": "Lambton Quay",
+					"locality": "Wellington",
+					"code": "6011",
+					"country": "NZ"
+				}
+			]
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "10",
+				"item": {
+					"name": "Consulting services",
+					"price": "100.00",
+					"unit": "h"
+				},
+				"sum": "1000.00",
+				"taxes": [
+					{
+						"cat": "GST",
+						"key": "standard",
+						"rate": "general",
+						"percent": "15.0%",
+						"ext": {
+							"untdid-tax-category": "S"
+						}
+					}
+				],
+				"total": "1000.00"
+			}
+		],
+		"payment": {
+			"terms": {
+				"key": "due-date",
+				"due_dates": [
+					{
+						"date": "2024-06-15",
+						"amount": "1150.00",
+						"percent": "100%"
+					}
+				]
+			},
+			"instructions": {
+				"key": "credit-transfer",
+				"credit_transfer": [
+					{
+						"number": "0100000000000",
+						"name": "Provide One Limited"
+					}
+				],
+				"ext": {
+					"untdid-payment-means": "30"
+				}
+			}
+		},
+		"totals": {
+			"sum": "1000.00",
+			"total": "1000.00",
+			"taxes": {
+				"categories": [
+					{
+						"code": "GST",
+						"rates": [
+							{
+								"key": "standard",
+								"ext": {
+									"untdid-tax-category": "S"
+								},
+								"base": "1000.00",
+								"percent": "15.0%",
+								"amount": "150.00"
+							}
+						],
+						"amount": "150.00"
+					}
+				],
+				"sum": "150.00"
+			},
+			"tax": "150.00",
+			"total_with_tax": "1150.00",
+			"payable": "1150.00"
+		}
+	}
+}

--- a/examples/nz/out/invoice-nz-zero-rated.json
+++ b/examples/nz/out/invoice-nz-zero-rated.json
@@ -1,0 +1,161 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
+		"dig": {
+			"alg": "sha256",
+			"val": "ad06a69fe08b2500f22369c62f391123bb383c0eb4a94dc3128c50176a636b4f"
+		},
+		"from": "iso6523-actorid-upis::0088:9429000000008",
+		"to": "iso6523-actorid-upis::0088:9429000000015"
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"$regime": "NZ",
+		"$addons": [
+			"eu-en16931-v2017",
+			"peppol-pint-v1"
+		],
+		"uuid": "0195ce71-dc9c-72c8-bf2c-9890a4a9f0a2",
+		"type": "standard",
+		"series": "SAMPLE",
+		"code": "002",
+		"issue_date": "2024-05-15",
+		"currency": "NZD",
+		"tax": {
+			"ext": {
+				"untdid-document-type": "380"
+			}
+		},
+		"supplier": {
+			"name": "Provide One Limited",
+			"tax_id": {
+				"country": "NZ",
+				"code": "49091850"
+			},
+			"endpoints": [
+				{
+					"uri": "iso6523-actorid-upis::0088:9429000000008"
+				}
+			],
+			"inboxes": [
+				{
+					"key": "peppol",
+					"scheme": "0088",
+					"code": "9429000000008"
+				}
+			],
+			"addresses": [
+				{
+					"num": "1",
+					"street": "Queen Street",
+					"locality": "Auckland",
+					"code": "1010",
+					"country": "NZ"
+				}
+			]
+		},
+		"customer": {
+			"name": "Sample Customer Limited",
+			"tax_id": {
+				"country": "NZ",
+				"code": "136410132"
+			},
+			"endpoints": [
+				{
+					"uri": "iso6523-actorid-upis::0088:9429000000015"
+				}
+			],
+			"inboxes": [
+				{
+					"key": "peppol",
+					"scheme": "0088",
+					"code": "9429000000015"
+				}
+			],
+			"addresses": [
+				{
+					"num": "10",
+					"street": "Lambton Quay",
+					"locality": "Wellington",
+					"code": "6011",
+					"country": "NZ"
+				}
+			]
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "10",
+				"item": {
+					"name": "Exported goods",
+					"price": "100.00",
+					"unit": "h"
+				},
+				"sum": "1000.00",
+				"taxes": [
+					{
+						"cat": "GST",
+						"key": "zero",
+						"percent": "0%",
+						"ext": {
+							"untdid-tax-category": "Z"
+						}
+					}
+				],
+				"total": "1000.00"
+			}
+		],
+		"payment": {
+			"terms": {
+				"key": "due-date",
+				"due_dates": [
+					{
+						"date": "2024-06-15",
+						"amount": "1000.00",
+						"percent": "100%"
+					}
+				]
+			},
+			"instructions": {
+				"key": "credit-transfer",
+				"credit_transfer": [
+					{
+						"number": "0100000000000",
+						"name": "Provide One Limited"
+					}
+				],
+				"ext": {
+					"untdid-payment-means": "30"
+				}
+			}
+		},
+		"totals": {
+			"sum": "1000.00",
+			"total": "1000.00",
+			"taxes": {
+				"categories": [
+					{
+						"code": "GST",
+						"rates": [
+							{
+								"key": "zero",
+								"ext": {
+									"untdid-tax-category": "Z"
+								},
+								"base": "1000.00",
+								"percent": "0%",
+								"amount": "0.00"
+							}
+						],
+						"amount": "0.00"
+					}
+				],
+				"sum": "0.00"
+			},
+			"tax": "0.00",
+			"total_with_tax": "1000.00",
+			"payable": "1000.00"
+		}
+	}
+}


### PR DESCRIPTION
Based on: #885

Add the base Peppol International (PINT) billing addon. Builds on EN 16931 and
re-maps the UNTDID 5305 tax category from the GOBL tax key so non-VAT schemes
(GST) are reported correctly — standard-rated GST as "S" instead of "O".

Changes:
- peppol-pint addon: tax-category normalizer (reuses en16931.TaxCategoryMap) + PINT rules not covered by core/en16931 (IBR-007/080/081/CO-26)
- Export en16931.TaxCategoryMap (was vatKeyMap) for reuse
- AU + NZ (standard and zero-rated) example invoices

Notes:
- Stacked on #885 (AU/NZ regimes); examples depend on them. Rebase after #885 merges.

## Pre-Review Checklist

- [x] Opened this PR as a draft
- [x] Read the CONTRIBUTING.md guide.
- [X] Performed a self-review of my code.
- [X] Added thorough tests with at **least** 90% code coverage.
- [x] Modified or created example GOBL documents to show my changes in use, if appropriate.
- [x] Added links to the source of the changes in tax regimes or addons, either structured or in the comments.
- [x] Run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [x] Reviewed and fixed all linter warnings.
- [x] Been obsessive with pointer nil checks to avoid panics.
- [x] Updated the CHANGELOG.md with an overview of my changes.
- [x] Marked this PR as ready for review.

And if you are part of the org:
- [] Requested a review from Copilot and fixed or dismissed (with a reason) all the feedback raised.
- [] Requested a review from @samlown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)