### PR TITLE
Add SDI issuer type extension for customer and third-party issuance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 - `net`: added `SandboxAuthorities` (defaulting to `lookup.sandbox.gobl.org`)
   and `WithSandbox`. Sandbox and live trust lists remain separate.
+- `it-sdi`: `it-sdi-issuer-type` extension for the FatturaPA `SoggettoEmittente`
+  field, set to `TZ` when the invoice ordering names an `issuer` and to `CC` on
+  self-billed invoices whose customer tax ID differs from the supplier's.
+- `it-sdi`: an ordering `issuer` must carry a tax ID code or a fiscal code
+  identity, as FatturaPA requires one of the two for the third-party block.
 
 ### Changed
 

--- a/addons/it/sdi/bill.go
+++ b/addons/it/sdi/bill.go
@@ -18,6 +18,35 @@ var partyHasTaxIDCode = org.PartyHasTaxIDCode()
 
 func normalizeInvoice(inv *bill.Invoice) {
 	normalizeSupplier(inv.Supplier)
+	normalizeIssuerType(inv)
+}
+
+// normalizeIssuerType reflects who compiled the invoice. Self-billing only
+// implies the customer did when the parties are distinguishable: some Italian
+// self-billed document types (e.g. TD27) are filed by the supplier itself.
+func normalizeIssuerType(inv *bill.Invoice) {
+	if inv.HasTags(tax.TagSelfBilled) && invoicePartiesDiffer(inv.Supplier, inv.Customer) {
+		inv.Tax = inv.Tax.MergeExtensions(tax.ExtensionsOf(cbc.CodeMap{
+			ExtKeyIssuerType: ExtCodeIssuerTypeCustomer,
+		}))
+	}
+	if inv.Ordering != nil && inv.Ordering.Issuer != nil {
+		inv.Tax = inv.Tax.MergeExtensions(tax.ExtensionsOf(cbc.CodeMap{
+			ExtKeyIssuerType: ExtCodeIssuerTypeThirdParty,
+		}))
+	}
+}
+
+// invoicePartiesDiffer reports whether both parties carry tax IDs that
+// identify them as different entities.
+func invoicePartiesDiffer(s, c *org.Party) bool {
+	if s == nil || c == nil || s.TaxID == nil || c.TaxID == nil {
+		return false
+	}
+	if s.TaxID.Code == "" || c.TaxID.Code == "" {
+		return false
+	}
+	return s.TaxID.Country != c.TaxID.Country || s.TaxID.Code != c.TaxID.Code
 }
 
 func normalizeSupplier(party *org.Party) {
@@ -173,6 +202,10 @@ func billInvoiceRules() *rules.Set {
 				),
 			),
 		),
+		// Issuer: identification required when a third party issues the invoice
+		rules.Assert("23", "issuer tax ID code or fiscal code is required",
+			is.Func("issuer identification check", invoiceIssuerHasTaxIDCodeOrFiscalCode),
+		),
 		// Payment: instructions required when terms have due dates
 		rules.Assert("21", "payment instructions are required when terms with due dates are present",
 			is.Func("payment instructions check", invoicePaymentInstructionsPresent),
@@ -258,6 +291,14 @@ func invoiceCustomerHasFiscalCodeIdentity(val any) bool {
 		return false
 	}
 	return org.IdentityForKey(ids, it.IdentityKeyFiscalCode) != nil
+}
+
+func invoiceIssuerHasTaxIDCodeOrFiscalCode(val any) bool {
+	inv, ok := val.(*bill.Invoice)
+	if !ok || inv == nil || inv.Ordering == nil || inv.Ordering.Issuer == nil {
+		return true
+	}
+	return partyHasTaxIDCode.Check(inv.Ordering.Issuer) || hasFiscalCode(inv.Ordering.Issuer)
 }
 
 func invoiceHasDeferredTag(val any) bool {

--- a/addons/it/sdi/bill_test.go
+++ b/addons/it/sdi/bill_test.go
@@ -177,6 +177,75 @@ func TestInvoiceNormalization(t *testing.T) {
 		require.Len(t, inv.Supplier.Telephones, 1)
 		assert.Equal(t, "333123456", inv.Supplier.Telephones[0].Number)
 	})
