### PR TITLE
net: sandbox authority list and WithSandbox client option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 - `net`: sandbox environment support. `SandboxAuthorities` (default `lookup.sandbox.gobl.org`) is the trust list for sandbox deployments — the same registration service with relaxed verification providers for test identities — and the `WithSandbox` client option switches a client onto it. The live and sandbox lists are disjoint: neither environment accepts the other's endorsements.
 
+### Changed
+
+- `net`: `Client.VerifyAuthority` reports `ErrUnavailable` when a candidate authority's key endpoint cannot be reached and no endorsement was found, instead of wrapping the failure as `ErrVerifyFailed` — the outcome is indeterminate, so callers (e.g. a verifier's inbox) answer 503 and the sender retries.
+
 ## [v0.504.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Added
+
+- `net`: sandbox environment support. `SandboxAuthorities` (default `lookup.sandbox.gobl.org`) is the trust list for sandbox deployments — the same registration service with relaxed verification providers for test identities — and the `WithSandbox` client option switches a client onto it. The live and sandbox lists are disjoint: neither environment accepts the other's endorsements.
+
 ## [v0.504.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 - `net`: sandbox environment support. `SandboxAuthorities` (default `lookup.sandbox.gobl.org`) is the trust list for sandbox deployments — the same registration service with relaxed verification providers for test identities — and the `WithSandbox` client option switches a client onto it. The live and sandbox lists are disjoint: neither environment accepts the other's endorsements.
 
+### Fixed
+
+- `head`: `SignedPayload` and `Header.Verify` report a payload error for a nil signature instead of panicking — a JSON `null` entry in an envelope's `sigs` array unmarshals without error, so a hostile envelope could crash a receiving inbox.
+
 ### Changed
 
 - `net`: signature checks search instead of indexing. The first signature still establishes the envelope's subject, but `Client.VerifyEnvelope`'s `expectedAud` is now satisfied by *any* valid subject signature carrying that audience, and `Client.Who` requires at least one audience-free self-signature instead of rejecting an audience-bound first signature. This resolves a conflict that made endorsed envelopes unpublishable: the registration hop demands a subject signature bound to the registry, while `/who` demands a publication signature with no audience — with search semantics both live on the same append-only envelope, so the countersigned envelope an Authority delivers can be served at `/who` verbatim, and the verifier's return to the registry binds through the subject's original registration signature.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Added
 
-- `net`: sandbox environment support. `SandboxAuthorities` (default `lookup.sandbox.gobl.org`) is the trust list for sandbox deployments — the same registration service with relaxed verification providers for test identities — and the `WithSandbox` client option switches a client onto it. The live and sandbox lists are disjoint: neither environment accepts the other's endorsements.
+- `net`: sandbox support: `SandboxAuthorities` (default `lookup.sandbox.gobl.org`) and the `WithSandbox` client option. The live and sandbox trust lists are disjoint.
 
 ### Fixed
 
-- `head`: `SignedPayload` and `Header.Verify` report a payload error for a nil signature instead of panicking — a JSON `null` entry in an envelope's `sigs` array unmarshals without error, so a hostile envelope could crash a receiving inbox.
+- `head`: `SignedPayload` and `Header.Verify` return an error for a nil signature (a JSON `null` entry in `sigs`) instead of panicking.
 
 ### Changed
 
-- `net`: signature checks search instead of indexing. The first signature still establishes the envelope's subject, but `Client.VerifyEnvelope`'s `expectedAud` is now satisfied by *any* valid subject signature carrying that audience, and `Client.Who` requires at least one audience-free self-signature instead of rejecting an audience-bound first signature. This resolves a conflict that made endorsed envelopes unpublishable: the registration hop demands a subject signature bound to the registry, while `/who` demands a publication signature with no audience — with search semantics both live on the same append-only envelope, so the countersigned envelope an Authority delivers can be served at `/who` verbatim, and the verifier's return to the registry binds through the subject's original registration signature.
-- `net`: `Client.VerifyAuthority` reports `ErrUnavailable` when a candidate authority's key endpoint cannot be reached and no endorsement was found, instead of wrapping the failure as `ErrVerifyFailed` — the outcome is indeterminate, so callers (e.g. a verifier's inbox) answer 503 and the sender retries.
+- `net`: signature checks search instead of indexing. The first signature still names the subject, but `Client.VerifyEnvelope` satisfies `expectedAud` with any valid subject signature carrying that audience, and `Client.Who` requires one audience-free self-signature while ignoring audience-bound ones. The endorsed envelope an Authority delivers can now be published at `/who` as-is.
+- `net`: `Client.VerifyAuthority` returns `ErrUnavailable` when a candidate authority's key endpoint cannot be reached and no endorsement was found, instead of `ErrVerifyFailed`.
 
 ## [v0.504.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Changed
 
+- `net`: signature checks search instead of indexing. The first signature still establishes the envelope's subject, but `Client.VerifyEnvelope`'s `expectedAud` is now satisfied by *any* valid subject signature carrying that audience, and `Client.Who` requires at least one audience-free self-signature instead of rejecting an audience-bound first signature. This resolves a conflict that made endorsed envelopes unpublishable: the registration hop demands a subject signature bound to the registry, while `/who` demands a publication signature with no audience — with search semantics both live on the same append-only envelope, so the countersigned envelope an Authority delivers can be served at `/who` verbatim, and the verifier's return to the registry binds through the subject's original registration signature.
 - `net`: `Client.VerifyAuthority` reports `ErrUnavailable` when a candidate authority's key endpoint cannot be reached and no endorsement was found, instead of wrapping the failure as `ErrVerifyFailed` — the outcome is indeterminate, so callers (e.g. a verifier's inbox) answer 503 and the sender retries.
 
 ## [v0.504.0]

