### PR TITLE
Describe it-ticket exemption codes

### DIFF
--- a/addons/it/ticket/extensions.go
+++ b/addons/it/ticket/extensions.go
@@ -29,12 +29,25 @@ var extensions = []*cbc.Definition{
 					i18n.EN: "Excluded pursuant to Art. 15, DPR 633/72",
 					i18n.IT: "Escluse ex. art. 15 del D.P.R. 633/1972",
 				},
+				Desc: i18n.String{
+					i18n.EN: here.Doc(`
+						Amounts excluded from the taxable base, such as default interest,
+						penalties, and sums advanced on behalf of the customer.
+					`),
+				},
 			},
 			{
 				Code: "N2",
 				Name: i18n.String{
 					i18n.EN: "Not subject",
 					i18n.IT: "Non soggette",
+				},
+				Desc: i18n.String{
+					i18n.EN: here.Doc(`
+						Operations outside the scope of Italian VAT, either because a
+						requirement for taxation is not met, or because of the supplier's
+						regime, such as the flat-rate regime (regime forfettario).
+					`),
 				},
 			},
 			{
@@ -43,12 +56,24 @@ var extensions = []*cbc.Definition{
 					i18n.EN: "Not taxable",
 					i18n.IT: "Non imponibili",
 				},
+				Desc: i18n.String{
+					i18n.EN: here.Doc(`
+						Operations within the scope of VAT but not taxable by law, such as
+						exports, international services, and intra-community supplies.
+					`),
+				},
 			},
 			{
 				Code: "N4",
 				Name: i18n.String{
 					i18n.EN: "Exempt",
 					i18n.IT: "Esenti",
+				},
+				Desc: i18n.String{
+					i18n.EN: here.Doc(`
+						Operations exempt under Art. 10 of DPR 633/72, such as medical,
+						financial, insurance, and educational services.
+					`),
 				},
 			},
 			{
@@ -57,12 +82,25 @@ var extensions = []*cbc.Definition{
 					i18n.EN: "Margin regime / VAT not exposed",
 					i18n.IT: "Regime del margine/IVA non esposta in fattura",
 				},
+				Desc: i18n.String{
+					i18n.EN: here.Doc(`
+						Sales under the margin scheme for second-hand goods, works of art,
+						and antiques, where VAT is included in the price but not shown
+						separately.
+					`),
+				},
 			},
 			{
 				Code: "N6",
 				Name: i18n.String{
 					i18n.EN: "Reverse charge",
 					i18n.IT: "Inversione contabile",
+				},
+				Desc: i18n.String{
+					i18n.EN: here.Doc(`
+						Operations for which the customer is liable for the VAT instead of
+						the supplier.
+					`),
 				},
 			},
 		},

--- a/data/addons/it-ticket-v1.json
+++ b/data/addons/it-ticket-v1.json
@@ -33,6 +33,9 @@
           "name": {
             "en": "Excluded pursuant to Art. 15, DPR 633/72",
             "it": "Escluse ex. art. 15 del D.P.R. 633/1972"
+          },
+          "desc": {
+            "en": "Amounts excluded from the taxable base, such as default interest,\npenalties, and sums advanced on behalf of the customer."
           }
         },
         {
@@ -40,6 +43,9 @@
           "name": {
             "en": "Not subject",
             "it": "Non soggette"
+          },
+          "desc": {
+            "en": "Operations outside the scope of Italian VAT, either because a\nrequirement for taxation is not met, or because of the supplier's\nregime, such as the flat-rate regime (regime forfettario)."
           }
         },
         {
@@ -47,6 +53,9 @@
           "name": {
             "en": "Not taxable",
             "it": "Non imponibili"
+          },
+          "desc": {
+            "en": "Operations within the scope of VAT but not taxable by law, such as\nexports, international services, and intra-community supplies."
           }
         },
         {
@@ -54,6 +63,9 @@
           "name": {
             "en": "Exempt",
             "it": "Esenti"
+          },
+          "desc": {
+            "en": "Operations exempt under Art. 10 of DPR 633/72, such as medical,\nfinancial, insurance, and educational services."
           }
         },
         {
@@ -61,6 +73,9 @@
           "name": {
             "en": "Margin regime / VAT not exposed",
             "it": "Regime del margine/IVA non esposta in fattura"
+          },
+          "desc": {
+            "en": "Sales under the margin scheme for second-hand goods, works of art,\nand antiques, where VAT is included in the price but not shown\nseparately."
           }
         },
         {
@@ -68,6 +83,9 @@
           "name": {
             "en": "Reverse charge",
             "it": "Inversione contabile"
+          },
+          "desc": {
+            "en": "Operations for which the customer is liable for the VAT instead of\nthe supplier."
           }
         }
       ]


### PR DESCRIPTION
## Context

The `it-ticket-exempt` codes are published with bare labels — "Not subject", "Not taxable", "Exempt" — which don't say what distinguishes them. An integrator picking a code for a zero-VAT line can't tell from the reference which one applies, and the wrong choice is a misdeclaration even though the VAT is zero either way. This came up in support: a customer asked us to explain the difference between N2, N3 and N4 after reading the addon page.

`it-sdi` already carries descriptions on its extensions, and `cbc.Definition.Desc` exists for exactly this.

## Changes

- **Add a description to each of the six exemption codes**, naming the kind of operation each one covers (excluded amounts, outside scope including the flat-rate regime, not taxable by law, exempt under Art. 10, margin scheme, reverse charge). Regenerated `data/addons/it-ticket-v1.json`, which is what docs.gobl.org renders.