### PR TITLE
Share party identity tests across regimes and addons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - `addons`: registered `dk-oioubl-v2` (implementation in `github.com/invopop/gobl.dk.oioubl`) on the approved external addon list, so it's now a valid `$addons` value.
 - `rules/is`: new `Not` test that passes when the wrapped test does not.
 - `org`: new `PartyHasTaxIDCode` test for a party with a tax identity code.
+- `org`: new `PartyHasIdentityTypeIn` and `PartyHasIdentityKeyIn` tests for a party carrying an identity with one of the given types or keys.
+
+### Fixed
+
+- `rules/is`: `AnyOf` and `OneOf` now prepare the tests they wrap, so that `Expr` and `Matches` work inside them.
 
 ## [v0.503.0] - 2026-07-15
 

--- a/addons/it/sdi/bill.go
+++ b/addons/it/sdi/bill.go
@@ -13,6 +13,9 @@ import (
 	"github.com/invopop/gobl/tax"
 )
 
+// partyHasTaxIDCode is reused by the invoice guards below.
+var partyHasTaxIDCode = org.PartyHasTaxIDCode()
+
 func normalizeInvoice(inv *bill.Invoice) {
 	normalizeSupplier(inv.Supplier)
 }
@@ -246,7 +249,7 @@ func invoiceCustomerIsItalianWithoutTaxIDCode(val any) bool {
 	if !ok || inv == nil || inv.Customer == nil {
 		return false
 	}
-	return isItalianParty(inv.Customer) && !hasTaxIDCode(inv.Customer)
+	return isItalianParty(inv.Customer) && !partyHasTaxIDCode.Check(inv.Customer)
 }
 
 func invoiceCustomerHasFiscalCodeIdentity(val any) bool {
@@ -291,10 +294,6 @@ func chargeIsFundContribution(val any) bool {
 		return false
 	}
 	return c.Key.Has(KeyFundContribution)
-}
-
-func hasTaxIDCode(party *org.Party) bool {
-	return party != nil && party.TaxID != nil && party.TaxID.Code != ""
 }
 
 func hasFiscalCode(party *org.Party) bool {

--- a/bill/invoice.go
+++ b/bill/invoice.go
@@ -143,7 +143,7 @@ func invoiceRules() *rules.Set {
 			),
 		),
 		rules.Field("customer",
-			rules.When(is.Func("has tax ID code", customerHasTaxIDCode),
+			rules.When(org.PartyHasTaxIDCode(),
 				rules.Field("name",
 					rules.Assert("07", "invoice customer name required when tax ID is set", is.Present),
 				),
@@ -180,19 +180,6 @@ func invoiceHasTaxPoint(val any) bool {
 		return false
 	}
 	return inv != nil && inv.Tax != nil && inv.Tax.Point != cbc.KeyEmpty
-}
-
-func customerHasTaxIDCode(val any) bool {
-	var p *org.Party
-	switch v := val.(type) {
-	case *org.Party:
-		p = v
-	case org.Party:
-		p = &v
-	default:
-		return false
-	}
-	return p != nil && p.TaxID != nil && p.TaxID.Code != ""
 }
 
 func invoiceNeedsLines(val any) bool {

--- a/data/rules/be.json
+++ b/data/rules/be.json
@@ -39,7 +39,7 @@
               "field": "supplier",
               "subsets": [
                 {
-                  "guard": "no BCE identity",
+                  "guard": "not (has a type in [BCE])",
                   "subsets": [
                     {
                       "field": "tax_id",
@@ -66,7 +66,7 @@
                   ]
                 },
                 {
-                  "guard": "no tax ID code",
+                  "guard": "not (has tax ID code)",
                   "subsets": [
                     {
                       "field": "identities",
@@ -74,7 +74,7 @@
                         {
                           "id": "GOBL-BE-BILL-INVOICE-03",
                           "desc": "supplier identities must include BCE type",
-                          "tests": "has BCE type"
+                          "tests": "has a type in [BCE]"
                         }
                       ]
                     }

--- a/data/rules/de.json
+++ b/data/rules/de.json
@@ -15,7 +15,7 @@
                 {
                   "id": "GOBL-DE-BILL-INVOICE-01",
                   "desc": "invoice DE supplier must have either tax ID code or identity with 'de-tax-number' key",
-                  "tests": "has tax ID code or identity with 'de-tax-number' key"
+                  "tests": "has tax ID code, or has a key in [de-tax-number]"
                 }
               ]
             }

--- a/data/rules/fr.json
+++ b/data/rules/fr.json
@@ -15,7 +15,7 @@
                 {
                   "id": "GOBL-FR-BILL-INVOICE-01",
                   "desc": "invoice supplier must have a tax ID code or a SIREN/SIRET identity",
-                  "tests": "has tax ID code or SIREN/SIRET identity"
+                  "tests": "has tax ID code, or has a type in [SIREN, SIRET]"
                 }
               ]
             }

--- a/data/rules/nl.json
+++ b/data/rules/nl.json
@@ -15,7 +15,7 @@
                 {
                   "id": "GOBL-NL-BILL-INVOICE-01",
                   "desc": "invoice supplier must have a tax ID code or a KVK/OIN identity",
-                  "tests": "has tax ID code or KVK/OIN identity"
+                  "tests": "has tax ID code, or has a type in [KVK, OIN]"
                 }
               ]
             }

