### PR TITLE
Add IsIBAN and IsBIC rules tests to pay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Added
 
+- `pay`: `IsIBAN` and `IsBIC` rules tests for bank details — the ISO 13616 structure with its ISO 7064 mod 97-10 check digits, and the ISO 9362 structure. Available to rule sets that need them; no core rule applies them.
+- `rules/is`: `AllOf` composes several tests into one that passes only when all of them do, alongside the existing `AnyOf` and `OneOf`.
 - `net`: request tokens (README §5.5): short-lived ES256 JWTs sent as `Authorization: Bearer` on `/who` and `/inbox` requests, identifying the requester — possibly a trusted intermediary distinct from the envelope's signer. `net.NewToken` mints one, `Client.VerifyToken` / `Client.VerifyAuthorization` verify inbound tokens against the issuer's published key, audience, and a 30s–5m freshness window, and the `net.WithIdentity` client option attaches one to every who and inbox request. New `ErrTokenInvalid` and `ErrTokenExpired` sentinels.
 - `net`: `Client.Send` delivers a signed envelope to an address's inbox: 202 is success, other non-retryable 4xx report `ErrInboxRejected`. The `Poster` interface extends a `Fetcher` with POST support; `HTTPFetcher` implements it.
 - `net`: `/who` may answer `202 Accepted` (new `ErrPending` sentinel) to record the authenticated request for deferred disclosure: the owner decides per requester and, if approved, delivers its party envelope to the requester's inbox later.

--- a/pay/validation.go
+++ b/pay/validation.go
@@ -1,0 +1,47 @@
+package pay
+
+import (
+	"regexp"
+
+	"github.com/invopop/gobl/rules/is"
+)
+
+var (
+	// ibanPattern reflects the ISO 13616 structure: country code, check
+	// digits, and 11 to 30 characters of national account data. Per-country
+	// lengths are not enforced.
+	ibanPattern = regexp.MustCompile(`^[A-Z]{2}\d{2}[A-Z0-9]{11,30}$`)
+
+	// bicPattern reflects the ISO 9362 structure: institution and country
+	// codes, a location code, and an optional branch code.
+	bicPattern = regexp.MustCompile(`^[A-Z]{6}[A-Z0-9]{2}([A-Z0-9]{3})?$`)
+)
+
+var (
+	// IsIBAN confirms the value is an International Bank Account Number.
+	IsIBAN = is.AllOf(
+		is.MatchesRegexp(ibanPattern),
+		is.StringFunc("has matching check digits", ibanCheckDigitsMatch),
+	)
+
+	// IsBIC confirms the value is a Business Identifier Code.
+	IsBIC = is.MatchesRegexp(bicPattern)
+)
+
+// ibanCheckDigitsMatch runs the ISO 7064 mod 97-10 calculation over the
+// account number moved in front of the country code and check digits, with
+// letters converted to two digits each (A is 10, Z is 35).
+func ibanCheckDigitsMatch(iban string) bool {
+	if len(iban) < 5 {
+		return false // too short to carry check digits and an account number
+	}
+	n := 0
+	for _, r := range iban[4:] + iban[:4] {
+		if r >= 'A' && r <= 'Z' {
+			n = (n*100 + int(r-'A') + 10) % 97
+		} else {
+			n = (n*10 + int(r-'0')) % 97
+		}
+	}
+	return n == 1
+}