+
+	t.Run("self-billed", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.SetTags(tax.TagSelfBilled)
+		norm.Normalize(inv, tax.AddonContext(sdi.V1))
+		assert.Equal(t, sdi.ExtCodeIssuerTypeCustomer, inv.Tax.Ext.Get(sdi.ExtKeyIssuerType))
+	})
+
+	t.Run("self-billed by the supplier itself", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.SetTags(tax.TagSelfBilled)
+		inv.Customer.TaxID.Code = inv.Supplier.TaxID.Code
+		norm.Normalize(inv, tax.AddonContext(sdi.V1))
+		assert.Empty(t, inv.Tax.Ext.Get(sdi.ExtKeyIssuerType).String())
+	})
+
+	t.Run("self-billed without customer tax ID code", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.SetTags(tax.TagSelfBilled)
+		inv.Customer.TaxID.Code = ""
+		norm.Normalize(inv, tax.AddonContext(sdi.V1))
+		assert.Empty(t, inv.Tax.Ext.Get(sdi.ExtKeyIssuerType).String())
+	})
+
+	t.Run("issuer takes precedence over self-billed", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.SetTags(tax.TagSelfBilled)
+		inv.Ordering = &bill.Ordering{
+			Issuer: &org.Party{
+				Name: "Test Issuer",
+				TaxID: &tax.Identity{
+					Country: "IT",
+					Code:    "12345678903",
+				},
+			},
+		}
+		norm.Normalize(inv, tax.AddonContext(sdi.V1))
+		assert.Equal(t, sdi.ExtCodeIssuerTypeThirdParty, inv.Tax.Ext.Get(sdi.ExtKeyIssuerType))
+	})
+
+	t.Run("with issuer", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Ordering = &bill.Ordering{
+			Issuer: &org.Party{
+				Name: "Test Issuer",
+				TaxID: &tax.Identity{
+					Country: "IT",
+					Code:    "12345678903",
+				},
+			},
+		}
+		norm.Normalize(inv, tax.AddonContext(sdi.V1))
+		assert.Equal(t, sdi.ExtCodeIssuerTypeThirdParty, inv.Tax.Ext.Get(sdi.ExtKeyIssuerType))
+	})
+
+	t.Run("explicit issuer type is kept for same-party self-billing", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.SetTags(tax.TagSelfBilled)
+		inv.Customer.TaxID.Code = inv.Supplier.TaxID.Code
+		inv.Tax.Ext = inv.Tax.Ext.Set(sdi.ExtKeyIssuerType, sdi.ExtCodeIssuerTypeCustomer)
+		norm.Normalize(inv, tax.AddonContext(sdi.V1))
+		assert.Equal(t, sdi.ExtCodeIssuerTypeCustomer, inv.Tax.Ext.Get(sdi.ExtKeyIssuerType))
+	})
+
+	t.Run("issued by supplier", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		norm.Normalize(inv, tax.AddonContext(sdi.V1))
+		assert.Empty(t, inv.Tax.Ext.Get(sdi.ExtKeyIssuerType).String())
+	})
 }
 
 func TestSupplierValidation(t *testing.T) {
@@ -797,6 +866,53 @@ func TestOrderingValidation(t *testing.T) {
 		}
 		require.NoError(t, inv.Calculate())
 		require.NoError(t, rules.Validate(inv))
+	})
+
+	t.Run("issuer with tax ID", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Ordering = &bill.Ordering{
+			Issuer: &org.Party{
+				Name: "Test Issuer",
+				TaxID: &tax.Identity{
+					Country: "IT",
+					Code:    "12345678903",
+				},
+			},
+		}
+		require.NoError(t, inv.Calculate())
+		require.NoError(t, rules.Validate(inv))
+	})
+
+	t.Run("issuer with fiscal code only", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Ordering = &bill.Ordering{
+			Issuer: &org.Party{
+				Name: "Test Issuer",
+				Identities: []*org.Identity{
+					{
+						Key:  it.IdentityKeyFiscalCode,
+						Code: "RSSMRA80A01H501U",
+					},
+				},
+			},
+		}
+		require.NoError(t, inv.Calculate())
+		require.NoError(t, rules.Validate(inv))
+	})
+
+	t.Run("issuer without tax ID code or fiscal code", func(t *testing.T) {
+		inv := testInvoiceStandard(t)
+		inv.Ordering = &bill.Ordering{
+			Issuer: &org.Party{
+				Name: "Test Issuer",
+				TaxID: &tax.Identity{
+					Country: "IT",
+				},
+			},
+		}
+		require.NoError(t, inv.Calculate())
+		err := rules.Validate(inv)
+		assert.ErrorContains(t, err, "issuer tax ID code or fiscal code is required")
 	})
 
 	t.Run("despatch with deferred tag and valid additional data", func(t *testing.T) {

--- a/addons/it/sdi/extensions.go
+++ b/addons/it/sdi/extensions.go
@@ -17,9 +17,17 @@ const (
 	ExtKeyPaymentMeans cbc.Key = "it-sdi-payment-means"
 	ExtKeyVATLiability cbc.Key = "it-sdi-vat-liability"
 	ExtKeyFundType     cbc.Key = "it-sdi-fund-type"
+	ExtKeyIssuerType   cbc.Key = "it-sdi-issuer-type"
 
 	ExtKeyLiquidationState cbc.Key = "it-sdi-liquidation-state"
 	ExtKeyShareholderState cbc.Key = "it-sdi-shareholder-state"
+)
+
+// Issuer type codes used to identify who compiled the invoice when it was not
+// the supplier.
+const (
+	ExtCodeIssuerTypeCustomer   cbc.Code = "CC" // Cessionario / Committente
+	ExtCodeIssuerTypeThirdParty cbc.Code = "TZ" // Terzo
 )
 
 var extensions = []*cbc.Definition{
@@ -1118,6 +1126,52 @@ var extensions = []*cbc.Definition{
 				Name: i18n.String{
 					i18n.EN: "Multiple shareholders",
 					i18n.IT: "Più soci",
+				},
+			},
+		},
+	},
+	{
+		Key: ExtKeyIssuerType,
+		Name: i18n.String{
+			i18n.EN: "Issuer Type",
+			i18n.IT: "Soggetto Emittente",
+		},
+		Sources: []*cbc.Source{
+			{
+				Title: i18n.String{
+					i18n.EN: "FatturaPA - Filling Guide",
+					i18n.IT: "Guida alla compilazione della fattura elettronica",
+				},
+				URL: "https://www.agenziaentrate.gov.it/portale/documents/20143/451259/Guida_compilazione-FE-Esterometro-V_1.9_2024-03-05.pdf",
+			},
+		},
+		Desc: i18n.String{
+			i18n.EN: here.Doc(`
+				Identifies who compiled the invoice when this was not the supplier, as
+				required by article 21 of DPR 633/1972. Mapped to the ~SoggettoEmittente~
+				field of a FatturaPA document.
+
+				Set automatically to ~TZ~ when the invoice's ordering section names an
+				~issuer~, and to ~CC~ when the invoice is ~self-billed~ and the
+				customer's tax ID differs from the supplier's. Left unset when a
+				self-billed invoice's supplier and customer are the same party, as in
+				an autofattura for self-consumption (TD27), where the supplier is the
+				one filing the document.
+			`),
+		},
+		Values: []*cbc.Definition{
+			{
+				Code: ExtCodeIssuerTypeCustomer,
+				Name: i18n.String{
+					i18n.EN: "Issued by Customer",
+					i18n.IT: "Emessa dal cessionario / committente",
+				},
+			},
+			{
+				Code: ExtCodeIssuerTypeThirdParty,
+				Name: i18n.String{
+					i18n.EN: "Issued by Third Party",
+					i18n.IT: "Emessa da un soggetto terzo",
 				},
 			},
 		},

--- a/data/addons/it-sdi-v1.json
+++ b/data/addons/it-sdi-v1.json
@@ -1135,6 +1135,41 @@
           }
         }
       ]