--- a/head/header.go
+++ b/head/header.go
@@ -307,9 +307,7 @@ func (h *Header) Verify(sig *dsig.Signature, keys ...*dsig.PublicKey) error {
 
 // SignedPayload extracts the (unverified) signed payload from a
 // signature, used to read iss before fetching the signer's keys.
-// A nil signature — e.g. a JSON `null` entry in an envelope's sigs
-// array, which unmarshals without error — is reported as a payload
-// error rather than dereferenced.
+// A nil signature (a JSON `null` sigs entry) is a payload error.
 func SignedPayload(sig *dsig.Signature) (*SigningPayload, error) {
 	if sig == nil {
 		return nil, ErrSignaturePayload

--- a/head/header.go
+++ b/head/header.go
@@ -275,6 +275,9 @@ func (h *Header) Sign(key *dsig.PrivateKey, opts ...SignOption) (*dsig.Signature
 // fall within it. The signed iss/aud are part of the statement and are
 // not validated here — read them with SignedPayload.
 func (h *Header) Verify(sig *dsig.Signature, keys ...*dsig.PublicKey) error {
+	if sig == nil {
+		return ErrSignaturePayload
+	}
 	if len(keys) == 0 {
 		p := new(SigningPayload)
 		if err := sig.UnsafePayload(p); err != nil {
@@ -304,7 +307,13 @@ func (h *Header) Verify(sig *dsig.Signature, keys ...*dsig.PublicKey) error {
 
 // SignedPayload extracts the (unverified) signed payload from a
 // signature, used to read iss before fetching the signer's keys.
+// A nil signature — e.g. a JSON `null` entry in an envelope's sigs
+// array, which unmarshals without error — is reported as a payload
+// error rather than dereferenced.
 func SignedPayload(sig *dsig.Signature) (*SigningPayload, error) {
+	if sig == nil {
+		return nil, ErrSignaturePayload
+	}
 	p := new(SigningPayload)
 	if err := sig.UnsafePayload(p); err != nil {
 		return nil, ErrSignaturePayload

--- a/head/header_test.go
+++ b/head/header_test.go
@@ -461,3 +461,14 @@ func mustParseTS(t *testing.T, s string) cal.Timestamp {
 	}
 	return ts
 }
+
+func TestNilSignatureGuards(t *testing.T) {
+	// A JSON `null` in an envelope's sigs array unmarshals to a nil
+	// *dsig.Signature without error: readers must report it as a
+	// payload error, never dereference it.
+	_, err := head.SignedPayload(nil)
+	require.ErrorIs(t, err, head.ErrSignaturePayload)
+
+	h := head.NewHeader()
+	require.ErrorIs(t, h.Verify(nil), head.ErrSignaturePayload)
+}

--- a/net/README.md
+++ b/net/README.md
@@ -560,6 +560,19 @@ authority (or none has been registered), `ErrSignatureExpired` when
 a verified authority signature has expired, and `ErrVerifyFailed`
 when a candidate fails its crypto check.
 
+**Sandbox.** The network runs a parallel sandbox environment:
+`lookup.sandbox.gobl.org` (the default entry in
+`net.SandboxAuthorities`) operates the same registration service as
+the live authority, backed by its own database and its own accepted
+verification providers — typically relaxed KYB suited to test
+identities. The live and sandbox trust lists are disjoint by
+construction and MUST stay that way: a live verifier never accepts
+a sandbox endorsement, and a sandbox verifier never needs a live
+one. Clients opt in with `net.WithSandbox()`, which replaces the
+trust list with the sandbox authorities; everything else — request
+tokens, endorsement checks, the verifier claim — behaves
+identically in both environments.
+
 Note the trust topology this creates: receivers list *registration*
 authorities; the verifiers those authorities name are trusted
 transitively, because the registry names them inside its signed

--- a/net/README.md
+++ b/net/README.md
@@ -75,7 +75,12 @@ document are to be interpreted as described in BCP 14 (RFC 2119, RFC 8174).
   `/.well-known/gobl/keys/<kid>`.
 - **Party Envelope** — A signed GOBL Envelope whose document is an
   `org.Party`, served at the who endpoint. The first signature is the
-  subject's self-signature; Authority countersignatures follow.
+  subject's self-signature, establishing whose identity it is; the
+  subject appends one audience-bound self-signature per delivery hop
+  (a registration, a verification request), and Authority and
+  verifier countersignatures accumulate alongside. Signature order
+  beyond the first is not significant: consumers search rather than
+  index.
 - **Sender / Receiver** — The two roles in a document exchange. A
   receiver only needs a domain, TLS, and (if it signs or makes
   authenticated requests — §5.5) published keys. A sender is
@@ -379,6 +384,12 @@ the verifier's inbox, the verifier countersigns that exact envelope
 Authority's inbox, and the Authority re-countersigns with the
 pointer and re-delivers to the subject — whose published envelope
 then carries both countersignatures, each with its own lifetime.
+The audience rule (§8.3) holds at every hop without new signatures
+from the verifier's side: the subject's registration signature
+(`aud` = the Authority) remains aboard the append-only envelope, so
+the returned delivery still binds to the Authority's inbox, and the
+Authority SHOULD verify its own earlier countersignature on the
+returned envelope before re-countersigning (§8.3).
 
 The two countersignatures carry independent `exp` claims and
 deliberately independent lifecycles. A registration
@@ -504,7 +515,10 @@ issuer address:
    from `/.well-known/gobl/keys/<kid>` (including its optional
    `valid_from` / `valid_until`).
 4. The envelope is verified against that public key.
-5. If `expectedAud` is non-empty, the signed `aud` MUST equal it.
+5. If `expectedAud` is non-empty, at least one valid signature by
+   the same subject MUST carry that signed `aud` — searched across
+   all signatures, since the subject appends one audience-bound
+   signature per delivery hop and their order is not significant.
 6. If the key declares a validity window, the signed `iat` MUST fall
    within `[valid_from, valid_until]` (each bound optional).
 7. The verified issuer address is returned.
@@ -515,9 +529,14 @@ issuer address:
 request token (§5.5) identifying itself. The response is the
 target's party envelope: document = the target's `org.Party`,
 first signature = the target's self-signature with `iss=target`
-and no `aud` (the response is the same signed document for every
-authorized caller), optionally followed by Authority
-countersignatures.
+(the response is the same signed document for every authorized
+caller). The envelope MUST carry at least one valid audience-free
+self-signature — the subject's publication assertion. Audience-
+bound self-signatures (delivery-hop artifacts, e.g. the
+registration signature) and Authority or verifier countersignatures
+MAY also be aboard and do not disqualify the response; this is what
+lets the endorsed envelope be published exactly as the Authority
+delivered it.
 
 `Client.Who(ctx, addr)` performs the lookup and verifies it:
 
@@ -533,7 +552,11 @@ countersignatures.
 3. The verified issuer MUST equal the fetched address — a valid
    envelope for a *different* identity served at this URL is
    rejected.
-4. The document MUST be an `org.Party`, else `ErrPartyMissing`.
+4. The envelope MUST carry at least one valid audience-free
+   self-signature; an envelope with only caller-bound signatures
+   (e.g. a deferred disclosure minted for someone else, §8.2) is
+   not a public identity and is rejected.
+5. The document MUST be an `org.Party`, else `ErrPartyMissing`.
 
 The response body is still a static signed document — the request
 token controls *access*; it does not bind the response to the
@@ -738,13 +761,19 @@ transmitting documents its customers signed) authenticates the
 document signer's. The two layers are independent and both
 required.
 
-The envelope layer is unchanged by the token: the signer (`iss`) is
-verified against its published key (fetched from
-`<iss>/.well-known/gobl/keys/<kid>`); the signed `aud` MUST be
-present and MUST equal this inbox's Address — envelopes signed
-without an audience, or bound to a different audience, MUST be
-rejected. The inbox SHOULD then apply its sender-endorsement
-policy: resolve the sender's who (§6.4) and require an Authority
+The envelope layer is unchanged by the token: the subject (the
+first signature's `iss`) is verified against its published key
+(fetched from `<iss>/.well-known/gobl/keys/<kid>`); at least one
+valid signature by the subject MUST carry `aud` equal to this
+inbox's Address — searched across all signatures, so an envelope
+that legitimately accumulated hop signatures (§5.3) still binds.
+Envelopes where the subject never signed for this inbox MUST be
+rejected. An inbox that finds its *own* earlier countersignature
+aboard (an Authority receiving back the envelope it endorsed)
+SHOULD verify that signature against its own keys and reject the
+envelope when it does not hold — a broken or forged copy of the
+Authority's signature means the envelope is not what it endorsed.
+The inbox SHOULD then apply its sender-endorsement policy: resolve the sender's who (§6.4) and require an Authority
 countersignature — optionally with a confirmed verifier (§5.3) when
 the operator demands verified identities. Endorsement attaches to
 the envelope's signer, never to the token's issuer. Status codes:
@@ -753,7 +782,7 @@ the envelope's signer, never to the token's issuer. Status codes:
 |------------------------------|------------------------------------------------------|
 | `202 Accepted`               | Envelope parsed, validated, signature verified, persisted. |
 | `400 Bad Request`            | Body could not be read or did not decode as JSON.    |
-| `401 Unauthorized`           | Missing or invalid request token (§5.5); envelope signature did not verify; or `aud` missing / not equal to this inbox. |
+| `401 Unauthorized`           | Missing or invalid request token (§5.5); envelope signature did not verify; or no subject signature carries `aud` equal to this inbox. |
 | `403 Forbidden`              | Sender (`iss`) is not endorsed by an Authority this inbox trusts, or lacks the verified status the operator requires (§5.3). |
 | `422 Unprocessable Entity`   | Envelope failed structural validation.               |
 | `500 Internal Server Error`  | Persistence failed.                                  |
@@ -796,8 +825,8 @@ operator has an outstanding who request to that address (§8.2,
 `202`) SHOULD be accepted without sender endorsement: it carries
 exactly the assertions a `200` who response would, so it needs no
 more trust than the lookup it answers. Verification is the same as
-`Client.Who` steps 2–4 (§6.2), except that the envelope's signed
-`aud` MUST name this inbox. Outside of an outstanding who request,
+`Client.Who` steps 2–3 and 5 (§6.2), except that the subject MUST
+have signed for this inbox (`aud`) rather than for publication. Outside of an outstanding who request,
 party envelopes are subject to the normal endorsement policy.
 
 In code, `Client.Send(ctx, addr, env)` performs the delivery: it

--- a/net/README.md
+++ b/net/README.md
@@ -371,9 +371,14 @@ require verification reject with `ErrNotVerified`
 valid bare address is treated as absent. Adding or revoking
 verification is the registration Authority's act: it re-countersigns
 the envelope with the pointer added or removed, which makes the
-registry the single source of truth for verification state and
-requires coordination between the two authorities when KYC
-completes.
+registry the single source of truth for verification state. The
+coordination when verification completes is an ordinary delivery
+with no new endpoints: the subject sends its registered envelope to
+the verifier's inbox, the verifier countersigns that exact envelope
+(same `uuid` + `dig`) and posts it back to the registration
+Authority's inbox, and the Authority re-countersigns with the
+pointer and re-delivers to the subject — whose published envelope
+then carries both countersignatures, each with its own lifetime.
 
 The two countersignatures carry independent `exp` claims and
 deliberately independent lifecycles. A registration

--- a/net/authorities.go
+++ b/net/authorities.go
@@ -20,6 +20,17 @@ var Authorities = []Address{
 	"lookup.gobl.org",
 }
 
+// SandboxAuthorities is the default trust list for sandbox
+// deployments: lookup.sandbox.gobl.org runs the same registration
+// service as the live authority but endorses test identities through
+// relaxed verification providers. The live and sandbox lists are
+// disjoint by construction — endorsements from a sandbox authority
+// MUST never be accepted in live contexts, and vice versa. Clients
+// opt in with WithSandbox.
+var SandboxAuthorities = []Address{
+	"lookup.sandbox.gobl.org",
+}
+
 // maxEnvelopeSignatures bounds how many signatures VerifyAuthority is
 // willing to examine: each candidate can cost a network key fetch, so
 // an unbounded envelope would be a fetch-amplification gadget.

--- a/net/authorities.go
+++ b/net/authorities.go
@@ -87,7 +87,10 @@ func (e *Endorsement) Verified() bool {
 // Every candidate authority signature is considered: an endorsement
 // with a confirmed verifier is preferred over a registered-only one
 // regardless of signature order. If no signature is from a known
-// authority, returns ErrUnknownAuthority. If a verified authority
+// authority, returns ErrUnknownAuthority. If a candidate's key could
+// not be fetched due to a transient condition and no endorsement was
+// found, returns ErrUnavailable — the outcome is indeterminate and
+// the caller should retry, not reject. If a verified authority
 // signature has expired, returns ErrSignatureExpired. If all
 // candidates fail crypto verification, returns ErrVerifyFailed
 // wrapping the last error.
@@ -118,10 +121,13 @@ func (c *Client) VerifyAuthority(ctx context.Context, env *gobl.Envelope) (*Endo
 
 	// claimErr records a candidate that verified cryptographically but
 	// carried an expired exp claim; it takes precedence over crypto
-	// failures from other candidates. registered holds the first
-	// valid registered-only endorsement while the remaining
-	// signatures are searched for one with a confirmed verifier.
-	var lastErr, claimErr error
+	// failures from other candidates. unavailableErr records a
+	// candidate whose key endpoint could not be reached — a transient
+	// condition that leaves the outcome indeterminate, so it outranks
+	// both. registered holds the first valid registered-only
+	// endorsement while the remaining signatures are searched for one
+	// with a confirmed verifier.
+	var lastErr, claimErr, unavailableErr error
 	var registered *Endorsement
 	for _, sig := range env.Signatures {
 		p, err := head.SignedPayload(sig)
@@ -138,7 +144,11 @@ func (c *Client) VerifyAuthority(ctx context.Context, env *gobl.Envelope) (*Endo
 		// Candidate from a known authority — verify it crypto-wise.
 		pub, err := c.FetchKey(ctx, issuer, sig.KeyID())
 		if err != nil {
-			lastErr = err
+			if errors.Is(err, ErrUnavailable) {
+				unavailableErr = err
+			} else {
+				lastErr = err
+			}
 			continue
 		}
 		if err := env.Head.Verify(sig, pub); err != nil {
@@ -171,6 +181,9 @@ func (c *Client) VerifyAuthority(ctx context.Context, env *gobl.Envelope) (*Endo
 	}
 	if registered != nil {
 		return registered, nil
+	}
+	if unavailableErr != nil {
+		return nil, unavailableErr
 	}
 	if claimErr != nil {
 		return nil, claimErr

--- a/net/authorities.go
+++ b/net/authorities.go
@@ -87,13 +87,11 @@ func (e *Endorsement) Verified() bool {
 // Every candidate authority signature is considered: an endorsement
 // with a confirmed verifier is preferred over a registered-only one
 // regardless of signature order. If no signature is from a known
-// authority, returns ErrUnknownAuthority. If a candidate's key could
-// not be fetched due to a transient condition and no endorsement was
-// found, returns ErrUnavailable — the outcome is indeterminate and
-// the caller should retry, not reject. If a verified authority
-// signature has expired, returns ErrSignatureExpired. If all
-// candidates fail crypto verification, returns ErrVerifyFailed
-// wrapping the last error.
+// authority, returns ErrUnknownAuthority. A transient key-fetch
+// failure with no endorsement found returns ErrUnavailable. If a
+// verified authority signature has expired, returns
+// ErrSignatureExpired. If all candidates fail crypto verification,
+// returns ErrVerifyFailed wrapping the last error.
 //
 // Callers that want to accept self-signed (no-authority) envelopes
 // should skip this call rather than ignore its error.
@@ -119,14 +117,11 @@ func (c *Client) VerifyAuthority(ctx context.Context, env *gobl.Envelope) (*Endo
 		}
 	}
 
-	// claimErr records a candidate that verified cryptographically but
-	// carried an expired exp claim; it takes precedence over crypto
-	// failures from other candidates. unavailableErr records a
-	// candidate whose key endpoint could not be reached — a transient
-	// condition that leaves the outcome indeterminate, so it outranks
-	// both. registered holds the first valid registered-only
-	// endorsement while the remaining signatures are searched for one
-	// with a confirmed verifier.
+	// claimErr records a candidate that verified but carries an
+	// expired exp; unavailableErr records a transient key-fetch
+	// failure and outranks it. registered holds the first valid
+	// registered-only endorsement while the search continues for a
+	// confirmed verifier.
 	var lastErr, claimErr, unavailableErr error
 	var registered *Endorsement
 	for _, sig := range env.Signatures {

--- a/net/authorities_test.go
+++ b/net/authorities_test.go
@@ -669,6 +669,24 @@ func TestVerifyAuthorityUnavailability(t *testing.T) {
 		assert.True(t, errors.Is(err, ErrUnavailable))
 	})
 
+	t.Run("unreachable authority key surfaces instead of rejecting", func(t *testing.T) {
+		// The outcome is indeterminate while the authority's key
+		// endpoint is down: callers must see the transient condition
+		// (retry) rather than a definitive verification failure.
+		c := NewClient(
+			WithAuthorities(authorityAddr),
+			WithFetcher(&mapFetcher{
+				errs: map[string]error{
+					authorityAddr.KeyURL(authKey.ID()): fmt.Errorf("%w: HTTP 503", ErrUnavailable),
+				},
+			}),
+		)
+		_, err := c.VerifyAuthority(ctx, buildVerified(t))
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrUnavailable))
+		assert.False(t, errors.Is(err, ErrVerifyFailed))
+	})
+
 	t.Run("removed verifier key still degrades to registered", func(t *testing.T) {
 		// A definitive 404 means the key is gone — revoked — and the
 		// endorsement degrades rather than erroring.

--- a/net/authorities_test.go
+++ b/net/authorities_test.go
@@ -695,3 +695,27 @@ func TestVerifyAuthorityUnavailability(t *testing.T) {
 		assert.Contains(t, err.Error(), "signatures")
 	})
 }
+
+func TestWithSandbox(t *testing.T) {
+	original := Authorities
+	t.Cleanup(func() { Authorities = original })
+	Authorities = []Address{"lookup.gobl.org"}
+
+	t.Run("switches to the sandbox trust list", func(t *testing.T) {
+		c := NewClient(WithSandbox())
+		assert.Equal(t, SandboxAuthorities, c.authorities)
+	})
+
+	t.Run("live default excludes sandbox authorities", func(t *testing.T) {
+		c := NewClient()
+		for _, sandbox := range SandboxAuthorities {
+			assert.NotContains(t, c.authorities, sandbox,
+				"live clients must never trust sandbox endorsements")
+		}
+	})
+
+	t.Run("last trust option wins", func(t *testing.T) {
+		c := NewClient(WithSandbox(), WithAuthorities("authority.corp.example"))
+		assert.Equal(t, []Address{"authority.corp.example"}, c.authorities)
+	})
+}

--- a/net/client.go
+++ b/net/client.go
@@ -276,6 +276,18 @@ func WithKeyCacheTTL(d time.Duration) ClientOption {
 	}
 }
 
+// WithSandbox switches the client's trusted registration authorities
+// to the sandbox list (net.SandboxAuthorities), replacing the live
+// default. Sandbox authorities endorse test identities with relaxed
+// verification, so the two environments never trust each other's
+// endorsements. Like WithAuthorities this replaces the trust list —
+// when both options are given, the last one wins.
+func WithSandbox() ClientOption {
+	return func(c *Client) {
+		c.authorities = append([]Address{}, SandboxAuthorities...)
+	}
+}
+
 // WithIdentity sets the client's own address and private key, used to
 // mint the request tokens that who and inbox requests carry in their
 // Authorization header. A client without an identity sends those

--- a/net/verify.go
+++ b/net/verify.go
@@ -10,15 +10,12 @@ import (
 )
 
 // VerifyEnvelope performs remote verification of a signed GOBL envelope.
-// It reads the subject's GOBL Net identity (iss) from the first
-// signature's signed payload, fetches that address's public keys, and
-// verifies that signature. When expectedAud is non-empty, at least one
-// valid signature by the subject must carry that signed audience —
-// searched across all signatures, since the subject appends one
-// audience-bound signature per delivery hop and their order is not
-// significant. The verified subject address is returned. Signatures by
-// other parties (e.g. authority countersignatures) are not checked
-// here; use VerifyAuthority for those.
+// The first signature names the subject: its iss is resolved to a
+// published key and the signature verified. When expectedAud is
+// non-empty, at least one valid subject signature must carry that
+// audience — searched, since the subject appends one audience-bound
+// signature per delivery hop. Returns the verified subject address.
+// Other parties' signatures are not checked here; use VerifyAuthority.
 func (c *Client) VerifyEnvelope(ctx context.Context, env *gobl.Envelope, expectedAud Address) (Address, error) {
 	// A malformed envelope may carry signatures without a header;
 	// reject rather than let header verification panic.
@@ -80,12 +77,10 @@ func (c *Client) VerifyEnvelope(ctx context.Context, env *gobl.Envelope, expecte
 	return issuer, nil
 }
 
-// subjectSignatureFor reports whether the envelope carries at least
-// one cryptographically valid signature by subject whose signed
-// payload satisfies match. The signature count is bounded the same
-// way as VerifyAuthority (each candidate can cost a key fetch); a
-// transient key-fetch failure is returned as ErrUnavailable when no
-// other candidate matched.
+// subjectSignatureFor reports whether the envelope carries a valid
+// signature by subject whose payload satisfies match. The signature
+// count is capped (each candidate can cost a key fetch); a transient
+// key-fetch failure returns ErrUnavailable when nothing else matched.
 func (c *Client) subjectSignatureFor(ctx context.Context, env *gobl.Envelope, subject Address, match func(*head.SigningPayload) bool) (bool, error) {
 	if len(env.Signatures) > maxEnvelopeSignatures {
 		return false, fmt.Errorf("%w: envelope carries %d signatures (max %d)",

--- a/net/verify.go
+++ b/net/verify.go
@@ -10,12 +10,15 @@ import (
 )
 
 // VerifyEnvelope performs remote verification of a signed GOBL envelope.
-// It reads the signer's GOBL Net identity (iss) from the first
+// It reads the subject's GOBL Net identity (iss) from the first
 // signature's signed payload, fetches that address's public keys, and
-// verifies that signature. When expectedAud is non-empty, the signature's
-// signed audience (aud) must equal it. The verified issuer address is
-// returned. Additional signatures (e.g. authority countersignatures) are
-// not checked here; use VerifyAuthority for those.
+// verifies that signature. When expectedAud is non-empty, at least one
+// valid signature by the subject must carry that signed audience —
+// searched across all signatures, since the subject appends one
+// audience-bound signature per delivery hop and their order is not
+// significant. The verified subject address is returned. Signatures by
+// other parties (e.g. authority countersignatures) are not checked
+// here; use VerifyAuthority for those.
 func (c *Client) VerifyEnvelope(ctx context.Context, env *gobl.Envelope, expectedAud Address) (Address, error) {
 	// A malformed envelope may carry signatures without a header;
 	// reject rather than let header verification panic.
@@ -62,11 +65,59 @@ func (c *Client) VerifyEnvelope(ctx context.Context, env *gobl.Envelope, expecte
 		if err != nil {
 			return "", fmt.Errorf("%w: %v", ErrVerifyFailed, err)
 		}
-		got, err := ParseAddress(p.Aud)
-		if err != nil || got != want {
-			return "", fmt.Errorf("%w: audience mismatch (got %q, want %q)", ErrVerifyFailed, p.Aud, want)
+		ok, err := c.subjectSignatureFor(ctx, env, issuer, func(sp *head.SigningPayload) bool {
+			aud, aerr := ParseAddress(sp.Aud)
+			return aerr == nil && aud == want
+		})
+		if err != nil {
+			return "", err
+		}
+		if !ok {
+			return "", fmt.Errorf("%w: no valid signature by %q for audience %q", ErrVerifyFailed, issuer, want)
 		}
 	}
 
 	return issuer, nil
+}
+
+// subjectSignatureFor reports whether the envelope carries at least
+// one cryptographically valid signature by subject whose signed
+// payload satisfies match. The signature count is bounded the same
+// way as VerifyAuthority (each candidate can cost a key fetch); a
+// transient key-fetch failure is returned as ErrUnavailable when no
+// other candidate matched.
+func (c *Client) subjectSignatureFor(ctx context.Context, env *gobl.Envelope, subject Address, match func(*head.SigningPayload) bool) (bool, error) {
+	if len(env.Signatures) > maxEnvelopeSignatures {
+		return false, fmt.Errorf("%w: envelope carries %d signatures (max %d)",
+			ErrVerifyFailed, len(env.Signatures), maxEnvelopeSignatures)
+	}
+	var unavailable error
+	for _, sig := range env.Signatures {
+		p, err := head.SignedPayload(sig)
+		if err != nil {
+			continue
+		}
+		iss, err := ParseAddress(p.Iss)
+		if err != nil || iss != subject {
+			continue
+		}
+		if !match(p) {
+			continue
+		}
+		pub, err := c.FetchKey(ctx, subject, sig.KeyID())
+		if err != nil {
+			if errors.Is(err, ErrUnavailable) {
+				unavailable = err
+			}
+			continue
+		}
+		if err := env.VerifySignature(sig, pub); err != nil {
+			continue
+		}
+		return true, nil
+	}
+	if unavailable != nil {
+		return false, unavailable
+	}
+	return false, nil
 }

--- a/net/verify_test.go
+++ b/net/verify_test.go
@@ -111,6 +111,38 @@ func TestVerifyEnvelope(t *testing.T) {
 		assert.True(t, errors.Is(err, ErrVerifyFailed))
 	})
 
+	t.Run("audience found on a later subject signature", func(t *testing.T) {
+		// The subject appends one audience-bound signature per delivery
+		// hop; the expected audience may sit on any of them, not just
+		// the first.
+		key := dsig.NewES256Key()
+		env := buildTestEnvelope(t, key, addr.String(), "")
+		require.NoError(t, env.Sign(key,
+			head.WithIssuer(addr.String()),
+			head.WithAudience("recipient.example.com")))
+
+		c := NewClient(WithFetcher(&mockFetcher{data: jwkFromKey(t, key)}))
+		issuer, err := c.VerifyEnvelope(ctx, env, "recipient.example.com")
+		require.NoError(t, err)
+		assert.Equal(t, addr, issuer)
+	})
+
+	t.Run("audience on another party's signature does not count", func(t *testing.T) {
+		// A countersignature by someone else naming the expected
+		// audience is not the subject's delivery intent.
+		key := dsig.NewES256Key()
+		env := buildTestEnvelope(t, key, addr.String(), "")
+		other := dsig.NewES256Key()
+		require.NoError(t, env.Sign(other,
+			head.WithIssuer("other.example.com"),
+			head.WithAudience("recipient.example.com")))
+
+		c := NewClient(WithFetcher(&mockFetcher{data: jwkFromKey(t, key)}))
+		_, err := c.VerifyEnvelope(ctx, env, "recipient.example.com")
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrVerifyFailed))
+	})
+
 	t.Run("not signed", func(t *testing.T) {
 		c := NewClient()
 		_, err := c.VerifyEnvelope(ctx, new(gobl.Envelope), "")

--- a/net/verify_test.go
+++ b/net/verify_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/invopop/gobl/dsig"
 	"github.com/invopop/gobl/head"
 	"github.com/invopop/gobl/note"
+	"github.com/invopop/gobl/org"
 	"github.com/invopop/gobl/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -294,4 +296,169 @@ func TestVerifyEnvelopeInvalidExpectedAud(t *testing.T) {
 	_, err := c.VerifyEnvelope(context.Background(), env, "not valid!")
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, ErrVerifyFailed))
+}
+
+func TestVerifyEnvelopeSubjectKeyUnavailable(t *testing.T) {
+	// A transient failure fetching the subject's key surfaces as
+	// ErrUnavailable, never as a definitive verification failure.
+	ctx := context.Background()
+	addr := Address("issuer.example.com")
+	key := dsig.NewES256Key()
+	env := buildTestEnvelope(t, key, addr.String(), "")
+
+	c := NewClient(WithFetcher(&mapFetcher{errs: map[string]error{
+		addr.KeyURL(key.ID()): fmt.Errorf("%w: HTTP 503", ErrUnavailable),
+	}}))
+	_, err := c.VerifyEnvelope(ctx, env, "")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrUnavailable))
+	assert.False(t, errors.Is(err, ErrVerifyFailed))
+}
+
+func TestVerifyEnvelopeAudienceSearch(t *testing.T) {
+	ctx := context.Background()
+	addr := Address("issuer.example.com")
+	aud := Address("recipient.example.com")
+
+	t.Run("hop signature key unavailable", func(t *testing.T) {
+		// The audience-bound hop signature uses a second key whose
+		// endpoint is down: the outcome is indeterminate, so the
+		// caller sees ErrUnavailable and retries rather than
+		// rejecting.
+		keyA, keyB := dsig.NewES256Key(), dsig.NewES256Key()
+		env := buildTestEnvelope(t, keyA, addr.String(), "")
+		require.NoError(t, env.Sign(keyB,
+			head.WithIssuer(addr.String()),
+			head.WithAudience(aud.String())))
+
+		c := NewClient(WithFetcher(&mapFetcher{
+			data: map[string][]byte{
+				addr.KeyURL(keyA.ID()): jwkFromKey(t, keyA),
+			},
+			errs: map[string]error{
+				addr.KeyURL(keyB.ID()): fmt.Errorf("%w: HTTP 503", ErrUnavailable),
+			},
+		}))
+		_, err := c.VerifyEnvelope(ctx, env, aud)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrUnavailable))
+	})
+
+	t.Run("forged hop signature does not bind", func(t *testing.T) {
+		// The audience-bound signature claims the subject but was made
+		// with a key that does not match the published one: the crypto
+		// check fails and the audience is not satisfied.
+		keyA, keyB := dsig.NewES256Key(), dsig.NewES256Key()
+		env := buildTestEnvelope(t, keyA, addr.String(), "")
+		require.NoError(t, env.Sign(keyB,
+			head.WithIssuer(addr.String()),
+			head.WithAudience(aud.String())))
+
+		// Publish a different key under keyB's kid so the fetch
+		// succeeds and the crypto check is what fails.
+		other := dsig.NewES256Key()
+		var jwk map[string]any
+		require.NoError(t, json.Unmarshal(jwkFromKey(t, other), &jwk))
+		jwk["kid"] = keyB.ID()
+		forged, err := json.Marshal(jwk)
+		require.NoError(t, err)
+
+		c := NewClient(WithFetcher(&mapFetcher{data: map[string][]byte{
+			addr.KeyURL(keyA.ID()): jwkFromKey(t, keyA),
+			addr.KeyURL(keyB.ID()): forged,
+		}}))
+		_, err = c.VerifyEnvelope(ctx, env, aud)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrVerifyFailed))
+	})
+
+	t.Run("hop signature key removed does not bind", func(t *testing.T) {
+		// A definitive 404 on the hop signature's key is not
+		// retryable: the search just fails to bind.
+		keyA, keyB := dsig.NewES256Key(), dsig.NewES256Key()
+		env := buildTestEnvelope(t, keyA, addr.String(), "")
+		require.NoError(t, env.Sign(keyB,
+			head.WithIssuer(addr.String()),
+			head.WithAudience(aud.String())))
+
+		c := NewClient(WithFetcher(&mapFetcher{data: map[string][]byte{
+			addr.KeyURL(keyA.ID()): jwkFromKey(t, keyA),
+		}}))
+		_, err := c.VerifyEnvelope(ctx, env, aud)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrVerifyFailed))
+		assert.False(t, errors.Is(err, ErrUnavailable))
+	})
+
+	t.Run("rejects an envelope with too many signatures", func(t *testing.T) {
+		key := dsig.NewES256Key()
+		env := buildTestEnvelope(t, key, addr.String(), aud.String())
+		for len(env.Signatures) <= maxEnvelopeSignatures {
+			env.Signatures = append(env.Signatures, env.Signatures[0])
+		}
+		c := NewClient(WithFetcher(&mapFetcher{data: map[string][]byte{
+			addr.KeyURL(key.ID()): jwkFromKey(t, key),
+		}}))
+		_, err := c.VerifyEnvelope(ctx, env, aud)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrVerifyFailed))
+		assert.Contains(t, err.Error(), "signatures")
+	})
+
+	t.Run("unreadable signature payloads are skipped", func(t *testing.T) {
+		// A nil signature — a JSON `null` in the sigs array unmarshals
+		// without error — must not panic the search or break it for a
+		// valid signature aboard.
+		key := dsig.NewES256Key()
+		env := buildTestEnvelope(t, key, addr.String(), aud.String())
+		env.Signatures = append([]*dsig.Signature{nil}, env.Signatures...)
+
+		c := NewClient(WithFetcher(&mapFetcher{data: map[string][]byte{
+			addr.KeyURL(key.ID()): jwkFromKey(t, key),
+		}}))
+		// The nil first signature also breaks subject resolution, so
+		// VerifyEnvelope rejects cleanly (no panic)...
+		_, err := c.VerifyEnvelope(ctx, env, aud)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrVerifyFailed))
+		// ...while the search itself skips it and finds the valid one.
+		ok, err := c.subjectSignatureFor(ctx, env, addr, func(p *head.SigningPayload) bool {
+			return p.Aud == aud.String()
+		})
+		require.NoError(t, err)
+		assert.True(t, ok)
+	})
+}
+
+func TestWhoPublicationSignatureUnavailable(t *testing.T) {
+	// The publication (audience-free) self-signature uses a second key
+	// whose endpoint is down while the hop signature verifies: Who
+	// reports the transient condition instead of rejecting.
+	ctx := context.Background()
+	subject := Address("issuer.example.com")
+	keyA, keyB := dsig.NewES256Key(), dsig.NewES256Key()
+
+	party := &org.Party{Name: "Flaky"}
+	party.SetUUID(uuid.V7())
+	env, err := gobl.Envelop(party)
+	require.NoError(t, err)
+	require.NoError(t, env.Sign(keyA,
+		head.WithIssuer(subject.String()),
+		head.WithAudience("lookup.example.com")))
+	require.NoError(t, env.Sign(keyB, head.WithIssuer(subject.String())))
+	data, err := json.Marshal(env)
+	require.NoError(t, err)
+
+	c := NewClient(WithFetcher(&mapFetcher{
+		data: map[string][]byte{
+			subject.WhoURL():          data,
+			subject.KeyURL(keyA.ID()): jwkFromKey(t, keyA),
+		},
+		errs: map[string]error{
+			subject.KeyURL(keyB.ID()): fmt.Errorf("%w: HTTP 503", ErrUnavailable),
+		},
+	}))
+	_, err = c.Who(ctx, subject)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrUnavailable))
 }

