### PR TITLE
WIP: share removed included taxes out between the rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Added
+
+- `tax`: `TotalCalculator.ExtractIncludedTaxes` provides the total of each taxable line with the included tax taken out, as shared by the `currency` rounding rule, so that the results add up to the bases determined by `Calculate`.
+
+### Fixed
+
+- `bill`: `RemoveIncludedTaxes` with the `currency` rounding rule now shares the removed tax out between the rows in the same way the tax totals do, instead of removing it from each price on its own. Line prices are nudged so that the resulting document keeps the tax bases it was issued with, and gains the accuracy needed for the line sums to still be recalculated from the prices presented. Previously a hotel invoice of 12 nights at a tax-inclusive 125.00 with 6% VAT ended up with a base of 1415.04 instead of 1415.09, and a `totals.rounding` of 0.06 that formats unable to express it would silently drop.
+
 ## [v0.503.0] - 2026-07-15
 
 ### Added

--- a/bill/calculator.go
+++ b/bill/calculator.go
@@ -75,18 +75,10 @@ func calculate(doc billable) error {
 
 	// Figure out rounding rules and if prices include tax early
 	var pit cbc.Code
-	var rr cbc.Key
-	if tx := doc.getTax(); tx != nil {
-		if tx.PricesInclude != "" {
-			pit = tx.PricesInclude
-		}
-		if tx.Rounding != "" {
-			rr = tx.Rounding
-		}
+	if tx := doc.getTax(); tx != nil && tx.PricesInclude != "" {
+		pit = tx.PricesInclude
 	}
-	if rr == "" {
-		rr = r.GetRoundingRule()
-	}
+	rr := roundingRule(doc)
 
 	// Do we need to deal with the customer-rates tag?
 	if doc.HasTags(tax.TagCustomerRates) {
@@ -256,6 +248,15 @@ func calculateOrgDocumentRefs(drs []*org.DocumentRef, cur currency.Code, rr cbc.
 	}
 }
 
+// roundingRule provides the rounding rule to use for the document's
+// calculations, either the one explicitly requested or the regime's default.
+func roundingRule(doc billable) cbc.Key {
+	if tx := doc.getTax(); tx != nil && tx.Rounding != "" {
+		return tx.Rounding
+	}
+	return doc.RegimeDef().GetRoundingRule()
+}
+
 func canRemoveIncludedTaxes(doc billable) bool {
 	return doc.getTax() != nil && !doc.getTax().PricesInclude.IsEmpty()
 }
@@ -267,6 +268,15 @@ func removeIncludedTaxes(doc billable) error {
 	tpi := doc.getTax().PricesInclude
 
 	totalWithTax := doc.getTotals().TotalWithTax
+
+	// Figure out the totals every row should end up with before touching any
+	// of the prices, as with the currency rounding rule the included tax is
+	// shared out between the rows instead of being removed from each one
+	// independently.
+	nt, err := prepareIncludedTaxNetTotals(doc, tpi)
+	if err != nil {
+		return err
+	}
 
 	doc.setTotals(new(Totals))
 	lines := doc.getLines()
@@ -291,6 +301,10 @@ func removeIncludedTaxes(doc billable) error {
 	tx.PricesInclude = ""
 
 	if err := calculate(doc); err != nil {
+		return err
+	}
+
+	if err := nt.align(doc); err != nil {
 		return err
 	}
 

--- a/bill/calculator_test.go
+++ b/bill/calculator_test.go
@@ -320,6 +320,204 @@ func TestRemoveIncludedTaxes(t *testing.T) {
 	})
 }
 
+func TestRemoveIncludedTaxesCurrencyRounding(t *testing.T) {
+	// roomRates provides the tax-inclusive lines of the hotel invoice that
+	// motivated sharing the removed tax out between the lines: 12 nights at
+	// 125.00 with 6% VAT included, whose base is 1415.09 even though removing
+	// the tax from each price on its own only adds up to 1415.04.
+	roomRates := func(n int) []*bill.Line {
+		lines := make([]*bill.Line, n)
+		for i := range lines {
+			lines[i] = &bill.Line{
+				Quantity: num.MakeAmount(1, 0),
+				Item: &org.Item{
+					Name:  "Room rate",
+					Price: num.NewAmount(12500, 2),
+				},
+				Taxes: tax.Set{
+					{
+						Category: tax.CategoryVAT,
+						Percent:  num.NewPercentage(6, 2),
+					},
+				},
+			}
+		}
+		return lines
+	}
+	// lineSum adds up the totals of every line in the invoice.
+	lineSum := func(inv *bill.Invoice) num.Amount {
+		sum := num.MakeAmount(0, 2)
+		for _, l := range inv.Lines {
+			sum = sum.Add(*l.Total)
+		}
+		return sum
+	}
+
+	t.Run("multiple lines", func(t *testing.T) {
+		inv := baseInvoice(t, roomRates(12)...)
+		inv.Tax.Rounding = tax.RoundingRuleCurrency
+		require.NoError(t, inv.Calculate())
+		require.NoError(t, inv.RemoveIncludedTaxes())
+
+		assert.Equal(t, "1415.09", inv.Totals.Sum.String())
+		assert.Equal(t, "1415.09", inv.Totals.Total.String())
+		assert.Equal(t, "84.91", inv.Totals.Tax.String())
+		assert.Equal(t, "1500.00", inv.Totals.TotalWithTax.String())
+		assert.Equal(t, "1500.00", inv.Totals.Payable.String())
+		assert.Nil(t, inv.Totals.Rounding, "no compensation needed")
+
+		rt := inv.Totals.Taxes.Categories[0].Rates[0]
+		assert.Equal(t, "1415.09", rt.Base.String())
+		assert.Equal(t, "84.91", rt.Amount.String())
+
+		// The lines carry the remainder, so they still add up to the base and
+		// each of their sums can be recalculated from the price presented.
+		assert.Equal(t, "1415.09", lineSum(inv).String())
+		assert.Equal(t, "117.9245", inv.Lines[0].Item.Price.String())
+		assert.Equal(t, "117.92", inv.Lines[0].Total.String())
+		assert.Equal(t, "117.93", inv.Lines[1].Item.Price.String())
+		assert.Equal(t, "117.93", inv.Lines[1].Total.String())
+		for _, l := range inv.Lines {
+			recalc := l.Item.Price.Multiply(l.Quantity).Rescale(2)
+			assert.Equal(t, l.Sum.String(), recalc.String(), "line %d", l.Index)
+		}
+	})
+
+	t.Run("large quantity", func(t *testing.T) {
+		// A single line needs more accuracy in its price to be able to absorb
+		// the remainder of a large quantity.
+		lines := roomRates(1)
+		lines[0].Quantity = num.MakeAmount(1000, 0)
+		inv := baseInvoice(t, lines...)
+		inv.Tax.Rounding = tax.RoundingRuleCurrency
+		require.NoError(t, inv.Calculate())
+		require.NoError(t, inv.RemoveIncludedTaxes())
+
+		assert.Equal(t, "117.92453", inv.Lines[0].Item.Price.String())
+		assert.Equal(t, "117924.53", inv.Totals.Total.String())
+		assert.Equal(t, "125000.00", inv.Totals.TotalWithTax.String())
+		assert.Nil(t, inv.Totals.Rounding)
+	})
+
+	t.Run("with line discounts", func(t *testing.T) {
+		lines := roomRates(10)
+		lines[0].Quantity = num.MakeAmount(3, 0)
+		lines[0].Discounts = []*bill.LineDiscount{
+			{
+				Percent: num.NewPercentage(10, 2),
+				Reason:  "promo",
+			},
+		}
+		inv := baseInvoice(t, lines...)
+		inv.Tax.Rounding = tax.RoundingRuleCurrency
+		require.NoError(t, inv.Calculate())
+		require.NoError(t, inv.RemoveIncludedTaxes())
+
+		assert.Equal(t, "1379.72", inv.Totals.Total.String())
+		assert.Equal(t, "1462.50", inv.Totals.TotalWithTax.String())
+		assert.Nil(t, inv.Totals.Rounding)
+		assert.Equal(t, "1379.72", lineSum(inv).String())
+		assert.Equal(t, "117.927", inv.Lines[0].Item.Price.String())
+		assert.Equal(t, "353.78", inv.Lines[0].Sum.String())
+	})
+
+	t.Run("with a document discount", func(t *testing.T) {
+		inv := baseInvoice(t, roomRates(12)...)
+		inv.Tax.Rounding = tax.RoundingRuleCurrency
+		inv.Discounts = []*bill.Discount{
+			{
+				Amount: num.MakeAmount(3333, 2),
+				Reason: "goodwill",
+				Taxes: tax.Set{
+					{
+						Category: tax.CategoryVAT,
+						Percent:  num.NewPercentage(6, 2),
+					},
+				},
+			},
+		}
+		require.NoError(t, inv.Calculate())
+		require.NoError(t, inv.RemoveIncludedTaxes())
+
+		assert.Equal(t, "31.44", inv.Totals.Discount.String())
+		assert.Equal(t, "1383.65", inv.Totals.Total.String())
+		assert.Equal(t, "1466.67", inv.Totals.TotalWithTax.String())
+		assert.Nil(t, inv.Totals.Rounding)
+	})
+
+	t.Run("with a document charge", func(t *testing.T) {
+		inv := baseInvoice(t, roomRates(12)...)
+		inv.Tax.Rounding = tax.RoundingRuleCurrency
+		inv.Charges = []*bill.Charge{
+			{
+				Amount: num.MakeAmount(3333, 2),
+				Reason: "late checkout",
+				Taxes: tax.Set{
+					{
+						Category: tax.CategoryVAT,
+						Percent:  num.NewPercentage(6, 2),
+					},
+				},
+			},
+		}
+		require.NoError(t, inv.Calculate())
+		require.NoError(t, inv.RemoveIncludedTaxes())
+
+		assert.Equal(t, "31.45", inv.Totals.Charge.String())
+		assert.Equal(t, "1446.54", inv.Totals.Total.String())
+		assert.Equal(t, "1533.33", inv.Totals.TotalWithTax.String())
+		assert.Nil(t, inv.Totals.Rounding)
+	})
+
+	t.Run("multiple rates", func(t *testing.T) {
+		extra := func(name string, price *num.Amount, percent *num.Percentage) *bill.Line {
+			return &bill.Line{
+				Quantity: num.MakeAmount(1, 0),
+				Item: &org.Item{
+					Name:  name,
+					Price: price,
+				},
+				Taxes: tax.Set{
+					{
+						Category: tax.CategoryVAT,
+						Percent:  percent,
+					},
+				},
+			}
+		}
+		lines := append(roomRates(2),
+			extra("Breakfast", num.NewAmount(1250, 2), num.NewPercentage(13, 2)),
+			extra("Breakfast", num.NewAmount(1250, 2), num.NewPercentage(13, 2)),
+			extra("Dinner menu", num.NewAmount(3580, 2), num.NewPercentage(13, 2)),
+			extra("Minibar drinks", num.NewAmount(795, 2), num.NewPercentage(23, 2)),
+			extra("Spa access", num.NewAmount(4500, 2), num.NewPercentage(23, 2)),
+		)
+		inv := baseInvoice(t, lines...)
+		inv.Tax.Rounding = tax.RoundingRuleCurrency
+		require.NoError(t, inv.Calculate())
+		bases := make([]string, 0, 3)
+		for _, rt := range inv.Totals.Taxes.Categories[0].Rates {
+			bases = append(bases, rt.Base.String())
+		}
+		require.NoError(t, inv.RemoveIncludedTaxes())
+
+		// Every rate keeps the base the invoice was issued with, sharing the
+		// remainder out between its own lines.
+		for i, rt := range inv.Totals.Taxes.Categories[0].Rates {
+			assert.Equal(t, bases[i], rt.Base.String(), "rate %s", rt.Percent)
+		}
+		assert.Equal(t, []string{"235.85", "53.81", "43.05"}, bases)
+		assert.Equal(t, "332.71", inv.Totals.Total.String())
+		assert.Equal(t, "332.71", lineSum(inv).String())
+
+		// The 13% tax of 6.99 that the tax-inclusive totals produced cannot be
+		// recalculated from a base of 53.81, which gives 7.00, so the resulting
+		// cent still needs to be compensated for.
+		assert.Equal(t, "-0.01", inv.Totals.Rounding.String())
+		assert.Equal(t, "363.75", inv.Totals.Payable.String())
+	})
+}
+
 func TestCalculatePricesIncludeCurrencyRounding(t *testing.T) {
 	t.Run("multiple lines", func(t *testing.T) {
 		lines := make([]*bill.Line, 12)

--- a/bill/invoice.go
+++ b/bill/invoice.go
@@ -310,8 +310,12 @@ func (inv *Invoice) supportedTags() []cbc.Key {
 //
 // This method will call "Calculate" on the invoice automatically after removing the taxes.
 //
-// If after removing taxes the totals don't match, a rounding error will be added to the
-// invoice totals. In most scenarios this shouldn't be more than a cent or two.
+// With the "currency" rounding rule the tax is shared out between the rows in the same
+// way the tax totals determine it, adjusting the net prices so that the invoice keeps the
+// tax bases it was issued with.
+//
+// If after removing taxes the totals still don't match, a rounding error will be added to
+// the invoice totals. In most scenarios this shouldn't be more than a cent or two.
 //
 // This method will replace the invoice contents in place, or return an error.
 func (inv *Invoice) RemoveIncludedTaxes() error {

--- a/bill/tax_removal.go
+++ b/bill/tax_removal.go
@@ -1,0 +1,217 @@
+package bill
+
+import (
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/currency"
+	"github.com/invopop/gobl/num"
+	"github.com/invopop/gobl/tax"
+)
+
+const (
+	// maxIncludedTaxAlignPasses limits how many times a document is
+	// recalculated while lining its rows up with their net totals.
+	maxIncludedTaxAlignPasses = 4
+	// maxIncludedTaxPriceAccuracy is the most extra decimal places that may be
+	// added to a net item price in order to reproduce a line's sum.
+	maxIncludedTaxPriceAccuracy uint32 = 6
+)
+
+// includedTaxNetTotals holds the total that each of a document's rows should
+// end up with once the taxes included in their prices have been removed. The
+// lists are aligned with the document's own, with nil entries for rows whose
+// total is of no interest.
+type includedTaxNetTotals struct {
+	cur       currency.Code
+	cat       cbc.Code
+	lines     []*num.Amount
+	discounts []*num.Amount
+	charges   []*num.Amount
+}
+
+// netTotalSlot points at the entry reserved for a row inside one of the
+// net total lists.
+type netTotalSlot struct {
+	list  []*num.Amount
+	index int
+}
+
+// prepareIncludedTaxNetTotals works out the total that each of the document's
+// rows should have once the taxes included in their prices have been removed.
+//
+// Only the currency rounding rule needs this: it extracts the tax from the sum
+// of each rate's tax-inclusive totals and shares it back over the rows, so
+// removing the tax from each price on its own rounds every row down and leaves
+// the document's tax bases short by a subunit or two. With precise rounding the
+// extra accuracy maintained in the prices already keeps the sums aligned.
+func prepareIncludedTaxNetTotals(doc billable, cat cbc.Code) (*includedTaxNetTotals, error) {
+	if roundingRule(doc) != tax.RoundingRuleCurrency {
+		return nil, nil
+	}
+
+	lines := doc.getLines()
+	discounts := doc.getDiscounts()
+	charges := doc.getCharges()
+
+	nt := &includedTaxNetTotals{
+		cur:       doc.GetCurrency(),
+		cat:       cat,
+		lines:     make([]*num.Amount, len(lines)),
+		discounts: make([]*num.Amount, len(discounts)),
+		charges:   make([]*num.Amount, len(charges)),
+	}
+
+	// Build the same list of taxable rows the calculator works with, keeping
+	// track of where each of the results belongs.
+	tls := make([]tax.TaxableLine, 0, len(lines)+len(discounts)+len(charges))
+	slots := make([]netTotalSlot, 0, cap(tls))
+	for i, l := range lines {
+		if l == nil || l.Total == nil {
+			continue
+		}
+		tls = append(tls, l)
+		slots = append(slots, netTotalSlot{nt.lines, i})
+	}
+	for i, d := range discounts {
+		if d == nil {
+			continue
+		}
+		tls = append(tls, d)
+		slots = append(slots, netTotalSlot{nt.discounts, i})
+	}
+	for i, c := range charges {
+		if c == nil {
+			continue
+		}
+		tls = append(tls, c)
+		slots = append(slots, netTotalSlot{nt.charges, i})
+	}
+	if len(tls) == 0 {
+		return nil, nil
+	}
+
+	date := doc.getValueDate()
+	if date == nil {
+		id := doc.getIssueDate()
+		date = &id
+	}
+	tc := &tax.TotalCalculator{
+		Currency: nt.cur,
+		Rounding: tax.RoundingRuleCurrency,
+		Country:  doc.RegimeDef().GetCountry(),
+		Date:     *date,
+		Lines:    tls,
+		Includes: cat,
+	}
+	totals, err := tc.ExtractIncludedTaxes()
+	if err != nil {
+		return nil, err
+	}
+	for i, total := range totals {
+		slots[i].list[slots[i].index] = &total
+	}
+
+	return nt, nil
+}
+
+// align nudges the prices and amounts of the document's rows until their totals
+// match the net totals, recalculating in between as line discounts and charges
+// may shift the results. Line prices are adjusted instead of the line totals
+// directly, so that every amount presented can still be recalculated from the
+// data alongside it.
+func (nt *includedTaxNetTotals) align(doc billable) error {
+	if nt == nil {
+		return nil
+	}
+	for range maxIncludedTaxAlignPasses {
+		if !nt.nudge(doc) {
+			return nil
+		}
+		if err := calculate(doc); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// nudge moves each of the document's rows towards its net total, reporting
+// whether anything was changed.
+func (nt *includedTaxNetTotals) nudge(doc billable) bool {
+	changed := false
+	for i, l := range doc.getLines() {
+		if i < len(nt.lines) && nt.nudgeLine(l, nt.lines[i]) {
+			changed = true
+		}
+	}
+	for i, d := range doc.getDiscounts() {
+		if i >= len(nt.discounts) || nt.discounts[i] == nil {
+			continue
+		}
+		// Percentages are always recalculated from the document's new sum.
+		if d == nil || d.Percent != nil || !hasTaxPercent(d.Taxes, nt.cat) {
+			continue
+		}
+		if a := nt.discounts[i].Negate(); !a.Equals(d.Amount) {
+			d.Amount = a
+			changed = true
+		}
+	}
+	for i, c := range doc.getCharges() {
+		if i >= len(nt.charges) || nt.charges[i] == nil {
+			continue
+		}
+		if c == nil || c.Percent != nil || !hasTaxPercent(c.Taxes, nt.cat) {
+			continue
+		}
+		if a := *nt.charges[i]; !a.Equals(c.Amount) {
+			c.Amount = a
+			changed = true
+		}
+	}
+	return changed
+}
+
+// nudgeLine adjusts the line's net item price so that the line's total matches
+// the net total provided, reporting whether the price was changed.
+func (nt *includedTaxNetTotals) nudgeLine(l *Line, net *num.Amount) bool {
+	if net == nil || l == nil || l.Sum == nil || l.Total == nil ||
+		l.Item == nil || l.Item.Price == nil || !hasTaxPercent(l.Taxes, nt.cat) {
+		return false
+	}
+	diff := net.Subtract(*l.Total)
+	if diff.IsZero() {
+		return false
+	}
+	// The net total accounts for the line's discounts and charges, but it is
+	// the sum that the item's price determines, so shift it by the same
+	// difference.
+	price := netItemPrice(l.Sum.Add(diff), l.Quantity, nt.cur)
+	if price == nil {
+		return false
+	}
+	l.Item.Price = price
+	return true
+}
+
+// netItemPrice provides the item price that will reproduce the given line sum
+// for the quantity, using the least accuracy needed so that the price
+// presented can be multiplied back into the sum.
+func netItemPrice(sum, quantity num.Amount, cur currency.Code) *num.Amount {
+	if quantity.IsZero() {
+		return nil
+	}
+	for extra := uint32(0); extra <= maxIncludedTaxPriceAccuracy; extra++ {
+		price := sum.Upscale(extra).Divide(quantity)
+		got := tax.ApplyRoundingRule(tax.RoundingRuleCurrency, cur, price.Multiply(quantity))
+		if got.Equals(sum) {
+			return &price
+		}
+	}
+	return nil
+}
+
+// hasTaxPercent determines if the set includes a percentage for the category,
+// which is what makes a row's price subject to tax removal.
+func hasTaxPercent(ts tax.Set, cat cbc.Code) bool {
+	c := ts.Get(cat)
+	return c != nil && c.Percent != nil
+}

--- a/tax/totals_calculator_currency.go
+++ b/tax/totals_calculator_currency.go
@@ -35,6 +35,39 @@ func (tc *TotalCalculator) calculateCurrencyTotals(t *Total, taxLines []*taxLine
 	return nil
 }
 
+// ExtractIncludedTaxes provides the total of each of the calculator's lines
+// with the tax included in their prices taken out, in the same order as the
+// lines were provided. As the tax is extracted from the sum of each rate's
+// tax-inclusive line totals and shared back over the lines, the results will
+// always add up to the bases determined by Calculate, which removing the tax
+// from every line on its own would not achieve.
+//
+// This is only meaningful with the currency rounding rule, where the line
+// totals are rounded to the currency's precision before being summed.
+func (tc *TotalCalculator) ExtractIncludedTaxes() ([]num.Amount, error) {
+	tc.zero = tc.Currency.Def().Zero()
+
+	taxLines := mapTaxLines(tc.Lines)
+	if err := tc.prepareCombos(taxLines); err != nil {
+		return nil, err
+	}
+	for _, tl := range taxLines {
+		tl.total = tl.total.Rescale(tc.zero.Exp())
+	}
+
+	// The rate totals are only needed to accumulate the running sums.
+	t := &Total{Categories: make([]*CategoryTotal, 0), Sum: tc.zero}
+	if err := tc.extractIncludedTaxes(t, taxLines); err != nil {
+		return nil, err
+	}
+
+	totals := make([]num.Amount, len(taxLines))
+	for i, tl := range taxLines {
+		totals[i] = tl.total
+	}
+	return totals, nil
+}
+
 // extractIncludedTaxes removes the included tax from each line's total.
 // The tax is calculated over the accumulated sum of the rate's tax-inclusive
 // line totals, with each line assuming the increment, so that the resulting

--- a/tax/totals_calculator_test.go
+++ b/tax/totals_calculator_test.go
@@ -1691,3 +1691,82 @@ func TestTotalCalculatorCurrencyRounding(t *testing.T) {
 		assert.Equal(t, "21.00", tot.Sum.String())
 	})
 }
+
+func TestExtractIncludedTaxes(t *testing.T) {
+	date := cal.MakeDate(2026, 7, 9)
+	extract := func(t *testing.T, country l10n.TaxCountryCode, lines ...tax.TaxableLine) []string {
+		t.Helper()
+		tc := &tax.TotalCalculator{
+			Country:  country,
+			Currency: currency.EUR,
+			Rounding: tax.RoundingRuleCurrency,
+			Date:     date,
+			Lines:    lines,
+			Includes: tax.CategoryVAT,
+		}
+		totals, err := tc.ExtractIncludedTaxes()
+		require.NoError(t, err)
+		out := make([]string, len(totals))
+		for i, a := range totals {
+			out[i] = a.String()
+		}
+		return out
+	}
+
+	t.Run("shares the remainder between the lines", func(t *testing.T) {
+		// 12 lines of 125.00 with 6% VAT included: taking the tax out of each
+		// line on its own would leave every one of them at 117.92, adding up to
+		// 1415.04 instead of the rate's base of 1415.09.
+		lines := make([]tax.TaxableLine, 12)
+		for i := range lines {
+			lines[i] = &taxableLine{
+				taxes:  tax.Set{{Category: tax.CategoryVAT, Rate: tax.RateReduced}},
+				amount: num.MakeAmount(12500, 2),
+			}
+		}
+		totals := extract(t, "PT", lines...)
+		assert.Equal(t, []string{
+			"117.92", "117.93", "117.92", "117.93", "117.92", "117.93",
+			"117.92", "117.93", "117.92", "117.93", "117.92", "117.92",
+		}, totals)
+
+		sum := num.MakeAmount(0, 2)
+		for _, a := range totals {
+			v, err := num.AmountFromString(a)
+			require.NoError(t, err)
+			sum = sum.Add(v)
+		}
+		assert.Equal(t, "1415.09", sum.String())
+	})
+
+	t.Run("keeps lines without the included tax", func(t *testing.T) {
+		totals := extract(t, "PT",
+			&taxableLine{
+				taxes:  tax.Set{{Category: tax.CategoryVAT, Rate: tax.RateReduced}},
+				amount: num.MakeAmount(12500, 2),
+			},
+			&taxableLine{
+				taxes:  nil,
+				amount: num.MakeAmount(2000, 2),
+			},
+		)
+		assert.Equal(t, []string{"117.92", "20.00"}, totals)
+	})
+
+	t.Run("with an invalid included category", func(t *testing.T) {
+		_, err := (&tax.TotalCalculator{
+			Country:  "ES",
+			Currency: currency.EUR,
+			Rounding: tax.RoundingRuleCurrency,
+			Date:     date,
+			Lines: []tax.TaxableLine{
+				&taxableLine{
+					taxes:  tax.Set{{Category: es.TaxCategoryIRPF, Rate: "pro"}},
+					amount: num.MakeAmount(10000, 2),
+				},
+			},
+			Includes: es.TaxCategoryIRPF,
+		}).ExtractIncludedTaxes()
+		assert.ErrorContains(t, err, "cannot include retained category")
+	})
+}


### PR DESCRIPTION
Follow-up to #895, which fixed the tax-inclusive **totals** under `rounding: currency` but not what happens when those prices are subsequently **removed** — which is mandatory for SAF-T/AT, as the format cannot express VAT-inclusive prices. Portuguese payment receipts were still being rejected as a result (Pylon #5267, customer Cloudbeds).

The currency calculator extracts the included tax from the sum of each rate's tax-inclusive line totals and shares it back over the lines, so a rate's base is *not* the sum of the tax removed from each line on its own. `RemoveIncludedTaxes` did the latter, rounding every line down: 12 nights at a tax-inclusive 125.00 with 6% VAT came out with a base of 1415.04 instead of the 1415.09 the invoice was issued with, plus a `totals.rounding` of 0.06 that formats unable to express it silently drop.

- `tax`: new exported `TotalCalculator.ExtractIncludedTaxes`, returning the total of each taxable line with the included tax taken out. This is the same per-line distribution `calculateCurrencyTotals` already performed internally and threw away, so there is no second implementation to keep in step.
- `bill`: `RemoveIncludedTaxes` under `rounding: currency` now snapshots the net total every row should end up with *before* touching the prices, then nudges the net line prices (and fixed document discount/charge amounts) until they add up to it, recalculating in between so line discounts and charges settle. Each nudged price takes the least accuracy that still reproduces its line's sum, so the sums stay recalculable from the prices presented; large quantities pick up extra decimals as needed (`117.92453` for a quantity of 1000).
- Documents using `rounding: precise` are untouched — every pre-existing removal test passes unchanged.

Result for the invoice above: base **1415.09**, tax **84.91**, `total_with_tax` **1500.00**, no `totals.rounding`, with the lines carrying the remainder as 7 × 117.9245 + 5 × 117.93. Checked end-to-end against `at-pt`: SAF-T now renders `NetTotal` 1415.09 / `TaxPayable` 84.91 / `GrossTotal` 1500.00, and a receipt with base 1415.09 passes both `validatePaymentLine` and `AvailToPay.ApplyPayment` — the two checks that previously demanded different roundings of the same economics and so could not both be satisfied.

Multi-rate documents now get the correct base for every rate. A ±0.01 residual can still remain where a rate's tax cannot be recalculated from its own 2-decimal base at all (13% of 53.81 gives 7.00, but the tax-inclusive 60.80 implies 6.99); that is irreducible and still lands in `totals.rounding`, which is exactly what the field is for.

## Pre-Review Checklist

- [x] Opened this PR as a draft
- [x] Read the CONTRIBUTING.md guide.
- [x] Performed a self-review of my code.
- [x] Added thorough tests with at **least** 90% code coverage.
- [ ] Modified or created example GOBL documents to show my changes in use, if appropriate. — n/a: the example runner only calculates, it never calls `RemoveIncludedTaxes`, so no example can exercise this path. The `pt` and `es` `prices-include` examples added in #895 already cover the calculation side.
- [x] Added links to the source of the changes in tax regimes or addons, either structured or in the comments.
- [x] Run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [x] Reviewed and fixed all linter warnings.
- [x] Been obsessive with pointer nil checks to avoid panics.
- [x] Updated the CHANGELOG.md with an overview of my changes.
- [ ] Marked this PR as ready for review.

And if you are part of the org:
- [ ] Requested a review from Copilot and fixed or dismissed (with a reason) all the feedback raised.
- [ ] Requested a review from @samlown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
