### PR TITLE
net: streamline spec and require independent verifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
   deliveries and deferred `/who` responses remain audience-bound.
 - `net`: a party that countersigns an envelope must replace its own previous
   countersignature. It may not remove signatures from other parties.
+- `net`: registration authorities can no longer verify their own endorsements;
+  the named identity verifier must be a different participant.
 - `net`: `Client.VerifyAuthority` returns `ErrUnavailable`, rather than
   `ErrVerifyFailed`, when authority keys are temporarily unreachable and no
   endorsement can be verified.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,23 +6,30 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
-### Changed
-
-- `net`: spec §5.3 — a party re-countersigning an envelope MUST replace its own earlier countersignatures (supersession); removing another party's signatures remains forbidden. In steady state an endorsed identity carries exactly three signatures: the subject's, the Authority's, and the verifier's.
-
 ### Added
 
-- `net`: sandbox support: `SandboxAuthorities` (default `lookup.sandbox.gobl.org`) and the `WithSandbox` client option. The live and sandbox trust lists are disjoint.
+- `net`: added `SandboxAuthorities` (defaulting to `lookup.sandbox.gobl.org`)
+  and `WithSandbox`. Sandbox and live trust lists remain separate.
+
+### Changed
+
+- `net`: signatures are no longer interpreted by position. `Client.VerifyEnvelope`
+  is replaced by `Client.VerifyParty`, which verifies the address declared by a
+  party, and `Client.VerifyDelivery`, which finds the sole issuer bound to an
+  inbox. `Client.Who` now requires an audience-free self-signature.
+- `net`: registration and verification may pass the same party envelope between
+  participants; request tokens convey delivery intent. Ordinary document
+  deliveries and deferred `/who` responses remain audience-bound.
+- `net`: a party that countersigns an envelope must replace its own previous
+  countersignature. It may not remove signatures from other parties.
+- `net`: `Client.VerifyAuthority` returns `ErrUnavailable`, rather than
+  `ErrVerifyFailed`, when authority keys are temporarily unreachable and no
+  endorsement can be verified.
 
 ### Fixed
 
-- `head`: `SignedPayload` and `Header.Verify` return an error for a nil signature (a JSON `null` entry in `sigs`) instead of panicking.
-
-### Changed
-
-- `net`: signature order is never significant — signatures all cover the same payload, so position cannot be trusted. `Client.VerifyEnvelope` is replaced by `Client.VerifyParty` (the subject is the address the party document declares as its `gobl:` endpoint, attested by a valid self-signature — the endpoint/subject match is now enforced) and `Client.VerifyDelivery` (the sender is the single issuer with a valid signature bound to the receiving inbox). `Client.Who` additionally requires one audience-free self-signature. The endorsed envelope an Authority delivers can be published at `/who` as-is.
-- `net`: party envelopes in the registration and verification flows are bearer documents (spec §8.3): the subject signs once, audience-free, and the same envelope registers, publishes, and verifies. Delivery intent comes from the request token; Authority and verifier countersignatures carry the directed `iss`/`aud`. Deferred who disclosures remain audience-bound. Document deliveries keep the signed `aud` requirement.
-- `net`: `Client.VerifyAuthority` returns `ErrUnavailable` when a candidate authority's key endpoint cannot be reached and no endorsement was found, instead of `ErrVerifyFailed`.
+- `head`: `SignedPayload` and `Header.Verify` now return an error for `null`
+  signature entries instead of panicking.
 
 ## [v0.504.0]
 

--- a/net/README.md
+++ b/net/README.md
@@ -156,10 +156,12 @@ A registration authority countersigns a party envelope with:
 - `aud` equal to the party address; and
 - optionally, `verifier` naming the address that performed KYC/KYB.
 
-The verifier MUST also countersign the same envelope. When the authority is
-also the verifier, one countersignature satisfies both roles. Missing, invalid,
-or expired verifier evidence reduces the result to registered; it does not
-invalidate a valid registration endorsement.
+The verifier MUST be a different participant from the registration authority
+and MUST countersign the same envelope. Separating these roles prevents the
+authority from attesting to identity checks that no independent verifier
+performed. A self-referential, missing, invalid, or expired verifier claim
+reduces the result to registered; it does not invalidate a valid registration
+endorsement.
 
 `Client.VerifyAuthority` checks all candidate authority signatures and prefers
 a confirmed verifier over a registration-only result. An authority signature's

--- a/net/README.md
+++ b/net/README.md
@@ -1,1084 +1,327 @@
 # GOBL Net
 
-> ⚠️ **EXPERIMENTAL** — GOBL Net is under active development. The package
-> API and the wire protocol may change without notice and are not yet
-> covered by any stability guarantee.
+> **Experimental:** the API and wire protocol may change without notice.
 