--- a/pay/validation_test.go
+++ b/pay/validation_test.go
@@ -1,0 +1,65 @@
+package pay_test
+
+import (
+	"testing"
+
+	"github.com/invopop/gobl/pay"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsIBAN(t *testing.T) {
+	tests := []struct {
+		name string
+		iban string
+		want bool
+	}{
+		{"Finnish IBAN", "FI2112345600000785", true},
+		{"German IBAN", "DE89370400440532013000", true},
+		{"Norwegian IBAN at the minimum length", "NO9386011117947", true},
+		{"check digits do not match", "FI2112345600000786", false},
+		{"check digits match but too short for ISO 13616", "FI2100021", false},
+		{"lower case", "fi2112345600000785", false},
+		{"grouping spaces", "FI21 1234 5600 0007 85", false},
+		{"not an account number", "NOT-AN-IBAN", false},
+		{"empty", "", false},
+		{"check digits only", "FI21", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, pay.IsIBAN.Check(tt.iban))
+		})
+	}
+
+	t.Run("not a string", func(t *testing.T) {
+		assert.False(t, pay.IsIBAN.Check(42))
+	})
+
+	t.Run("description lists both conditions", func(t *testing.T) {
+		assert.Equal(t,
+			`matches ^[A-Z]{2}\d{2}[A-Z0-9]{11,30}$, and has matching check digits`,
+			pay.IsIBAN.String())
+	})
+}
+
+func TestIsBIC(t *testing.T) {
+	tests := []struct {
+		name string
+		bic  string
+		want bool
+	}{
+		{"eight characters", "NDEAFIHH", true},
+		{"eleven characters with branch code", "DEUTDEFF500", true},
+		{"too short", "NDEA", false},
+		{"nine characters", "NDEAFIHHX", false},
+		{"lower case", "ndeafihh", false},
+		{"digit in the institution code", "N1EAFIHH", false},
+		// The pattern tests in rules/is skip absent values so that presence
+		// is asserted separately.
+		{"empty", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, pay.IsBIC.Check(tt.bic))
+		})
+	}
+}

