### PR TITLE
Add fi-finvoice-v3 addon for Finnish Finvoice 3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Added
+
+- `addons/fi/finvoice`: new `fi-finvoice-v3` addon for the Finnish Finvoice 3.0 format. Builds on `eu-en16931-v2017` and adds the Finvoice-specific requirements: a named customer, and unconditional payment details — credit transfer instructions with a checksum-validated IBAN, a payment reference, and at least one due date — since Finvoice's `EpiDetails` block is mandatory on every invoice, including credit notes. IBANs and payment references are normalized to their machine form (grouping spaces removed, IBANs upper-cased).
+
 ## [v0.503.0] - 2026-07-15
 
 ### Added

--- a/addons/addons.go
+++ b/addons/addons.go
@@ -18,6 +18,7 @@ import (
 	_ "github.com/invopop/gobl/addons/es/tbai"
 	_ "github.com/invopop/gobl/addons/es/verifactu"
 	_ "github.com/invopop/gobl/addons/eu/en16931"
+	_ "github.com/invopop/gobl/addons/fi/finvoice"
 	_ "github.com/invopop/gobl/addons/fr/choruspro"
 	_ "github.com/invopop/gobl/addons/fr/facturx"
 	_ "github.com/invopop/gobl/addons/gr/mydata"

--- a/addons/fi/finvoice/bill_invoices.go
+++ b/addons/fi/finvoice/bill_invoices.go
@@ -1,0 +1,106 @@
+package finvoice
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/pay"
+	"github.com/invopop/gobl/rules"
+	"github.com/invopop/gobl/rules/is"
+)
+
+// Finvoice's EpiDetails payment block is mandatory on every invoice,
+// including credit notes, so the payment rules below apply unconditionally
+// rather than only when an amount is due (en16931 BR-CO-25).
+//
+// EpiBfiIdentifier (the BIC) is optional in the Finvoice schema and SEPA
+// practice no longer requires it for domestic transfers, so the addon
+// recommends but does not require it.
+func billInvoiceRules() *rules.Set {
+	return rules.For(new(bill.Invoice),
+		rules.Field("customer",
+			rules.Assert("01", "customer is required (Finvoice BuyerPartyDetails)", is.Present),
+			rules.Field("name",
+				rules.Assert("02", "customer name is required (Finvoice BuyerOrganisationName)", is.Present),
+			),
+		),
+		rules.Field("payment",
+			rules.Assert("03", "payment details are required (Finvoice EpiDetails)", is.Present),
+			rules.Field("instructions",
+				rules.Assert("04", "payment instructions are required (Finvoice EpiDetails)", is.Present),
+				rules.Field("key",
+					rules.Assert("05", "payment instructions key must be credit-transfer",
+						cbc.HasValidKeyIn(pay.MeansKeyCreditTransfer),
+					),
+				),
+				rules.Field("ref",
+					rules.Assert("06", "payment reference is required (Finvoice EpiReference)", is.Present),
+				),
+				rules.Field("credit_transfer",
+					rules.Assert("07", "credit transfer details are required (Finvoice EpiAccountID)", is.Present),
+					rules.Assert("08", "first credit transfer IBAN is required (Finvoice EpiAccountID)",
+						is.Func("first entry has IBAN", firstCreditTransferHasIBAN),
+					),
+					rules.Each(
+						rules.Field("iban",
+							rules.AssertIfPresent("09", "credit transfer IBAN is not valid",
+								is.StringFunc("mod-97 checksum", validIBAN),
+							),
+						),
+					),
+				),
+			),
+			rules.Field("terms",
+				rules.Assert("10", "payment terms are required (Finvoice EpiDateOptionDate)", is.Present),
+				rules.Field("due_dates",
+					rules.Assert("11", "at least one due date is required (Finvoice EpiDateOptionDate)", is.Present),
+				),
+			),
+		),
+	)
+}
+
+// firstCreditTransferHasIBAN checks the entry the UBL converter maps to
+// EpiAccountID. An empty list is handled by the presence assertion.
+func firstCreditTransferHasIBAN(val any) bool {
+	cts, ok := val.([]*pay.CreditTransfer)
+	if !ok || len(cts) == 0 {
+		return true
+	}
+	return cts[0] != nil && cts[0].IBAN != ""
+}
+
+// ibanPattern covers the ISO 13616 shape: country code, two check digits,
+// and up to 30 alphanumeric BBAN characters.
+var ibanPattern = regexp.MustCompile(`^[A-Z]{2}\d{2}[A-Z0-9]{1,30}$`)
+
+// validIBAN reports whether the IBAN satisfies the ISO 7064 mod 97-10
+// checksum. Country-specific lengths are not checked.
+func validIBAN(iban string) bool {
+	if !ibanPattern.MatchString(iban) {
+		return false
+	}
+	n := 0
+	for _, r := range iban[4:] + iban[:4] {
+		if r >= 'A' && r <= 'Z' {
+			n = (n*100 + int(r-'A') + 10) % 97
+		} else {
+			n = (n*10 + int(r-'0')) % 97
+		}
+	}
+	return n == 1
+}
+
+// normalizePayInstructions strips the grouping spaces conventionally used
+// when displaying Finnish reference numbers and RF references.
+func normalizePayInstructions(instr *pay.Instructions) {
+	instr.Ref = cbc.Code(strings.ReplaceAll(instr.Ref.String(), " ", ""))
+}
+
+// normalizePayCreditTransfer converts the IBAN to its machine form: no
+// grouping spaces, upper case.
+func normalizePayCreditTransfer(ct *pay.CreditTransfer) {
+	ct.IBAN = strings.ToUpper(strings.ReplaceAll(ct.IBAN, " ", ""))
+}