+    },
+    {
+      "key": "it-sdi-issuer-type",
+      "name": {
+        "en": "Issuer Type",
+        "it": "Soggetto Emittente"
+      },
+      "desc": {
+        "en": "Identifies who compiled the invoice when this was not the supplier, as\nrequired by article 21 of DPR 633/1972. Mapped to the `SoggettoEmittente`\nfield of a FatturaPA document.\n\nSet automatically to `TZ` when the invoice's ordering section names an\n`issuer`, and to `CC` when the invoice is `self-billed` and the\ncustomer's tax ID differs from the supplier's. Left unset when a\nself-billed invoice's supplier and customer are the same party, as in\nan autofattura for self-consumption (TD27), where the supplier is the\none filing the document."
+      },
+      "sources": [
+        {
+          "title": {
+            "en": "FatturaPA - Filling Guide",
+            "it": "Guida alla compilazione della fattura elettronica"
+          },
+          "url": "https://www.agenziaentrate.gov.it/portale/documents/20143/451259/Guida_compilazione-FE-Esterometro-V_1.9_2024-03-05.pdf"
+        }
+      ],
+      "values": [
+        {
+          "code": "CC",
+          "name": {
+            "en": "Issued by Customer",
+            "it": "Emessa dal cessionario / committente"
+          }
+        },
+        {
+          "code": "TZ",
+          "name": {
+            "en": "Issued by Third Party",
+            "it": "Emessa da un soggetto terzo"
+          }
+        }
+      ]
     }
   ],
   "tags": [

--- a/examples/it/b2b-third-party-issuer.json
+++ b/examples/it/b2b-third-party-issuer.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://gobl.org/draft-0/bill/invoice",
+  "$addons": ["it-sdi-v1"],
+  "uuid": "0190a63a-1a80-7e1e-a868-08c7859b6471",
+  "series": "FT",
+  "code": "021",
+  "currency": "EUR",
+  "issue_date": "2024-07-12",
+  "tax": {
+    "prices_include": "VAT"
+  },
+  "type": "standard",
+  "supplier": {
+    "tax_id": {
+      "country": "IT",
+      "code": "12345678903"
+    },
+    "name": "Company Name S.r.l.",
+    "registration": {
+      "capital": "50000.00",
+      "currency": "EUR",
+      "entry": "123456",
+      "office": "RM"
+    },
+    "addresses": [
+      {
+        "num": "102",
+        "street": "Via California",
+        "locality": "Palermo",
+        "region": "PA",
+        "code": "33213",
+        "country": "IT"
+      }
+    ]
+  },
+  "customer": {
+    "tax_id": {
+      "country": "IT",
+      "code": "13029381004"
+    },
+    "name": "Cliente S.p.A.",
+    "addresses": [
+      {
+        "num": "23",
+        "street": "Via dei Mille",
+        "locality": "Firenze",
+        "region": "FI",
+        "code": "00100",
+        "country": "IT"
+      }
+    ]
+  },
+  "ordering": {
+    "issuer": {
+      "tax_id": {
+        "country": "IT",
+        "code": "01234567897"
+      },
+      "name": "Fatturazione Terzi S.r.l."
+    }
+  },
+  "lines": [
+    {
+      "quantity": "1",
+      "item": {
+        "name": "Cleaning services",
+        "price": "125.00"
+      },
+      "taxes": [
+        {
+          "cat": "VAT",
+          "rate": "standard"
+        }
+      ]
+    }
+  ]
+}

