### PR TITLE
Add clearing code to credit transfers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Added
 
+- `pay`: `CreditTransfer` now supports a `clearing` code for national bank or branch identifiers such as Danish registration numbers, UK sort codes, and US routing numbers. Its `iban`, `bic`, `number`, and `clearing` identifiers use the flexible `cbc.Code` type; the descriptive bank `name` remains a string.
 - `pay`: `IsIBAN` and `IsBIC` rules tests for bank details — the ISO 13616 structure with its ISO 7064 mod 97-10 check digits, and the ISO 9362 structure. Available to rule sets that need them; no core rule applies them.
 - `rules/is`: `AllOf` composes several tests into one that passes only when all of them do, alongside the existing `AnyOf` and `OneOf`.
 - `fi-finvoice-v3`: approved as an external addon implemented by [`github.com/invopop/gobl.fi.finvoice`](https://github.com/invopop/gobl.fi.finvoice) — Finland's Finvoice 3.0 e-invoicing format. As with other external addons, the module must be imported (`_ "github.com/invopop/gobl.fi.finvoice/addon"`) for documents declaring the key to calculate and validate.

--- a/bill/payment_test.go
+++ b/bill/payment_test.go
@@ -551,7 +551,7 @@ func TestPaymentLegacyMethodMigration(t *testing.T) {
 	assert.Equal(t, pay.MeansKeyCreditTransfer, pmt.Methods[0].Key)
 	assert.Equal(t, "Wire transfer from BBVA", pmt.Methods[0].Description)
 	require.NotNil(t, pmt.Methods[0].CreditTransfer)
-	assert.Equal(t, "ES1234567890123456789012", pmt.Methods[0].CreditTransfer.IBAN)
+	assert.Equal(t, cbc.Code("ES1234567890123456789012"), pmt.Methods[0].CreditTransfer.IBAN)
 }
 
 func TestPaymentFromToEndpoint(t *testing.T) {

--- a/data/schemas/pay/credit-transfer.json
+++ b/data/schemas/pay/credit-transfer.json
@@ -6,19 +6,24 @@
     "pay.CreditTransfer": {
       "properties": {
         "iban": {
-          "type": "string",
+          "$ref": "https://gobl.org/draft-0/cbc/code",
           "title": "IBAN",
           "description": "International Bank Account Number"
         },
         "bic": {
-          "type": "string",
+          "$ref": "https://gobl.org/draft-0/cbc/code",
           "title": "BIC",
           "description": "Bank Identifier Code used for international transfers."
         },
         "number": {
-          "type": "string",
+          "$ref": "https://gobl.org/draft-0/cbc/code",
           "title": "Number",
           "description": "Account number, if IBAN not available."
+        },
+        "clearing": {
+          "$ref": "https://gobl.org/draft-0/cbc/code",
+          "title": "Clearing Code",
+          "description": "National bank or branch clearing identifier, such as a Danish registration\nnumber, UK sort code, or US routing number."
         },
         "name": {
           "type": "string",

--- a/pay/instructions.go
+++ b/pay/instructions.go
@@ -72,11 +72,14 @@ type DirectDebit struct {
 // a bank transfer or wire.
 type CreditTransfer struct {
 	// International Bank Account Number
-	IBAN string `json:"iban,omitempty" jsonschema:"title=IBAN"`
+	IBAN cbc.Code `json:"iban,omitempty" jsonschema:"title=IBAN"`
 	// Bank Identifier Code used for international transfers.
-	BIC string `json:"bic,omitempty" jsonschema:"title=BIC"`
+	BIC cbc.Code `json:"bic,omitempty" jsonschema:"title=BIC"`
 	// Account number, if IBAN not available.
-	Number string `json:"number,omitempty" jsonschema:"title=Number"`
+	Number cbc.Code `json:"number,omitempty" jsonschema:"title=Number"`
+	// National bank or branch clearing identifier, such as a Danish registration
+	// number, UK sort code, or US routing number.
+	Clearing cbc.Code `json:"clearing,omitempty" jsonschema:"title=Clearing Code"`
 	// Name of the bank.
 	Name string `json:"name,omitempty" jsonschema:"title=Name"`
 	// Bank office branch address, not normally required.

--- a/pay/instructions_test.go
+++ b/pay/instructions_test.go
@@ -33,6 +33,34 @@ func TestInstructionsNormalize(t *testing.T) {
 	})
 }
 
+func TestCreditTransferNormalize(t *testing.T) {
+	ct := &pay.CreditTransfer{
+		IBAN:     " DK50 0040 0440 1162 43 ",
+		BIC:      " DABADKKK ",
+		Number:   " 0440-116243 ",
+		Clearing: " 1234 ",
+		Name:     "Example Bank",
+	}
+
+	norm.Normalize(ct)
+
+	assert.Equal(t, cbc.Code("DK50 0040 0440 1162 43"), ct.IBAN)
+	assert.Equal(t, cbc.Code("DABADKKK"), ct.BIC)
+	assert.Equal(t, cbc.Code("0440-116243"), ct.Number)
+	assert.Equal(t, cbc.Code("1234"), ct.Clearing)
+	assert.Equal(t, "Example Bank", ct.Name)
+
+	data, err := json.Marshal(ct)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{
+		"iban": "DK50 0040 0440 1162 43",
+		"bic": "DABADKKK",
+		"number": "0440-116243",
+		"clearing": "1234",
+		"name": "Example Bank"
+	}`, string(data))
+}
+
 func TestOnline(t *testing.T) {
 	instr := &pay.Instructions{
 		Key: pay.MeansKeyOnline,


### PR DESCRIPTION
## Summary

- add a generic `clearing` identifier to `pay.CreditTransfer` for national bank or branch clearing codes
- use `cbc.Code` for the IBAN, BIC, account number, and clearing identifier fields
- keep the descriptive bank name as a string
- regenerate the credit transfer JSON schema

This allows formats such as OIOUBL to represent a Danish bank registration number without overloading the bank name field. The same field can also represent concepts such as UK sort codes and US routing numbers.

## Testing

- `go test ./...`
- `go generate .`