--- a/data/rules/se.json
+++ b/data/rules/se.json
@@ -41,7 +41,7 @@
                 {
                   "id": "GOBL-SE-BILL-INVOICE-01",
                   "desc": "invoice SE supplier must have either tax ID code or identity with ON, PN, or CN type",
-                  "tests": "has tax ID code or identity with type in [ON, PN, CN]"
+                  "tests": "has tax ID code, or has a type in [ON, PN, CN]"
                 }
               ]
             }

--- a/data/rules/sg.json
+++ b/data/rules/sg.json
@@ -15,7 +15,7 @@
                 {
                   "id": "GOBL-SG-BILL-INVOICE-01",
                   "desc": "invoice supplier in Singapore must have a GST tax ID code or a UEN identity",
-                  "tests": "has GST tax ID code or UEN identity"
+                  "tests": "has tax ID code, or has a type in [UEN]"
                 }
               ]
             }

--- a/org/party.go
+++ b/org/party.go
@@ -91,16 +91,44 @@ func PartyHasTaxIDCode() rules.Test {
 }
 
 func partyHasTaxIDCode(obj any) bool {
-	var p *Party
+	p := partyFrom(obj)
+	return p != nil && p.TaxID != nil && p.TaxID.Code != ""
+}
+
+// PartyHasIdentityTypeIn provides a test that will determine if at least one of
+// the party's identities has one of the given types.
+func PartyHasIdentityTypeIn(typ ...cbc.Code) rules.Test {
+	return partyIdentities(IdentitiesTypeIn(typ...))
+}
+
+// PartyHasIdentityKeyIn provides a test that will determine if at least one of
+// the party's identities has one of the given keys.
+func PartyHasIdentityKeyIn(key ...cbc.Key) rules.Test {
+	return partyIdentities(IdentitiesKeyIn(key...))
+}
+
+// partyIdentities adapts a test for a party's identities so that it can be
+// applied to the party itself.
+func partyIdentities(test rules.Test) rules.Test {
+	return is.Func(test.String(), func(obj any) bool {
+		p := partyFrom(obj)
+		if p == nil {
+			return false
+		}
+		return test.Check(p.Identities)
+	})
+}
+
+// partyFrom extracts a party from either a pointer or a value, as object level
+// tests may receive either shape.
+func partyFrom(obj any) *Party {
 	switch v := obj.(type) {
 	case *Party:
-		p = v
+		return v
 	case Party:
-		p = &v
-	default:
-		return false
+		return &v
 	}
-	return p != nil && p.TaxID != nil && p.TaxID.Code != ""
+	return nil
 }
 
 // JSONSchemaExtend adds extra details to the schema.

--- a/org/party_test.go
+++ b/org/party_test.go
@@ -172,3 +172,58 @@ func TestPartyHasTaxIDCode(t *testing.T) {
 		assert.Equal(t, "has tax ID code", test.String())
 	})
 }
