### PR TITLE
Suppress deprecation lint on the Italy tax ID type migration test

### DIFF
--- a/regimes/it/org_party_test.go
+++ b/regimes/it/org_party_test.go
@@ -16,7 +16,7 @@ func TestPartyNormalization(t *testing.T) {
 		cus.TaxID = &tax.Identity{
 			Country: "IT",
 			Code:    "RSSGNN60R30H501U",
-			Type:    "individual",
+			Type:    "individual", //nolint:staticcheck
 		}
 		norm.Normalize(cus, tax.RegimeContext("IT"))
 		assert.Empty(t, cus.TaxID.Code)
@@ -31,7 +31,7 @@ func TestPartyNormalization(t *testing.T) {
 		cus.TaxID = &tax.Identity{
 			Country: "XX",
 			Code:    "RSSGNN60R30H501U",
-			Type:    "individual",
+			Type:    "individual", //nolint:staticcheck
 		}
 		norm.Normalize(cus, tax.RegimeContext("IT"))
 		assert.Equal(t, "RSSGNN60R30H501U", cus.TaxID.Code.String())


### PR DESCRIPTION
Lint fails on `main` with the current `golangci-lint`: `regimes/it/org_party_test.go` sets the deprecated `tax.Identity.Type` on lines 19 and 34, and the newer staticcheck flags those writes as well as the read that line 22 already suppresses. Every open PR is red as a result.

## Changes

- **Suppresses the deprecation warning** on the two writes, matching the existing suppression on the read. The test exercises the migration of that field into `identities`, so using it there is deliberate.

## Pre-Review Checklist

- [x] Opened this PR as a draft
- [x] Read the CONTRIBUTING.md guide.
- [x] Performed a self-review of my code.
- [x] Added thorough tests with at **least** 90% code coverage.
- [x] Modified or created example GOBL documents to show my changes in use, if appropriate. (not applicable, test-only change)
- [x] Added links to the source of the changes in tax regimes or addons, either structured or in the comments. (not applicable)
- [x] Run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [x] Reviewed and fixed all linter warnings.
- [x] Been obsessive with pointer nil checks to avoid panics.
- [x] Updated the CHANGELOG.md with an overview of my changes. (not applicable, no behaviour change)
- [ ] Marked this PR as ready for review.

And if you are part of the org:
- [ ] Requested a review from Copilot and fixed or dismissed (with a reason) all the feedback raised.
- [ ] Requested a review from @samlown.