--- a/rules/README.md
+++ b/rules/README.md
@@ -201,6 +201,7 @@ import (
 | `is.FuncError(desc, func(any) error)`                 | Error message is discarded; use `desc`                                 |
 | `is.FuncContext(desc, func(rules.Context, any) bool)` | Context-aware custom function                                          |
 | `is.Or(tests...)`                                     | Passes if any test passes                                              |
+| `is.AllOf(tests...)`                                  | Passes only if every test passes                                       |
 | `is.InContext(test)`                                  | Passes when any context value satisfies the inner test                 |
 
 The `rules/is` package also re-exports all format tests from `github.com/invopop/validation/is`
@@ -257,6 +258,14 @@ Tax — `github.com/invopop/gobl/tax`:
 | `tax.IdentityIn(codes...)`                    | `tax.Identity` country code                                 |
 | `tax.HasAddon(key)` / `tax.AddonIn(keys...)`  | Object declares the addon / context carries it              |
 | `tax.TagsIn(tags...)`                         | All of the object's tags are in the list                    |
+
+Payments — `github.com/invopop/gobl/pay`:
+
+| Test                   | Notes                                                      |
+| ---------------------- | ---------------------------------------------------------- |
+| `pay.HasValidMeansKey` | Instructions key is based on one of the defined means keys  |
+| `pay.IsIBAN`           | ISO 13616 structure with matching mod 97-10 check digits     |
+| `pay.IsBIC`            | ISO 9362 structure                                          |
 
 Organisation and documents:
 

--- a/rules/is/all_of.go
+++ b/rules/is/all_of.go
@@ -1,0 +1,57 @@
+package is
+
+import (
+	"strings"
+
+	"github.com/invopop/gobl/rules"
+)
+
+type allOfTest struct {
+	desc  string
+	tests []rules.Test
+}
+
+// AllOf defines a test that will pass when every one of the provided tests
+// passes. Assertions already require all their tests to pass, so this is for
+// composing a single named test out of several conditions.
+func AllOf(tests ...rules.Test) rules.Test {
+	var descs []string
+	for _, t := range tests {
+		descs = append(descs, t.String())
+	}
+	return allOfTest{
+		desc:  strings.Join(descs, ", and "),
+		tests: tests,
+	}
+}
+
+// Check will run each of the tests on the object and return true only if
+// all of them pass.
+func (t allOfTest) Check(obj any) bool {
+	for _, test := range t.tests {
+		if !test.Check(obj) {
+			return false
+		}
+	}
+	return true
+}
+
+// CheckWithContext implements rules.ContextualTest so that AllOf(InContext(...), ...)
+// correctly threads the context through to each inner test.
+func (t allOfTest) CheckWithContext(rc *rules.Context, val any) bool {
+	for _, test := range t.tests {
+		if ct, ok := test.(rules.ContextualTest); ok {
+			if !ct.CheckWithContext(rc, val) {
+				return false
+			}
+		} else if !test.Check(val) {
+			return false
+		}
+	}
+	return true
+}
+
+// String provides the string representation of the test.
+func (t allOfTest) String() string {
+	return t.desc
+}

--- a/rules/is/all_of_test.go
+++ b/rules/is/all_of_test.go
@@ -1,0 +1,70 @@
+package is_test
+
+import (
+	"testing"
+
+	"github.com/invopop/gobl/rules"
+	"github.com/invopop/gobl/rules/is"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAllOf(t *testing.T) {
+	alwaysPass := is.Func("pass", func(any) bool { return true })
+	alwaysFail := is.Func("fail", func(any) bool { return false })
+
+	t.Run("all tests pass", func(t *testing.T) {
+		assert.True(t, is.AllOf(alwaysPass, alwaysPass).Check("x"))
+	})
+
+	t.Run("only test passes", func(t *testing.T) {
+		assert.True(t, is.AllOf(alwaysPass).Check("x"))
+	})
+
+	t.Run("first test fails", func(t *testing.T) {
+		assert.False(t, is.AllOf(alwaysFail, alwaysPass).Check("x"))
+	})
+
+	t.Run("second test fails", func(t *testing.T) {
+		assert.False(t, is.AllOf(alwaysPass, alwaysFail).Check("x"))
+	})
+
+	t.Run("no tests (empty AllOf)", func(t *testing.T) {
+		assert.True(t, is.AllOf().Check("x"))
+	})
+
+	t.Run("String output", func(t *testing.T) {
+		result := is.AllOf(alwaysPass, alwaysFail).String()
+		assert.Equal(t, "pass, and fail", result)
+	})
+}
+
+func TestAllOfCheckWithContext(t *testing.T) {
+	alwaysPass := is.Func("pass", func(any) bool { return true })
+
+	t.Run("context-aware inner test passes", func(t *testing.T) {
+		inner := contextTest{key: "k", expect: "v"}
+		aoTest := is.AllOf(inner, alwaysPass)
+		rc := &rules.Context{}
+		rc.Set("k", "v")
+		ct := aoTest.(rules.ContextualTest)
+		assert.True(t, ct.CheckWithContext(rc, nil))
+	})
+
+	t.Run("context-aware inner test fails", func(t *testing.T) {
+		inner := contextTest{key: "k", expect: "v"}
+		aoTest := is.AllOf(inner, alwaysPass)
+		rc := &rules.Context{}
+		rc.Set("k", "other")
+		ct := aoTest.(rules.ContextualTest)
+		assert.False(t, ct.CheckWithContext(rc, nil))
+	})
+
+	t.Run("plain inner test fails", func(t *testing.T) {
+		alwaysFail := is.Func("fail", func(any) bool { return false })
+		aoTest := is.AllOf(contextTest{key: "k", expect: "v"}, alwaysFail)
+		rc := &rules.Context{}
+		rc.Set("k", "v")
+		ct := aoTest.(rules.ContextualTest)
+		assert.False(t, ct.CheckWithContext(rc, nil))
+	})
+}


### PR DESCRIPTION
## Context

Bank-detail validation keeps coming up in addon rule sets, and `rules/README.md` asks for tests that are generally useful to a GOBL type to live in that type's package rather than privately in an addon. These two are the IBAN and BIC checks the Finnish Finvoice addon needs.

## Changes

- **`pay.IsIBAN`** — the ISO 13616 structure composed with its ISO 7064 mod 97-10 check digits. Per-country lengths are not enforced.
- **`pay.IsBIC`** — the ISO 9362 structure.
- Both live in `pay/validation.go`, following `num` and `uuid`. Neither hand-checks absent values: the pattern tests in `rules/is` skip them so that presence is asserted separately, and an empty IBAN is invalid.
- **`is.AllOf`** — composes several tests into one that passes only when all of them do, alongside the existing `AnyOf` and `OneOf` and built the same way. It is what lets `IsIBAN` read as its two conditions. `is.MatchesRegexp` rather than `is.Matches` inside it, since composites do not compile their nested tests.
- `rules/README.md` gains a `pay` section in the domain-tests tables, including the pre-existing `HasValidMeansKey`, plus the `AllOf` entry.