+
+func TestPartyHasIdentityTypeIn(t *testing.T) {
+	test := org.PartyHasIdentityTypeIn("CVR", "CPR")
+
+	t.Run("with matching type", func(t *testing.T) {
+		p := &org.Party{Identities: []*org.Identity{{Type: "CPR", Code: "1111111118"}}}
+		assert.True(t, test.Check(p))
+		assert.True(t, test.Check(*p))
+	})
+
+	t.Run("with other type", func(t *testing.T) {
+		p := &org.Party{Identities: []*org.Identity{{Type: "FOO", Code: "123"}}}
+		assert.False(t, test.Check(p))
+	})
+
+	t.Run("without identities", func(t *testing.T) {
+		assert.False(t, test.Check(&org.Party{}))
+	})
+
+	t.Run("nil party", func(t *testing.T) {
+		var p *org.Party
+		assert.False(t, test.Check(p))
+	})
+
+	t.Run("other type", func(t *testing.T) {
+		assert.False(t, test.Check("foo"))
+	})
+
+	t.Run("description", func(t *testing.T) {
+		assert.Equal(t, "has a type in [CVR, CPR]", test.String())
+	})
+}
+
+func TestPartyHasIdentityKeyIn(t *testing.T) {
+	test := org.PartyHasIdentityKeyIn("de-tax-number")
+
+	t.Run("with matching key", func(t *testing.T) {
+		p := &org.Party{Identities: []*org.Identity{{Key: "de-tax-number", Code: "123"}}}
+		assert.True(t, test.Check(p))
+	})
+
+	t.Run("with other key", func(t *testing.T) {
+		p := &org.Party{Identities: []*org.Identity{{Key: "other", Code: "123"}}}
+		assert.False(t, test.Check(p))
+	})
+
+	t.Run("nil party", func(t *testing.T) {
+		var p *org.Party
+		assert.False(t, test.Check(p))
+	})
+
+	t.Run("description", func(t *testing.T) {
+		assert.Equal(t, "has a key in [de-tax-number]", test.String())
+	})
+}

--- a/regimes/be/bill_invoices.go
+++ b/regimes/be/bill_invoices.go
@@ -15,7 +15,7 @@ func billInvoiceRules() *rules.Set {
 			is.InContext(tax.RegimeIn(l10n.BE.Tax())),
 			rules.Field("supplier",
 				rules.When(
-					is.Func("no BCE identity", supplierNoBCEIdentity),
+					is.Not(org.PartyHasIdentityTypeIn(IdentityTypeBCE)),
 					rules.Field("tax_id",
 						rules.Assert("01", "supplier tax ID required for Belgian regime", is.Present),
 						rules.Field("code",
@@ -24,39 +24,13 @@ func billInvoiceRules() *rules.Set {
 					),
 				),
 				rules.When(
-					is.Func("no tax ID code", supplierNoTaxIDCode),
+					is.Not(org.PartyHasTaxIDCode()),
 					rules.Field("identities",
 						rules.Assert("03", "supplier identities must include BCE type",
-							is.Func("has BCE type", identitiesIncludeBCE)),
+							org.IdentitiesTypeIn(IdentityTypeBCE)),
 					),
 				),
 			),
 		),
 	)
-}
-
-func supplierNoBCEIdentity(val any) bool {
-	p, _ := val.(*org.Party)
-	return !hasIdentityBCE(p)
-}
-
-func supplierNoTaxIDCode(val any) bool {
-	p, _ := val.(*org.Party)
-	return !hasTaxIDCode(p)
-}
-
-func identitiesIncludeBCE(val any) bool {
-	idents, _ := val.([]*org.Identity)
-	return org.IdentityForType(idents, IdentityTypeBCE) != nil
-}
-
-func hasTaxIDCode(party *org.Party) bool {
-	return party != nil && party.TaxID != nil && party.TaxID.Code != ""
-}
-
-func hasIdentityBCE(party *org.Party) bool {
-	if party == nil || len(party.Identities) == 0 {
-		return false
-	}
-	return org.IdentityForType(party.Identities, IdentityTypeBCE) != nil
 }

--- a/regimes/de/bill_invoices.go
+++ b/regimes/de/bill_invoices.go
@@ -17,28 +17,12 @@ func billInvoiceRules() *rules.Set {
 			is.InContext(tax.RegimeIn(l10n.DE.Tax())),
 			rules.Field("supplier",
 				rules.Assert("01", fmt.Sprintf("invoice DE supplier must have either tax ID code or identity with '%s' key", IdentityKeyTaxNumber),
-					is.Func(
-						fmt.Sprintf("has tax ID code or identity with '%s' key", IdentityKeyTaxNumber),
-						hasTaxIDOrIdentity,
+					is.AnyOf(
+						org.PartyHasTaxIDCode(),
+						org.PartyHasIdentityKeyIn(IdentityKeyTaxNumber),
 					),
 				),
 			),
 		),
 	)