--- a/addons/fi/finvoice/bill_invoices_test.go
+++ b/addons/fi/finvoice/bill_invoices_test.go
@@ -1,0 +1,263 @@
+package finvoice_test
+
+import (
+	"testing"
+
+	_ "github.com/invopop/gobl"
+	"github.com/invopop/gobl/addons/fi/finvoice"
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/cal"
+	"github.com/invopop/gobl/num"
+	"github.com/invopop/gobl/org"
+	"github.com/invopop/gobl/pay"
+	"github.com/invopop/gobl/rules"
+	"github.com/invopop/gobl/tax"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testInvoiceStandard(t *testing.T) *bill.Invoice {
+	t.Helper()
+	return &bill.Invoice{
+		Regime:    tax.WithRegime("FI"),
+		Addons:    tax.WithAddons(finvoice.V3),
+		IssueDate: cal.MakeDate(2026, 7, 1),
+		Type:      "standard",
+		Currency:  "EUR",
+		Series:    "2026",
+		Code:      "1000",
+		Supplier: &org.Party{
+			Name: "Myyjä Oy",
+			TaxID: &tax.Identity{
+				Country: "FI",
+				Code:    "23456780",
+			},
+			Addresses: []*org.Address{
+				{
+					Street:   "Esimerkkikatu 1",
+					Locality: "Helsinki",
+					Code:     "00100",
+					Country:  "FI",
+				},
+			},
+		},
+		Customer: &org.Party{
+			Name: "Ostaja Oy",
+			TaxID: &tax.Identity{
+				Country: "FI",
+				Code:    "01120389",
+			},
+			Addresses: []*org.Address{
+				{
+					Street:   "Testitie 2",
+					Locality: "Espoo",
+					Code:     "02100",
+					Country:  "FI",
+				},
+			},
+		},
+		Payment: &bill.PaymentDetails{
+			Instructions: &pay.Instructions{
+				Key: "credit-transfer+sepa",
+				Ref: "RF18539007547034",
+				CreditTransfer: []*pay.CreditTransfer{
+					{
+						IBAN: "FI2112345600000785",
+					},
+				},
+			},
+			Terms: &pay.Terms{
+				DueDates: []*pay.DueDate{
+					{
+						Date:   cal.NewDate(2026, 7, 31),
+						Amount: num.MakeAmount(12750, 2),
+					},
+				},
+			},
+		},
+		Lines: []*bill.Line{
+			{
+				Quantity: num.MakeAmount(10, 0),
+				Item: &org.Item{
+					Name:  "Test Item",
+					Price: num.NewAmount(1000, 2),
+					Unit:  "item",
+				},
+				Taxes: tax.Set{
+					{
+						Category: "VAT",
+						Rate:     "general",
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestBillInvoiceRules(t *testing.T) {
+	t.Run("valid invoice", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		require.NoError(t, inv.Calculate())
+		assert.NoError(t, rules.Validate(inv))
+	})
+
+	t.Run("valid invoice without BIC", func(t *testing.T) {
+		// Finvoice recommends the BIC alongside the IBAN but the schema does
+		// not require it, so its absence must not fail validation.
+		inv := testInvoiceStandard(t)
+		require.NoError(t, inv.Calculate())
+		require.Empty(t, inv.Payment.Instructions.CreditTransfer[0].BIC)
+		assert.NoError(t, rules.Validate(inv))
+	})
+
+	t.Run("missing customer", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.SetTags(tax.TagSimplified)
+		inv.Customer = nil
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "customer is required")
+	})
+
+	t.Run("missing customer name", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Customer.Name = ""
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "customer name is required")
+	})
+
+	t.Run("missing payment", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Payment = nil
+		require.NoError(t, inv.Calculate())
+		faults := rules.Validate(inv)
+		require.NotNil(t, faults)
+		assert.True(t, faults.HasCode("GOBL-FI-FINVOICE-BILL-INVOICE-03"))
+	})
+
+	t.Run("credit note requires payment too", func(t *testing.T) {
+		// en16931 only requires payment details when an amount is due, which
+		// exempts credit notes. Finvoice's EpiDetails is mandatory on every
+		// invoice, so the addon must fault here on its own.
+		inv := testInvoiceStandard(t)
+		inv.Type = bill.InvoiceTypeCreditNote
+		inv.Preceding = []*org.DocumentRef{
+			{
+				Series:    "2026",
+				Code:      "0999",
+				IssueDate: cal.NewDate(2026, 6, 1),
+			},
+		}
+		inv.Payment = nil
+		require.NoError(t, inv.Calculate())
+		faults := rules.Validate(inv)
+		require.NotNil(t, faults)
+		assert.True(t, faults.HasCode("GOBL-FI-FINVOICE-BILL-INVOICE-03"))
+	})
+
+	t.Run("missing payment instructions", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Payment.Instructions = nil
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "payment instructions are required")
+	})
+
+	t.Run("instructions key must be credit transfer", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Payment.Instructions.Key = pay.MeansKeyCash
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "credit-transfer")
+	})
+
+	t.Run("missing payment reference", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Payment.Instructions.Ref = ""
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "payment reference is required")
+	})
+
+	t.Run("missing credit transfer", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Payment.Instructions.CreditTransfer = nil
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "credit transfer details are required")
+	})
+
+	t.Run("missing IBAN in first credit transfer", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Payment.Instructions.CreditTransfer[0].IBAN = ""
+		inv.Payment.Instructions.CreditTransfer[0].Number = "12345-678"
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "IBAN is required")
+	})
+
+	t.Run("invalid IBAN checksum", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Payment.Instructions.CreditTransfer[0].IBAN = "FI2112345600000786"
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "IBAN is not valid")
+	})
+
+	t.Run("malformed IBAN", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Payment.Instructions.CreditTransfer[0].IBAN = "NOT-AN-IBAN"
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "IBAN is not valid")
+	})
+
+	t.Run("missing payment terms", func(t *testing.T) {
+		// A credit note has no amount due, so en16931's BR-CO-25 does not
+		// require terms here — only the addon does.
+		inv := testInvoiceStandard(t)
+		inv.Type = bill.InvoiceTypeCreditNote
+		inv.Preceding = []*org.DocumentRef{
+			{
+				Series:    "2026",
+				Code:      "0999",
+				IssueDate: cal.NewDate(2026, 6, 1),
+			},
+		}
+		inv.Payment.Terms = nil
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "payment terms are required")
+	})
+
+	t.Run("terms with notes but no due dates", func(t *testing.T) {
+		// en16931 accepts terms with notes only (BR-CO-25); Finvoice needs a
+		// dated entry to fill EpiDateOptionDate.
+		inv := testInvoiceStandard(t)
+		inv.Payment.Terms = &pay.Terms{
+			Notes: "Payable on receipt",
+		}
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "due date is required")
+	})
+}
+
+func TestNormalization(t *testing.T) {
+	t.Run("strips spaces and uppercases IBAN", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Payment.Instructions.CreditTransfer[0].IBAN = "fi21 1234 5600 0007 85"
+		require.NoError(t, inv.Calculate())
+		assert.Equal(t, "FI2112345600000785", inv.Payment.Instructions.CreditTransfer[0].IBAN)
+		assert.NoError(t, rules.Validate(inv))
+	})
+
+	t.Run("strips spaces from payment reference", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Payment.Instructions.Ref = "RF18 5390 0754 7034"
+		require.NoError(t, inv.Calculate())
+		assert.Equal(t, "RF18539007547034", inv.Payment.Instructions.Ref.String())
+	})
+}

