### PR TITLE
Make pay.DueDate.Amount a pointer so absent amounts stay absent

### DIFF
--- a/addons/ar/arca/bill_invoice_test.go
+++ b/addons/ar/arca/bill_invoice_test.go
@@ -1840,7 +1840,7 @@ func testPayment() *bill.PaymentDetails {
 			DueDates: []*pay.DueDate{
 				{
 					Date:   cal.NewDate(2024, 2, 15),
-					Amount: num.MakeAmount(10000, 2),
+					Amount: num.NewAmount(10000, 2),
 				},
 			},
 		},

--- a/addons/eu/en16931/bill_test.go
+++ b/addons/eu/en16931/bill_test.go
@@ -337,7 +337,7 @@ func testInvoiceStandard(t *testing.T) *bill.Invoice {
 				DueDates: []*pay.DueDate{
 					{
 						Date:   cal.NewDate(2025, time.January, 1),
-						Amount: num.MakeAmount(1000, 2),
+						Amount: num.NewAmount(1000, 2),
 					},
 				},
 			},
@@ -657,7 +657,7 @@ func TestValidateBillPayment(t *testing.T) {
 			DueDates: []*pay.DueDate{
 				{
 					Date:   cal.NewDate(2025, time.January, 1),
-					Amount: num.MakeAmount(1000, 2),
+					Amount: num.NewAmount(1000, 2),
 				},
 			},
 		}

--- a/addons/eu/en16931/pay_test.go
+++ b/addons/eu/en16931/pay_test.go
@@ -44,7 +44,7 @@ func TestPayInstructions(t *testing.T) {
 				DueDates: []*pay.DueDate{
 					{
 						Date:   cal.NewDate(2025, time.January, 1),
-						Amount: num.MakeAmount(1000, 2),
+						Amount: num.NewAmount(1000, 2),
 					},
 				},
 			},
@@ -62,7 +62,7 @@ func TestPayTerms(t *testing.T) {
 			DueDates: []*pay.DueDate{
 				{
 					Date:   cal.NewDate(2025, time.January, 1),
-					Amount: num.MakeAmount(1000, 2),
+					Amount: num.NewAmount(1000, 2),
 				},
 			},
 		}

--- a/data/schemas/pay/terms.json
+++ b/data/schemas/pay/terms.json
@@ -33,8 +33,7 @@
       },
       "type": "object",
       "required": [
-        "date",
-        "amount"
+        "date"
       ],
       "description": "DueDate contains an amount that should be paid by the given date."
     },

--- a/pay/terms.go
+++ b/pay/terms.go
@@ -120,7 +120,7 @@ func (t *Terms) UnmarshalJSON(data []byte) error {
 type DueDate struct {
 	Date     *cal.Date       `json:"date" jsonschema:"title=Date,description=When the payment is due."`
 	Notes    string          `json:"notes,omitempty" jsonschema:"title=Notes,description=Other details to take into account for the due date."`
-	Amount   num.Amount      `json:"amount" jsonschema:"title=Amount,description=How much needs to be paid by the date."`
+	Amount   *num.Amount     `json:"amount,omitempty" jsonschema:"title=Amount,description=How much needs to be paid by the date."`
 	Percent  *num.Percentage `json:"percent,omitempty" jsonschema:"title=Percent,description=Percentage of the total that should be paid by the date."`
 	Currency currency.Code   `json:"currency,omitempty" jsonschema:"title=Currency,description=If different from the parent document's base currency."`
 }
@@ -157,9 +157,13 @@ func (t *Terms) CalculateDues(zero num.Amount, sum num.Amount) {
 			continue
 		}
 		if dd.Percent != nil && !dd.Percent.IsZero() {
-			dd.Amount = dd.Percent.Of(sum)
+			a := dd.Percent.Of(sum)
+			dd.Amount = &a
 		}
-		dd.Amount = dd.Amount.Rescale(zero.Exp())
+		if dd.Amount != nil {
+			a := dd.Amount.Rescale(zero.Exp())
+			dd.Amount = &a
+		}
 	}
 }
 

--- a/pay/terms_test.go
+++ b/pay/terms_test.go
@@ -44,6 +44,19 @@ func TestTermsValidation(t *testing.T) {
 			},
 		}
 		err := rules.Validate(tm)
+		assert.NoError(t, err, "an absent amount is allowed")
+	})
+
+	t.Run("with due dates and zero amount", func(t *testing.T) {
+		tm := new(pay.Terms)
+		tm.Key = pay.TermKeyDueDate
+		tm.DueDates = []*pay.DueDate{
+			{
+				Date:   cal.NewDate(2021, 11, 10),
+				Amount: num.NewAmount(0, 2),
+			},
+		}
+		err := rules.Validate(tm)
 		assert.ErrorContains(t, err, "amount must not be zero")
 	})
 }
@@ -151,13 +164,13 @@ func TestTermsCalculateDues(t *testing.T) {
 	}
 	terms.CalculateDues(zero, sum)
 
-	assert.Equal(t, num.MakeAmount(4000, 2), terms.DueDates[0].Amount)
-	assert.Equal(t, num.MakeAmount(6000, 2), terms.DueDates[1].Amount)
+	assert.Equal(t, num.NewAmount(4000, 2), terms.DueDates[0].Amount)
+	assert.Equal(t, num.NewAmount(6000, 2), terms.DueDates[1].Amount)
 
 	terms.DueDates = []*pay.DueDate{
 		{
 			Date:   cal.NewDate(2021, 11, 10),
-			Amount: num.MakeAmount(40, 0),
+			Amount: num.NewAmount(40, 0),
 		},
 	}
 	terms.CalculateDues(zero, sum)


### PR DESCRIPTION
Due dates parsed from documents without an explicit amount (e.g. CII payment terms without PartialPaymentAmount) were marshalled as a zero amount and failed the "amount must not be zero" rule. Absence and zero are now distinguishable.

Changes:
- `pay.DueDate.Amount` is now `*num.Amount` with `omitempty`
- Absent (nil) amounts are valid; an explicit zero still fails validation
- `CalculateDues` handles the pointer (percent-derived amounts unchanged)
- JSON schema regenerated: `amount` no longer required on due dates

Notes:
- Breaking change for consumers building `pay.DueDate` literals (gobl.cii, gobl.ubl); they need `num.NewAmount`/`&amt` on their next bump.

Generated with Claude Code — https://claude.ai/code/session_01UcTfAWVtfJ3YLD9i8GXjRD