-}
-
-func hasTaxIDOrIdentity(value any) bool {
-	party, _ := value.(*org.Party)
-	return hasTaxIDCode(party) || hasIdentityTaxNumber(party)
-}
-
-func hasTaxIDCode(party *org.Party) bool {
-	return party != nil && party.TaxID != nil && party.TaxID.Code != ""
-}
-
-func hasIdentityTaxNumber(party *org.Party) bool {
-	if party == nil || len(party.Identities) == 0 {
-		return false
-	}
-	return org.IdentityForKey(party.Identities, IdentityKeyTaxNumber) != nil
 }

--- a/regimes/fr/bill_invoices.go
+++ b/regimes/fr/bill_invoices.go
@@ -15,30 +15,12 @@ func billInvoiceRules() *rules.Set {
 			is.InContext(tax.RegimeIn(l10n.FR.Tax())),
 			rules.Field("supplier",
 				rules.Assert("01", "invoice supplier must have a tax ID code or a SIREN/SIRET identity",
-					is.Func("has tax ID code or SIREN/SIRET identity", hasSupplierTaxIDOrIdentity),
+					is.AnyOf(
+						org.PartyHasTaxIDCode(),
+						org.PartyHasIdentityTypeIn(IdentityTypeSIREN, IdentityTypeSIRET),
+					),
 				),
 			),
 		),
 	)
-}
-
-func hasSupplierTaxIDOrIdentity(value any) bool {
-	party, _ := value.(*org.Party)
-	return hasTaxIDCode(party) || hasSupplierIdentity(party)
-}
-
-func hasTaxIDCode(party *org.Party) bool {
-	return party != nil && party.TaxID != nil && party.TaxID.Code != ""
-}
-
-func hasSupplierIdentity(party *org.Party) bool {
-	if party == nil || len(party.Identities) == 0 {
-		return false
-	}
-	for _, id := range party.Identities {
-		if id.Type == IdentityTypeSIREN || id.Type == IdentityTypeSIRET {
-			return true
-		}
-	}
-	return false
 }

--- a/regimes/nl/bill_invoices.go
+++ b/regimes/nl/bill_invoices.go
@@ -15,30 +15,12 @@ func billInvoiceRules() *rules.Set {
 			is.InContext(tax.RegimeIn(l10n.NL.Tax())),
 			rules.Field("supplier",
 				rules.Assert("01", "invoice supplier must have a tax ID code or a KVK/OIN identity",
-					is.Func("has tax ID code or KVK/OIN identity", hasSupplierTaxIDOrIdentity),
+					is.AnyOf(
+						org.PartyHasTaxIDCode(),
+						org.PartyHasIdentityTypeIn(IdentityTypeKVK, IdentityTypeOIN),
+					),
 				),
 			),
 		),
 	)
-}
-
-func hasSupplierTaxIDOrIdentity(value any) bool {
-	party, _ := value.(*org.Party)
-	return hasTaxIDCode(party) || hasSupplierIdentity(party)
-}
-
-func hasTaxIDCode(party *org.Party) bool {
-	return party != nil && party.TaxID != nil && party.TaxID.Code != ""
-}
-
-func hasSupplierIdentity(party *org.Party) bool {
-	if party == nil || len(party.Identities) == 0 {
-		return false
-	}
-	for _, id := range party.Identities {
-		if id.Type == IdentityTypeKVK || id.Type == IdentityTypeOIN {
-			return true
-		}
-	}
-	return false
 }

--- a/regimes/se/bill_invoice.go
+++ b/regimes/se/bill_invoice.go
@@ -17,34 +17,12 @@ func billInvoiceRules() *rules.Set {
 			is.InContext(tax.RegimeIn(l10n.SE.Tax())),
 			rules.Field("supplier",
 				rules.Assert("01", fmt.Sprintf("invoice SE supplier must have either tax ID code or identity with %s, %s, or %s type", IdentityTypeOrgNr, IdentityTypePersonNr, IdentityTypeCoordinationNr),
-					is.Func(
-						fmt.Sprintf("has tax ID code or identity with type in [%s, %s, %s]", IdentityTypeOrgNr, IdentityTypePersonNr, IdentityTypeCoordinationNr),
-						hasSupplierTaxIDOrIdentity,
+					is.AnyOf(
+						org.PartyHasTaxIDCode(),
+						org.PartyHasIdentityTypeIn(IdentityTypeOrgNr, IdentityTypePersonNr, IdentityTypeCoordinationNr),
 					),
 				),
 			),
 		),
 	)
