### PR TITLE
Switch to precise rounding when removing included taxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Fixed
+
+- `bill`: removing taxes included in prices from a document using the `currency` rounding rule now switches it to `precise`, so that the resulting tax bases and amounts match those of the original document. Before, the tax-exclusive line totals were rounded to the currency's precision, which drifted from the original tax amounts by an amount that grew with the number of lines and left the difference in the document's `rounding` total.
+
 ## [v0.504.0]
 
 ### Added

--- a/bill/calculator.go
+++ b/bill/calculator.go
@@ -290,6 +290,17 @@ func removeIncludedTaxes(doc billable) error {
 	tx := doc.getTax()
 	tx.PricesInclude = ""
 
+	// Tax-exclusive prices need more decimal places than the currency to
+	// represent the original amounts, so the currency rounding rule can no
+	// longer be applied without losing the tax totals.
+	rr := tx.Rounding
+	if rr == "" {
+		rr = doc.RegimeDef().GetRoundingRule()
+	}
+	if rr == tax.RoundingRuleCurrency {
+		tx.Rounding = tax.RoundingRulePrecise
+	}
+
 	if err := calculate(doc); err != nil {
 		return err
 	}

--- a/bill/calculator_test.go
+++ b/bill/calculator_test.go
@@ -281,6 +281,44 @@ func TestRemoveIncludedTaxes(t *testing.T) {
 		assert.Equal(t, "1000.00", inv.Totals.Payable.String())
 	})
 
+	t.Run("with currency rounding rule", func(t *testing.T) {
+		lines := make([]*bill.Line, 12)
+		for i := range lines {
+			lines[i] = &bill.Line{
+				Quantity: num.MakeAmount(1, 0),
+				Item: &org.Item{
+					Name:  "Room rate",
+					Price: num.NewAmount(12500, 2),
+				},
+				Taxes: tax.Set{
+					{
+						Category: tax.CategoryVAT,
+						Percent:  num.NewPercentage(6, 2),
+					},
+				},
+			}
+		}
+		inv := baseInvoice(t, lines...)
+		inv.Tax.Rounding = tax.RoundingRuleCurrency
+		require.NoError(t, inv.Calculate())
+		require.NoError(t, inv.RemoveIncludedTaxes())
+
+		// The document can no longer use the currency's precision for the
+		// line prices, so it switches to the precise rounding rule in order
+		// to maintain the original tax amounts.
+		assert.Equal(t, tax.RoundingRulePrecise, inv.Tax.Rounding)
+		assert.Equal(t, "117.9245", inv.Lines[0].Item.Price.String())
+		assert.Equal(t, "1415.09", inv.Totals.Sum.String())
+		assert.Equal(t, "1415.09", inv.Totals.Total.String())
+		assert.Equal(t, "84.91", inv.Totals.Tax.String())
+		assert.Equal(t, "1500.00", inv.Totals.TotalWithTax.String())
+		assert.Equal(t, "1500.00", inv.Totals.Payable.String())
+		assert.Nil(t, inv.Totals.Rounding, "no rounding adjustment needed")
+		rt := inv.Totals.Taxes.Categories[0].Rates[0]
+		assert.Equal(t, "1415.09", rt.Base.String())
+		assert.Equal(t, "84.91", rt.Amount.String())
+	})
+
 	t.Run("from discounts", func(t *testing.T) {
 		inv := baseInvoiceWithLines(t)
 		inv.Discounts = []*bill.Discount{

--- a/bill/invoice.go
+++ b/bill/invoice.go
@@ -300,6 +300,10 @@ func (inv *Invoice) supportedTags() []cbc.Key {
 // If after removing taxes the totals don't match, a rounding error will be added to the
 // invoice totals. In most scenarios this shouldn't be more than a cent or two.
 //
+// Documents using the `currency` rounding rule are switched to `precise`, as the
+// tax-exclusive prices need more decimal places than the currency to reproduce the
+// original tax amounts.
+//
 // This method will replace the invoice contents in place, or return an error.
 func (inv *Invoice) RemoveIncludedTaxes() error {
 	return removeIncludedTaxes(inv)


### PR DESCRIPTION
When an invoice combines `tax.prices_include: VAT` with `tax.rounding: currency`, `RemoveIncludedTaxes` produced a tax breakdown that no longer matched the original document.

## The problem

In currency mode, `extractIncludedTaxes` derives the tax from the **running sum** of the tax-inclusive line totals and shares the rounding back over the lines, so the ex-tax base it reports is not the sum of independently-rounded per-line ex-tax amounts.

The convertor discarded that: it divides each unit price by the rate (+2 decimal places), and `calculateLine` then re-rounds each line total down to the currency's precision. For identical lines the per-line loss has the same sign every time, so it accumulates:

| Case | Original base / tax | After removal | `totals.rounding` |
|---|---|---|---|
| 1 × 100.00 @ 21% | 82.64 / 17.36 | 82.64 / 17.**35** | 0.01 |
| 12 × 125.00 @ 6% | 1415.09 / 84.91 | 1415.**04** / 84.**90** | 0.06 |
| 30 × 125.00 @ 6% | 3537.74 / 212.26 | 3537.**60** / 212.26 | 0.14 |
| 50 × 19.99 @ 19% | 839.92 / 159.58 | 840.**00** / 159.**60** | −0.10 |

`Payable` stayed correct because the residual landed in `Totals.Rounding` (BT-144), but the tax breakdown itself — the part that gets reported — was wrong, and the error grew with the number of lines rather than staying within the "cent or two" the method documents.

## The fix

`removeIncludedTaxes` switches a `currency`-rounded document to `precise`, resolving the regime default first so the rule is explicit in the output.

Currency rounding's contract is that every amount is rounded to the currency before summing. Once included taxes are removed the unit price carries extra decimal places, so that contract is already broken and cannot be restored. Precise mode keeps the line total at the price's precision and rounds once at the base, which is arithmetically the same operation as `Percent.From(inclusive_sum)`. All four cases above then reproduce the original base and tax exactly, with no rounding adjustment at all.

## Alternative considered

Making currency mode respect the item price's precision when it exceeds the currency's also fixes the totals, but `examples/de/invoice-de-rounding-2.json` pins the opposite requirement: 4-decimal input prices under currency rounding must yield 2-decimal line totals, as XRechnung/ZUGFeRD require. That approach was dropped.

## Trade-off

Converted documents now carry line totals with more decimal places than the currency. If a downstream format requires 2-decimal line amounts this matters, though the alternative was an incorrect tax breakdown plus a rounding line, which those formats also reject. The switch is a single condition and easy to gate at the addon or caller level if that turns out to be preferable.

## Test

`TestRemoveIncludedTaxes/with currency rounding rule` covers the 12 × 125.00 @ 6% case; verified failing without the fix (base 1415.04 vs 1415.09, tax 84.90 vs 84.91). Full suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)