--- a/addons/fi/finvoice/finvoice.go
+++ b/addons/fi/finvoice/finvoice.go
@@ -1,0 +1,63 @@
+// Package finvoice provides validations for the Finnish Finvoice 3.0 format.
+package finvoice
+
+import (
+	"github.com/invopop/gobl/addons/eu/en16931"
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/i18n"
+	"github.com/invopop/gobl/norm"
+	"github.com/invopop/gobl/pkg/here"
+	"github.com/invopop/gobl/rules"
+	"github.com/invopop/gobl/rules/is"
+	"github.com/invopop/gobl/tax"
+)
+
+const (
+	// Key identifies the Finvoice addon family. Individual versions append a
+	// suffix; the family key is used as the fault-code namespace so that
+	// rules that carry across versions keep stable codes.
+	Key cbc.Key = "fi-finvoice"
+
+	// V3 is the key for the Finvoice version 3.0
+	V3 cbc.Key = Key + "-v3"
+)
+
+func init() {
+	tax.RegisterAddonDef(newAddon())
+	rules.RegisterWithGuard(
+		Key.String(),
+		rules.GOBL.Add("FI-FINVOICE"),
+		is.InContext(tax.AddonIn(V3)),
+		billInvoiceRules(),
+	)
+	norm.RegisterWithGuard(
+		is.InContext(tax.AddonIn(V3)),
+		norm.For(normalizePayInstructions),
+		norm.For(normalizePayCreditTransfer),
+	)
+}
+
+func newAddon() *tax.AddonDef {
+	return &tax.AddonDef{
+		Key: V3,
+		Name: i18n.String{
+			i18n.EN: "Finland Finvoice 3.0",
+		},
+		Requires: []cbc.Key{
+			en16931.V2017,
+		},
+		Description: i18n.String{
+			i18n.EN: here.Doc(`
+				Support for the Finnish Finvoice 3.0 format for electronic invoicing.
+				Finvoice conforms to the European Norm (EN) 16931, so this addon only adds
+				the Finvoice-specific requirements on top of the EN 16931 rules: a named
+				customer, and the payment data needed to build the Finvoice EpiDetails
+				payment block (credit transfer instructions with an IBAN, a payment
+				reference, and a due date), which is mandatory on every invoice.
+
+				For more information on Finvoice, visit
+				[www.finanssiala.fi](https://www.finanssiala.fi/en/topics/finvoice-implementation-guidelines/).
+			`),
+		},
+	}
+}