-}
-
-func hasSupplierTaxIDOrIdentity(value any) bool {
-	party, _ := value.(*org.Party)
-	return hasTaxIDCode(party) || hasSupplierIdentity(party)
-}
-
-func hasTaxIDCode(party *org.Party) bool {
-	return party != nil && party.TaxID != nil && party.TaxID.Code != ""
-}
-
-func hasSupplierIdentity(party *org.Party) bool {
-	if party == nil || len(party.Identities) == 0 {
-		return false
-	}
-	for _, id := range party.Identities {
-		switch id.Type {
-		case IdentityTypeOrgNr, IdentityTypePersonNr, IdentityTypeCoordinationNr:
-			return true
-		}
-	}
-	return false
 }

--- a/regimes/sg/bill_invoices.go
+++ b/regimes/sg/bill_invoices.go
@@ -14,31 +14,12 @@ func billInvoiceRules() *rules.Set {
 			is.InContext(tax.RegimeIn(CountryCode)),
 			rules.Field("supplier",
 				rules.Assert("01", "invoice supplier in Singapore must have a GST tax ID code or a UEN identity",
-					is.Func("has GST tax ID code or UEN identity", hasSupplierTaxIDOrIdentity),
+					is.AnyOf(
+						org.PartyHasTaxIDCode(),
+						org.PartyHasIdentityTypeIn(IdentityTypeUEN),
+					),
 				),
 			),
 		),
 	)
-}
-
-func hasSupplierTaxIDOrIdentity(value any) bool {
-	party, _ := value.(*org.Party)
-	return hasTaxIDCode(party) || hasSupplierIdentity(party)
-}
-
-func hasTaxIDCode(party *org.Party) bool {
-	return party != nil && party.TaxID != nil && party.TaxID.Code != ""
-}
-
-func hasSupplierIdentity(party *org.Party) bool {
-	if party == nil || len(party.Identities) == 0 {
-		return false
-	}
-	for _, id := range party.Identities {
-		switch id.Type {
-		case IdentityTypeUEN:
-			return true
-		}
-	}
-	return false
 }

--- a/rules/README.md
+++ b/rules/README.md
@@ -271,6 +271,8 @@ Organisation and documents:
 | `org.IdentitiesExtensionIn(key, values...)`         | Any identity has the ext key with one of the values  |
 | `org.AttributesHaveUniqueKeys()`                    | No duplicate keys in `[]*org.Attribute`              |
 | `org.PartyHasTaxIDCode()`                           | `*org.Party` has a tax identity with a code          |
+| `org.PartyHasIdentityTypeIn(types...)`              | Any of the party's identities has the type           |
+| `org.PartyHasIdentityKeyIn(keys...)`                | Any of the party's identities has the key            |
 | `bill.InvoiceTypeIn(types...)`                      | `*bill.Invoice` type; a `When` guard                 |
 | `bill.PaymentTypeIn(types...)`                      | `*bill.Payment` type; a `When` guard                 |
 | `bill.StatusTypeIn(types...)`                       | `*bill.Status` type; a `When` guard                  |
@@ -374,6 +376,46 @@ name against the struct at initialisation and panics immediately instead.
 Custom functions are still the right answer for genuine cross-field logic, for
 domain lookups (regime currency, exchange rates, catalogue codes), and for
 anything an existing test cannot express — see the next two sections.
