### PR TITLE
Register dk-addon and add CPR org identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Added
 
-- `regimes/dk`: new `IdentityTypeCPR` alongside the existing `IdentityTypeCVR`, and the supplier rule (`GOBL-DK-BILL-INVOICE-01`) now accepts either -- a CPR-identified supplier (a natural person, not a VAT-registered business) had no way to satisfy it before, even though this is a valid, schematron-permitted OIOUBL shape.
+- `regimes/dk`: new `IdentityTypeCPR` alongside the existing `IdentityTypeCVR`, and the supplier rule (`GOBL-DK-BILL-INVOICE-01`) now accepts either -- a CPR-identified supplier (a natural person, not a VAT-registered business) had no way to satisfy it before, even though this is a valid, schematron-permitted OIOUBL shape. The fault is now reported at `$.supplier.identities` instead of `$.supplier`.
 - `addons`: registered `dk-oioubl-v2` (implementation in `github.com/invopop/gobl.dk.oioubl`) on the approved external addon list, so it's now a valid `$addons` value.
+- `rules/is`: new `Not` test that passes when the wrapped test does not.
+- `org`: new `PartyHasTaxIDCode` test for a party with a tax identity code.
 
 ## [v0.503.0] - 2026-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - `addons`: registered `dk-oioubl-v2` (implementation in `github.com/invopop/gobl.dk.oioubl`) on the approved external addon list, so it's now a valid `$addons` value.
 - `rules/is`: new `Not` test that passes when the wrapped test does not.
 - `org`: new `PartyHasTaxIDCode` test for a party with a tax identity code.
+- `org`: new `PartyHasIdentityTypeIn` and `PartyHasIdentityKeyIn` tests for a party carrying an identity with one of the given types or keys.
+
+### Fixed
+
+- `rules/is`: `AnyOf` and `OneOf` now prepare the tests they wrap, so that `Expr` and `Matches` work inside them.
 
 ## [v0.503.0] - 2026-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Added
+
+- `regimes/dk`: new `IdentityTypeCPR` alongside the existing `IdentityTypeCVR`, and the supplier rule (`GOBL-DK-BILL-INVOICE-01`) now accepts either -- a CPR-identified supplier (a natural person, not a VAT-registered business) had no way to satisfy it before, even though this is a valid, schematron-permitted OIOUBL shape.
+- `addons`: registered `dk-oioubl-v2` (implementation in `github.com/invopop/gobl.dk.oioubl`) on the approved external addon list, so it's now a valid `$addons` value.
+
 ## [v0.503.0] - 2026-07-15
 
 ### Added

--- a/addons/external.go
+++ b/addons/external.go
@@ -86,4 +86,12 @@ func init() {
 		},
 		Module: "github.com/invopop/gobl.mx.cfdi",
 	})
+	tax.RegisterApprovedAddon(&tax.ExternalAddon{
+		Key: "dk-oioubl-v2",
+		Name: i18n.String{
+			i18n.EN: "Danish OIOUBL 2.1",
+			i18n.DA: "Dansk OIOUBL 2.1",
+		},
+		Module: "github.com/invopop/gobl.dk.oioubl",
+	})
 }

--- a/addons/external_test.go
+++ b/addons/external_test.go
@@ -49,6 +49,12 @@ func TestApprovedAddons(t *testing.T) {
 				"mx-cfdi-v4": "github.com/invopop/gobl.mx.cfdi",
 			},
 		},