--- a/net/who.go
+++ b/net/who.go
@@ -52,15 +52,22 @@ func (c *Client) Who(ctx context.Context, addr Address) (*gobl.Envelope, error) 
 	if issuer != addr {
 		return nil, fmt.Errorf("%w: who issuer %q does not match address %q", ErrVerifyFailed, issuer, addr)
 	}
-	// A who response is a public document: a caller-bound (aud-carrying)
-	// envelope is not a conforming identity and must not be treated as
-	// one.
-	p, err := head.SignedPayload(env.Signatures[0])
+	// A who response is a public document: it must carry at least one
+	// audience-free self-signature — the subject's publication
+	// assertion. Audience-bound self-signatures may also be aboard
+	// (one per delivery hop, e.g. a registration) and are ignored
+	// here: they are hop artifacts, not the public identity claim. An
+	// envelope carrying only caller-bound signatures (e.g. a deferred
+	// disclosure minted for someone else) is not a conforming
+	// identity and must not be treated as one.
+	ok, err := c.subjectSignatureFor(ctx, env, addr, func(p *head.SigningPayload) bool {
+		return p.Aud == ""
+	})
 	if err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrVerifyFailed, err)
+		return nil, err
 	}
-	if p.Aud != "" {
-		return nil, fmt.Errorf("%w: who response must not be audience-bound (aud %q)", ErrVerifyFailed, p.Aud)
+	if !ok {
+		return nil, fmt.Errorf("%w: who response carries no audience-free self-signature", ErrVerifyFailed)
 	}
 	if _, ok := env.Extract().(*org.Party); !ok {
 		return nil, ErrPartyMissing

--- a/net/who.go
+++ b/net/who.go
@@ -52,14 +52,10 @@ func (c *Client) Who(ctx context.Context, addr Address) (*gobl.Envelope, error) 
 	if issuer != addr {
 		return nil, fmt.Errorf("%w: who issuer %q does not match address %q", ErrVerifyFailed, issuer, addr)
 	}
-	// A who response is a public document: it must carry at least one
-	// audience-free self-signature — the subject's publication
-	// assertion. Audience-bound self-signatures may also be aboard
-	// (one per delivery hop, e.g. a registration) and are ignored
-	// here: they are hop artifacts, not the public identity claim. An
-	// envelope carrying only caller-bound signatures (e.g. a deferred
-	// disclosure minted for someone else) is not a conforming
-	// identity and must not be treated as one.
+	// A who response is a public document: it must carry at least
+	// one audience-free self-signature. Audience-bound self-
+	// signatures (delivery-hop artifacts) are ignored; an envelope
+	// with only caller-bound signatures is not a public identity.
 	ok, err := c.subjectSignatureFor(ctx, env, addr, func(p *head.SigningPayload) bool {
 		return p.Aud == ""
 	})

--- a/net/who_test.go
+++ b/net/who_test.go
@@ -110,7 +110,37 @@ func TestWho(t *testing.T) {
 		_, err = c.Who(ctx, subject)
 		require.Error(t, err)
 		assert.True(t, errors.Is(err, ErrVerifyFailed))
-		assert.Contains(t, err.Error(), "audience-bound")
+		assert.Contains(t, err.Error(), "audience-free")
+	})
+
+	t.Run("accepts hop-bound self-signatures alongside the publication one", func(t *testing.T) {
+		// A published endorsed envelope: the subject's registration
+		// signature is audience-bound to the registry, an authority
+		// countersignature is aboard, and an audience-free
+		// self-signature asserts the public identity. Signature order
+		// is not significant.
+		party := &org.Party{Name: "Endorsed"}
+		party.SetUUID(uuid.V7())
+		env, err := gobl.Envelop(party)
+		require.NoError(t, err)
+		require.NoError(t, env.Sign(subjKey,
+			head.WithIssuer(subject.String()),
+			head.WithAudience("lookup.example.com")))
+		authKey := dsig.NewES256Key()
+		require.NoError(t, env.Sign(authKey,
+			head.WithIssuer("lookup.example.com"),
+			head.WithAudience(subject.String())))
+		require.NoError(t, env.Sign(subjKey, head.WithIssuer(subject.String())))
+		data, err := json.Marshal(env)
+		require.NoError(t, err)
+
+		c := NewClient(WithFetcher(&mapFetcher{data: map[string][]byte{
+			subject.WhoURL():             data,
+			subject.KeyURL(subjKey.ID()): jwkOf(subjKey),
+		}}))
+		got, err := c.Who(ctx, subject)
+		require.NoError(t, err)
+		require.Len(t, got.Signatures, 3, "countersignatures preserved for VerifyAuthority")
 	})
 
 	t.Run("rejects a non-party document", func(t *testing.T) {


### PR DESCRIPTION
Adds first-class sandbox support to GOBL Net's trust model, for the parallel deployment at `lookup.sandbox.gobl.org` (see the companion deploy PR):

- `net.SandboxAuthorities` — the sandbox trust list, defaulting to `lookup.sandbox.gobl.org`: the same registration service as live, with its own database and its own accepted verification providers (relaxed KYB for test identities).
- `net.WithSandbox()` — switches a client's trusted registration authorities to the sandbox list. Like `WithAuthorities`, it replaces the list; last option wins.
- The spec (§6.3) documents the environment split and its invariant: the live and sandbox trust lists are disjoint and MUST stay that way — a live verifier never accepts a sandbox endorsement. Everything else (request tokens, endorsement checks, the `verifier` claim) behaves identically in both environments.
- Tests pin the invariant: the live default excludes sandbox authorities, `WithSandbox` swaps the list, and trust options compose last-wins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)