+
+### Either-or across fields
+
+Combine domain tests with `is.AnyOf` instead of a function that navigates both
+fields. Most regimes need this to accept a party identified by either a tax ID
+code or a national identity:
+
+```go
+// Avoid
+rules.Field("supplier",
+    rules.Assert("01", "supplier must have a tax ID code or a UEN identity",
+        is.Func("has tax ID code or UEN identity", hasSupplierTaxIDOrIdentity),
+    ),
+)
+
+// Prefer
+rules.Field("supplier",
+    rules.Assert("01", "supplier must have a tax ID code or a UEN identity",
+        is.AnyOf(
+            org.PartyHasTaxIDCode(),
+            org.PartyHasIdentityTypeIn(IdentityTypeUEN),
+        ),
+    ),
+)
+```
+
+Use `is.Not` with a `When` guard when only one of the branches carries the
+requirement, so that the fault lands on the field that must be corrected:
+
+```go
+rules.Field("supplier",
+    rules.When(is.Not(org.PartyHasTaxIDCode()),
+        rules.Field("identities",
+            rules.Assert("01", "supplier without a tax ID code requires a CVR identity",
+                org.IdentitiesTypeIn(IdentityTypeCVR),
+            ),
+        ),
+    ),
+)
+```
 
 ### Required field with format check
 

--- a/rules/is/any_of.go
+++ b/rules/is/any_of.go
@@ -56,6 +56,12 @@ func (t anyOfTest) CheckWithContext(rc *rules.Context, val any) bool {
 	return false
 }
 
+// Compile prepares each of the wrapped tests that require compilation, such as
+// Expr or Matches.
+func (t anyOfTest) Compile(val any) error {
+	return compileTests(val, t.tests)
+}
+
 // String provides the string representation of the test.
 func (t anyOfTest) String() string {
 	return t.desc

--- a/rules/is/any_of_test.go
+++ b/rules/is/any_of_test.go
@@ -96,3 +96,27 @@ func TestAnyOfCheckWithContext(t *testing.T) {
 		assert.True(t, ct.CheckWithContext(rc, nil))
 	})
 }
+
+func TestAnyOfCompile(t *testing.T) {
+	type anyOfThing struct {
+		Code string `json:"code"`
+	}
+
+	t.Run("compiles wrapped tests", func(t *testing.T) {
+		set := rules.For(new(anyOfThing),
+			rules.Field("code",
+				rules.Assert("001", "code must be numeric or empty",
+					is.AnyOf(is.Matches(`^\d+$`), is.Empty),
+				),
+			),
+		)
+		assert.Nil(t, set.Validate(&anyOfThing{Code: "123"}))
+		assert.Nil(t, set.Validate(&anyOfThing{}))
+		assert.NotNil(t, set.Validate(&anyOfThing{Code: "abc"}))
+	})
+
+	t.Run("reports compilation errors", func(t *testing.T) {
+		aoTest := is.AnyOf(is.Matches(`^(\d+$`)).(interface{ Compile(any) error })
+		assert.Error(t, aoTest.Compile(new(anyOfThing)))
+	})
+}