+		{
+			name: "DK OIOUBL",
+			modules: map[cbc.Key]string{
+				"dk-oioubl-v2": "github.com/invopop/gobl.dk.oioubl",
+			},
+		},
 	}
 
 	for _, group := range groups {

--- a/addons/it/sdi/bill.go
+++ b/addons/it/sdi/bill.go
@@ -13,6 +13,9 @@ import (
 	"github.com/invopop/gobl/tax"
 )
 
+// partyHasTaxIDCode is reused by the invoice guards below.
+var partyHasTaxIDCode = org.PartyHasTaxIDCode()
+
 func normalizeInvoice(inv *bill.Invoice) {
 	normalizeSupplier(inv.Supplier)
 }
@@ -246,7 +249,7 @@ func invoiceCustomerIsItalianWithoutTaxIDCode(val any) bool {
 	if !ok || inv == nil || inv.Customer == nil {
 		return false
 	}
-	return isItalianParty(inv.Customer) && !hasTaxIDCode(inv.Customer)
+	return isItalianParty(inv.Customer) && !partyHasTaxIDCode.Check(inv.Customer)
 }
 
 func invoiceCustomerHasFiscalCodeIdentity(val any) bool {
@@ -291,10 +294,6 @@ func chargeIsFundContribution(val any) bool {
 		return false
 	}
 	return c.Key.Has(KeyFundContribution)
-}
-
-func hasTaxIDCode(party *org.Party) bool {
-	return party != nil && party.TaxID != nil && party.TaxID.Code != ""
 }
 
 func hasFiscalCode(party *org.Party) bool {

--- a/bill/invoice.go
+++ b/bill/invoice.go
@@ -143,7 +143,7 @@ func invoiceRules() *rules.Set {
 			),
 		),
 		rules.Field("customer",
-			rules.When(is.Func("has tax ID code", customerHasTaxIDCode),
+			rules.When(org.PartyHasTaxIDCode(),
 				rules.Field("name",
 					rules.Assert("07", "invoice customer name required when tax ID is set", is.Present),
 				),
@@ -180,19 +180,6 @@ func invoiceHasTaxPoint(val any) bool {
 		return false
 	}
 	return inv != nil && inv.Tax != nil && inv.Tax.Point != cbc.KeyEmpty
-}
-
-func customerHasTaxIDCode(val any) bool {
-	var p *org.Party
-	switch v := val.(type) {
-	case *org.Party:
-		p = v
-	case org.Party:
-		p = &v
-	default:
-		return false
-	}
-	return p != nil && p.TaxID != nil && p.TaxID.Code != ""
 }
 
 func invoiceNeedsLines(val any) bool {

--- a/data/regimes/dk.json
+++ b/data/regimes/dk.json
@@ -18,6 +18,13 @@
         "da": "CVR-nummer",
         "en": "CVR Number"
       }
+    },
+    {
+      "code": "CPR",
+      "name": {
+        "da": "CPR-nummer",
+        "en": "CPR Number"
+      }
     }
   ],
   "corrections": [

--- a/data/rules/be.json
+++ b/data/rules/be.json
@@ -39,7 +39,7 @@
               "field": "supplier",
               "subsets": [
                 {
-                  "guard": "no BCE identity",
+                  "guard": "not (has a type in [BCE])",
                   "subsets": [
                     {
                       "field": "tax_id",
@@ -66,7 +66,7 @@
                   ]
                 },
                 {
-                  "guard": "no tax ID code",
+                  "guard": "not (has tax ID code)",
                   "subsets": [
                     {
                       "field": "identities",
@@ -74,7 +74,7 @@
                         {
                           "id": "GOBL-BE-BILL-INVOICE-03",
                           "desc": "supplier identities must include BCE type",
-                          "tests": "has BCE type"
+                          "tests": "has a type in [BCE]"
                         }
                       ]
                     }

--- a/data/rules/de.json
+++ b/data/rules/de.json
@@ -15,7 +15,7 @@
                 {
                   "id": "GOBL-DE-BILL-INVOICE-01",
                   "desc": "invoice DE supplier must have either tax ID code or identity with 'de-tax-number' key",
-                  "tests": "has tax ID code or identity with 'de-tax-number' key"
+                  "tests": "has tax ID code, or has a key in [de-tax-number]"
                 }
               ]
             }

--- a/data/rules/dk.json
+++ b/data/rules/dk.json
@@ -14,8 +14,8 @@
               "assert": [
                 {
                   "id": "GOBL-DK-BILL-INVOICE-01",
-                  "desc": "invoice DK supplier must have either tax ID code or identity with 'CVR' type",
-                  "tests": "has tax ID code or identity with 'CVR' type"
+                  "desc": "invoice DK supplier must have either tax ID code or identity with 'CVR' or 'CPR' type",
+                  "tests": "has tax ID code or identity with 'CVR' or 'CPR' type"
                 }
               ]
             }
@@ -28,18 +28,43 @@
       "object": "org.Identity",
       "subsets": [
         {
-          "guard": "is CVR",
+          "guard": "context: regime in [DK]",
           "subsets": [
             {
-              "field": "code",
+              "guard": "type in [CVR]",
               "subsets": [
                 {
-                  "guard": "present",
-                  "assert": [
+                  "field": "code",
+                  "subsets": [
                     {
-                      "id": "GOBL-DK-ORG-IDENTITY-01",
-                      "desc": "invalid Danish CVR identity code",
-                      "tests": "valid"
+                      "guard": "present",
+                      "assert": [
+                        {
+                          "id": "GOBL-DK-ORG-IDENTITY-01",
+                          "desc": "invalid Danish CVR identity code",
+                          "tests": "valid"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "guard": "type in [CPR]",
+              "subsets": [
+                {
+                  "field": "code",
+                  "subsets": [
+                    {
+                      "guard": "present",
+                      "assert": [
+                        {
+                          "id": "GOBL-DK-ORG-IDENTITY-02",
+                          "desc": "invalid Danish CPR identity code",
+                          "tests": "valid"
+                        }
+                      ]
                     }
                   ]
                 }

--- a/data/rules/dk.json
+++ b/data/rules/dk.json
@@ -11,11 +11,21 @@
           "subsets": [
             {
               "field": "supplier",
-              "assert": [
+              "subsets": [
                 {
-                  "id": "GOBL-DK-BILL-INVOICE-01",
-                  "desc": "invoice DK supplier must have either tax ID code or identity with 'CVR' or 'CPR' type",
-                  "tests": "has tax ID code or identity with 'CVR' or 'CPR' type"
+                  "guard": "not (has tax ID code)",
+                  "subsets": [
+                    {
+                      "field": "identities",
+                      "assert": [
+                        {
+                          "id": "GOBL-DK-BILL-INVOICE-01",
+                          "desc": "invoice DK supplier without a tax ID code requires an identity with 'CVR' or 'CPR' type",
+                          "tests": "has a type in [CVR, CPR]"
+                        }
+                      ]
+                    }
+                  ]
                 }
               ]
             }
@@ -62,7 +72,7 @@
                         {
                           "id": "GOBL-DK-ORG-IDENTITY-02",
                           "desc": "invalid Danish CPR identity code",
-                          "tests": "valid"
+                          "tests": "length between 10 and 10, digit"
                         }
                       ]
                     }

--- a/data/rules/fr.json
+++ b/data/rules/fr.json
@@ -15,7 +15,7 @@
                 {
                   "id": "GOBL-FR-BILL-INVOICE-01",
                   "desc": "invoice supplier must have a tax ID code or a SIREN/SIRET identity",
-                  "tests": "has tax ID code or SIREN/SIRET identity"
+                  "tests": "has tax ID code, or has a type in [SIREN, SIRET]"
                 }
               ]
             }

--- a/data/rules/nl.json
+++ b/data/rules/nl.json
@@ -15,7 +15,7 @@
                 {
                   "id": "GOBL-NL-BILL-INVOICE-01",
                   "desc": "invoice supplier must have a tax ID code or a KVK/OIN identity",
-                  "tests": "has tax ID code or KVK/OIN identity"
+                  "tests": "has tax ID code, or has a type in [KVK, OIN]"
                 }
               ]
             }

--- a/data/rules/se.json
+++ b/data/rules/se.json
@@ -41,7 +41,7 @@
                 {
                   "id": "GOBL-SE-BILL-INVOICE-01",
                   "desc": "invoice SE supplier must have either tax ID code or identity with ON, PN, or CN type",
-                  "tests": "has tax ID code or identity with type in [ON, PN, CN]"
+                  "tests": "has tax ID code, or has a type in [ON, PN, CN]"
                 }
               ]
             }

--- a/data/rules/sg.json
+++ b/data/rules/sg.json
@@ -15,7 +15,7 @@
                 {
                   "id": "GOBL-SG-BILL-INVOICE-01",
                   "desc": "invoice supplier in Singapore must have a GST tax ID code or a UEN identity",
-                  "tests": "has GST tax ID code or UEN identity"
+                  "tests": "has tax ID code, or has a type in [UEN]"
                 }
               ]
             }

--- a/data/schemas/tax/addon-list.json
+++ b/data/schemas/tax/addon-list.json
@@ -32,6 +32,10 @@
             "title": "German ZUGFeRD 2.X"
           },
           {
+            "const": "dk-oioubl-v2",
+            "title": "Danish OIOUBL 2.1"
+          },
+          {
             "const": "es-facturae-v3",
             "title": "Spain FacturaE"
           },

--- a/examples/dk/invoice-cpr.json
+++ b/examples/dk/invoice-cpr.json
@@ -1,0 +1,88 @@
+{
+	"$schema": "https://gobl.org/draft-0/bill/invoice",
+	"uuid": "892da681-72e6-4cea-962b-baaaa0ca39e1",
+	"$regime": "DK",
+	"$addons": ["eu-en16931-v2017"],
+	"type": "standard",
+	"series": "S2025",
+	"code": "002",
+	"issue_date": "2025-05-20",
+	"currency": "DKK",
+	"supplier": {
+		"name": "Jens Hansen",
+		"identities": [
+			{
+				"scope": "legal",
+				"type": "CPR",
+				"code": "1111111118"
+			}
+		],
+		"addresses": [
+			{
+				"num": "8",
+				"street": "Strøget",
+				"locality": "København",
+				"region": "Hovedstaden",
+				"code": "1155",
+				"country": "DK"
+			}
+		],
+		"emails": [
+			{
+				"addr": "jens.hansen@example.dk"
+			}
+		]
+	},
+	"customer": {
+		"name": "Sample Customer ApS",
+		"tax_id": {
+			"country": "DK",
+			"code": "88146328"
+		},
+		"identities": [
+			{
+				"scope": "legal",
+				"type": "CVR",
+				"code": "88146328"
+			}
+		],
+		"addresses": [
+			{
+				"num": "15",
+				"street": "Amagertorv",
+				"locality": "København",
+				"region": "Hovedstaden",
+				"code": "1160",
+				"country": "DK"
+			}
+		]
+	},
+	"payment": {
+		"terms": {
+			"due_dates": [
+				{
+					"date": "2025-05-30",
+					"percent": "100%"
+				}
+			]
+		}
+	},
+	"lines": [
+		{
+			"i": 1,
+			"quantity": "10",
+			"item": {
+				"name": "Freelance design services",
+				"price": "500.00",
+				"unit": "h"
+			},
+			"taxes": [
+				{
+					"cat": "VAT",
+					"rate": "general",
+					"percent": "25.0%"
+				}
+			]
+		}
+	]
+}

--- a/examples/dk/out/invoice-cpr.json
+++ b/examples/dk/out/invoice-cpr.json
@@ -1,0 +1,142 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
+		"dig": {
+			"alg": "sha256",
+			"val": "799f50eb30b44191e079786b6758a6fc323d28ad4eb10d7d0d2e4189badad2ec"
+		}
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"$regime": "DK",
+		"$addons": [
+			"eu-en16931-v2017"
+		],
+		"uuid": "892da681-72e6-4cea-962b-baaaa0ca39e1",
+		"type": "standard",
+		"series": "S2025",
+		"code": "002",
+		"issue_date": "2025-05-20",
+		"currency": "DKK",
+		"tax": {
+			"ext": {
+				"untdid-document-type": "380"
+			}
+		},
+		"supplier": {
+			"name": "Jens Hansen",
+			"identities": [
+				{
+					"scope": "legal",
+					"type": "CPR",
+					"code": "1111111118"
+				}
+			],
+			"addresses": [
+				{
+					"num": "8",
+					"street": "Strøget",
+					"locality": "København",
+					"region": "Hovedstaden",
+					"code": "1155",
+					"country": "DK"
+				}
+			],
+			"emails": [
+				{
+					"addr": "jens.hansen@example.dk"
+				}
+			]
+		},
+		"customer": {
+			"name": "Sample Customer ApS",
+			"tax_id": {
+				"country": "DK",
+				"code": "88146328"
+			},
+			"identities": [
+				{
+					"scope": "legal",
+					"type": "CVR",
+					"code": "88146328",
+					"ext": {
+						"iso-scheme-id": "0184"
+					}
+				}
+			],
+			"addresses": [
+				{
+					"num": "15",
+					"street": "Amagertorv",
+					"locality": "København",
+					"region": "Hovedstaden",
+					"code": "1160",
+					"country": "DK"
+				}
+			]
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "10",
+				"item": {
+					"name": "Freelance design services",
+					"price": "500.00",
+					"unit": "h"
+				},
+				"sum": "5000.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "general",
+						"percent": "25.0%",
+						"ext": {
+							"untdid-tax-category": "S"
+						}
+					}
+				],
+				"total": "5000.00"
+			}
+		],
+		"payment": {
+			"terms": {
+				"due_dates": [
+					{
+						"date": "2025-05-30",
+						"amount": "6250.00",
+						"percent": "100%"
+					}
+				]
+			}
+		},
+		"totals": {
+			"sum": "5000.00",
+			"total": "5000.00",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"ext": {
+									"untdid-tax-category": "S"
+								},
+								"base": "5000.00",
+								"percent": "25.0%",
+								"amount": "1250.00"
+							}
+						],
+						"amount": "1250.00"
+					}
+				],
+				"sum": "1250.00"
+			},
+			"tax": "1250.00",
+			"total_with_tax": "6250.00",
+			"payable": "6250.00"
+		}
+	}
+}

