### PR TITLE
docs: update README with correct tax country code and pricing methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ inv := &bill.Invoice{
 	IssueDate: cal.MakeDate(2023, time.May, 11),
 	Supplier: &org.Party{
 		TaxID: &tax.Identity{
-			Country: l10n.US,
+			Country: l10n.US.Tax(),
 		},
 		Name:  "Provider One Inc.",
 		Alias: "Provider One",
@@ -122,7 +122,7 @@ inv := &bill.Invoice{
 				Locality: "San Francisco",
 				Region:   "CA",
 				Code:     "94105",
-				Country:  l10n.US,
+				Country:  l10n.US.ISO(),
 			},
 		},
 	},
@@ -139,12 +139,12 @@ inv := &bill.Invoice{
 			Quantity: num.MakeAmount(20, 0),
 			Item: &org.Item{
 				Name:  "A stylish mug",
-				Price: num.MakeAmount(2000, 2),
+				Price: num.NewAmount(2000, 2),
 				Unit:  org.UnitHour,
 			},
 			Taxes: []*tax.Combo{
 				{
-					Category: common.TaxCategoryST,
+					Category: tax.CategoryST,
 					Percent:  num.NewPercentage(85, 3),
 				},
 			},


### PR DESCRIPTION
## Changes
Fix compile errors in README example:
- Updates the README invoice example to use the correct tax and ISO country-code helpers, pointer-based pricing, and the current tax category constant.

## Pre-Review Checklist

- [ ] Opened this PR as a draft
- [x] Read the CONTRIBUTING.md guide.
- [x] Performed a self-review of my code.
- [ ] Added thorough tests with at **least** 90% code coverage.
- [x] Modified or created example GOBL documents to show my changes in use, if appropriate.
- [ ] Added links to the source of the changes in tax regimes or addons, either structured or in the comments.
- [x] Run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [x] Reviewed and fixed all linter warnings.
- [x] Been obsessive with pointer nil checks to avoid panics.
- [ ] Updated the CHANGELOG.md with an overview of my changes.
- [x] Marked this PR as ready for review.

And if you are part of the org:
- [ ] Requested a review from Copilot and fixed or dismissed (with a reason) all the feedback raised.
- [ ] Requested a review from @samlown.