--- a/examples/it/out/b2b-third-party-issuer.json
+++ b/examples/it/out/b2b-third-party-issuer.json
@@ -1,0 +1,128 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
+		"dig": {
+			"alg": "sha256",
+			"val": "86bcdd31c5131a550524410904896eb0afbacc8a9366a757d9bc829a05907b9a"
+		}
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"$regime": "IT",
+		"$addons": [
+			"it-sdi-v1"
+		],
+		"uuid": "0190a63a-1a80-7e1e-a868-08c7859b6471",
+		"type": "standard",
+		"series": "FT",
+		"code": "021",
+		"issue_date": "2024-07-12",
+		"currency": "EUR",
+		"tax": {
+			"prices_include": "VAT",
+			"ext": {
+				"it-sdi-document-type": "TD01",
+				"it-sdi-format": "FPR12",
+				"it-sdi-issuer-type": "TZ"
+			}
+		},
+		"supplier": {
+			"name": "Company Name S.r.l.",
+			"tax_id": {
+				"country": "IT",
+				"code": "12345678903"
+			},
+			"addresses": [
+				{
+					"num": "102",
+					"street": "Via California",
+					"locality": "Palermo",
+					"region": "PA",
+					"code": "33213",
+					"country": "IT"
+				}
+			],
+			"registration": {
+				"capital": "50000.00",
+				"currency": "EUR",
+				"office": "RM",
+				"entry": "123456"
+			},
+			"ext": {
+				"it-sdi-fiscal-regime": "RF01"
+			}
+		},
+		"customer": {
+			"name": "Cliente S.p.A.",
+			"tax_id": {
+				"country": "IT",
+				"code": "13029381004"
+			},
+			"addresses": [
+				{
+					"num": "23",
+					"street": "Via dei Mille",
+					"locality": "Firenze",
+					"region": "FI",
+					"code": "00100",
+					"country": "IT"
+				}
+			]
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "1",
+				"item": {
+					"name": "Cleaning services",
+					"price": "125.00"
+				},
+				"sum": "125.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "general",
+						"percent": "22.0%"
+					}
+				],
+				"total": "125.00"
+			}
+		],
+		"ordering": {
+			"issuer": {
+				"name": "Fatturazione Terzi S.r.l.",
+				"tax_id": {
+					"country": "IT",
+					"code": "01234567897"
+				}
+			}
+		},
+		"totals": {
+			"sum": "125.00",
+			"tax_included": "22.54",
+			"total": "102.46",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"base": "102.46",
+								"percent": "22.0%",
+								"amount": "22.54"
+							}
+						],
+						"amount": "22.54"
+					}
+				],
+				"sum": "22.54"
+			},
+			"tax": "22.54",
+			"total_with_tax": "125.00",
+			"payable": "125.00"
+		}
+	}
+}