--- a/org/party.go
+++ b/org/party.go
@@ -3,6 +3,8 @@ package org
 import (
 	"github.com/invopop/gobl/cbc"
 	"github.com/invopop/gobl/norm"
+	"github.com/invopop/gobl/rules"
+	"github.com/invopop/gobl/rules/is"
 	"github.com/invopop/gobl/schema"
 	"github.com/invopop/gobl/tax"
 	"github.com/invopop/gobl/uuid"
@@ -80,6 +82,25 @@ func (p *Party) FirstEndpoint() *Endpoint {
 		}
 	}
 	return nil
+}
+
+// PartyHasTaxIDCode provides a test that will determine if the party has a
+// tax identity with a code.
+func PartyHasTaxIDCode() rules.Test {
+	return is.Func("has tax ID code", partyHasTaxIDCode)
+}
+
+func partyHasTaxIDCode(obj any) bool {
+	var p *Party
+	switch v := obj.(type) {
+	case *Party:
+		p = v
+	case Party:
+		p = &v
+	default:
+		return false
+	}
+	return p != nil && p.TaxID != nil && p.TaxID.Code != ""
 }
 
 // JSONSchemaExtend adds extra details to the schema.

--- a/org/party.go
+++ b/org/party.go
@@ -91,16 +91,44 @@ func PartyHasTaxIDCode() rules.Test {
 }
 
 func partyHasTaxIDCode(obj any) bool {
-	var p *Party
+	p := partyFrom(obj)
+	return p != nil && p.TaxID != nil && p.TaxID.Code != ""
+}
+
+// PartyHasIdentityTypeIn provides a test that will determine if at least one of
+// the party's identities has one of the given types.
+func PartyHasIdentityTypeIn(typ ...cbc.Code) rules.Test {
+	return partyIdentities(IdentitiesTypeIn(typ...))
+}
+
+// PartyHasIdentityKeyIn provides a test that will determine if at least one of
+// the party's identities has one of the given keys.
+func PartyHasIdentityKeyIn(key ...cbc.Key) rules.Test {
+	return partyIdentities(IdentitiesKeyIn(key...))
+}
+
+// partyIdentities adapts a test for a party's identities so that it can be
+// applied to the party itself.
+func partyIdentities(test rules.Test) rules.Test {
+	return is.Func(test.String(), func(obj any) bool {
+		p := partyFrom(obj)
+		if p == nil {
+			return false
+		}
+		return test.Check(p.Identities)
+	})
+}
+
+// partyFrom extracts a party from either a pointer or a value, as object level
+// tests may receive either shape.
+func partyFrom(obj any) *Party {
 	switch v := obj.(type) {
 	case *Party:
-		p = v
+		return v
 	case Party:
-		p = &v
-	default:
-		return false
+		return &v
 	}
-	return p != nil && p.TaxID != nil && p.TaxID.Code != ""
+	return nil
 }
 
 // JSONSchemaExtend adds extra details to the schema.

--- a/org/party_test.go
+++ b/org/party_test.go
@@ -172,3 +172,58 @@ func TestPartyHasTaxIDCode(t *testing.T) {
 		assert.Equal(t, "has tax ID code", test.String())
 	})
 }
+
+func TestPartyHasIdentityTypeIn(t *testing.T) {
+	test := org.PartyHasIdentityTypeIn("CVR", "CPR")
+
+	t.Run("with matching type", func(t *testing.T) {
+		p := &org.Party{Identities: []*org.Identity{{Type: "CPR", Code: "1111111118"}}}
+		assert.True(t, test.Check(p))
+		assert.True(t, test.Check(*p))
+	})
+
+	t.Run("with other type", func(t *testing.T) {
+		p := &org.Party{Identities: []*org.Identity{{Type: "FOO", Code: "123"}}}
+		assert.False(t, test.Check(p))
+	})
+
+	t.Run("without identities", func(t *testing.T) {
+		assert.False(t, test.Check(&org.Party{}))
+	})
+
+	t.Run("nil party", func(t *testing.T) {
+		var p *org.Party
+		assert.False(t, test.Check(p))
+	})
+
+	t.Run("other type", func(t *testing.T) {
+		assert.False(t, test.Check("foo"))
+	})
+
+	t.Run("description", func(t *testing.T) {
+		assert.Equal(t, "has a type in [CVR, CPR]", test.String())
+	})
+}
+
+func TestPartyHasIdentityKeyIn(t *testing.T) {
+	test := org.PartyHasIdentityKeyIn("de-tax-number")
+
+	t.Run("with matching key", func(t *testing.T) {
+		p := &org.Party{Identities: []*org.Identity{{Key: "de-tax-number", Code: "123"}}}
+		assert.True(t, test.Check(p))
+	})
+
+	t.Run("with other key", func(t *testing.T) {
+		p := &org.Party{Identities: []*org.Identity{{Key: "other", Code: "123"}}}
+		assert.False(t, test.Check(p))
+	})
+
+	t.Run("nil party", func(t *testing.T) {
+		var p *org.Party
+		assert.False(t, test.Check(p))
+	})
+
+	t.Run("description", func(t *testing.T) {
+		assert.Equal(t, "has a key in [de-tax-number]", test.String())
+	})
+}

--- a/org/party_test.go
+++ b/org/party_test.go
@@ -140,3 +140,35 @@ func TestPartyValidation(t *testing.T) {
 		assert.ErrorContains(t, err, "German tax number code must be in valid format")
 	})
 }