-**Status:** Draft. This document is the wire-protocol specification for
-GOBL Net and describes the current state of the
-`github.com/invopop/gobl/net` package and related supporting code in
-`dsig`. CLI commands (`gobl init`, `gobl net who/send/serve`, `gobl sign
---domain …`, `gobl verify --remote`) and the reference server live in
-[`github.com/invopop/gobl.dev`](https://github.com/invopop/gobl.dev/#gobl-net) —
-that README covers on-disk layout, ACME, structured logging, and the
-operational stances. The protocol is pre-1.0 and subject to change.
+**Status:** Draft
 
 ## Abstract
 
-GOBL Net is a decentralized identity and discovery protocol for signed GOBL
-documents. It binds a document signature to a fully qualified domain name
-(FQDN), and defines a small set of well-known HTTPS endpoints at that domain:
+GOBL Net is a decentralized discovery and delivery protocol for signed GOBL
+documents. A participant is identified by a fully qualified domain name
+(FQDN). HTTPS binds that address to three well-known resources:
 
-- `/.well-known/gobl/keys/<kid>` — a single public JWK looked up by key
-  ID, used to verify signatures.
-- `/.well-known/gobl/who` — a signed GOBL Envelope carrying an
-  `org.Party` document, endorsing the holder's identity, retrieved
-  with an authenticated GET.
-- `/.well-known/gobl/inbox` — a write endpoint that accepts signed
-  envelopes addressed to the holder.
+| Resource | Purpose |
+|---|---|
+| `/.well-known/gobl/keys/<kid>` | Publish one verification key. |
+| `/.well-known/gobl/who` | Publish a signed `org.Party` identity. |
+| `/.well-known/gobl/inbox` | Accept signed GOBL envelopes. |
 
-Trust in an identity is anchored to the TLS certificate for the
-Address's FQDN: a signature's verifiable origin lives in its signed
-`iss`, the verifier fetches the corresponding public key from
-`https://<iss>/.well-known/gobl/keys/<kid>`, and the HTTPS connection
-proves the response really came from that FQDN. Key discovery is
-unconditional: it works the same for every participant and every
-policy below layers on top of it, never replaces it.
+A signature names its issuer in the signed `iss` claim. A verifier obtains the
+key from the issuer's domain and relies on Web PKI to authenticate the HTTPS
+response. Registration authorities add an optional trust layer by
+countersigning party envelopes.
 
-The two roles in an exchange carry asymmetric requirements. *Anyone*
-may provision a receiving address — publishing an inbox requires no
-approval from any third party, and a receive-only participant need
-not even publish identity details (§8.2). *Senders*, by contrast, are
-expected to carry an endorsement: a countersignature on their `/who`
-identity from a KYC vendor ("Authority") that receivers trust.
-Receivers accept or reject incoming documents on the strength of that
-endorsement (§6.4, §8.4).
-
-Requests to the who and inbox endpoints are themselves
-authenticated: every caller presents a short-lived request token
-(§5.5) signed with its own published key, so servers always know —
-and may record (§11.9) — who is asking.
-
-The protocol layers on top of standards already in use by GOBL:
-
-- **RFC 7515** — JSON Web Signature, for envelope signing.
-- **RFC 7517** — JSON Web Key Set, for key discovery.
-- **RFC 7519** — JSON Web Token, for request authentication.
-- **RFC 3986** — URI syntax, for discovery transport.
-
-GOBL Net does not define new cryptographic primitives. It defines (a) how a
-GOBL signature identifies its origin, (b) how to discover the verifying
-keys, (c) how to retrieve an endorsed identity for an address, and (d) how
-to deliver a signed envelope to its recipient.
+This package implements the client, address, authentication, and verification
+parts of the protocol. The reference server and CLI live in
+[`github.com/invopop/gobl.dev`](https://github.com/invopop/gobl.dev/#gobl-net).
 
 ## 1. Conventions
 
-The key words "MUST", "MUST NOT", "SHOULD", "SHOULD NOT", and "MAY" in this
-document are to be interpreted as described in BCP 14 (RFC 2119, RFC 8174).
+The terms MUST, MUST NOT, SHOULD, SHOULD NOT, and MAY are interpreted as
+described in BCP 14 (RFC 2119 and RFC 8174).
 
-## 2. Terminology
+## 2. Addresses and discovery
 
-- **Address** — An FQDN identifying a GOBL Net participant, e.g.
-  `billing.invopop.com`. Represented in code as `net.Address`.
-- **Published key** — A `dsig.PublicKey` (an RFC 7517 JWK plus the
-  optional `valid_from` / `valid_until` extension members) served at
-  `/.well-known/gobl/keys/<kid>`.
-- **Party Envelope** — A signed GOBL Envelope whose document is an
-  `org.Party`, served at the who endpoint. Its subject is the address
-  the party document itself declares as its `gobl:` endpoint, attested
-  by the subject's audience-free self-signature; Authority and
-  verifier countersignatures (each bound to the subject with `iss` +
-  `aud`) accumulate alongside. The party envelope is a bearer
-  document: the same envelope registers, publishes, and verifies
-  without per-hop signatures — delivery intent is carried by the
-  request token (§5.5). Signature order is not significant: consumers
-  search, never index.
-- **Sender / Receiver** — The two roles in a document exchange. A
-  receiver only needs a domain, TLS, and (if it signs or makes
-  authenticated requests — §5.5) published keys. A sender is
-  additionally expected to carry an Authority endorsement on its who
-  identity (§6.4).
-- **Authority / Verifier** — An Authority is an address receivers
-  trust to countersign who identities, asserting registration
-  (FQDN ownership). A Verifier is an authority named by a
-  registration Authority's `verifier` claim as having performed
-  identity verification (KYC/KYB) of the subject, confirmed by its
-  own countersignature (§5.3).
-- **iss / aud** — Fields in a signature's *signed payload* carrying the
-  verifiable GOBL Net origin (`iss`) and the address the signature is
-  bound to (`aud`), both as bare GOBL Net addresses (FQDNs) — GOBL
-  Net is implied inside the signed payload, so no URI scheme is
-  carried. These are the authoritative, tamper-proof identities.
-- **Request token** — A short-lived JWT presented in the
-  `Authorization` header of who and inbox requests, identifying the
-  party *making the HTTP request* (§5.5). Its `iss` may name a
-  trusted intermediary and is independent of any signature inside
-  the request body.
-- **header from / to** — Optional unsigned `cbc.URI` fields on the
-  envelope header expressing *intent/routing* in any scheme
-  (`iso6523-actorid-upis:`, `mailto:`, `gobl:`…). Useful for interop
-  with other formats; not used for verification.
+A GOBL Net address is an FQDN without a scheme, port, path, query, or fragment.
+`ParseAddress`:
 
-## 3. Addressing
+1. trims surrounding whitespace and one trailing dot;
+2. converts internationalized names to lowercase ASCII A-labels using the
+   IDNA2008 lookup profile;
+3. validates DNS label syntax; and
+4. requires at least two labels.
 
-### 3.1 Address Format
+An empty value returns `ErrAddressEmpty`; other invalid values return
+`ErrAddressInvalid`. Protocol fields and comparisons MUST use the canonical
+ASCII form.
 
-A GOBL Net Address is an FQDN. It MUST NOT contain a scheme, port, path,
-query, or fragment.
+For address `supplier.example.com`:
 
-Parsing is performed by `net.ParseAddress` and applies the following
-normalizations and constraints:
-
-1. Surrounding whitespace is trimmed.
-2. A trailing dot, if present, is stripped.
-3. The input is normalised to its ASCII (A-Label / Punycode) form via
-   `golang.org/x/net/idna` Lookup profile (IDNA2008). This converts
-   any U-Labels to A-Labels and lowercases ASCII labels in one step;
-   invalid IDN labels MUST be rejected with `ErrAddressInvalid`.
-4. The result MUST satisfy `is.DNSName` (RFC 1035 label syntax).
-5. The result MUST contain at least one dot (i.e. at least two labels).
-
-Inputs that contain a scheme, port, or path MUST be rejected with
-`ErrAddressInvalid`. An empty input MUST be rejected with `ErrAddressEmpty`.
-
-**Canonical form.** Addresses on the wire — in `iss`, `aud`,
-well-known URLs, and identity files — MUST be ASCII
-A-Labels. Implementations are free to accept U-Label input from
-humans (e.g. CLI flags) but MUST normalise to A-Label before
-signing, fetching, or comparing.
-
-**Examples.** Accepted (after normalization):
-
-| Input                       | Parsed Address           |
-|-----------------------------|--------------------------|
-| `billing.invopop.com`       | `billing.invopop.com`    |
-| `sub.domain.example.org`    | `sub.domain.example.org` |
-| `Billing.Invopop.COM`       | `billing.invopop.com`    |
-| `billing.invopop.com.`      | `billing.invopop.com`    |
-| `  billing.invopop.com  `   | `billing.invopop.com`    |
-| `München.DE`                | `xn--mnchen-3ya.de`      |
-| `xn--mnchen-3ya.de`         | `xn--mnchen-3ya.de`      |
-
-Rejected:
-
-| Input                  | Error                |
-|------------------------|----------------------|
-| `` (empty)             | `ErrAddressEmpty`    |
-| `localhost`            | `ErrAddressInvalid` (single label) |
-| `http://example.com`   | `ErrAddressInvalid` (scheme) |
-| `example.com/path`     | `ErrAddressInvalid` (path)   |
-| `example.com:8080`     | `ErrAddressInvalid` (port)   |
-| `not valid!.com`       | `ErrAddressInvalid` (illegal characters) |
-| `-bad.com`             | `ErrAddressInvalid` (invalid IDN label) |
-
-### 3.2 Well-Known Paths
-
-The following constants are defined in `net/address.go`:
-
-| Constant         | Value                                |
-|------------------|--------------------------------------|
-| `WellKnownPath`  | `/.well-known/gobl`                  |
-| `KeysPath`       | `/.well-known/gobl/keys` (prefix)    |
-| `KeyPath(kid)`   | `/.well-known/gobl/keys/<kid>`       |
-| `WhoPath`        | `/.well-known/gobl/who`              |
-| `InboxPath`      | `/.well-known/gobl/inbox`            |
-| `JWKSPath`       | `/.well-known/jwks.json`             |
-
-For an Address `A`, the canonical URI and URLs are
-
-```
-<A>                                        ← Address.String() (iss / aud / verifier value)
-gobl:<A>                                   ← Address.URI()  (endpoint / header from-to value)
-https://<A>/.well-known/gobl/keys/<kid>    ← KeyURL(kid)
-https://<A>/.well-known/gobl/who           ← WhoURL()
-https://<A>/.well-known/gobl/inbox         ← InboxURL()
-https://<A>/.well-known/jwks.json          ← JWKSURL()
+```text
+supplier.example.com
+gobl:supplier.example.com
+https://supplier.example.com/.well-known/gobl/keys/<kid>
+https://supplier.example.com/.well-known/gobl/who
+https://supplier.example.com/.well-known/gobl/inbox
+https://supplier.example.com/.well-known/jwks.json
 ```
 
-The protocol exposes two key-discovery surfaces:
-
-1. **Per-kid** at `/.well-known/gobl/keys/<kid>` — single-JWK lookups,
-   used by `Client.FetchKey` during verification. Scales as keys
-   rotate; an absent or retired kid returns `404`.
-2. **Bulk JWKS** at `/.well-known/jwks.json` — standard RFC 7517 JWK
-   Set. GOBL Net signatures do **not** carry a `jku` header, so this
-   endpoint is for tooling that fetches a JWK Set by convention
-   (e.g. derived from the signer's domain) rather than from a JWS
-   header reference.
-
-The scheme MUST be `https`. HTTP is not a permitted alternative for
-production deployments; client tooling MAY offer an opt-in for plain
-HTTP solely for local development.
-
-Responses are always JSON, so file extensions are omitted from the paths.
-
-## 4. Keys
-
-Each domain publishes one or more public keys, each individually
-addressable by its `kid` at `/.well-known/gobl/keys/<kid>`. The response
-body is a single RFC 7517 JSON Web Key, optionally augmented with a
-GOBL Net validity window:
-
-```
-{
-  "kty": "EC", "crv": "P-256", "kid": "…", "x": "…", "y": "…",
-  "valid_from":  "2026-01-01T00:00:00.000Z",
-  "valid_until": "2027-01-01T00:00:00.000Z"
-}
-```
-
-`valid_from` and `valid_until` are *additional JWK members* in the sense
-of RFC 7517 §4 — implementations that do not recognise them MUST ignore
-them, so the response remains a conformant JWK for any standard JOSE
-consumer.
-
-When set, the validity window bounds the signing time that each
-signature may carry in its signed payload (`iat`). A verifier rejects
-a signature whose `iat` falls outside `[valid_from, valid_until]`.
-The checks degrade gracefully: an absent bound on the key, or an
-absent `iat` on the signature, simply skips that half of the
-comparison.
-
-`valid_from` is stamped automatically when a key is generated.
-`valid_until` is left empty and is meant to be set when the operator
-rotates the key out — either at retirement, or in advance of a
-planned rotation. A retired key remains published so that historical
-envelopes signed within its window still verify; only signatures with
-an `iat` past `valid_until` are rejected.
-
-Verifiers MUST treat unknown kids as `404 Not Found`; this is how a
-domain expresses that a key has been removed entirely (as distinct from
-"retired but still serving historical verification"). The per-kid path
-is the only one GOBL's own `Client.FetchKey` uses.
-
-### 4a. Bulk JWKS endpoint (jwt.io interop)
-
-In addition to the per-kid endpoint, the server publishes a standard
-RFC 7517 JWK Set at `/.well-known/jwks.json`. This is provided as a
-convenience for operators inspecting their keys via `curl` and for
-third-party JOSE tooling that prefers to fetch a full key set by URL
-rather than per-kid. GOBL Net's own verifier
-(`Client.FetchKey` → per-kid endpoint) does not use it.
-
-Response shape:
-
-```json
-{
-  "keys": [
-    { "kty": "EC", "kid": "<newest UUIDv7>", "valid_from": "…", … },
-    { "kty": "EC", "kid": "<older  UUIDv7>", "valid_until": "…", … }
-  ]
-}
-```
-
-Keys are returned **newest first**, ordered by `valid_from`
-descending; entries without a `valid_from` sort last. Since key IDs
-are UUIDv7 (time-ordered), kid descending is the deterministic
-tie-breaker.
-
-The JOSE header on each signature carries `alg` and `kid` only. The
-signed payload's `iss` value names the issuing GOBL Net address; a
-verifier resolves that to the per-kid URL via `Client.FetchKey`.
-
-The key type and the validity-window enforcement live in the `dsig`
-package: a published key is a `dsig.PublicKey`. `head.Header.Verify`
-calls `dsig.PublicKey.Allows` automatically, so every signed-envelope
-verifier — whether through GOBL Net or a direct `Envelope.Verify` call
-— enforces the window.
-
-A conforming server MUST serve each published key verbatim at
-`/.well-known/gobl/keys/<kid>` and the bulk set at
-`/.well-known/jwks.json`. The reference implementation in
-`gobl.dev`'s `gobl net serve` stores one file per `kid` on disk and
-maps 1:1 to a future row-per-`kid` database — but the on-disk layout
-is an implementation detail of that server, not part of this
-protocol.
-
-Endorsement of a participant happens at the identity layer (see §6) and
-does *not* live inside the key material itself.
-
-## 5. Signatures
-
-### 5.1 Signed identities: `iss` / `aud` / `iat`
-
-Each signature signs a payload of `{uuid, dig, iss, aud, iat}`:
-
-- `uuid` + `dig` identify the document (immutable after signing).
-- `iss` is the signer's verifiable GOBL Net address as a bare FQDN
-  (e.g. `billing.invopop.com`). The verifier reads it to discover
-  *which* per-key endpoint to fetch. No URI scheme is carried:
-  within the protocol the value can only be a GOBL Net address, and
-  since an FQDN can never contain a colon, a future revision could
-  admit URI forms without ambiguity.
-- `aud` is the GOBL Net address the signature is bound to. It is
-  optional at the protocol layer (e.g. a self-signed identity
-  document, or an envelope archived for later inspection, may omit
-  it), but **inboxes MUST require it** (§8.3): an envelope POSTed
-  to a `/inbox` MUST carry `aud == <inbox-owner>`, otherwise the
-  request is rejected. Binding the audience inside the signature
-  prevents the same valid invoice from being replayed against
-  multiple inboxes.
-- `iat` is the signing time as a JWT-standard NumericDate (Unix
-  seconds, per RFC 7519 §2). It is set automatically by `Sign`;
-  verifiers read it for the per-key validity window check but no
-  freshness policy is enforced by default — receivers may apply their
-  own max-age window when relevant.
-- `exp` (optional, JWT-standard per RFC 7519 §4.1.4, set with
-  `head.WithExpiration`) is the time after which the signature's
-  assertions should no longer be relied upon. Ordinary transport
-  signatures omit it — archived envelopes must keep verifying
-  indefinitely. Authorities set it on their countersignatures to
-  bound the endorsement's lifetime (§5.3).
-
-Because `iss`/`aud`/`iat` are inside the signed payload, the origin,
-audience, and signing time are all tamper-proof. Multiple parties may
-countersign the same document (shared `uuid`+`dig`) each with their own
-`iss`/`aud`/`iat`.
-
-The header `from`/`to` (`cbc.URI`) are a *separate*, unsigned layer for
-intent/routing in any scheme; they are never used for verification.
-
-### 5.2 Envelope Signing
-
-`Envelope.Sign(key, opts...)` (→ `head.Header.Sign`) signs the document
-identity plus the signer's `iss` and optional `aud`, set with the
-`head.WithIssuer` and `head.WithAudience` options. Both may be omitted
-for a plain, non-GOBL-Net signature.
-
-### 5.3 Authority countersignatures and verification
-
-A `/who` response (and any envelope an Authority chooses to endorse)
-MAY carry one or more countersignatures from addresses in the
-receiver's `Authorities` list (§6.3). A countersignature from a
-trusted Authority asserts that the subject is **registered**: the
-Authority has confirmed the subject controls the named GOBL Net
-address (FQDN ownership).
-
-**Verified identities.** When the subject has additionally passed
-identity verification (KYC/KYB), the registration Authority's
-countersignature carries a `verifier` claim: the GOBL Net address
-(a bare FQDN) of the authority that performed the verification.
-The named verifier MUST also countersign the same envelope; the
-subject is **verified** only when both hold — the registration
-Authority's pointer authorizes *which* signature to trust for
-verification, and the verifier's own signature is the evidence. An
-Authority that performs verification itself names itself, and its
-single countersignature serves as both attestations. Both levels
-are structural rather than declared: registration is asserted by
-the countersignature's presence, verification by the confirmed
-`verifier` claim.
-
-```go
-// Registration authority (e.g. lookup.gobl.org):
-env.Sign(authorityKey,
-    head.WithIssuer(authorityAddr.String()),
-    head.WithAudience(subjectAddr.String()),
-    head.WithVerifier(verifierAddr.String()))
-// Verifying authority (KYC/KYB vendor):
-env.Sign(verifierKey,
-    head.WithIssuer(verifierAddr.String()),
-    head.WithAudience(subjectAddr.String()))
-```
-
-A named verifier whose countersignature is absent, invalid, or
-expired MUST degrade the endorsement to registered rather than
-invalidate it: the registration stands on its own, and callers that
-require verification reject with `ErrNotVerified`
-(`Endorsement.Verified` in code). A `verifier` value that is not a
-valid bare address is treated as absent. Adding or revoking
-verification is the registration Authority's act: it re-countersigns
-the envelope with the pointer added or removed, which makes the
-registry the single source of truth for verification state. A party
-re-countersigning an envelope MUST replace its own earlier
-countersignatures rather than accumulate copies: supersession is
-what makes the latest statement authoritative — a lingering older
-signature could assert a verifier the Authority has since revoked.
-No party may remove another party's signatures. The
-coordination when verification completes is an ordinary delivery
-with no new endpoints: the subject sends its registered envelope to
-the verifier's inbox, the verifier countersigns that exact envelope
-(same `uuid` + `dig`) and posts it back to the registration
-Authority's inbox, and the Authority re-countersigns with the
-pointer and re-delivers to the subject — whose published envelope
-then carries both countersignatures, each with its own lifetime.
-The same bearer envelope flows through every hop with no per-hop
-subject signatures (§8.3): delivery intent is each request's token,
-while the countersignatures carry the directed statements (`iss` +
-`aud` = the subject). Each role gates its own inbox: the Authority
-requires the subject's who eligibility (§6.2), the verifier
-requires the Authority's countersignature, and the subject's inbox
-accepts party envelopes whose subject is itself — the returns. The
-Authority SHOULD verify its own earlier countersignature on the
-returned envelope before re-countersigning. Anyone may re-submit a
-published envelope, but every outcome is delivered to the subject's
-own inbox and endorsements are scoped by each client's trust list,
-so third-party submission is at worst an unsolicited renewal.
-
-The two countersignatures carry independent `exp` claims and
-deliberately independent lifecycles. A registration
-countersignature SHOULD carry an `exp` of at most 90 days, after
-which the subject renews its registration (§11.4). A verifier
-countersignature MAY be much longer-lived — a year or more, in the
-spirit of EV TLS certificates — since the underlying KYC/KYB
-process is expensive to repeat; its `exp` bounds the verification
-independently of the registration cycle. Verifiers of either kind
-MUST treat an expired countersignature as absent:
-`Client.VerifyAuthority` rejects expired registration candidates
-with `ErrSignatureExpired` and degrades an expired verifier
-signature to registered. A countersignature without `exp` does not
-expire; verifiers MAY apply their own `iat` max-age policy to such
-legacy endorsements.
-
-### 5.4 X.509 evidence (optional, long-term storage)
-
-JWS allows an `x5c` header carrying an X.509 certificate chain (RFC
-7515 §4.1.6). GOBL Net does **not** use `x5c` for signature
-verification — the trust anchor is the signed `iss` resolved through
-the per-key endpoint, secured by the issuer's TLS certificate (see
-§11.1). But signers MAY stamp `x5c` on a signature as additional,
-self-contained evidence for archival and long-term verification: a
-recipient who keeps the envelope for many years, long after the
-issuer's `/.well-known/gobl/keys/<kid>` may have stopped responding,
-can still verify the signature against the embedded chain and walk
-that chain to a CA they trust at audit time.
-
-Treat `x5c` as supplementary evidence, not as a replacement for §11.1:
-the chain proves that *some* CA-attested entity signed the document,
-but does not bind the signature to a GOBL Net Address. Verifiers MAY
-consult `x5c` for archival proofs, but for live verification of an
-inbox delivery or `/who` lookup the signed `iss` + Web PKI MUST be
-the authoritative chain.
-
-The library does not stamp `x5c` automatically. Operators with an
-archival need can add it via a future `dsig.WithX5C` option or by
-constructing the JWS with the underlying go-jose options directly.
-
-### 5.5 Request tokens (`Authorization` header)
-
-Requests to the who and inbox endpoints (§8.2, §8.3) MUST carry a
-request token: a compact JWS in the JWT form (RFC 7519), sent as an
-`Authorization: Bearer` header (RFC 6750) and signed with the same
-ES256 key material as any other GOBL Net signature (§4, §5). The
-token authenticates the party *making the HTTP request*; it is
-independent of, and may name a different party than, any signature
-inside the request body.
-
-The signed claims are:
-
-- `iss` — the requester's Address as a bare FQDN. This MAY be a
-  trusted intermediary transmitting a document on behalf of its
-  signer; the envelope's own `iss` (§5.1) remains the authoritative
-  document origin.
-- `aud` — the destination Address as a bare FQDN. Verifiers MUST
-  reject a token whose `aud` is not their own address: binding the
-  audience prevents a captured token from being replayed against a
-  different server.
-- `iat` — issue time as a NumericDate. REQUIRED.
-- `exp` — expiry. REQUIRED. Clients are responsible for keeping the
-  window short: `exp − iat` SHOULD be between 30 seconds and 5
-  minutes (60 seconds is a sensible default).
-- `jti` — OPTIONAL unique token id (UUID) for audit correlation.
-
-The protected header MUST carry the signing key's `kid` and MAY
-carry `typ: "JWT"` for generic-tooling interop.
-
-**Verification.** The server reads the unverified `iss` and `kid`,
-fetches the key from `https://<iss>/.well-known/gobl/keys/<kid>`
-(key endpoints are open — §8.1 — so request authentication never
-recurses), verifies the signature, and checks that `aud` equals its
-own address and that the key's validity window (§4) allows `iat`.
-Freshness: a token MUST be rejected when `exp` has passed, when
-`iat` lies in the future, or when `iat` is older than 5 minutes
-regardless of `exp`; verifiers SHOULD allow 30 seconds of clock
-skew. A request with a missing or invalid token MUST be rejected
-with `401 Unauthorized`. A verifier that cannot *reach* the
-issuer's key endpoint (`ErrUnavailable`: network failure, 429, 5xx)
-MUST NOT treat the token as invalid — the server responds
-`503 Service Unavailable` so the client retries, rather than `401`,
-which clients treat as a definitive rejection.
-
-Published keys are immutable per `kid` (§4), so verifiers SHOULD
-cache fetched keys for a short TTL rather than re-fetch per
-request; the reference client caches for 5 minutes (§7.1). When
-the request token and the body's signature are made with the same
-key — the common case of a sender delivering its own documents —
-token and envelope verification then share a single key fetch. The
-TTL also bounds how long a key removed from the issuer's endpoint
-(§4, 404) keeps verifying; `Client.FlushKeyCache` empties the cache
-on demand for operators reacting to a reported compromise.
-
-Any participant with published keys can mint a request token —
-endorsement requirements (§6.4) attach to the *document signer*,
-not the requester. Servers MAY keep an audit log of authenticated
-requests (§11.9) and MAY apply their own policy to which requesters
-they serve.
-
-Because tokens are cheap to mint and single-purpose, clients SHOULD
-mint a fresh token per request rather than reuse one across
-requests; `jti` gives operators a hook for replay suppression
-within the freshness window, but the protocol does not require it.
-
-In code: `net.NewToken(key, iss, aud, ttl)` mints a token, a
-`Client` configured with `net.WithIdentity(addr, key)` attaches one
-to every who and inbox request automatically, and servers verify
-inbound tokens with `Client.VerifyToken(ctx, token, aud)`, which
-returns the verified requester Address.
-
-## 6. Verification
-
-### 6.1 Envelope Verification Flow
-
-Verification never depends on signature order — any holder of an
-envelope can permute its signatures without invalidating them, so
-nothing may be read from position. Two entry points cover the two
-envelope roles.
-
-`Client.VerifyParty(ctx, env)` establishes the subject of an
-identity envelope:
-
-1. The envelope MUST be signed and its document MUST be an
-   `org.Party` declaring a `gobl:` endpoint — that address is the
-   subject.
-2. At least one signature whose `iss` is the subject MUST verify
-   against the subject's published keys (`FetchKey`, including the
-   key's optional `valid_from` / `valid_until` window against the
-   signed `iat`).
-3. The subject address is returned.
-
-`Client.VerifyDelivery(ctx, env, self)` establishes the sender of a
-document delivery:
-
-1. The envelope MUST be signed.
-2. Among all signatures, those whose signed `aud` equals `self` and
-   which verify against their issuer's published keys are the
-   delivery bindings. Exactly one issuer may bind: none rejects the
-   delivery, more than one is ambiguous.
-3. That issuer — the sender — is returned.
-
-### 6.2 Identity lookup (`GET /who`)
-
-`/who` is an authenticated GET (see §8.2): the caller presents a
-request token (§5.5) identifying itself. The response is the
-target's party envelope (the same signed document for every
-authorized caller): its document MUST declare the target as its
-`gobl:` endpoint, and the envelope MUST carry at least one valid
-audience-free self-signature — the subject's publication assertion.
-Authority or verifier countersignatures and audience-bound
-self-signatures (from older protocol revisions) MAY also be aboard
-and do not disqualify the response; the endorsed envelope is
-published exactly as the Authority delivered it.
-
-`Client.Who(ctx, addr)` performs the lookup and verifies it:
-
-1. A request token for `aud=<addr>` is minted from the client's
-   identity (`WithIdentity`) and sent with
-   `GET https://<addr>/.well-known/gobl/who`. A `204` returns
-   `ErrNoContent` — the address exists but publishes no identity
-   details (a receive-only account). A `202` returns `ErrPending` —
-   the request was recorded and the owner may deliver its party
-   envelope to the caller's inbox later (§8.2).
-2. The subject is established via `VerifyParty` (§6.1): the party
-   document's declared endpoint, attested by a valid
-   self-signature. It MUST equal the fetched address — a valid
-   envelope for a *different* identity served at this URL is
-   rejected.
-3. The envelope MUST carry at least one valid audience-free
-   self-signature; an envelope with only caller-bound signatures
-   (e.g. a deferred disclosure minted for someone else, §8.2) is
-   not a public identity and is rejected.
-
-The response body is still a static signed document — the request
-token controls *access*; it does not bind the response to the
-caller. The identity's integrity comes from the self-signature and
-the TLS origin, so clients MAY cache the verified envelope locally
-within a modest TTL (§8.2), which also avoids minting a fresh token
-per lookup.
-
-### 6.3 Trusted Authorities
-
-The package-level slice `net.Authorities` holds GOBL Net addresses
-treated as trusted registration authorities. The default list
-contains the network's default authority, `lookup.gobl.org`, and
-`net.RegisterAuthority` appends to it. The `WithAuthorities` client
-option *replaces* the list for that client: whoever configures
-trust states it fully, so closed deployments can exclude the
-default authority entirely (include it explicitly to supplement).
-
-`Client.VerifyAuthority(ctx, env)` returns an `Endorsement` iff the
-envelope carries at least one signature whose signed `iss` is in the
-client's authorities AND that signature cryptographically verifies
-against the authority's published key AND its signed `exp` claim
-(if any) has not passed. The endorsement names the authority and,
-when the authority's `verifier` claim is confirmed by the named
-verifier's own countersignature (§5.3), the verifier;
-`Endorsement.Verified` reports the distinction. It returns
-`ErrUnknownAuthority` when no candidate signature is from a known
-authority (or none has been registered), `ErrSignatureExpired` when
-a verified authority signature has expired, and `ErrVerifyFailed`
-when a candidate fails its crypto check.
-
-**Sandbox.** The network runs a parallel sandbox environment:
-`lookup.sandbox.gobl.org` (the default entry in
-`net.SandboxAuthorities`) operates the same registration service as
-the live authority, backed by its own database and its own accepted
-verification providers — typically relaxed KYB suited to test
-identities. The live and sandbox trust lists are disjoint by
-construction and MUST stay that way: a live verifier never accepts
-a sandbox endorsement, and a sandbox verifier never needs a live
-one. Clients opt in with `net.WithSandbox()`, which replaces the
-trust list with the sandbox authorities; everything else — request
-tokens, endorsement checks, the verifier claim — behaves
-identically in both environments.
-
-Note the trust topology this creates: receivers list *registration*
-authorities; the verifiers those authorities name are trusted
-transitively, because the registry names them inside its signed
-payload. Operators wanting tighter control can additionally inspect
-`Endorsement.Verifier` against their own policy.
-
-Endorsement requirements attach to the **sending** role. Verifiers
-resolving a *receiver's* identity MUST NOT demand an authority
-countersignature: receiving addresses are self-provisioned and MAY be
-entirely self-signed, or publish nothing at all (204). The trust
-anchor in §11.1 — TLS-bound `iss` — does not depend on authorities;
-authorities are an additional, opt-in policy layer on top.
-
-### 6.4 Sender verification
-
-`Client.VerifySender(ctx, addr, requireVerified)` combines the two:
-it resolves `addr`'s identity via `Who` and requires an Authority
-countersignature via `VerifyAuthority`, returning the endorsed
-`org.Party`. When `requireVerified` is true the endorsement must
-additionally carry a confirmed verifier (§5.3), else
-`ErrNotVerified` — registration suffices for most exchanges;
-verification may be demanded before acting on inbox deliveries from
-new counterparties. Receiving inboxes call it with the verified
-issuer of an incoming envelope before accepting the delivery
-(§8.4). A receive-only account (204) or a merely self-signed
-identity fails this check by construction — such addresses can
-receive but cannot act as approved senders.
-
-## 7. Discovery Transport
-
-### 7.1 HTTP Client Defaults
-
-The default `HTTPFetcher` enforces:
-
-| Parameter             | Value              |
-|-----------------------|--------------------|
-| Request timeout       | 10 seconds         |
-| Dial timeout          | 5 seconds          |
-| Maximum response size | 1 MiB              |
-| Required `Accept`     | `application/json` |
-| Required scheme       | `https`            |
-| Required status       | `200 OK` (`204` → `ErrNoContent`, `202` → `ErrPending`) |
-| Key cache TTL         | 5 minutes          |
-
-Responses larger than 1 MiB are truncated. A `204 No Content`
-response causes `ErrNoContent` and a `202 Accepted` response causes
-`ErrPending` — distinct sentinels because at the who endpoint both
-empty responses are meaningful (§8.2). Transient conditions — 429,
-any 5xx, or a transport failure — cause the retryable
-`ErrUnavailable`; any other non-200 response causes the permanent
-`ErrFetchFailed`.
-
-A `Client` configured with an identity (`net.WithIdentity`) mints a
-fresh request token (§5.5) per who or inbox request and sends it as
-`Authorization: Bearer`. Key fetches are always sent bare — key
-endpoints are open (§8.1).
-
-`Client.FetchKey` caches fetched keys per URL for a short TTL (5
-minutes by default, tunable with `net.WithKeyCacheTTL`; zero
-disables), since published keys are immutable per `kid` (§5.5).
-The cache holds successes only and is capped in size, so hostile
-`iss`/`kid` values cannot grow it without bound.
-
-**SSRF defense.** The fetcher's transport refuses to dial any host
-whose resolved IP is loopback, private (RFC 1918 / RFC 6598),
-link-local, multicast, or unspecified. A signed `iss` URI is
-attacker-controlled, so the FQDN it names could resolve to an
-internal service (e.g. AWS metadata at `169.254.169.254`, a
-container's localhost, a corporate intranet) — refusing those at
-dial time prevents the verifier from being used as an SSRF gadget.
-There is no public escape hatch; in-process test fixtures (e.g.
-`httptest`) should inject their own `Fetcher` via
-`net.WithFetcher`.
-
-### 7.2 Pluggable Fetcher
-
-The `Fetcher` interface (`Fetch(ctx, url, header) ([]byte, error)`
-and `Post(ctx, url, body, header) error`) allows substituting the
-HTTP transport, e.g. for testing, in-process resolution, or
-alternative transports; `header` carries any `Authorization`
-request token the `Client` has minted for the request, and `Post`
-is what `Client.Send` (§8.3) delivers envelopes through.
-Verification-only transports may implement `Post` as a plain error
-return. Use `net.WithFetcher(f)` when constructing a `Client`.
-
-## 8. Server-Side Endpoints
-
-### 8.1 `GET /.well-known/gobl/keys/<kid>`
-
-Open. Returns a single RFC 7517 JSON Web Key as `application/json` —
-the file `<domain>/keys/<kid>.json`, optionally carrying GOBL Net's
-`valid_from` / `valid_until` extension members (see §4). Unknown kid
-returns `404 Not Found`. No bulk endpoint is exposed.
-
-### 8.2 `GET /.well-known/gobl/who`
-
-Authenticated. The caller MUST present a request token (§5.5); a
-request without a valid token is rejected with `401 Unauthorized`.
-Returns the domain's party envelope: an `org.Party` document,
-self-signed with `iss=self` as the **first** signature (no
-`aud`), optionally carrying Authority countersignatures. The
-response body is a static signed document — the same bytes for
-every authorized caller; the token controls access and feeds the
-audit log (§11.9), it does not change the response.
-
-| Status            | Cause                                                |
-|-------------------|------------------------------------------------------|
-| `200 OK`          | Returns the signed party envelope.                   |
-| `202 Accepted`    | Request authenticated and recorded; the owner discloses selectively. If the owner approves, it delivers its party envelope to the requester's inbox (the token's `iss`), signed `iss=owner`, `aud=requester` (§8.3). There is no guarantee and no deadline — requesters MUST NOT wait synchronously and proceed with the details they already hold. |
-| `204 No Content`  | The account exists but publishes no identity details. A 204 account is receive-only: it cannot pass sender verification (§6.4), but deliveries *to* it are unaffected. |
-| `401 Unauthorized`| Missing or invalid request token (§5.5).             |
-| `404 Not Found`   | The address does not participate in GOBL Net.        |
-| `503 Service Unavailable` | The requester's key endpoint could not be reached to verify the token (§5.5); retry later. |
-
-`202` and `204` express different stances: `204` means "there is
-nothing to share, ever" — the account publishes no identity details
-to anyone; `202` means "there may be something to share, but the
-owner decides per requester". Deferred disclosure is not the
-default — most participants serve `200` to any authenticated
-caller — but it suits individuals (B2C) whose party details are
-personal data they would rather not hand to every requester
-(§11.8).
-
-Because the response requires authentication it MUST NOT be served
-from shared public caches: servers SHOULD send
-`Cache-Control: private` (adding `Vary: Authorization` where an
-intermediary cache is in play). Clients MAY cache the *verified*
-party envelope locally instead. Keep the TTL modest (minutes to a
-few hours): a cached who bounds how quickly an Authority's
-revocation of an endorsement is observed (§11.4). A consequence of
-mandatory authentication is that `/who` and `/inbox` can no longer
-be served by a static file host; the key endpoints (§8.1) still
-can.
-
-Key discovery (§8.1) is independent of who visibility and remains
-open: a participant that signs anything MUST serve its published
-keys regardless of whether its who returns 200, 202 or 204. Open
-key endpoints are also what keep request-token verification from
-recursing (§5.5).
-
-> **Note.** Earlier drafts specified `/who` as an authenticated POST
-> exchange so the target could pre-approve requesters and log who
-> asked for its details; an interim revision replaced it with an
-> open GET. This revision restores negotiated disclosure in GET
-> form: the request token supplies the requester identity the POST
-> body used to carry, and the `202` path supplies the pre-approval
-> hook.
-
-### 8.3 `POST /.well-known/gobl/inbox`
-
-Accepts a signed GOBL Envelope. The request MUST carry a request
-token (§5.5) identifying the transmitting party; a request without
-a valid token is rejected with `401 Unauthorized` before the body
-is considered. The token's `iss` MAY differ from the envelope's
-signed `iss`: a trusted intermediary (e.g. a hosted provider
-transmitting documents its customers signed) authenticates the
-*request* with its own identity while the envelope carries the
-document signer's. The two layers are independent and both
-required.
-
-The envelope layer is unchanged by the token. For document
-deliveries the sender is established by the delivery binding
-(§6.1): the issuer of a valid signature whose signed `aud` equals
-this inbox's Address — searched, so a sender signs once per
-intended recipient and each inbox finds its own binding; exactly
-one issuer may bind. Envelopes nobody signed for this inbox MUST be
-rejected.
-
-Party envelopes in the registration and verification flows are the
-exception: bearer documents with no audience binding — the request
-token carries delivery intent, and each receiving role's own rule
-is defined with that role (registration §5.3, verification §5.3,
-returns to the subject's inbox §5.3, deferred disclosures §8.2).
-
-An inbox that finds its *own* earlier countersignature aboard (an
-Authority receiving back the envelope it endorsed) SHOULD verify
-that signature against its own keys and reject the envelope when it
-does not hold — a broken or forged copy of the Authority's
-signature means the envelope is not what it endorsed. The inbox
-SHOULD then apply its sender-endorsement policy: resolve the sender's who (§6.4) and require an Authority
-countersignature — optionally with a confirmed verifier (§5.3) when
-the operator demands verified identities. Endorsement attaches to
-the envelope's signer, never to the token's issuer. Status codes:
-
-| Status                       | Cause                                                |
-|------------------------------|------------------------------------------------------|
-| `202 Accepted`               | Envelope parsed, validated, signature verified, persisted. |
-| `400 Bad Request`            | Body could not be read or did not decode as JSON.    |
-| `401 Unauthorized`           | Missing or invalid request token (§5.5); envelope signature did not verify; or (documents) no subject signature carries `aud` equal to this inbox. |
-| `403 Forbidden`              | Sender (`iss`) is not endorsed by an Authority this inbox trusts, or lacks the verified status the operator requires (§5.3). |
-| `422 Unprocessable Entity`   | Envelope failed structural validation.               |
-| `500 Internal Server Error`  | Persistence failed.                                  |
-| `503 Service Unavailable`    | A key endpoint needed to verify the token or envelope could not be reached (§5.5); retry later. |
-
-The request body size is capped at 1 MiB. The protocol does not
-mandate where or how an accepted envelope is persisted — that is an
-implementation decision for the operator running the inbox (a
-filesystem directory, an object store, a database row, a message
-queue, an in-process handler, …). A 202 simply MUST mean the
-envelope is durable enough that the server is willing to confirm
-receipt. The reference server in
-[`gobl.dev`](https://github.com/invopop/gobl.dev/#gobl-net) writes
-each accepted envelope to `<config>/<domain>/inbox/<envelope-uuid>.json`;
-that layout is one valid choice, not a protocol requirement.
-
-The empty `202 Accepted` body is deliberate: it asserts durable
-persistence by the inbox and nothing more. There are no transport
-receipts in GOBL Net — experience with receipt-bearing networks
-shows they attest to a handoff between intermediaries, not to
-anything the recipient actually did. Business-level processing is
-signalled instead by follow-up documents (e.g. a `bill.Status`
-envelope) sent back through the same inbox mechanism — which, like
-any other sending, requires the responding party to be an endorsed
-sender (§6.4). Receive-only participants do not send status; a
-supplier delivering to consumers should treat delivery as
-fire-and-forget beyond the 202.
-
-Inbox delivery MUST be idempotent on the envelope's identity: a
-re-POST of an envelope with the same `uuid` and `dig` returns `202`
-without creating a duplicate record. Since a status response may
-never come, "retry until 202" is the sender's correct recovery
-strategy, and idempotency is what makes it safe. (The signed `aud`
-already prevents the same envelope being replayed against a
-*different* inbox.)
-
-**Deferred who deliveries.** A party envelope (an `org.Party`
-document, self-signed by its subject) arriving at an inbox whose
-operator has an outstanding who request to that address (§8.2,
-`202`) SHOULD be accepted without sender endorsement: it carries
-exactly the assertions a `200` who response would, so it needs no
-more trust than the lookup it answers. Verification is the same as
-`Client.Who` steps 2–3 and 5 (§6.2), except that the subject MUST
-have signed for this inbox (`aud`) rather than for publication. Outside of an outstanding who request,
-party envelopes are subject to the normal endorsement policy.
-
-In code, `Client.Send(ctx, addr, env)` performs the delivery: it
-mints a request token for the target inbox, POSTs the envelope, and
-returns nil on `202`, `ErrInboxRejected` on a definitive 4xx (do
-not retry — the inbox has decided), and the retryable
-`ErrUnavailable` on 429, 5xx, or transport failure. "Retry on
-`ErrUnavailable` until `202`" is the sender's recovery strategy.
-
-### 8.4 End-to-end delivery flow
-
-The canonical invoice exchange between a Supplier (sender) and a
-Customer (receiver — a business or an individual consumer):
-
-1. Supplier needs to send an invoice to Customer, whose GOBL Net
-   Address it learned out-of-band (checkout, contract, directory).
-2. *Optionally*, Supplier performs `GET /who` on Customer — with a
-   request token naming itself (§5.5) — to fetch complete invoicing
-   details. A `204 No Content` means the account exists but shares
-   nothing; a `202 Accepted` means the Customer may deliver its
-   details to the Supplier's inbox later. Either way the Supplier
-   proceeds with the details it already holds.
-3. Supplier signs the invoice envelope with `iss=supplier`,
-   `aud=customer` and POSTs it to Customer's `/inbox`, again
-   presenting a request token. When a service provider transmits on
-   the Supplier's behalf, the token names the provider while the
-   envelope keeps `iss=supplier`.
-4. Customer verifies the request token, then the envelope signature
-   and audience (§6.1), then resolves the Supplier's identity with
-   `GET /who` on the verified issuer (a cached copy MAY be used
-   within its TTL).
-5. Customer accepts iff the Supplier's who carries a countersignature
-   from an Authority the Customer trusts (§6.4) — optionally
-   requiring a confirmed verifier (§5.3) — i.e. the sender is
-   registered, and KYC'd where demanded.
-6. `202 Accepted` (empty body) confirms reception to the Supplier.
-
-Only step 5 involves any registration requirement, and it applies
-solely to the sending party. The Customer's own address never needs
-Authority approval — steps 1–3 work against any self-provisioned
-endpoint.
-
-Sending is one role, whoever performs it: any follow-up document
-the Customer might send back — a `bill.Status` reporting
-acceptance or payment, a corrective exchange — is itself a
-delivery under this flow and requires the Customer to be an
-endorsed sender. A receive-only Customer sends nothing, and the
-Supplier expects nothing: for B2C, the 202 in step 6 is the end of
-the exchange. Status flows are a feature of exchanges between
-registered participants.
-
-## 9. Reference Implementation
-
-GOBL Net's reference client lives in this package (`net.Client`,
-`net.Address`, `net.Authorities`). The reference server and the
-operator-facing CLI (`gobl init`, `gobl net who/send/serve`,
-`gobl sign --domain …`, `gobl verify --remote`) live in
-[`gobl.dev`](https://github.com/invopop/gobl.dev/#gobl-net), which also
-documents the server's on-disk layout, ACME setup, multi-tenant
-routing, structured logging, and Docker deployment. The network's
-default registration Authority, `lookup.gobl.org` (§6.3), is
-implemented in
-[`gobl.lookup`](https://github.com/invopop/gobl.lookup).
-
-The protocol is transport-defined; any conforming implementation can
-serve the well-known endpoints from §8 over HTTPS.
+The first form is used in signed `iss`, `aud`, and `verifier` claims. The
+`gobl:` URI is used in `org.Party` endpoints and optional envelope routing
+fields. Production endpoints MUST use HTTPS.
+
+## 3. Keys
+
+Each signing key MUST be available as a single RFC 7517 JWK at
+`/.well-known/gobl/keys/<kid>`. Unknown or removed key IDs return `404`. The
+optional `/.well-known/jwks.json` endpoint exposes all keys as an RFC 7517 JWK
+Set for generic tooling; GOBL Net verification uses the per-key endpoint.
+
+A published `dsig.PublicKey` may include `valid_from` and `valid_until`.
+When a signature has an `iat`, verification rejects it if the signing time is
+outside those bounds. A missing bound or missing `iat` skips the corresponding
+comparison. Retired keys SHOULD remain available when historical signatures
+must remain verifiable.
+
+Signatures identify keys with `kid`; they do not carry a `jku` header.
+
+## 4. Envelope signatures
+
+The signed payload contains the document `uuid` and digest plus these protocol
+claims:
+
+| Claim | Meaning |
+|---|---|
+| `iss` | Signer's canonical GOBL Net address. |
+| `aud` | Address to which the signature is bound; optional except for ordinary inbox deliveries. |
+| `iat` | Signing time, as an RFC 7519 NumericDate. |
+| `exp` | Optional expiry, used primarily for endorsements. |
+| `verifier` | Optional verifier named by a registration authority. |
+
+Envelope header `from` and `to` fields are unsigned routing hints and MUST NOT
+be used for verification.
+
+Signature order has no meaning. Implementations MUST search all signatures and
+MUST NOT assign roles by array position.
+
+### 4.1 Party identities
+
+A party envelope contains an `org.Party` with a `gobl:` endpoint. That endpoint
+defines the subject. `Client.VerifyParty` requires a valid signature whose
+`iss` equals the subject and returns the canonical subject address. It does not
+check authority endorsements.
+
+A public `/who` response has the following additional requirements:
+
+- the subject MUST equal the address queried; and
+- the envelope MUST contain a valid audience-free self-signature.
+
+Other self-signatures and countersignatures may be present.
+
+### 4.2 Deliveries
+
+For an ordinary inbox delivery, `Client.VerifyDelivery(ctx, env, receiver)`
+searches for valid signatures with `aud` equal to `receiver`. All matching
+signatures MUST have the same issuer. The method returns that issuer, or fails
+if no issuer or multiple issuers bind the delivery.
+
+Registration, verification, and deferred identity workflows may carry party
+envelopes without an audience binding. Their receiver-specific rules must be
+applied separately.
+
+## 5. Request authentication
+
+Requests to `/who` and `/inbox` MUST include a compact ES256 request token as
+`Authorization: Bearer <token>`. Key discovery is unauthenticated.
+
+The token contains:
+
+| Claim | Requirement |
+|---|---|
+| `iss` | Requester's canonical address. |
+| `aud` | Destination address. |
+| `iat` | Required issue time. |
+| `exp` | Required expiry. |
+| `jti` | Optional identifier; generated by `NewToken`. |
+
+The requester may be an intermediary and need not be the envelope signer.
+Authentication of the HTTP request and verification of the document are
+independent.
+
+`NewToken` uses a one-minute lifetime by default and clamps explicit lifetimes
+to 30 seconds through five minutes. `VerifyToken` verifies the issuer's
+published key, audience, signature, key validity window, and freshness. It
+allows 30 seconds of clock skew and rejects tokens issued more than five
+minutes ago regardless of `exp`. `VerifyAuthorization` additionally parses the
+Bearer header.
+
+If the issuer's key endpoint is temporarily unavailable, verification returns
+`ErrUnavailable`; a server SHOULD answer `503`, not `401`.
+
+## 6. Authorities and sender policy
+
+A registration authority countersigns a party envelope with:
+
+- `iss` equal to the authority address;
+- `aud` equal to the party address; and
+- optionally, `verifier` naming the address that performed KYC/KYB.
+
+The verifier MUST also countersign the same envelope. When the authority is
+also the verifier, one countersignature satisfies both roles. Missing, invalid,
+or expired verifier evidence reduces the result to registered; it does not
+invalidate a valid registration endorsement.
+
+`Client.VerifyAuthority` checks all candidate authority signatures and prefers
+a confirmed verifier over a registration-only result. An authority signature's
+`exp`, when present, is enforced. The method returns an `Endorsement`:
+
+- `Authority` identifies the trusted registration authority;
+- `Verifier` is set only when verifier evidence is confirmed; and
+- `Endorsement.Verified()` reports whether `Verifier` is set.
+
+The default live authority is `lookup.gobl.org`. `WithAuthorities` replaces the
+client's trust list. `WithSandbox` replaces it with
+`lookup.sandbox.gobl.org`; live and sandbox trust lists are separate.
+
+`Client.VerifySender(ctx, addr, requireVerified)` combines `/who` lookup and
+authority verification. It always requires registration and, when
+`requireVerified` is true, confirmed identity verification.
+
+Authority endorsement is a sender policy, not a prerequisite for receiving.
+A receive-only address may publish only an inbox and keys, and may return `204`
+from `/who`.
+
+## 7. Endpoints
+
+### 7.1 `GET /.well-known/gobl/keys/<kid>`
+
+This endpoint is public and returns one JWK as `application/json`.
+
+| Status | Meaning |
+|---|---|
+| `200` | Key returned. |
+| `404` | Key is unknown or removed. |
+| `429`, `5xx` | Temporary failure. |
+
+### 7.2 `GET /.well-known/gobl/who`
+
+This endpoint requires a valid request token. It returns a signed party
+envelope or one of these empty responses:
+
+| Status | Meaning |
+|---|---|
+| `200` | Party envelope returned. |
+| `202` | Request recorded for possible deferred disclosure. |
+| `204` | The participant does not publish identity details. |
+| `401` | Request token missing or invalid. |
+| `404` | Address does not participate. |
+| `503` | A required key endpoint is unavailable. |
+
+`Client.Who` maps `202` to `ErrPending` and `204` to `ErrNoContent`, then
+verifies a `200` response as described in section 4.1. Authenticated responses
+SHOULD use `Cache-Control: private`. Clients may cache verified identities for
+a bounded period.
+
+### 7.3 `POST /.well-known/gobl/inbox`
+
+This endpoint requires both a valid request token and a signed GOBL envelope.
+For ordinary documents, the envelope MUST have exactly one issuer bound to the
+inbox address as described in section 4.2. The receiver may then apply its
+sender endorsement policy.
+
+| Status | Meaning |
+|---|---|
+| `202` | Envelope accepted and durably recorded. |
+| `400` | Body is unreadable or invalid JSON. |
+| `401` | Authentication or delivery signature failed. |
+| `403` | Sender policy rejected the envelope. |
+| `422` | Envelope failed structural validation. |
+| `500` | Persistence failed. |
+| `503` | A required key endpoint is unavailable. |
+
+Acceptance MUST be idempotent on the envelope UUID and digest. Clients may
+retry `ErrUnavailable`; they SHOULD NOT retry `ErrInboxRejected` without
+changing the request.
+
+`Client.Send` serializes the envelope, adds a fresh request token when the
+client has an identity, and succeeds only on `202`.
+
+## 8. Client and transport
+
+`NewClient` uses `HTTPFetcher`, the default live authority list, and a
+five-minute public-key cache. Configure it with:
+
+| Option | Effect |
+|---|---|
+| `WithIdentity` | Sets the address and key used for request tokens. |
+| `WithAuthorities` | Replaces trusted registration authorities. |
+| `WithSandbox` | Replaces live authorities with sandbox authorities. |
+| `WithKeyCacheTTL` | Changes the key cache lifetime; zero disables it. |
+| `WithFetcher` | Replaces the HTTP transport. |
+
+The default `HTTPFetcher` has a 10-second request timeout, a five-second dial
+timeout, and a 1 MiB response limit. It classifies `429`, `5xx`, and transport
+failures as `ErrUnavailable`. Other unsuccessful fetch responses are
+`ErrFetchFailed`; definitive inbox `4xx` responses are `ErrInboxRejected`.
+
+To reduce SSRF risk, the default dialer rejects hosts resolving to loopback,
+private, link-local, multicast, or unspecified addresses. Custom `Fetcher`
+implementations SHOULD provide equivalent protection. Tests and local services
+can inject a custom fetcher.
+
+Fetched keys are cached by URL, only on success, with a maximum of 1,024
+entries. `FlushKeyCache` forces subsequent verification to fetch keys again.
+
+## 9. Typical delivery flow
+
+1. The sender obtains the receiver's address out of band.
+2. The sender may call `/who` for the receiver's invoicing details.
+3. The sender signs the envelope with `iss=sender` and `aud=receiver`.
+4. The sender posts it to the receiver's inbox with a request token.
+5. The receiver verifies the token and calls `VerifyDelivery`.
+6. The receiver may call `VerifySender` on the returned issuer.
+7. A `202` confirms durable receipt.
+
+Only step 6 requires authority endorsement, and that requirement applies to
+the sender. Any response document is a new delivery and is subject to the same
+rules.
 
 ## 10. Errors
 
-The package exports the following sentinel errors:
+| Error | Meaning |
+|---|---|
+| `ErrAddressEmpty` | Address is empty. |
+| `ErrAddressInvalid` | Address is not a valid FQDN. |
+| `ErrFetchFailed` | Permanent fetch, content, or configuration failure. |
+| `ErrUnavailable` | Retryable network, `429`, or `5xx` failure. |
+| `ErrNoContent` | Endpoint returned `204`. |
+| `ErrPending` | Endpoint returned `202` where a body was expected. |
+| `ErrTokenInvalid` | Request token is malformed or invalid. |
+| `ErrTokenExpired` | Request token failed freshness checks. |
+| `ErrVerifyFailed` | Envelope or signature verification failed. |
+| `ErrUnknownAuthority` | No trusted authority endorsement was found. |
+| `ErrNotVerified` | Registration is valid but verification was required. |
+| `ErrSignatureExpired` | Authority endorsement has expired. |
+| `ErrPartyMissing` | Identity envelope has no `org.Party`. |
+| `ErrInboxRejected` | Inbox returned a definitive `4xx`. |
 
-| Error                  | Cause                                                            |
-|------------------------|------------------------------------------------------------------|
-| `ErrAddressEmpty`      | Empty input to `ParseAddress`.                                   |
-| `ErrAddressInvalid`    | Input is not a valid FQDN per §3.1.                              |
-| `ErrFetchFailed`       | Well-known resource fetch failed for a reason retrying will not cure (definitive non-2xx, malformed content, invalid input). |
-| `ErrUnavailable`       | A well-known resource could not be reached (network failure, 429, 5xx) — a transient, retryable condition. Servers respond 503, not 401, when token verification hits it. |
-| `ErrNoContent`         | The resource exists but has no content (HTTP 204) — a who endpoint that publishes no identity details. |
-| `ErrPending`           | A who request was accepted for deferred disclosure (HTTP 202) — the owner may deliver its party envelope to the requester's inbox later. |
-| `ErrTokenInvalid`      | A request token failed verification (parse, signature, key fetch, `aud` mismatch, key validity window). |
-| `ErrTokenExpired`      | A request token failed the freshness check (`exp` passed, `iat` too old or in the future). |
-| `ErrVerifyFailed`      | Envelope verification failed (no signature, invalid `iss`, key fetch failed, signature mismatch, `aud` mismatch, `iat` outside the key's validity window, who issuer/address mismatch). |
-| `ErrUnknownAuthority`  | An endorser on a `/who` envelope is not in `Authorities` (only raised by callers that opt into authority enforcement). |
-| `ErrNotVerified`       | A sender's endorsement is valid but carries no confirmed verifier (§5.3) and the caller required identity verification. |
-| `ErrSignatureExpired`  | An authority countersignature verified but its `exp` claim has passed. |
-| `ErrPartyMissing`      | A `/who` response did not contain an `org.Party` document.       |
-| `ErrInboxRejected`     | A receiving inbox did not return 202.                            |
+Callers should classify wrapped errors with `errors.Is`.
 
-All callers using `errors.Is` against these sentinels MUST continue to
-work after wrapping with `fmt.Errorf("%w: ...", err)`.
+## 11. Security considerations
 
-## 11. Security Considerations
-
-### 11.1 Trust Model
-
-A signature's verifiable origin is the signed `iss` URI. Verification
-fetches the public key from
-`https://<iss-fqdn>/.well-known/gobl/keys/<kid>`, and the HTTPS
-connection's certificate proves the response really came from that
-FQDN. The trust anchor is therefore the Web PKI binding of the
-Address to the entity that controls its TLS certificate.
-
-A forged `iss` pointing to an attacker-controlled host can only
-produce a signature that verifies against an attacker-controlled key
-served from that host — distinguishable from the expected identity
-at the application layer. Callers that already know the expected
-Address SHOULD pass it as `expectedAud` to `Client.VerifyEnvelope`,
-or compare the returned issuer Address against the expected sender
-before acting on the document.
-
-### 11.2 TLS
-
-All well-known endpoints are served over HTTPS in production. Verifiers
-rely on the host's TLS certificate to establish that the served content
-originates from the named Address. Operators MUST ensure that TLS
-certificate issuance is properly controlled for any Address they intend
-to use as an identity.
-
-### 11.3 Authority Trust
-
-`Authorities` is an opt-in allowlist of FQDNs (see §6.3). For
-verifiers that *do* enforce it, the threat is symmetrical to §11.1
-but multiplied: an attacker who gains the ability to issue a TLS
-certificate for any address in `Authorities` can serve a forged
-`/who` for any participant whose envelopes the verifier accepts on
-the strength of that authority's countersignature. Where this hook
-is used, the authority list MUST be kept short and reviewed
-regularly.
-
-### 11.4 Inbox Authentication and Sender Endorsement
-
-The inbox endpoint authenticates at two independent layers: the
-request token (§5.5) identifies the transmitting peer before the
-body is read, and the envelope signature identifies the document's
-signer. The sender-endorsement policy (§6.4, §8.4) is the layer
-that restricts acceptance to Authority-registered participants.
-Operators choose the trusted Authority list and whether to demand
-verified identities (§5.3).
-
-Endorsement revocation is bounded by two mechanisms. First, the
-countersignature's own `exp` claim (§5.3): with the recommended
-90-day maximum, a revoked sender's endorsement dies on its own even
-if the stale who keeps being served — and the renewal cycle this
-forces (re-registering before expiry, in the spirit of Let's
-Encrypt certificates) gives the Authority a recurring checkpoint at
-which to decline. Second, who caching: once an Authority stops
-countersigning a sender (or the sender re-publishes its who without
-the countersignature), receivers continue to accept only until
-their cached copy expires. Inboxes enforcing endorsement MUST
-resolve the sender's who with a bounded TTL rather than trusting a
-cached copy indefinitely, and MAY additionally apply a max-age
-policy to the `iat` of countersignatures that carry no `exp`.
-
-Verification revocation has a third, faster path: because the
-`verifier` pointer lives inside the *registration* countersignature
-(§5.3), the registry can withdraw verified status at any renewal —
-or immediately, by re-signing without the pointer — without waiting
-for the verifier's own longer-lived signature to expire. The
-long-lived verifier signature is only evidence when the short-lived
-registration signature points at it.
-
-### 11.5 Response Size and Signature Count
-
-The 1 MiB cap on Key, Who, and inbox bodies limits memory amplification
-from hostile or misconfigured peers. `VerifyAuthority` additionally
-refuses envelopes carrying more than 32 signatures: each candidate
-countersignature can cost a network key fetch, so an unbounded
-signature list would turn a hostile who envelope into a
-fetch-amplification gadget against verifying inboxes.
-
-### 11.6 SSRF / non-public dial targets
-
-A signed `iss` URI is supplied by the signer, so a verifier that
-blindly fetches `https://<iss-fqdn>/.well-known/...` could be
-tricked into hitting an internal address controlled by the attacker
-(loopback, cloud metadata at `169.254.169.254`, an RFC 1918 host on
-the verifier's network). The default `HTTPFetcher` defends against
-this by resolving the host at dial time and refusing any loopback,
-private, link-local, multicast, or unspecified address (see §7.1).
-Operators that swap in a custom `Fetcher` SHOULD apply equivalent
-checks.
-
-### 11.7 Address Canonicalization
-
-`ParseAddress` lowercases and strips trailing dots before validation, so
-two visually distinct strings such as `Example.COM.` and `example.com`
-normalize to the same Address. Callers MUST use `ParseAddress` (directly
-or via `Address.Validate`) before comparing addresses for equality.
-
-### 11.8 Identity Privacy
-
-`GET /who` requires a request token (§5.5), so published party
-details are readable only by callers holding a verifiable GOBL Net
-identity — never anonymously. Bulk harvesting therefore carries a
-cost the open GET did not: every request names a resolvable domain
-identity and MAY be recorded (§11.9). Sending participants
-generally publish business details that are public record anyway;
-individuals and other receive-only participants SHOULD respond
-`204` rather than publish personal data, or use deferred
-disclosure (`202`, §8.2) to decide per requester. Servers MAY
-additionally rate-limit the endpoint. Hosted providers offering
-per-user sub-addresses (`alice.inbox.provider.example`) hold the
-keys and the inbox contents for their users; that concentration of
-trust is a deployment choice outside this protocol, but users of
-such services should understand the provider can read anything
-delivered to them.
-
-### 11.9 Request audit logs
-
-Servers MAY keep an audit log of authenticated requests — the
-token's `iss`, `jti` and `iat`, the endpoint, and the outcome. The
-guarantee that every request is attributable to a requester is a
-design goal of §5.5, and the audit log is how operators realize
-it. Operators should remember the log is itself personal data:
-requester addresses reveal business relationships (who is invoicing
-whom, and when). Retention SHOULD be bounded, and logs SHOULD NOT
-be published.
+- **Web PKI:** control of an address and its TLS certificate controls its
+  published keys. Applications must compare verified issuers with the
+  identities they expect or apply authority policy.
+- **Key removal:** the client cache may continue to accept a removed key until
+  its TTL expires. Use short TTLs and `FlushKeyCache` during incident response.
+- **Endorsement freshness:** authority and verifier `exp` claims bound their
+  lifetimes. Identity caches must also have bounded lifetimes.
+- **Resource limits:** clients limit response bodies to 1 MiB and verification
+  to 32 signatures per envelope. Servers should impose comparable request
+  limits.
+- **Privacy:** request tokens identify callers but do not make party data
+  public. Operators should limit audit-log retention because requester metadata
+  can reveal business relationships.
+- **Routing fields:** unsigned `from` and `to` values are hints only. Security
+  decisions must use signed claims.
 
 ## 12. References
 
-- RFC 2119 — Key words for use in RFCs to Indicate Requirement Levels
-- RFC 6750 — OAuth 2.0 Bearer Token Usage (`Authorization: Bearer`)
-- RFC 7515 — JSON Web Signature (JWS)
-- RFC 7517 — JSON Web Key (JWK)
-- RFC 7518 — JSON Web Algorithms (JWA)
-- RFC 7519 — JSON Web Token (JWT)
-- RFC 8174 — Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words
-- `github.com/invopop/gobl/dsig` — Signature, key, and digest primitives
-- `github.com/invopop/gobl/org` — `org.Party` schema
+- RFC 2119 and RFC 8174 — requirement keywords
+- RFC 6750 — Bearer token usage
+- RFC 7515 — JSON Web Signature
+- RFC 7517 — JSON Web Key
+- RFC 7518 — JSON Web Algorithms
+- RFC 7519 — JSON Web Token
+- `github.com/invopop/gobl/dsig` — signature and key primitives
+- `github.com/invopop/gobl/org` — party schema

--- a/net/README.md
+++ b/net/README.md
@@ -30,7 +30,32 @@ parts of the protocol. The reference server and CLI live in
 The terms MUST, MUST NOT, SHOULD, SHOULD NOT, and MAY are interpreted as
 described in BCP 14 (RFC 2119 and RFC 8174).
 
-## 2. Addresses and discovery
+## 2. Terminology
+
+| Term | Meaning |
+|---|---|
+| **Participant** | An entity identified by a GOBL Net address. A participant may hold different roles in different exchanges. |
+| **Subject** | The participant described by a party envelope. Its address comes from the party's `gobl:` endpoint. |
+| **Issuer** | The participant identified by a signature's `iss` claim. This is a signature-level role. |
+| **Audience** | The participant identified by a signature's `aud` claim. The signature is bound to this address. |
+| **Sender** | The issuer of a valid document signature whose audience is the receiving inbox. |
+| **Receiver** | The participant operating the inbox to which a document is delivered. For ordinary deliveries, the receiver is also the signature's audience. |
+| **Requester** | The issuer of an HTTP request token. A requester may be an intermediary and need not be the document sender. |
+| **Authority** | A trusted participant that confirms the subject controls its GOBL Net address and countersigns its party envelope. |
+| **Verifier** | A participant, independent of the Authority, that performs KYC/KYB and countersigns the subject's party envelope. |
+| **Endorsement** | A valid Authority countersignature, optionally supported by a confirmed Verifier countersignature. |
+| **Party envelope** | A signed GOBL envelope containing an `org.Party`. It identifies its Subject and may carry Authority and Verifier countersignatures. |
+
+Issuer, Sender, and Requester often refer to the same participant in a direct
+delivery, but the protocol does not assume they are the same. Audience and
+Receiver are equivalent for ordinary document delivery; in other signatures,
+such as an Authority endorsement, the Audience is the Subject rather than the
+recipient of an HTTP request.
+
+An Authority and Verifier MUST be different participants. Other roles may
+overlap where their definitions permit it.
+
+## 3. Addresses and discovery
 
 A GOBL Net address is an FQDN without a scheme, port, path, query, or fragment.
 `ParseAddress`:
@@ -60,7 +85,7 @@ The first form is used in signed `iss`, `aud`, and `verifier` claims. The
 `gobl:` URI is used in `org.Party` endpoints and optional envelope routing
 fields. Production endpoints MUST use HTTPS.
 
-## 3. Keys
+## 4. Keys
 
 Each signing key MUST be available as a single RFC 7517 JWK at
 `/.well-known/gobl/keys/<kid>`. Unknown or removed key IDs return `404`. The
@@ -75,7 +100,7 @@ must remain verifiable.
 
 Signatures identify keys with `kid`; they do not carry a `jku` header.
 
-## 4. Envelope signatures
+## 5. Envelope signatures
 
 The signed payload contains the document `uuid` and digest plus these protocol
 claims:
@@ -94,7 +119,7 @@ be used for verification.
 Signature order has no meaning. Implementations MUST search all signatures and
 MUST NOT assign roles by array position.
 
-### 4.1 Party identities
+### 5.1 Party identities
 
 A party envelope contains an `org.Party` with a `gobl:` endpoint. That endpoint
 defines the subject. `Client.VerifyParty` requires a valid signature whose
@@ -108,7 +133,7 @@ A public `/who` response has the following additional requirements:
 
 Other self-signatures and countersignatures may be present.
 
-### 4.2 Deliveries
+### 5.2 Deliveries
 
 For an ordinary inbox delivery, `Client.VerifyDelivery(ctx, env, receiver)`
 searches for valid signatures with `aud` equal to `receiver`. All matching
@@ -119,7 +144,7 @@ Registration, verification, and deferred identity workflows may carry party
 envelopes without an audience binding. Their receiver-specific rules must be
 applied separately.
 
-## 5. Request authentication
+## 6. Request authentication
 
 Requests to `/who` and `/inbox` MUST include a compact ES256 request token as
 `Authorization: Bearer <token>`. Key discovery is unauthenticated.
@@ -148,7 +173,7 @@ Bearer header.
 If the issuer's key endpoint is temporarily unavailable, verification returns
 `ErrUnavailable`; a server SHOULD answer `503`, not `401`.
 
-## 6. Authorities and sender policy
+## 7. Authorities and sender policy
 
 A registration authority countersigns a party envelope with:
 
@@ -183,9 +208,9 @@ Authority endorsement is a sender policy, not a prerequisite for receiving.
 A receive-only address may publish only an inbox and keys, and may return `204`
 from `/who`.
 
-## 7. Endpoints
+## 8. Endpoints
 
-### 7.1 `GET /.well-known/gobl/keys/<kid>`
+### 8.1 `GET /.well-known/gobl/keys/<kid>`
 
 This endpoint is public and returns one JWK as `application/json`.
 
@@ -195,7 +220,7 @@ This endpoint is public and returns one JWK as `application/json`.
 | `404` | Key is unknown or removed. |
 | `429`, `5xx` | Temporary failure. |
 
-### 7.2 `GET /.well-known/gobl/who`
+### 8.2 `GET /.well-known/gobl/who`
 
 This endpoint requires a valid request token. It returns a signed party
 envelope or one of these empty responses:
@@ -210,15 +235,15 @@ envelope or one of these empty responses:
 | `503` | A required key endpoint is unavailable. |
 
 `Client.Who` maps `202` to `ErrPending` and `204` to `ErrNoContent`, then
-verifies a `200` response as described in section 4.1. Authenticated responses
+verifies a `200` response as described in section 5.1. Authenticated responses
 SHOULD use `Cache-Control: private`. Clients may cache verified identities for
 a bounded period.
 
-### 7.3 `POST /.well-known/gobl/inbox`
+### 8.3 `POST /.well-known/gobl/inbox`
 
 This endpoint requires both a valid request token and a signed GOBL envelope.
 For ordinary documents, the envelope MUST have exactly one issuer bound to the
-inbox address as described in section 4.2. The receiver may then apply its
+inbox address as described in section 5.2. The receiver may then apply its
 sender endorsement policy.
 
 | Status | Meaning |
@@ -238,7 +263,7 @@ changing the request.
 `Client.Send` serializes the envelope, adds a fresh request token when the
 client has an identity, and succeeds only on `202`.
 
-## 8. Client and transport
+## 9. Client and transport
 
 `NewClient` uses `HTTPFetcher`, the default live authority list, and a
 five-minute public-key cache. Configure it with:
@@ -264,7 +289,7 @@ can inject a custom fetcher.
 Fetched keys are cached by URL, only on success, with a maximum of 1,024
 entries. `FlushKeyCache` forces subsequent verification to fetch keys again.
 
-## 9. Typical delivery flow
+## 10. Typical delivery flow
 
 1. The sender obtains the receiver's address out of band.
 2. The sender may call `/who` for the receiver's invoicing details.
@@ -278,7 +303,7 @@ Only step 6 requires authority endorsement, and that requirement applies to
 the sender. Any response document is a new delivery and is subject to the same
 rules.
 
-## 10. Errors
+## 11. Errors
 
 | Error | Meaning |
 |---|---|
@@ -299,7 +324,7 @@ rules.
 
 Callers should classify wrapped errors with `errors.Is`.
 
-## 11. Security considerations
+## 12. Security considerations
 
 - **Web PKI:** control of an address and its TLS certificate controls its
   published keys. Applications must compare verified issuers with the
@@ -317,7 +342,7 @@ Callers should classify wrapped errors with `errors.Is`.
 - **Routing fields:** unsigned `from` and `to` values are hints only. Security
   decisions must use signed claims.
 
-## 12. References
+## 13. References
 
 - RFC 2119 and RFC 8174 — requirement keywords
 - RFC 6750 — Bearer token usage

--- a/net/address.go
+++ b/net/address.go
@@ -10,28 +10,19 @@ import (
 	"github.com/invopop/gobl/rules/is"
 )
 
-// addressIDNA is the Lookup profile (the strict IDN form used for DNS
-// lookups). ToASCII converts U-Labels to A-Labels, lowercases ASCII
-// labels, and rejects labels that don't satisfy the IDNA2008 lookup
-// rules — exactly the canonicalization GOBL Net needs.
+// addressIDNA canonicalizes and validates names using the IDNA lookup profile.
 var addressIDNA = idna.New(
 	idna.MapForLookup(),
 	idna.Transitional(false),
 	idna.StrictDomainName(true),
 )
 
-// Address represents a GOBL Net address, which is a fully qualified
-// domain name (FQDN) used for key discovery and network identification.
+// Address is a GOBL Net participant's fully qualified domain name.
 type Address string
 
-// ParseAddress validates and returns an Address from a string.
-// The input must be a valid FQDN (no scheme, no path, no port).
-//
-// Internationalised domain names (IDN) in U-Label form are accepted
-// and normalised to their ASCII (A-Label / Punycode) representation,
-// so the canonical form on the wire and in `iss`/`aud` is always
-// ASCII. `München.DE` and `xn--mnchen-3ya.de` parse to the same
-// Address.
+// ParseAddress validates an FQDN and returns its canonical ASCII form.
+// It accepts internationalized names, trims whitespace and a trailing dot,
+// and rejects schemes, ports, paths, and single-label names.
 func ParseAddress(fqdn string) (Address, error) {
 	fqdn = strings.TrimSpace(fqdn)
 	if fqdn == "" {
@@ -61,19 +52,14 @@ func (a Address) String() string {
 	return string(a)
 }
 
-// URI returns the address as a gobl: scheme cbc.URI, e.g.
-// "gobl:acme.example.com", for use where multiple schemes coexist —
-// org.Endpoint lists and the envelope header's unsigned from/to
-// routing fields. Signed iss/aud/verifier claims carry the bare
-// address (Address.String) instead: within the protocol they can
-// only be GOBL Net addresses, so no scheme is needed.
+// URI returns the address as a gobl URI for party endpoints and routing fields.
+// Signed iss, aud, and verifier claims use String instead.
 func (a Address) URI() cbc.URI {
 	return cbc.URI(Scheme + ":" + string(a))
 }
 
-// JWKSURL returns the deterministic JWK Set discovery URL for this
-// address. The matching JOSE `jku` header on a signature points here
-// so generic JWT verifiers can fetch the public keys automatically.
+// JWKSURL returns the conventional bulk JWK Set URL for the address.
+// GOBL Net verification uses KeyURL; signatures do not carry jku.
 func (a Address) JWKSURL() string {
 	return "https://" + string(a) + JWKSPath
 }

--- a/net/auth.go
+++ b/net/auth.go
@@ -21,12 +21,8 @@ const (
 	tokenClockSkew  = 30 * time.Second
 )
 
-// TokenClaims is the signed payload of a request token presented in
-// the Authorization header of who and inbox requests. Iss names the
-// party making the request — possibly a trusted intermediary distinct
-// from any document signer inside the request body — and Aud names
-// the destination address the token is bound to. Both are bare GOBL
-// Net addresses (FQDNs).
+// TokenClaims is the signed payload of a Who or Send request token. Iss is the
+// requester, which may differ from an envelope signer, and Aud is the target.
 type TokenClaims struct {
 	Iss Address `json:"iss"`
 	Aud Address `json:"aud"`
@@ -35,11 +31,8 @@ type TokenClaims struct {
 	JTI string  `json:"jti,omitempty"`
 }
 
-// NewToken mints a request token: a compact ES256 JWS asserting that
-// iss is making a request to aud. A ttl of zero uses the one minute
-// default; other values are clamped to the 30 second – 5 minute
-// window the protocol allows. A jti is stamped automatically for
-// audit correlation.
+// NewToken creates a compact ES256 request token from iss to aud. A zero TTL
+// uses one minute; other values are clamped to 30 seconds through five minutes.
 func NewToken(key *dsig.PrivateKey, iss, aud Address, ttl time.Duration) (string, error) {
 	iss, err := ParseAddress(string(iss))
 	if err != nil {
@@ -72,11 +65,8 @@ func NewToken(key *dsig.PrivateKey, iss, aud Address, ttl time.Duration) (string
 	return sig.String(), nil
 }
 
-// VerifyToken verifies a request token received on an inbound who or
-// inbox request. The token's signature is checked against the
-// issuer's published key, its aud claim must equal the given address,
-// and its freshness window must include the current time. The
-// verified requester address is returned.
+// VerifyToken verifies a request token's signature, audience, key validity, and
+// freshness, then returns the canonical requester address.
 func (c *Client) VerifyToken(ctx context.Context, token string, aud Address) (Address, error) {
 	if token == "" {
 		return "", fmt.Errorf("%w: token is empty", ErrTokenInvalid)
@@ -138,10 +128,8 @@ func (c *Client) VerifyToken(ctx context.Context, token string, aud Address) (Ad
 	return issuer, nil
 }
 
-// VerifyAuthorization verifies the value of an Authorization header,
-// stripping the "Bearer" scheme before passing the token to
-// VerifyToken. Servers call this with the raw header of an inbound
-// who or inbox request and their own address.
+// VerifyAuthorization verifies a Bearer Authorization header for aud and
+// returns the canonical requester address.
 func (c *Client) VerifyAuthorization(ctx context.Context, header string, aud Address) (Address, error) {
 	scheme, token, found := strings.Cut(strings.TrimSpace(header), " ")
 	if !found || !strings.EqualFold(scheme, "Bearer") {

--- a/net/authorities.go
+++ b/net/authorities.go
@@ -10,23 +10,13 @@ import (
 	"github.com/invopop/gobl/head"
 )
 
-// Authorities is the hardcoded set of GOBL Net Addresses considered
-// trusted registration authorities. A /who response is only
-// considered endorsed if it is signed by at least one of these.
-//
-// lookup.gobl.org is the network's default authority; operators may
-// add their own with RegisterAuthority or WithAuthorities.
+// Authorities is the default list of trusted registration authorities.
 var Authorities = []Address{
 	"lookup.gobl.org",
 }
 
-// SandboxAuthorities is the default trust list for sandbox
-// deployments: lookup.sandbox.gobl.org runs the same registration
-// service as the live authority but endorses test identities through
-// relaxed verification providers. The live and sandbox lists are
-// disjoint by construction — endorsements from a sandbox authority
-// MUST never be accepted in live contexts, and vice versa. Clients
-// opt in with WithSandbox.
+// SandboxAuthorities is the trust list selected by WithSandbox. Sandbox
+// endorsements must not be accepted in live contexts.
 var SandboxAuthorities = []Address{
 	"lookup.sandbox.gobl.org",
 }
@@ -37,16 +27,13 @@ var SandboxAuthorities = []Address{
 // Legitimate envelopes carry a handful of signatures.
 const maxEnvelopeSignatures = 32
 
-// RegisterAuthority adds an address to the global set of trusted
-// authority addresses.
+// RegisterAuthority appends addr to the default authority list.
 func RegisterAuthority(addr Address) {
 	Authorities = append(Authorities, addr)
 }
 
-// Endorsement describes a successful authority check on an envelope:
-// the trusted authority that countersigned it and, when that
-// countersignature names a verifier whose own countersignature also
-// verifies, the verifier's address.
+// Endorsement identifies the trusted authority behind an envelope and any
+// confirmed identity verifier it named.
 type Endorsement struct {
 	// Authority is the trusted address whose countersignature
 	// endorsed the envelope: the subject is a registered identity.
@@ -66,35 +53,13 @@ func (e *Endorsement) Verified() bool {
 	return e != nil && e.Verifier != ""
 }
 
-// VerifyAuthority checks that the envelope carries at least one
-// signature whose signed `iss` resolves to an address in the
-// client's known authorities (the package-level Authorities slice
-// plus anything added via WithAuthorities). Each candidate signature
-// is cryptographically verified against the authority's own
-// published key, and a candidate whose signed exp claim has passed
-// is rejected: expired endorsements are not evidence.
-//
-// When the authority's countersignature carries a `verifier` claim,
-// the named address's own countersignature on the same envelope is
-// looked up and verified the same way; if it holds, the returned
-// endorsement carries the verifier's address. A verifier that names
-// itself needs no second signature — its own countersignature serves
-// as both attestations. A named verifier whose countersignature is
-// missing, invalid, or expired degrades the endorsement to
-// registered rather than failing it: the registration stands on its
-// own. Callers that require verification check Endorsement.Verified.
-//
-// Every candidate authority signature is considered: an endorsement
-// with a confirmed verifier is preferred over a registered-only one
-// regardless of signature order. If no signature is from a known
-// authority, returns ErrUnknownAuthority. A transient key-fetch
-// failure with no endorsement found returns ErrUnavailable. If a
-// verified authority signature has expired, returns
-// ErrSignatureExpired. If all candidates fail crypto verification,
-// returns ErrVerifyFailed wrapping the last error.
-//
-// Callers that want to accept self-signed (no-authority) envelopes
-// should skip this call rather than ignore its error.
+// VerifyAuthority verifies countersignatures from the client's trusted
+// authorities. It returns the strongest endorsement found, preferring one with
+// confirmed verifier evidence. Missing or invalid verifier evidence leaves a
+// registration-only endorsement valid. It returns ErrUnknownAuthority when no
+// trusted candidate exists, ErrSignatureExpired for expired authority evidence,
+// ErrUnavailable for transient key lookup failures, or ErrVerifyFailed when
+// candidates fail cryptographic verification.
 func (c *Client) VerifyAuthority(ctx context.Context, env *gobl.Envelope) (*Endorsement, error) {
 	// A malformed envelope may carry signatures without a header;
 	// reject rather than let header verification panic.

--- a/net/authorities.go
+++ b/net/authorities.go
@@ -33,7 +33,7 @@ func RegisterAuthority(addr Address) {
 }
 
 // Endorsement identifies the trusted authority behind an envelope and any
-// confirmed identity verifier it named.
+// confirmed, independent identity verifier it named.
 type Endorsement struct {
 	// Authority is the trusted address whose countersignature
 	// endorsed the envelope: the subject is a registered identity.
@@ -55,7 +55,8 @@ func (e *Endorsement) Verified() bool {
 
 // VerifyAuthority verifies countersignatures from the client's trusted
 // authorities. It returns the strongest endorsement found, preferring one with
-// confirmed verifier evidence. Missing or invalid verifier evidence leaves a
+// confirmed verifier evidence. The verifier must differ from the authority;
+// self-referential, missing, or invalid verifier evidence leaves a
 // registration-only endorsement valid. It returns ErrUnknownAuthority when no
 // trusted candidate exists, ErrSignatureExpired for expired authority evidence,
 // ErrUnavailable for transient key lookup failures, or ErrVerifyFailed when
@@ -156,23 +157,19 @@ func (c *Client) VerifyAuthority(ctx context.Context, env *gobl.Envelope) (*Endo
 
 // confirmVerifier resolves the verifier claim on a verified authority
 // countersignature. It returns the verifier's address when the claim
-// names a valid bare address whose own countersignature on the
-// envelope verifies (or names the authority itself, whose signature
-// has already been checked), and "" when the claim is absent,
-// malformed, or its countersignature is definitively invalid — an
-// unconfirmed verifier degrades to registered, it does not
-// invalidate the endorsement. A transient failure to fetch the
-// verifier's key (ErrUnavailable) is returned as an error instead:
-// "could not check" must not silently downgrade a verified identity.
+// names a valid address, distinct from the authority, whose countersignature
+// verifies. An absent, self-referential, malformed, or invalid claim returns
+// "", degrading the endorsement to registered. A transient key-fetch failure
+// returns ErrUnavailable instead of silently downgrading the endorsement.
 func (c *Client) confirmVerifier(ctx context.Context, env *gobl.Envelope, authority Address, p *head.SigningPayload) (Address, error) {
 	verifier, err := ParseAddress(p.Verifier)
 	if err != nil {
 		return "", nil //nolint:nilerr // malformed claim degrades to registered
 	}
-	// An authority that performs verification itself names itself;
-	// the countersignature just checked serves as both attestations.
+	// Registration and identity verification must be performed by distinct
+	// participants. A self-referential claim provides no verifier evidence.
 	if verifier == authority {
-		return verifier, nil
+		return "", nil
 	}
 	if err := c.verifySignatureBy(ctx, env, verifier); err != nil {
 		if errors.Is(err, ErrUnavailable) {

--- a/net/authorities_test.go
+++ b/net/authorities_test.go
@@ -140,7 +140,7 @@ func TestVerifyAuthority(t *testing.T) {
 		assert.True(t, end.Verified())
 	})
 
-	t.Run("authority naming itself needs no second signature", func(t *testing.T) {
+	t.Run("authority cannot verify itself", func(t *testing.T) {
 		msg := &note.Message{Content: "party doc"}
 		msg.SetUUID(uuid.V7())
 		env, err := gobl.Envelop(msg)
@@ -157,8 +157,9 @@ func TestVerifyAuthority(t *testing.T) {
 		)
 		end, err := c.VerifyAuthority(ctx, env)
 		require.NoError(t, err)
-		assert.Equal(t, authorityAddr, end.Verifier)
-		assert.True(t, end.Verified())
+		assert.Equal(t, authorityAddr, end.Authority)
+		assert.Empty(t, end.Verifier)
+		assert.False(t, end.Verified())
 	})
 
 	t.Run("degrades to registered when the verifier signature is missing", func(t *testing.T) {
@@ -588,10 +589,12 @@ func TestVerifySignatureByEdgeCases(t *testing.T) {
 
 	t.Run("prefers a verified endorsement regardless of signature order", func(t *testing.T) {
 		// Two trusted authorities countersign: the first is registered
-		// only, the second names itself as verifier. The verified
-		// endorsement must win even though it appears later.
+		// only, while the second names an independent verifier. The
+		// verified endorsement must win even though it appears later.
 		secondAddr := Address("auth.example.org")
 		secondKey := dsig.NewES256Key()
+		verifierAddr := Address("verify.example.org")
+		verifierKey := dsig.NewES256Key()
 		msg := &note.Message{Content: "party doc"}
 		msg.SetUUID(uuid.V7())
 		env, err := gobl.Envelop(msg)
@@ -599,20 +602,23 @@ func TestVerifySignatureByEdgeCases(t *testing.T) {
 		require.NoError(t, env.Sign(authKey, head.WithIssuer(authorityAddr.String())))
 		require.NoError(t, env.Sign(secondKey,
 			head.WithIssuer(secondAddr.String()),
-			head.WithVerifier(secondAddr.String())))
+			head.WithVerifier(verifierAddr.String())))
+		require.NoError(t, env.Sign(verifierKey,
+			head.WithIssuer(verifierAddr.String())))
 
 		c := NewClient(
 			WithAuthorities(authorityAddr, secondAddr),
 			WithFetcher(&mapFetcher{data: map[string][]byte{
-				authorityAddr.KeyURL(authKey.ID()): jwkOf(authKey),
-				secondAddr.KeyURL(secondKey.ID()):  jwkOf(secondKey),
+				authorityAddr.KeyURL(authKey.ID()):    jwkOf(authKey),
+				secondAddr.KeyURL(secondKey.ID()):     jwkOf(secondKey),
+				verifierAddr.KeyURL(verifierKey.ID()): jwkOf(verifierKey),
 			}}),
 		)
 		end, err := c.VerifyAuthority(ctx, env)
 		require.NoError(t, err)
 		assert.True(t, end.Verified())
 		assert.Equal(t, secondAddr, end.Authority)
-		assert.Equal(t, secondAddr, end.Verifier)
+		assert.Equal(t, verifierAddr, end.Verifier)
 	})
 }
 

--- a/net/client.go
+++ b/net/client.go
@@ -31,13 +31,9 @@ const (
 // dialTimeout is the per-attempt timeout for the SSRF-safe dialer.
 const dialTimeout = 5 * time.Second
 
-// safeDialContext is the DialContext used by the default HTTPFetcher.
-// It resolves the target host and refuses to connect when any of the
-// resolved IPs is a loopback, private, link-local, or unspecified
-// address — the standard SSRF defense for a client that dials hosts
-// derived from signed payloads (a `gobl:` `iss` URI). Tests and local
-// development should inject a custom Fetcher rather than relaxing
-// this default.
+// safeDialContext is the SSRF-resistant dialer used by HTTPFetcher. It rejects
+// hosts that resolve to non-public addresses. Tests and local services should
+// inject a custom Fetcher.
 func safeDialContext(ctx context.Context, network, addr string) (stdnet.Conn, error) {
 	host, port, err := stdnet.SplitHostPort(addr)
 	if err != nil {
@@ -220,8 +216,7 @@ func copyHeader(dst, src http.Header) {
 	}
 }
 
-// Client provides GOBL Net operations including KeySet fetching
-// and remote verification.
+// Client performs GOBL Net discovery, delivery, and verification.
 type Client struct {
 	fetcher     Fetcher
 	authorities []Address
@@ -255,12 +250,7 @@ func WithFetcher(f Fetcher) ClientOption {
 	}
 }
 
-// WithAuthorities sets the client's trusted registration authorities,
-// replacing the default list (net.Authorities, which carries the
-// network's default authority). Operators who want to supplement the
-// default rather than replace it include it explicitly, or grow the
-// global default with RegisterAuthority. Replacement semantics let
-// closed deployments exclude the default authority entirely.
+// WithAuthorities replaces the client's trusted registration authorities.
 func WithAuthorities(addrs ...Address) ClientOption {
 	return func(c *Client) {
 		c.authorities = append([]Address{}, addrs...)
@@ -276,22 +266,16 @@ func WithKeyCacheTTL(d time.Duration) ClientOption {
 	}
 }
 
-// WithSandbox switches the client's trusted registration authorities
-// to the sandbox list (net.SandboxAuthorities), replacing the live
-// default. Sandbox authorities endorse test identities with relaxed
-// verification, so the two environments never trust each other's
-// endorsements. Like WithAuthorities this replaces the trust list —
-// when both options are given, the last one wins.
+// WithSandbox replaces the client's trust list with SandboxAuthorities.
+// If combined with WithAuthorities, the last option wins.
 func WithSandbox() ClientOption {
 	return func(c *Client) {
 		c.authorities = append([]Address{}, SandboxAuthorities...)
 	}
 }
 
-// WithIdentity sets the client's own address and private key, used to
-// mint the request tokens that who and inbox requests carry in their
-// Authorization header. A client without an identity sends those
-// requests bare and conforming servers reject them.
+// WithIdentity sets the address and key used to authenticate Who and Send
+// requests. Without an identity, those requests have no Authorization header.
 func WithIdentity(addr Address, key *dsig.PrivateKey) ClientOption {
 	return func(c *Client) {
 		c.identity = &identity{addr: addr, key: key}
@@ -416,8 +400,7 @@ func (c *Client) storeKey(url string, pk *dsig.PublicKey) {
 	c.keyCache[url] = keyCacheEntry{key: pk, exp: now.Add(c.keyTTL)}
 }
 
-// FetchPublicKey is an alias for FetchKey retained for clarity at
-// call sites that only need the verification primitive.
+// FetchPublicKey is an alias for FetchKey.
 func (c *Client) FetchPublicKey(ctx context.Context, addr Address, kid string) (*dsig.PublicKey, error) {
 	return c.FetchKey(ctx, addr, kid)
 }

--- a/net/errors.go
+++ b/net/errors.go
@@ -33,8 +33,7 @@ var (
 	ErrTokenExpired = errors.New("net: request token expired")
 	// ErrVerifyFailed is returned when verification fails.
 	ErrVerifyFailed = errors.New("net: verification failed")
-	// ErrUnknownAuthority is returned when a /who envelope is signed by an
-	// address not in the Authorities list.
+	// ErrUnknownAuthority is returned when no trusted authority endorsement is found.
 	ErrUnknownAuthority = errors.New("net: endorser is not a recognised authority")
 	// ErrNotVerified is returned when a sender's endorsement is valid but
 	// carries no confirmed verifier and the caller required identity
@@ -43,8 +42,7 @@ var (
 	// ErrSignatureExpired is returned when an authority countersignature
 	// verifies but its exp claim is in the past.
 	ErrSignatureExpired = errors.New("net: signature expired")
-	// ErrPartyMissing is returned when a /who response does not contain an
-	// org.Party document.
+	// ErrPartyMissing is returned when an identity envelope has no org.Party.
 	ErrPartyMissing = errors.New("net: /who response did not contain a party document")
 	// ErrInboxRejected is returned when an inbox endpoint rejects an envelope.
 	ErrInboxRejected = errors.New("net: inbox rejected envelope")

--- a/net/net.go
+++ b/net/net.go
@@ -1,4 +1,5 @@
-// Package net provides models and utilities for GOBL Net, a decentralized identity and communication protocol.
+// Package net implements GOBL Net identity discovery, authentication,
+// envelope delivery, and remote signature verification.
 //
 // EXPERIMENTAL: GOBL Net is under active development. Its API and wire
 // protocol may change without notice and carry no stability guarantee yet.
@@ -20,10 +21,8 @@ const (
 	WhoPath = WellKnownPath + "/who"
 	// InboxPath is the well-known path accepting envelope deliveries.
 	InboxPath = WellKnownPath + "/inbox"
-	// JWKSPath is the bulk JWK Set endpoint published at the root
-	// well-known directory so generic JWT tooling (jwt.io, OIDC-style
-	// verifiers) can resolve `jku` and verify signatures without
-	// out-of-band key exchange.
+	// JWKSPath is the conventional bulk JWK Set endpoint for generic tooling.
+	// GOBL Net verification uses the per-key endpoint instead.
 	JWKSPath = "/.well-known/jwks.json"
 )
 

--- a/net/send.go
+++ b/net/send.go
@@ -8,19 +8,10 @@ import (
 	"github.com/invopop/gobl"
 )
 
-// Send delivers a signed envelope to the address's inbox with a POST
-// on its well-known inbox endpoint. The request carries a bearer
-// request token minted from the client's identity (WithIdentity),
-// which may name a different party than the envelope's signer — a
-// trusted intermediary transmitting on the signer's behalf.
-//
-// A 202 response means the inbox has persisted the envelope. Any
-// other 4xx — except 429 — returns ErrInboxRejected: the inbox has
-// decided, do not retry. Transient conditions (429, 5xx, transport
-// failures) return ErrUnavailable, and delivery is idempotent on the
-// envelope's uuid and digest, so "retry on ErrUnavailable until 202"
-// is the correct recovery strategy. Other errors are permanent input
-// or configuration failures.
+// Send posts an envelope to addr's inbox. WithIdentity adds a request token;
+// its issuer may differ from the envelope signer. A 202 response succeeds,
+// definitive 4xx responses return ErrInboxRejected, and transient failures
+// return ErrUnavailable.
 func (c *Client) Send(ctx context.Context, addr Address, env *gobl.Envelope) error {
 	if env == nil {
 		return fmt.Errorf("%w: envelope is nil", ErrFetchFailed)

--- a/net/verify.go
+++ b/net/verify.go
@@ -10,11 +10,9 @@ import (
 	"github.com/invopop/gobl/org"
 )
 
-// VerifyParty establishes the subject of a party envelope: the address
-// the party document itself declares as its gobl: endpoint. The
-// envelope must carry at least one valid self-signature by that
-// address; signature order is not significant. Returns the subject.
-// Countersignatures are not checked here; use VerifyAuthority.
+// VerifyParty returns the address declared by a party envelope's gobl endpoint
+// after verifying a self-signature from that address. It does not verify
+// authority endorsements.
 func (c *Client) VerifyParty(ctx context.Context, env *gobl.Envelope) (Address, error) {
 	if env == nil || env.Head == nil || !env.Signed() {
 		return "", fmt.Errorf("%w: envelope is not signed", ErrVerifyFailed)
@@ -43,11 +41,8 @@ func (c *Client) VerifyParty(ctx context.Context, env *gobl.Envelope) (Address, 
 	return subject, nil
 }
 
-// VerifyDelivery establishes the sender of a document delivery: the
-// issuer of a valid signature whose signed aud equals self, the
-// receiving inbox. Exactly one issuer may bind — none rejects the
-// delivery, more than one is ambiguous. Signature order is not
-// significant.
+// VerifyDelivery returns the sole issuer of valid signatures addressed to
+// self. It fails if no issuer or multiple issuers bind the delivery.
 func (c *Client) VerifyDelivery(ctx context.Context, env *gobl.Envelope, self Address) (Address, error) {
 	if env == nil || env.Head == nil || !env.Signed() {
 		return "", fmt.Errorf("%w: envelope is not signed", ErrVerifyFailed)

--- a/net/who.go
+++ b/net/who.go
@@ -10,21 +10,9 @@ import (
 	"github.com/invopop/gobl/org"
 )
 
-// Who fetches the public identity for the given address with a GET on
-// its well-known who endpoint and verifies it. The response must be a
-// party envelope whose subject (the address its document declares —
-// see VerifyParty) equals the fetched address, carrying an
-// audience-free self-signature. Authority countersignatures, if any,
-// are preserved on the returned envelope for VerifyAuthority.
-//
-// The request carries a bearer request token minted from the client's
-// identity (WithIdentity); conforming servers reject requests without
-// one.
-//
-// A 204 response returns ErrNoContent: the address exists but does not
-// publish identity details (a receive-only account). A 202 response
-// returns ErrPending: the request was recorded and the owner may
-// deliver its party envelope to the requester's inbox later.
+// Who fetches and verifies addr's party envelope. The subject must equal addr
+// and have an audience-free self-signature. WithIdentity authenticates the
+// request. HTTP 204 and 202 responses return ErrNoContent and ErrPending.
 func (c *Client) Who(ctx context.Context, addr Address) (*gobl.Envelope, error) {
 	// Canonicalize so well-known URLs and the issuer comparison use
 	// the ASCII form regardless of how the address was written.
@@ -67,14 +55,9 @@ func (c *Client) Who(ctx context.Context, addr Address) (*gobl.Envelope, error) 
 	return env, nil
 }
 
-// VerifySender confirms that the given address is approved to send
-// documents: its who identity must verify (see Who) and carry a
-// countersignature from one of the client's trusted authorities.
-// When requireVerified is true the endorsement must additionally
-// carry a confirmed verifier (see VerifyAuthority), else
-// ErrNotVerified. Returns the sender's endorsed party on success.
-// Receiving inboxes call this with the verified issuer of an
-// incoming envelope before accepting it.
+// VerifySender returns addr's party after verifying its identity and a trusted
+// authority endorsement. If requireVerified is true, the endorsement must also
+// include confirmed verifier evidence.
 func (c *Client) VerifySender(ctx context.Context, addr Address, requireVerified bool) (*org.Party, error) {
 	env, err := c.Who(ctx, addr)
 	if err != nil {

--- a/net/who_test.go
+++ b/net/who_test.go
@@ -214,8 +214,10 @@ func TestVerifySender(t *testing.T) {
 	ctx := context.Background()
 	subject := Address("supplier.example.com")
 	authority := Address("kyc.example.com")
+	verifier := Address("verify.example.com")
 	subjKey := dsig.NewES256Key()
 	authKey := dsig.NewES256Key()
+	verifierKey := dsig.NewES256Key()
 
 	jwkOf := func(k *dsig.PrivateKey) []byte {
 		t.Helper()
@@ -224,10 +226,22 @@ func TestVerifySender(t *testing.T) {
 		return out
 	}
 
+	endorsedEnvelope := new(gobl.Envelope)
+	require.NoError(t, json.Unmarshal(
+		buildPartyEnvelope(t, subjKey, subject, authKey, authority, verifier),
+		endorsedEnvelope,
+	))
+	require.NoError(t, endorsedEnvelope.Sign(verifierKey,
+		head.WithIssuer(verifier.String()),
+		head.WithAudience(subject.String())))
+	endorsedData, err := json.Marshal(endorsedEnvelope)
+	require.NoError(t, err)
+
 	endorsed := map[string][]byte{
-		subject.WhoURL():               buildPartyEnvelope(t, subjKey, subject, authKey, authority, authority),
-		subject.KeyURL(subjKey.ID()):   jwkOf(subjKey),
-		authority.KeyURL(authKey.ID()): jwkOf(authKey),
+		subject.WhoURL():                  endorsedData,
+		subject.KeyURL(subjKey.ID()):      jwkOf(subjKey),
+		authority.KeyURL(authKey.ID()):    jwkOf(authKey),
+		verifier.KeyURL(verifierKey.ID()): jwkOf(verifierKey),
 	}
 
 	t.Run("accepts an authority-endorsed sender", func(t *testing.T) {


### PR DESCRIPTION
- Rewrite the GOBL Net README as a concise RFC-style specification.
- Clarify exported package and method documentation.
- Resolve contradictions around JWKS discovery, signature ordering, and verification APIs.
- Require registration authorities and identity verifiers to be distinct participants; self-referential verifier claims now produce registration-only endorsements.
- Condense and reorganize the unreleased changelog entries.

## Pre-Review Checklist

- [x] Opened this PR as a draft
- [x] Read the CONTRIBUTING.md guide.
- [x] Performed a self-review of my code.
- [x] Updated verification tests; `go test ./net` passes.
- [x] Examples are not applicable.
- [x] Source links are not applicable.
- [x] Generated schemas and regime data are unaffected.
- [x] `git diff --check` passes.
- [x] Reviewed nil handling.
- [x] Updated the CHANGELOG.md with an overview of my changes.
- [ ] Marked this PR as ready for review.