--- a/data/addons/fi-finvoice-v3.json
+++ b/data/addons/fi-finvoice-v3.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://gobl.org/draft-0/tax/addon-def",
+  "key": "fi-finvoice-v3",
+  "requires": [
+    "eu-en16931-v2017"
+  ],
+  "name": {
+    "en": "Finland Finvoice 3.0"
+  },
+  "description": {
+    "en": "Support for the Finnish Finvoice 3.0 format for electronic invoicing.\nFinvoice conforms to the European Norm (EN) 16931, so this addon only adds\nthe Finvoice-specific requirements on top of the EN 16931 rules: a named\ncustomer, and the payment data needed to build the Finvoice EpiDetails\npayment block (credit transfer instructions with an IBAN, a payment\nreference, and a due date), which is mandatory on every invoice.\n\nFor more information on Finvoice, visit\n[www.finanssiala.fi](https://www.finanssiala.fi/en/topics/finvoice-implementation-guidelines/)."
+  },
+  "extensions": null,
+  "scenarios": null,
+  "corrections": null
+}

--- a/data/rules/fi-finvoice.json
+++ b/data/rules/fi-finvoice.json
@@ -1,0 +1,138 @@
+{
+  "id": "GOBL-FI-FINVOICE",
+  "package": "fi-finvoice",
+  "guard": "context: addon in [fi-finvoice-v3]",
+  "subsets": [
+    {
+      "id": "GOBL-FI-FINVOICE-BILL-INVOICE",
+      "object": "bill.Invoice",
+      "subsets": [
+        {
+          "field": "customer",
+          "assert": [
+            {
+              "id": "GOBL-FI-FINVOICE-BILL-INVOICE-01",
+              "desc": "customer is required (Finvoice BuyerPartyDetails)",
+              "tests": "present"
+            }
+          ],
+          "subsets": [
+            {
+              "field": "name",
+              "assert": [
+                {
+                  "id": "GOBL-FI-FINVOICE-BILL-INVOICE-02",
+                  "desc": "customer name is required (Finvoice BuyerOrganisationName)",
+                  "tests": "present"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "field": "payment",
+          "assert": [
+            {
+              "id": "GOBL-FI-FINVOICE-BILL-INVOICE-03",
+              "desc": "payment details are required (Finvoice EpiDetails)",
+              "tests": "present"
+            }
+          ],
+          "subsets": [
+            {
+              "field": "instructions",
+              "assert": [
+                {
+                  "id": "GOBL-FI-FINVOICE-BILL-INVOICE-04",
+                  "desc": "payment instructions are required (Finvoice EpiDetails)",
+                  "tests": "present"
+                }
+              ],
+              "subsets": [
+                {
+                  "field": "key",
+                  "assert": [
+                    {
+                      "id": "GOBL-FI-FINVOICE-BILL-INVOICE-05",
+                      "desc": "payment instructions key must be credit-transfer",
+                      "tests": "be or starts with one of [credit-transfer]"
+                    }
+                  ]
+                },
+                {
+                  "field": "ref",
+                  "assert": [
+                    {
+                      "id": "GOBL-FI-FINVOICE-BILL-INVOICE-06",
+                      "desc": "payment reference is required (Finvoice EpiReference)",
+                      "tests": "present"
+                    }
+                  ]
+                },
+                {
+                  "field": "credit_transfer",
+                  "assert": [
+                    {
+                      "id": "GOBL-FI-FINVOICE-BILL-INVOICE-07",
+                      "desc": "credit transfer details are required (Finvoice EpiAccountID)",
+                      "tests": "present"
+                    },
+                    {
+                      "id": "GOBL-FI-FINVOICE-BILL-INVOICE-08",
+                      "desc": "first credit transfer IBAN is required (Finvoice EpiAccountID)",
+                      "tests": "first entry has IBAN"
+                    }
+                  ],
+                  "subsets": [
+                    {
+                      "each": true,
+                      "subsets": [
+                        {
+                          "field": "iban",
+                          "subsets": [
+                            {
+                              "guard": "present",
+                              "assert": [
+                                {
+                                  "id": "GOBL-FI-FINVOICE-BILL-INVOICE-09",
+                                  "desc": "credit transfer IBAN is not valid",
+                                  "tests": "mod-97 checksum"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "field": "terms",
+              "assert": [
+                {
+                  "id": "GOBL-FI-FINVOICE-BILL-INVOICE-10",
+                  "desc": "payment terms are required (Finvoice EpiDateOptionDate)",
+                  "tests": "present"
+                }
+              ],
+              "subsets": [
+                {
+                  "field": "due_dates",
+                  "assert": [
+                    {
+                      "id": "GOBL-FI-FINVOICE-BILL-INVOICE-11",
+                      "desc": "at least one due date is required (Finvoice EpiDateOptionDate)",
+                      "tests": "present"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/data/schemas/tax/addon-list.json
+++ b/data/schemas/tax/addon-list.json
@@ -52,6 +52,10 @@
             "title": "EN 16931-1:2017"
           },
           {
+            "const": "fi-finvoice-v3",
+            "title": "Finland Finvoice 3.0"
+          },
+          {
             "const": "fr-choruspro-v1",
             "title": "Chorus Pro"
           },


### PR DESCRIPTION
## Context

Finvoice 3.0 is the Finnish national e-invoicing format, conformant with EN 16931. Several elements that are optional in EN 16931 are mandatory in the Finvoice schema — most notably the `EpiDetails` payment block, which every invoice must carry, credit notes included.

This adds a `fi-finvoice-v3` addon following the same split as `de-xrechnung`: it declares `Requires: eu-en16931-v2017` and only adds the Finvoice-specific tightening on top.

## Changes

- **New `addons/fi/finvoice` package** defining `fi-finvoice-v3`, wired into `addons/addons.go` with regenerated data files.
- **Customer must be present and named** — `BuyerOrganisationName` is schema-mandatory.
- **Payment details are required on every invoice** — `EpiDetails` is mandatory even on credit notes, so the rule doesn't inherit EN 16931's "only when an amount is due" condition (BR-CO-25).
- **Credit transfer instructions with an IBAN** — the instructions key must be `credit-transfer` (extensions like `credit-transfer+sepa` are fine) and the first credit transfer entry must carry an IBAN (`EpiAccountID`), validated with the ISO 7064 mod 97-10 checksum. Country-specific lengths are not checked.
- **Payment reference is required** (`EpiReference`) — presence only; Finnish reference / RF check-digit validation could come later.
- **At least one dated due date** (`EpiDateOptionDate`) — EN 16931 accepts terms with notes only.
- **Normalizers strip grouping spaces** from IBANs (also upper-casing them) and payment references, so display-formatted values like `FI21 1234 5600 0007 85` validate.
- **BIC stays recommend-only** — `EpiBfiIdentifier` is optional in the schema.

Sources: [Finvoice 3.0 XSD](https://file.finanssiala.fi/finvoice/css/270923/Finvoice3.0.xsd) and the [Finvoice implementation guidelines](https://www.finanssiala.fi/en/topics/finvoice-implementation-guidelines/).