+
+func TestPartyHasTaxIDCode(t *testing.T) {
+	test := org.PartyHasTaxIDCode()
+
+	t.Run("with tax ID code", func(t *testing.T) {
+		p := &org.Party{TaxID: &tax.Identity{Country: "DK", Code: "12345674"}}
+		assert.True(t, test.Check(p))
+		assert.True(t, test.Check(*p))
+	})
+
+	t.Run("with empty tax ID code", func(t *testing.T) {
+		p := &org.Party{TaxID: &tax.Identity{Country: "DK"}}
+		assert.False(t, test.Check(p))
+	})
+
+	t.Run("without tax ID", func(t *testing.T) {
+		assert.False(t, test.Check(&org.Party{}))
+	})
+
+	t.Run("nil party", func(t *testing.T) {
+		var p *org.Party
+		assert.False(t, test.Check(p))
+	})
+
+	t.Run("other type", func(t *testing.T) {
+		assert.False(t, test.Check("foo"))
+	})
+
+	t.Run("description", func(t *testing.T) {
+		assert.Equal(t, "has tax ID code", test.String())
+	})
+}

--- a/regimes/be/bill_invoices.go
+++ b/regimes/be/bill_invoices.go
@@ -15,7 +15,7 @@ func billInvoiceRules() *rules.Set {
 			is.InContext(tax.RegimeIn(l10n.BE.Tax())),
 			rules.Field("supplier",
 				rules.When(
-					is.Func("no BCE identity", supplierNoBCEIdentity),
+					is.Not(org.PartyHasIdentityTypeIn(IdentityTypeBCE)),
 					rules.Field("tax_id",
 						rules.Assert("01", "supplier tax ID required for Belgian regime", is.Present),
 						rules.Field("code",
@@ -24,39 +24,13 @@ func billInvoiceRules() *rules.Set {
 					),
 				),
 				rules.When(
-					is.Func("no tax ID code", supplierNoTaxIDCode),
+					is.Not(org.PartyHasTaxIDCode()),
 					rules.Field("identities",
 						rules.Assert("03", "supplier identities must include BCE type",
-							is.Func("has BCE type", identitiesIncludeBCE)),
+							org.IdentitiesTypeIn(IdentityTypeBCE)),
 					),
 				),
 			),
 		),
 	)
-}
-
-func supplierNoBCEIdentity(val any) bool {
-	p, _ := val.(*org.Party)
-	return !hasIdentityBCE(p)
-}
-
-func supplierNoTaxIDCode(val any) bool {
-	p, _ := val.(*org.Party)
-	return !hasTaxIDCode(p)
-}
-
-func identitiesIncludeBCE(val any) bool {
-	idents, _ := val.([]*org.Identity)
-	return org.IdentityForType(idents, IdentityTypeBCE) != nil
-}
-
-func hasTaxIDCode(party *org.Party) bool {
-	return party != nil && party.TaxID != nil && party.TaxID.Code != ""
-}
-
-func hasIdentityBCE(party *org.Party) bool {
-	if party == nil || len(party.Identities) == 0 {
-		return false
-	}
-	return org.IdentityForType(party.Identities, IdentityTypeBCE) != nil
 }

--- a/regimes/de/bill_invoices.go
+++ b/regimes/de/bill_invoices.go
@@ -17,28 +17,12 @@ func billInvoiceRules() *rules.Set {
 			is.InContext(tax.RegimeIn(l10n.DE.Tax())),
 			rules.Field("supplier",
 				rules.Assert("01", fmt.Sprintf("invoice DE supplier must have either tax ID code or identity with '%s' key", IdentityKeyTaxNumber),
-					is.Func(
-						fmt.Sprintf("has tax ID code or identity with '%s' key", IdentityKeyTaxNumber),
-						hasTaxIDOrIdentity,
+					is.AnyOf(
+						org.PartyHasTaxIDCode(),
+						org.PartyHasIdentityKeyIn(IdentityKeyTaxNumber),
 					),
 				),
 			),
 		),
 	)
-}
-
-func hasTaxIDOrIdentity(value any) bool {
-	party, _ := value.(*org.Party)
-	return hasTaxIDCode(party) || hasIdentityTaxNumber(party)
-}
-
-func hasTaxIDCode(party *org.Party) bool {
-	return party != nil && party.TaxID != nil && party.TaxID.Code != ""
-}
-
-func hasIdentityTaxNumber(party *org.Party) bool {
-	if party == nil || len(party.Identities) == 0 {
-		return false
-	}
-	return org.IdentityForKey(party.Identities, IdentityKeyTaxNumber) != nil
 }