--- a/rules/is/compile.go
+++ b/rules/is/compile.go
@@ -1,0 +1,30 @@
+package is
+
+import (
+	"github.com/invopop/gobl/rules"
+)
+
+// compilable is implemented by tests that need to be prepared before use,
+// such as Expr or Matches. It mirrors the unexported interface used by the
+// rules package so that tests wrapping other tests can pass compilation on.
+type compilable interface {
+	Compile(val any) error
+}
+
+// compileTest prepares the given test when it requires compilation.
+func compileTest(val any, test rules.Test) error {
+	if ct, ok := test.(compilable); ok {
+		return ct.Compile(val)
+	}
+	return nil
+}
+
+// compileTests prepares each of the given tests that require compilation.
+func compileTests(val any, tests []rules.Test) error {
+	for _, test := range tests {
+		if err := compileTest(val, test); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/rules/is/not.go
+++ b/rules/is/not.go
@@ -30,10 +30,7 @@ func (t notTest) CheckWithContext(rc *rules.Context, val any) bool {
 // Compile prepares the wrapped test when it requires compilation, such as
 // Expr or Matches.
 func (t notTest) Compile(val any) error {
-	if ct, ok := t.test.(interface{ Compile(any) error }); ok {
-		return ct.Compile(val)
-	}
-	return nil
+	return compileTest(val, t.test)
 }
 
 // String provides the string representation of the test.

--- a/rules/is/one_of.go
+++ b/rules/is/one_of.go
@@ -60,6 +60,12 @@ func (t oneOfTest) CheckWithContext(rc *rules.Context, val any) bool {
 	return passed == 1
 }
 
+// Compile prepares each of the wrapped tests that require compilation, such as
+// Expr or Matches.
+func (t oneOfTest) Compile(val any) error {
+	return compileTests(val, t.tests)
+}
+
 // String provides the string representation of the test.
 func (t oneOfTest) String() string {
 	return t.desc

--- a/rules/is/one_of_test.go
+++ b/rules/is/one_of_test.go
@@ -97,3 +97,26 @@ func TestOneOfCheckWithContext(t *testing.T) {
 		assert.True(t, ct.CheckWithContext(rc, nil))
 	})
 }
+
+func TestOneOfCompile(t *testing.T) {
+	type oneOfThing struct {
+		Code string `json:"code"`
+	}
+
+	t.Run("compiles wrapped tests", func(t *testing.T) {
+		set := rules.For(new(oneOfThing),
+			rules.Field("code",
+				rules.Assert("001", "code must be numeric or empty, not both",
+					is.OneOf(is.Matches(`^\d+$`), is.Empty),
+				),
+			),
+		)
+		assert.Nil(t, set.Validate(&oneOfThing{Code: "123"}))
+		assert.NotNil(t, set.Validate(&oneOfThing{Code: "abc"}))
+	})
+
+	t.Run("reports compilation errors", func(t *testing.T) {
+		ooTest := is.OneOf(is.Matches(`^(\d+$`)).(interface{ Compile(any) error })
+		assert.Error(t, ooTest.Compile(new(oneOfThing)))
+	})
+}


### PR DESCRIPTION
Follow-up to #908, which added `org.PartyHasTaxIDCode` and `is.Not` for the DK supplier rule. This PR applies them to the rest of the codebase and removes the duplication they were extracted from.

**Based on `adding-dk-cpr-identity-type` (#908)** since it depends on the tests introduced there — retarget to `main` once #908 merges.

## What changed

`hasTaxIDCode(party *org.Party) bool` was copy-pasted verbatim in 7 packages, and each site paired it with a hand-rolled identity scan:

- `regimes/de`, `fr`, `nl`, `se`, `sg`: the single supplier assertion now reads `is.AnyOf(org.PartyHasTaxIDCode(), org.PartyHasIdentityTypeIn(...))` (or `PartyHasIdentityKeyIn` for DE), deleting 3 helper functions each
- `regimes/be`: guards become `is.Not(org.PartyHasTaxIDCode())` and `is.Not(org.PartyHasIdentityTypeIn(IdentityTypeBCE))`, with `org.IdentitiesTypeIn` for the assertion — 4 helpers deleted
- `bill/invoice.go`: `customerHasTaxIDCode` deleted in favour of `org.PartyHasTaxIDCode()` — the description is identical, so the generated rule data is unchanged
- `addons/it/sdi`: local `hasTaxIDCode` deleted, its one caller uses the shared test

## New shared API

- `org.PartyHasIdentityTypeIn(types...)` and `org.PartyHasIdentityKeyIn(keys...)` — party-level adapters over the existing `IdentitiesTypeIn`/`IdentitiesKeyIn` tests, so an `AnyOf` can mix a tax ID check with an identity check on the same party
- `rules/is`: `AnyOf` and `OneOf` now forward `Compile` to the tests they wrap. Previously `is.AnyOf(is.Expr(...))` panicked with *"expression test was not compiled"* and `is.AnyOf(is.Matches(...))` would have used a nil regexp. `Not` already forwarded; the logic is now shared in `rules/is/compile.go`

## Compatibility

No fault codes, paths or messages change. The only generated-data difference is the human-readable test descriptions, which get more precise, e.g. for `GOBL-FR-BILL-INVOICE-01`:

```diff
-"tests": "has tax ID code or SIREN/SIRET identity"
+"tests": "has tax ID code, or has a type in [SIREN, SIRET]"
```

## Verification

- Full `go test ./...` and repo-wide `golangci-lint run` clean; `data/` regenerated
- 100% statement coverage on every new function: `PartyHasIdentityTypeIn`, `PartyHasIdentityKeyIn`, `partyIdentities`, `partyFrom`, `compileTest`, `compileTests`, and both new `Compile` methods
- New tests cover pointer/value/nil/wrong-type party inputs, matching and non-matching types and keys, descriptions, and compilation of wrapped `Matches` tests including the error path
- Existing regime tests pass unmodified, which is the behaviour-preservation check

## Docs

`rules/README.md` gains rows for the three new `org` tests and an "Either-or across fields" pattern section showing both the `AnyOf` and `Not` + `When` shapes. `CHANGELOG.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)