### PR TITLE
Allow item attributes to hold more than one value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Changed
+
+- `org`: an `Attribute` may now hold more than one of the `text`, `code`, `amount`, or `date` values, where before exactly one was required, so that formats grouping related values under a single name can be mapped directly. At least one value is still needed.
+
 ## [v0.503.0] - 2026-07-15
 
 ### Added

--- a/data/rules/org.json
+++ b/data/rules/org.json
@@ -44,8 +44,8 @@
         },
         {
           "id": "GOBL-ORG-ATTRIBUTE-02",
-          "desc": "attribute must have exactly one of the text, code, amount, or date values",
-          "tests": "(Text == \"\" ? 0 : 1) + (string(Code) == \"\" ? 0 : 1) + (Amount == nil ? 0 : 1) + (Date == nil ? 0 : 1) == 1"
+          "desc": "attribute must have at least one of the text, code, amount, or date values",
+          "tests": "(Text == \"\" ? 0 : 1) + (string(Code) == \"\" ? 0 : 1) + (Amount == nil ? 0 : 1) + (Date == nil ? 0 : 1) \u003e= 1"
         }
       ],
       "subsets": [

--- a/org/attribute.go
+++ b/org/attribute.go
@@ -151,7 +151,7 @@ var AttributeKeyDefinitions = []*cbc.Definition{
 
 // Attribute describes a named feature or property of the parent object,
 // such as the color or size of an item. Attributes are identified by
-// either a key or a type, and hold exactly one of the text, code, amount,
+// either a key or a type, and hold at least one of the text, code, amount,
 // or date value fields.
 type Attribute struct {
 	// Label for the attribute, used for presentation in converted outputs
@@ -168,7 +168,7 @@ type Attribute struct {
 	// and customer.
 	Type cbc.Code `json:"type,omitempty" jsonschema:"title=Type"`
 
-	// Value fields; exactly one must be provided.
+	// Value fields; at least one must be provided.
 
 	// Text value of the attribute.
 	Text string `json:"text,omitempty" jsonschema:"title=Text"`
@@ -188,8 +188,8 @@ func attributeRules() *rules.Set {
 		rules.Assert("01", "attribute must have either a key or a type, but not both",
 			is.Expr(`(string(Key) == "") != (string(Type) == "")`),
 		),
-		rules.Assert("02", "attribute must have exactly one of the text, code, amount, or date values",
-			is.Expr(`(Text == "" ? 0 : 1) + (string(Code) == "" ? 0 : 1) + (Amount == nil ? 0 : 1) + (Date == nil ? 0 : 1) == 1`),
+		rules.Assert("02", "attribute must have at least one of the text, code, amount, or date values",
+			is.Expr(`(Text == "" ? 0 : 1) + (string(Code) == "" ? 0 : 1) + (Amount == nil ? 0 : 1) + (Date == nil ? 0 : 1) >= 1`),
 		),
 		rules.When(is.Expr(`string(Unit) != ""`),
 			rules.Assert("03", "attribute unit may only be used alongside an amount",

--- a/org/attribute_test.go
+++ b/org/attribute_test.go
@@ -74,27 +74,35 @@ func TestAttributeValidation(t *testing.T) {
 		}
 		assert.ErrorContains(t, rules.Validate(a), "attribute must have either a key or a type, but not both")
 	})
-	t.Run("missing value", func(t *testing.T) {
+	t.Run("valid with text and date", func(t *testing.T) {
 		a := &org.Attribute{
-			Key: org.AttributeKeyColor,
+			Type: "INTENTO",
+			Text: "08060120341234567-000001",
+			Date: cal.NewDate(2026, time.March, 10),
 		}
-		assert.ErrorContains(t, rules.Validate(a), "attribute must have exactly one of the text, code, amount, or date values")
+		assert.NoError(t, rules.Validate(a))
 	})
-	t.Run("multiple values", func(t *testing.T) {
+	t.Run("valid with text and amount", func(t *testing.T) {
 		a := &org.Attribute{
 			Key:    org.AttributeKeyWeight,
 			Text:   "200g",
 			Amount: num.NewAmount(200, 0),
 		}
-		assert.ErrorContains(t, rules.Validate(a), "attribute must have exactly one of the text, code, amount, or date values")
+		assert.NoError(t, rules.Validate(a))
 	})
-	t.Run("text and code", func(t *testing.T) {
+	t.Run("valid with text and code", func(t *testing.T) {
 		a := &org.Attribute{
 			Key:  org.AttributeKeyColor,
 			Text: "Black",
 			Code: "RAL 9005",
 		}
-		assert.ErrorContains(t, rules.Validate(a), "attribute must have exactly one of the text, code, amount, or date values")
+		assert.NoError(t, rules.Validate(a))
+	})
+	t.Run("missing value", func(t *testing.T) {
+		a := &org.Attribute{
+			Key: org.AttributeKeyColor,
+		}
+		assert.ErrorContains(t, rules.Validate(a), "attribute must have at least one of the text, code, amount, or date values")
 	})
 	t.Run("unit without amount", func(t *testing.T) {
 		a := &org.Attribute{


### PR DESCRIPTION
* `org`: rule `GOBL-ORG-ATTRIBUTE-02` relaxed from *exactly one* of `text`, `code`, `amount`, or `date` to *at least one*, so an attribute can group related values under a single name. An attribute with no value at all is still invalid.
* Doc comment and `data/rules/org.json` updated to match. The JSON schema is unchanged, as it only carries the first sentence of the type description.
* Tests: the previous "multiple values" and "text and code" failure cases become valid, plus a case for an attribute holding both a text and a date.

## Pre-Review Checklist

- [X] Opened this PR as a draft
- [X] Read the CONTRIBUTING.md guide.
- [X] Performed a self-review of my code.
- [X] Added thorough tests with at **least** 90% code coverage.
- [ ] Modified or created example GOBL documents to show my changes in use, if appropriate.
- [X] Added links to the source of the changes in tax regimes or addons, either structured or in the comments.
- [X] Run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [X] Reviewed and fixed all linter warnings.
- [X] Been obsessive with pointer nil checks to avoid panics.
- [X] Updated the CHANGELOG.md with an overview of my changes.
- [X] Marked this PR as ready for review.

And if you are part of the org:

- [X] Requested a review from Copilot and fixed or dismissed (with a reason) all the feedback raised.
- [X] Requested a review from @samlown.