### PR DESCRIPTION
Adds the `it-sdi-issuer-type` extension so an Italian invoice can say who compiled it when that was not the supplier. FatturaPA carries this in `SoggettoEmittente` (issuing party), with `TZ` for a third party and `CC` for the customer (*cessionario/committente*). The field is required whenever the compiler differs from the supplier (art. 21 DPR 633/1972), and until now GOBL had no way to express it. This follows `es-verifactu-issuer-type`, which covers the same concept for Spain.

## Changes

- **Adds `it-sdi-issuer-type`** with values `TZ` and `CC`, sourced from the AdE compilation guide.
- **Sets `TZ` automatically** when the invoice's ordering names an `issuer`, as the Spanish addon does.
- **Requires the issuer to be identifiable.** An `ordering.issuer` must carry a tax ID code or a fiscal code identity, since the FatturaPA third-party block needs one of the two.
- **Sets `CC` only when the parties are distinct.** A `self-billed` invoice gets `CC` when the customer's tax ID differs from the supplier's. Italy also uses self-billing for documents where supplier and customer are the same company and the supplier files (TD27 is the clearest case) — there the field stays unset, and integrators can still set it explicitly.
- **Adds an example invoice** issued by a third party.

## Pre-Review Checklist

- [x] Opened this PR as a draft
- [x] Read the CONTRIBUTING.md guide.
- [x] Performed a self-review of my code.
- [x] Added thorough tests with at **least** 90% code coverage.
- [x] Modified or created example GOBL documents to show my changes in use, if appropriate.
- [x] Added links to the source of the changes in tax regimes or addons, either structured or in the comments.
- [x] Run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [x] Reviewed and fixed all linter warnings.
- [x] Been obsessive with pointer nil checks to avoid panics.
- [x] Updated the CHANGELOG.md with an overview of my changes.
- [ ] Marked this PR as ready for review.

And if you are part of the org:
- [ ] Requested a review from Copilot and fixed or dismissed (with a reason) all the feedback raised.
- [ ] Requested a review from @samlown.
