### PR TITLE
net: re-countersigning supersedes a party's own earlier signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Changed
+
+- `net`: spec §5.3 — a party re-countersigning an envelope MUST replace its own earlier countersignatures (supersession); removing another party's signatures remains forbidden. In steady state an endorsed identity carries exactly three signatures: the subject's, the Authority's, and the verifier's.
+
 ### Added
 
 - `net`: sandbox support: `SandboxAuthorities` (default `lookup.sandbox.gobl.org`) and the `WithSandbox` client option. The live and sandbox trust lists are disjoint.

--- a/net/README.md
+++ b/net/README.md
@@ -378,7 +378,12 @@ require verification reject with `ErrNotVerified`
 valid bare address is treated as absent. Adding or revoking
 verification is the registration Authority's act: it re-countersigns
 the envelope with the pointer added or removed, which makes the
-registry the single source of truth for verification state. The
+registry the single source of truth for verification state. A party
+re-countersigning an envelope MUST replace its own earlier
+countersignatures rather than accumulate copies: supersession is
+what makes the latest statement authoritative — a lingering older
+signature could assert a verifier the Authority has since revoked.
+No party may remove another party's signatures. The
 coordination when verification completes is an ordinary delivery
 with no new endpoints: the subject sends its registered envelope to
 the verifier's inbox, the verifier countersigns that exact envelope


### PR DESCRIPTION
Observed live after the first complete verification round: the published envelope carried four signatures — the subject's, the verifier's, and **two** Authority countersignatures (the registration round's and the verification round's), with more to come on every renewal.

Spec §5.3 now requires supersession: a party re-countersigning an envelope MUST replace its own earlier countersignatures (it may never touch another party's). Beyond the clutter, this is a correctness rule — a lingering older signature could assert a verifier the Authority has since revoked, and consumers scanning all signatures would still see it as verified until the old `exp` passed. Steady state is exactly three signatures: subject, Authority (with `verifier`), verifier.

Companions implementing it: invopop/gobl.lookup and invopop/gobl.kyb.sandbox strip their own earlier signatures before countersigning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)