--- a/regimes/dk/bill_invoices.go
+++ b/regimes/dk/bill_invoices.go
@@ -16,45 +16,18 @@ func billInvoiceRules() *rules.Set {
 		rules.When(
 			is.InContext(tax.RegimeIn(l10n.DK.Tax())),
 			rules.Field("supplier",
-				rules.Assert("01", fmt.Sprintf(
-					"invoice DK supplier must have either tax ID code or identity with '%s' or '%s' type",
-					IdentityTypeCVR, IdentityTypeCPR,
-				),
-					is.Func(
-						fmt.Sprintf("has tax ID code or identity with '%s' or '%s' type", IdentityTypeCVR, IdentityTypeCPR),
-						hasTaxIDOrIdentity,
+				rules.When(
+					is.Not(org.PartyHasTaxIDCode()),
+					rules.Field("identities",
+						rules.Assert("01", fmt.Sprintf(
+							"invoice DK supplier without a tax ID code requires an identity with '%s' or '%s' type",
+							IdentityTypeCVR, IdentityTypeCPR,
+						),
+							org.IdentitiesTypeIn(IdentityTypeCVR, IdentityTypeCPR),
+						),
 					),
 				),
 			),
 		),
 	)
-}
-
-func hasTaxIDOrIdentity(value any) bool {
-	party, _ := value.(*org.Party)
-	if hasTaxIDCode(party) {
-		return true
-	}
-	if hasIdentityCVR(party) {
-		return true
-	}
-	return hasIdentityCPR(party)
-}
-
-func hasTaxIDCode(party *org.Party) bool {
-	return party != nil && party.TaxID != nil && party.TaxID.Code != ""
-}
-
-func hasIdentityCVR(party *org.Party) bool {
-	if party == nil || len(party.Identities) == 0 {
-		return false
-	}
-	return org.IdentityForType(party.Identities, IdentityTypeCVR) != nil
-}
-
-func hasIdentityCPR(party *org.Party) bool {
-	if party == nil || len(party.Identities) == 0 {
-		return false
-	}
-	return org.IdentityForType(party.Identities, IdentityTypeCPR) != nil
 }

--- a/regimes/dk/bill_invoices.go
+++ b/regimes/dk/bill_invoices.go
@@ -16,9 +16,12 @@ func billInvoiceRules() *rules.Set {
 		rules.When(
 			is.InContext(tax.RegimeIn(l10n.DK.Tax())),
 			rules.Field("supplier",
-				rules.Assert("01", fmt.Sprintf("invoice DK supplier must have either tax ID code or identity with '%s' type", IdentityTypeCVR),
+				rules.Assert("01", fmt.Sprintf(
+					"invoice DK supplier must have either tax ID code or identity with '%s' or '%s' type",
+					IdentityTypeCVR, IdentityTypeCPR,
+				),
 					is.Func(
-						fmt.Sprintf("has tax ID code or identity with '%s' type", IdentityTypeCVR),
+						fmt.Sprintf("has tax ID code or identity with '%s' or '%s' type", IdentityTypeCVR, IdentityTypeCPR),
 						hasTaxIDOrIdentity,
 					),
 				),
@@ -29,7 +32,13 @@ func billInvoiceRules() *rules.Set {
 
 func hasTaxIDOrIdentity(value any) bool {
 	party, _ := value.(*org.Party)
-	return hasTaxIDCode(party) || hasIdentityCVR(party)
+	if hasTaxIDCode(party) {
+		return true
+	}
+	if hasIdentityCVR(party) {
+		return true
+	}
+	return hasIdentityCPR(party)
 }
 
 func hasTaxIDCode(party *org.Party) bool {
@@ -41,4 +50,11 @@ func hasIdentityCVR(party *org.Party) bool {
 		return false
 	}
 	return org.IdentityForType(party.Identities, IdentityTypeCVR) != nil
+}
+
+func hasIdentityCPR(party *org.Party) bool {
+	if party == nil || len(party.Identities) == 0 {
+		return false
+	}
+	return org.IdentityForType(party.Identities, IdentityTypeCPR) != nil
 }

--- a/regimes/dk/bill_invoices_test.go
+++ b/regimes/dk/bill_invoices_test.go
@@ -62,8 +62,34 @@ func TestInvoiceValidation(t *testing.T) {
 		inv := validInvoice()
 		inv.Supplier.TaxID.Code = ""
 		require.NoError(t, inv.Calculate())
-		err := rules.Validate(inv)
-		assert.ErrorContains(t, err, "[GOBL-DK-BILL-INVOICE-01]")
+		faults := rules.Validate(inv)
+		require.NotNil(t, faults)
+		assert.True(t, faults.HasCode("GOBL-DK-BILL-INVOICE-01"))
+		assert.True(t, faults.HasPath("$.supplier.identities"))
+	})
+
+	t.Run("supplier with unrelated identity type", func(t *testing.T) {
+		inv := validInvoice()
+		inv.Supplier.TaxID = nil
+		inv.Supplier.Identities = []*org.Identity{
+			{
+				Type: "FOO",
+				Code: "12345674",
+			},
+		}
+		require.NoError(t, inv.Calculate())
+		faults := rules.Validate(inv)
+		require.NotNil(t, faults)
+		assert.True(t, faults.HasCode("GOBL-DK-BILL-INVOICE-01"))
+	})
+
+	t.Run("missing supplier", func(t *testing.T) {
+		inv := validInvoice()
+		inv.Supplier = nil
+		_ = inv.Calculate()
+		faults := rules.Validate(inv)
+		require.NotNil(t, faults)
+		assert.False(t, faults.HasCode("GOBL-DK-BILL-INVOICE-01"))
 	})
 
 	t.Run("supplier with CVR identity instead of tax ID", func(t *testing.T) {

--- a/regimes/dk/bill_invoices_test.go
+++ b/regimes/dk/bill_invoices_test.go
@@ -91,4 +91,17 @@ func TestInvoiceValidation(t *testing.T) {
 		require.NoError(t, inv.Calculate())
 		assert.NoError(t, rules.Validate(inv))
 	})
+
+	t.Run("supplier with nil tax ID and CPR identity", func(t *testing.T) {
+		inv := validInvoice()
+		inv.Supplier.TaxID = nil
+		inv.Supplier.Identities = []*org.Identity{
+			{
+				Type: dk.IdentityTypeCPR,
+				Code: "1111111118",
+			},
+		}
+		require.NoError(t, inv.Calculate())
+		assert.NoError(t, rules.Validate(inv))
+	})
 }

--- a/regimes/dk/dk.go
+++ b/regimes/dk/dk.go
@@ -9,6 +9,7 @@ import (
 	"github.com/invopop/gobl/norm"
 	"github.com/invopop/gobl/pkg/here"
 	"github.com/invopop/gobl/rules"
+	"github.com/invopop/gobl/rules/is"
 	"github.com/invopop/gobl/tax"
 )
 
@@ -24,6 +25,9 @@ func init() {
 	)
 	norm.Register(
 		norm.When(tax.IdentityIn(CountryCode), norm.For(func(id *tax.Identity) { tax.NormalizeIdentity(id) })),
+	)
+	norm.RegisterWithGuard(is.InContext(tax.RegimeIn(CountryCode)),
+		norm.For(normalizeOrgIdentity),
 	)
 }
 

--- a/regimes/dk/org_identities.go
+++ b/regimes/dk/org_identities.go
@@ -51,7 +51,7 @@ func orgIdentityRules() *rules.Set {
 				org.IdentityTypeIn(IdentityTypeCPR),
 				rules.Field("code",
 					rules.AssertIfPresent("02", "invalid Danish CPR identity code",
-						is.Func("valid", isValidCPRCode)),
+						is.Length(10, 10), is.Digit),
 				),
 			),
 		),
@@ -61,12 +61,6 @@ func orgIdentityRules() *rules.Set {
 func isValidCVRCode(val any) bool {
 	code, _ := val.(cbc.Code)
 	return validateTaxCode(code) == nil
-}
-
-// isValidCPRCode checks a Danish CPR number is 10 digits. There is no
-// checksum or other validation.
-func isValidCPRCode(val any) bool {
-	return is.Length(10, 10).Check(val) && is.Digit.Check(val)
 }
 
 // normalizeOrgIdentity strips separators from a Danish CPR number, e.g.

--- a/regimes/dk/org_identities.go
+++ b/regimes/dk/org_identities.go
@@ -6,12 +6,17 @@ import (
 	"github.com/invopop/gobl/org"
 	"github.com/invopop/gobl/rules"
 	"github.com/invopop/gobl/rules/is"
+	"github.com/invopop/gobl/tax"
 )
 
 const (
 	// IdentityTypeCVR represents the Danish "CVR-nummer" (Centrale Virksomhedsregister),
 	// the Central Business Register number used to identify businesses in Denmark.
 	IdentityTypeCVR cbc.Code = "CVR"
+
+	// IdentityTypeCPR represents the Danish "CPR-nummer" (Det Centrale Personregister),
+	// the personal identification number used to identify individuals in Denmark.
+	IdentityTypeCPR cbc.Code = "CPR"
 )
 
 var identityTypeDefinitions = []*cbc.Definition{
@@ -22,26 +27,53 @@ var identityTypeDefinitions = []*cbc.Definition{
 			i18n.DA: "CVR-nummer",
 		},
 	},
+	{
+		Code: IdentityTypeCPR,
+		Name: i18n.String{
+			i18n.EN: "CPR Number",
+			i18n.DA: "CPR-nummer",
+		},
+	},
 }
 
 func orgIdentityRules() *rules.Set {
 	return rules.For(new(org.Identity),
 		rules.When(
-			is.Func("is CVR", isCVRIdentity),
-			rules.Field("code",
-				rules.AssertIfPresent("01", "invalid Danish CVR identity code",
-					is.Func("valid", isValidCVRCode)),
+			is.InContext(tax.RegimeIn(CountryCode)),
+			rules.When(
+				org.IdentityTypeIn(IdentityTypeCVR),
+				rules.Field("code",
+					rules.AssertIfPresent("01", "invalid Danish CVR identity code",
+						is.Func("valid", isValidCVRCode)),
+				),
+			),
+			rules.When(
+				org.IdentityTypeIn(IdentityTypeCPR),
+				rules.Field("code",
+					rules.AssertIfPresent("02", "invalid Danish CPR identity code",
+						is.Func("valid", isValidCPRCode)),
+				),
 			),
 		),
 	)
 }
 
-func isCVRIdentity(val any) bool {
-	id, _ := val.(*org.Identity)
-	return id != nil && id.Type == IdentityTypeCVR
-}
-
 func isValidCVRCode(val any) bool {
 	code, _ := val.(cbc.Code)
 	return validateTaxCode(code) == nil
+}
+
+// isValidCPRCode checks a Danish CPR number is 10 digits. There is no
+// checksum or other validation.
+func isValidCPRCode(val any) bool {
+	return is.Length(10, 10).Check(val) && is.Digit.Check(val)
+}
+
+// normalizeOrgIdentity strips separators from a Danish CPR number, e.g.
+// "150605-4321" becomes "1506054321".
+func normalizeOrgIdentity(id *org.Identity) {
+	if id.Type != IdentityTypeCPR {
+		return
+	}
+	id.Code = cbc.NormalizeNumericalCode(id.Code)
 }

--- a/regimes/dk/org_identities_test.go
+++ b/regimes/dk/org_identities_test.go
@@ -3,15 +3,20 @@ package dk_test
 import (
 	"testing"
 
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/norm"
 	"github.com/invopop/gobl/org"
 	"github.com/invopop/gobl/regimes/dk"
 	"github.com/invopop/gobl/rules"
+	"github.com/invopop/gobl/tax"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestIdentityTypeDefinitions(t *testing.T) {
 	// Test that the CVR identity type constant is correctly defined
 	assert.Equal(t, "CVR", string(dk.IdentityTypeCVR))
+	// Test that the CPR identity type constant is correctly defined
+	assert.Equal(t, "CPR", string(dk.IdentityTypeCPR))
 }
 
 func TestValidateIdentity(t *testing.T) {
@@ -88,11 +93,46 @@ func TestValidateIdentity(t *testing.T) {
 				Code: "invalid",
 			},
 		},
+		{
+			name: "valid CPR",
+			identity: &org.Identity{
+				Type: "CPR",
+				Code: "1111111118",
+			},
+		},
+		{
+			name: "CPR too short",
+			identity: &org.Identity{
+				Type: "CPR",
+				Code: "123456789",
+			},
+			err: "[GOBL-DK-ORG-IDENTITY-02]",
+		},
+		{
+			name: "CPR too long",
+			identity: &org.Identity{
+				Type: "CPR",
+				Code: "12345678901",
+			},
+			err: "[GOBL-DK-ORG-IDENTITY-02]",
+		},
+		{
+			name: "CPR contains letters",
+			identity: &org.Identity{
+				Type: "CPR",
+				Code: "123456789A",
+			},
+			err: "[GOBL-DK-ORG-IDENTITY-02]",
+		},
+	}
+
+	opts := []rules.WithContext{
+		tax.RegimeContext(dk.CountryCode),
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := rules.Validate(tt.identity)
+			err := rules.Validate(tt.identity, opts...)
 			if tt.err == "" {
 				assert.NoError(t, err)
 			} else {
@@ -100,4 +140,18 @@ func TestValidateIdentity(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNormalizeOrgIdentity(t *testing.T) {
+	t.Run("CPR with hyphen", func(t *testing.T) {
+		id := &org.Identity{Type: dk.IdentityTypeCPR, Code: "150605-4321"}
+		norm.Normalize(id, tax.RegimeContext(dk.CountryCode))
+		assert.Equal(t, cbc.Code("1506054321"), id.Code)
+	})
+
+	t.Run("unknown type ignored", func(t *testing.T) {
+		id := &org.Identity{Type: "OTHER", Code: "150605-4321"}
+		norm.Normalize(id, tax.RegimeContext(dk.CountryCode))
+		assert.Equal(t, cbc.Code("150605-4321"), id.Code)
+	})
 }

--- a/regimes/fr/bill_invoices.go
+++ b/regimes/fr/bill_invoices.go
@@ -15,30 +15,12 @@ func billInvoiceRules() *rules.Set {
 			is.InContext(tax.RegimeIn(l10n.FR.Tax())),
 			rules.Field("supplier",
 				rules.Assert("01", "invoice supplier must have a tax ID code or a SIREN/SIRET identity",
-					is.Func("has tax ID code or SIREN/SIRET identity", hasSupplierTaxIDOrIdentity),
+					is.AnyOf(
+						org.PartyHasTaxIDCode(),
+						org.PartyHasIdentityTypeIn(IdentityTypeSIREN, IdentityTypeSIRET),
+					),
 				),
 			),
 		),
 	)
-}
-
-func hasSupplierTaxIDOrIdentity(value any) bool {
-	party, _ := value.(*org.Party)
-	return hasTaxIDCode(party) || hasSupplierIdentity(party)
-}
-
-func hasTaxIDCode(party *org.Party) bool {
-	return party != nil && party.TaxID != nil && party.TaxID.Code != ""
-}
-
-func hasSupplierIdentity(party *org.Party) bool {
-	if party == nil || len(party.Identities) == 0 {
-		return false
-	}
-	for _, id := range party.Identities {
-		if id.Type == IdentityTypeSIREN || id.Type == IdentityTypeSIRET {
-			return true
-		}
-	}
-	return false
 }

--- a/regimes/nl/bill_invoices.go
+++ b/regimes/nl/bill_invoices.go
@@ -15,30 +15,12 @@ func billInvoiceRules() *rules.Set {
 			is.InContext(tax.RegimeIn(l10n.NL.Tax())),
 			rules.Field("supplier",
 				rules.Assert("01", "invoice supplier must have a tax ID code or a KVK/OIN identity",
-					is.Func("has tax ID code or KVK/OIN identity", hasSupplierTaxIDOrIdentity),
+					is.AnyOf(
+						org.PartyHasTaxIDCode(),
+						org.PartyHasIdentityTypeIn(IdentityTypeKVK, IdentityTypeOIN),
+					),
 				),
 			),
 		),
 	)
-}
-
-func hasSupplierTaxIDOrIdentity(value any) bool {
-	party, _ := value.(*org.Party)
-	return hasTaxIDCode(party) || hasSupplierIdentity(party)
-}
-
-func hasTaxIDCode(party *org.Party) bool {
-	return party != nil && party.TaxID != nil && party.TaxID.Code != ""
-}
-
-func hasSupplierIdentity(party *org.Party) bool {
-	if party == nil || len(party.Identities) == 0 {
-		return false
-	}
-	for _, id := range party.Identities {
-		if id.Type == IdentityTypeKVK || id.Type == IdentityTypeOIN {
-			return true
-		}
-	}
-	return false
 }

--- a/regimes/se/bill_invoice.go
+++ b/regimes/se/bill_invoice.go
@@ -17,34 +17,12 @@ func billInvoiceRules() *rules.Set {
 			is.InContext(tax.RegimeIn(l10n.SE.Tax())),
 			rules.Field("supplier",
 				rules.Assert("01", fmt.Sprintf("invoice SE supplier must have either tax ID code or identity with %s, %s, or %s type", IdentityTypeOrgNr, IdentityTypePersonNr, IdentityTypeCoordinationNr),
-					is.Func(
-						fmt.Sprintf("has tax ID code or identity with type in [%s, %s, %s]", IdentityTypeOrgNr, IdentityTypePersonNr, IdentityTypeCoordinationNr),
-						hasSupplierTaxIDOrIdentity,
+					is.AnyOf(
+						org.PartyHasTaxIDCode(),
+						org.PartyHasIdentityTypeIn(IdentityTypeOrgNr, IdentityTypePersonNr, IdentityTypeCoordinationNr),
 					),
 				),
 			),
 		),
 	)
-}
-
-func hasSupplierTaxIDOrIdentity(value any) bool {
-	party, _ := value.(*org.Party)
-	return hasTaxIDCode(party) || hasSupplierIdentity(party)
-}
-
-func hasTaxIDCode(party *org.Party) bool {
-	return party != nil && party.TaxID != nil && party.TaxID.Code != ""
-}
-
-func hasSupplierIdentity(party *org.Party) bool {
-	if party == nil || len(party.Identities) == 0 {
-		return false
-	}
-	for _, id := range party.Identities {
-		switch id.Type {
-		case IdentityTypeOrgNr, IdentityTypePersonNr, IdentityTypeCoordinationNr:
-			return true
-		}
-	}
-	return false
 }

--- a/regimes/sg/bill_invoices.go
+++ b/regimes/sg/bill_invoices.go
@@ -14,31 +14,12 @@ func billInvoiceRules() *rules.Set {
 			is.InContext(tax.RegimeIn(CountryCode)),
 			rules.Field("supplier",
 				rules.Assert("01", "invoice supplier in Singapore must have a GST tax ID code or a UEN identity",
-					is.Func("has GST tax ID code or UEN identity", hasSupplierTaxIDOrIdentity),
+					is.AnyOf(
+						org.PartyHasTaxIDCode(),
+						org.PartyHasIdentityTypeIn(IdentityTypeUEN),
+					),
 				),
 			),
 		),
 	)
-}
-
-func hasSupplierTaxIDOrIdentity(value any) bool {
-	party, _ := value.(*org.Party)
-	return hasTaxIDCode(party) || hasSupplierIdentity(party)
-}
-
-func hasTaxIDCode(party *org.Party) bool {
-	return party != nil && party.TaxID != nil && party.TaxID.Code != ""
-}
-
-func hasSupplierIdentity(party *org.Party) bool {
-	if party == nil || len(party.Identities) == 0 {
-		return false
-	}
-	for _, id := range party.Identities {
-		switch id.Type {
-		case IdentityTypeUEN:
-			return true
-		}
-	}
-	return false
 }

--- a/rules/README.md
+++ b/rules/README.md
@@ -200,7 +200,9 @@ import (
 | `is.StringFunc(desc, func(string) bool)`              | Convenience for string-typed fields                                    |
 | `is.FuncError(desc, func(any) error)`                 | Error message is discarded; use `desc`                                 |
 | `is.FuncContext(desc, func(rules.Context, any) bool)` | Context-aware custom function                                          |
-| `is.Or(tests...)`                                     | Passes if any test passes                                              |
+| `is.AnyOf(tests...)`                                  | Passes if any test passes; `is.Or` is a deprecated alias               |
+| `is.OneOf(tests...)`                                  | Passes only if exactly one test passes                                 |
+| `is.Not(test)`                                        | Passes when the wrapped test does not                                  |
 | `is.InContext(test)`                                  | Passes when any context value satisfies the inner test                 |
 
 The `rules/is` package also re-exports all format tests from `github.com/invopop/validation/is`
@@ -268,6 +270,7 @@ Organisation and documents:
 | `org.IdentitiesKeyIn(keys...)`                      | Any of `[]*org.Identity` has the key                 |
 | `org.IdentitiesExtensionIn(key, values...)`         | Any identity has the ext key with one of the values  |
 | `org.AttributesHaveUniqueKeys()`                    | No duplicate keys in `[]*org.Attribute`              |
+| `org.PartyHasTaxIDCode()`                           | `*org.Party` has a tax identity with a code          |
 | `bill.InvoiceTypeIn(types...)`                      | `*bill.Invoice` type; a `When` guard                 |
 | `bill.PaymentTypeIn(types...)`                      | `*bill.Payment` type; a `When` guard                 |
 | `bill.StatusTypeIn(types...)`                       | `*bill.Status` type; a `When` guard                  |

--- a/rules/README.md
+++ b/rules/README.md
@@ -271,6 +271,8 @@ Organisation and documents:
 | `org.IdentitiesExtensionIn(key, values...)`         | Any identity has the ext key with one of the values  |
 | `org.AttributesHaveUniqueKeys()`                    | No duplicate keys in `[]*org.Attribute`              |
 | `org.PartyHasTaxIDCode()`                           | `*org.Party` has a tax identity with a code          |
+| `org.PartyHasIdentityTypeIn(types...)`              | Any of the party's identities has the type           |
+| `org.PartyHasIdentityKeyIn(keys...)`                | Any of the party's identities has the key            |
 | `bill.InvoiceTypeIn(types...)`                      | `*bill.Invoice` type; a `When` guard                 |
 | `bill.PaymentTypeIn(types...)`                      | `*bill.Payment` type; a `When` guard                 |
 | `bill.StatusTypeIn(types...)`                       | `*bill.Status` type; a `When` guard                  |
@@ -374,6 +376,46 @@ name against the struct at initialisation and panics immediately instead.
 Custom functions are still the right answer for genuine cross-field logic, for
 domain lookups (regime currency, exchange rates, catalogue codes), and for
 anything an existing test cannot express — see the next two sections.
+
+### Either-or across fields
+
+Combine domain tests with `is.AnyOf` instead of a function that navigates both
+fields. Most regimes need this to accept a party identified by either a tax ID
+code or a national identity:
+
+```go
+// Avoid
+rules.Field("supplier",
+    rules.Assert("01", "supplier must have a tax ID code or a UEN identity",
+        is.Func("has tax ID code or UEN identity", hasSupplierTaxIDOrIdentity),
+    ),
+)
+
+// Prefer
+rules.Field("supplier",
+    rules.Assert("01", "supplier must have a tax ID code or a UEN identity",
+        is.AnyOf(
+            org.PartyHasTaxIDCode(),
+            org.PartyHasIdentityTypeIn(IdentityTypeUEN),
+        ),
+    ),
+)
+```
+
+Use `is.Not` with a `When` guard when only one of the branches carries the
+requirement, so that the fault lands on the field that must be corrected:
+
+```go
+rules.Field("supplier",
+    rules.When(is.Not(org.PartyHasTaxIDCode()),
+        rules.Field("identities",
+            rules.Assert("01", "supplier without a tax ID code requires a CVR identity",
+                org.IdentitiesTypeIn(IdentityTypeCVR),
+            ),
+        ),
+    ),
+)
+```
 
 ### Required field with format check
 

--- a/rules/is/any_of.go
+++ b/rules/is/any_of.go
@@ -56,6 +56,12 @@ func (t anyOfTest) CheckWithContext(rc *rules.Context, val any) bool {
 	return false
 }
 
+// Compile prepares each of the wrapped tests that require compilation, such as
+// Expr or Matches.
+func (t anyOfTest) Compile(val any) error {
+	return compileTests(val, t.tests)
+}
+
 // String provides the string representation of the test.
 func (t anyOfTest) String() string {
 	return t.desc

--- a/rules/is/any_of_test.go
+++ b/rules/is/any_of_test.go
@@ -96,3 +96,27 @@ func TestAnyOfCheckWithContext(t *testing.T) {
 		assert.True(t, ct.CheckWithContext(rc, nil))
 	})
 }
+
+func TestAnyOfCompile(t *testing.T) {
+	type anyOfThing struct {
+		Code string `json:"code"`
+	}
+
+	t.Run("compiles wrapped tests", func(t *testing.T) {
+		set := rules.For(new(anyOfThing),
+			rules.Field("code",
+				rules.Assert("001", "code must be numeric or empty",
+					is.AnyOf(is.Matches(`^\d+$`), is.Empty),
+				),
+			),
+		)
+		assert.Nil(t, set.Validate(&anyOfThing{Code: "123"}))
+		assert.Nil(t, set.Validate(&anyOfThing{}))
+		assert.NotNil(t, set.Validate(&anyOfThing{Code: "abc"}))
+	})
+
+	t.Run("reports compilation errors", func(t *testing.T) {
+		aoTest := is.AnyOf(is.Matches(`^(\d+$`)).(interface{ Compile(any) error })
+		assert.Error(t, aoTest.Compile(new(anyOfThing)))
+	})
+}

--- a/rules/is/compile.go
+++ b/rules/is/compile.go
@@ -1,0 +1,30 @@
+package is
+
+import (
+	"github.com/invopop/gobl/rules"
+)
+
+// compilable is implemented by tests that need to be prepared before use,
+// such as Expr or Matches. It mirrors the unexported interface used by the
+// rules package so that tests wrapping other tests can pass compilation on.
+type compilable interface {
+	Compile(val any) error
+}
+
+// compileTest prepares the given test when it requires compilation.
+func compileTest(val any, test rules.Test) error {
+	if ct, ok := test.(compilable); ok {
+		return ct.Compile(val)
+	}
+	return nil
+}
+
+// compileTests prepares each of the given tests that require compilation.
+func compileTests(val any, tests []rules.Test) error {
+	for _, test := range tests {
+		if err := compileTest(val, test); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/rules/is/not.go
+++ b/rules/is/not.go
@@ -1,0 +1,42 @@
+package is
+
+import (
+	"github.com/invopop/gobl/rules"
+)
+
+type notTest struct {
+	test rules.Test
+}
+
+// Not defines a test that will pass when the provided test does not.
+func Not(test rules.Test) rules.Test {
+	return notTest{test: test}
+}
+
+// Check will run the wrapped test on the object and invert the result.
+func (t notTest) Check(obj any) bool {
+	return !t.test.Check(obj)
+}
+
+// CheckWithContext implements rules.ContextualTest so that Not(InContext(...))
+// correctly threads the context through to the wrapped test.
+func (t notTest) CheckWithContext(rc *rules.Context, val any) bool {
+	if ct, ok := t.test.(rules.ContextualTest); ok {
+		return !ct.CheckWithContext(rc, val)
+	}
+	return !t.test.Check(val)
+}
+
+// Compile prepares the wrapped test when it requires compilation, such as
+// Expr or Matches.
+func (t notTest) Compile(val any) error {
+	if ct, ok := t.test.(interface{ Compile(any) error }); ok {
+		return ct.Compile(val)
+	}
+	return nil
+}
+
+// String provides the string representation of the test.
+func (t notTest) String() string {
+	return "not (" + t.test.String() + ")"
+}

--- a/rules/is/not.go
+++ b/rules/is/not.go
@@ -30,10 +30,7 @@ func (t notTest) CheckWithContext(rc *rules.Context, val any) bool {
 // Compile prepares the wrapped test when it requires compilation, such as
 // Expr or Matches.
 func (t notTest) Compile(val any) error {
-	if ct, ok := t.test.(interface{ Compile(any) error }); ok {
-		return ct.Compile(val)
-	}
-	return nil
+	return compileTest(val, t.test)
 }
 
 // String provides the string representation of the test.

--- a/rules/is/not_test.go
+++ b/rules/is/not_test.go
@@ -1,0 +1,71 @@
+package is_test
+
+import (
+	"testing"
+
+	"github.com/invopop/gobl/rules"
+	"github.com/invopop/gobl/rules/is"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNot(t *testing.T) {
+	alwaysPass := is.Func("pass", func(any) bool { return true })
+	alwaysFail := is.Func("fail", func(any) bool { return false })
+
+	t.Run("wrapped test passes", func(t *testing.T) {
+		assert.False(t, is.Not(alwaysPass).Check("x"))
+	})
+
+	t.Run("wrapped test fails", func(t *testing.T) {
+		assert.True(t, is.Not(alwaysFail).Check("x"))
+	})
+
+	t.Run("String output", func(t *testing.T) {
+		assert.Equal(t, "not (pass)", is.Not(alwaysPass).String())
+	})
+
+	t.Run("context-aware wrapped test", func(t *testing.T) {
+		nt := is.Not(contextTest{key: "k", expect: "v"})
+		ct, ok := nt.(rules.ContextualTest)
+		require.True(t, ok)
+
+		rc := &rules.Context{}
+		rc.Set("k", "v")
+		assert.False(t, ct.CheckWithContext(rc, nil))
+
+		rc = &rules.Context{}
+		rc.Set("k", "other")
+		assert.True(t, ct.CheckWithContext(rc, nil))
+	})
+
+	t.Run("compiles wrapped test", func(t *testing.T) {
+		type notThing struct {
+			Code string `json:"code"`
+		}
+		set := rules.For(new(notThing),
+			rules.Field("code",
+				rules.Assert("001", "code must not be numeric",
+					is.Not(is.Matches(`^\d+$`)),
+				),
+			),
+		)
+		assert.Nil(t, set.Validate(&notThing{Code: "foo"}))
+		assert.NotNil(t, set.Validate(&notThing{Code: "1234"}))
+	})
+
+	t.Run("wrapped test needs no compilation", func(t *testing.T) {
+		type notPlain struct {
+			Code string `json:"code"`
+		}
+		set := rules.For(new(notPlain),
+			rules.Field("code",
+				rules.Assert("001", "code is required",
+					is.Not(is.Empty),
+				),
+			),
+		)
+		assert.Nil(t, set.Validate(&notPlain{Code: "foo"}))
+		assert.NotNil(t, set.Validate(&notPlain{}))
+	})
+}

--- a/rules/is/one_of.go
+++ b/rules/is/one_of.go
@@ -60,6 +60,12 @@ func (t oneOfTest) CheckWithContext(rc *rules.Context, val any) bool {
 	return passed == 1
 }
 
+// Compile prepares each of the wrapped tests that require compilation, such as
+// Expr or Matches.
+func (t oneOfTest) Compile(val any) error {
+	return compileTests(val, t.tests)
+}
+
 // String provides the string representation of the test.
 func (t oneOfTest) String() string {
 	return t.desc

--- a/rules/is/one_of_test.go
+++ b/rules/is/one_of_test.go
@@ -97,3 +97,26 @@ func TestOneOfCheckWithContext(t *testing.T) {
 		assert.True(t, ct.CheckWithContext(rc, nil))
 	})
 }
+
+func TestOneOfCompile(t *testing.T) {
+	type oneOfThing struct {
+		Code string `json:"code"`
+	}
+
+	t.Run("compiles wrapped tests", func(t *testing.T) {
+		set := rules.For(new(oneOfThing),
+			rules.Field("code",
+				rules.Assert("001", "code must be numeric or empty, not both",
+					is.OneOf(is.Matches(`^\d+$`), is.Empty),
+				),
+			),
+		)
+		assert.Nil(t, set.Validate(&oneOfThing{Code: "123"}))
+		assert.NotNil(t, set.Validate(&oneOfThing{Code: "abc"}))
+	})
+
+	t.Run("reports compilation errors", func(t *testing.T) {
+		ooTest := is.OneOf(is.Matches(`^(\d+$`)).(interface{ Compile(any) error })
+		assert.Error(t, ooTest.Compile(new(oneOfThing)))
+	})
+}


### PR DESCRIPTION
- Adds `IdentityTypeCPR` alongside the existing `IdentityTypeCVR` in the DK regime, plus a normalizer that strips separators (`DDMMYY-SSSS` -> `DDMMYYSSSS`) and format-only validation (10 digits, no checksum -- Denmark deprecated it post-2007, and replacement CPR numbers offset the day by +60 so a calendar check would reject legitimate ones).
- Widens the supplier rule (`GOBL-DK-BILL-INVOICE-01`) to accept either a tax ID, a CVR identity, or a CPR identity. A CPR-identified supplier is a natural person (not a VAT-registered business).
- Registers `dk-oioubl-v2` (`github.com/invopop/gobl.dk.oioubl`) on the approved external addon list.
- Adds `examples/dk/invoice-cpr.json` showing a CPR-identified freelance supplier.

## Pre-Review Checklist

- [x] Opened this PR as a draft
- [x] Read the CONTRIBUTING.md guide.
- [x] Performed a self-review of my code.
- [x] Added thorough tests with at **least** 90% code coverage.
- [x] Modified or created example GOBL documents to show my changes in use, if appropriate.
- [x] Added links to the source of the changes in tax regimes or addons, either structured or in the comments.
- [x] Run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [x] Reviewed and fixed all linter warnings.
- [x] Been obsessive with pointer nil checks to avoid panics.
- [x] Updated the CHANGELOG.md with an overview of my changes.
- [x] Marked this PR as ready for review.

And if you are part of the org:
- [x] Requested a review from Copilot and fixed or dismissed (with a reason) all the feedback raised.
- [x] Requested a review from @samlown.
