### PR TITLE
Accept the 24 prefix for Argentine CUIT/CUIL tax identities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 - `head`: `SignedPayload` and `Header.Verify` now return an error for `null`
   signature entries instead of panicking.
+- `regimes/ar`: CUIT/CUIL tax identities with the `24` prefix (an individual
+  contingency prefix) are no longer wrongly rejected as having an invalid prefix.
 
 ## [v0.504.0]
 

--- a/regimes/ar/tax_identity.go
+++ b/regimes/ar/tax_identity.go
@@ -29,6 +29,7 @@ import (
 // Common prefixes:
 //   - 20: Male individual (CUIL)
 //   - 23: Individual with check digit conflict resolution
+//   - 24: Individual (contingency prefix, used when 20/27 is unavailable, e.g. a shared DNI)
 //   - 27: Female individual (CUIL)
 //   - 30: Company/Legal entity (CUIT)
 //   - 33: Company with check digit conflict resolution
@@ -37,7 +38,7 @@ import (
 // - Algorithm explanation: https://whiz.tools/en/legal-business/argentinian-cuit-cuil-generator-validator
 // - Wikipedia: https://es.wikipedia.org/wiki/Clave_%C3%9Anica_de_Identificaci%C3%B3n_Tributaria
 
-var validTypeCodes = []string{"20", "23", "27", "30", "33"}
+var validTypeCodes = []string{"20", "23", "24", "27", "30", "33"}
 
 func normalizeTaxIdentity(tID *tax.Identity) {
 	// Use standard normalization to remove spaces and convert to uppercase

--- a/regimes/ar/tax_identity_test.go
+++ b/regimes/ar/tax_identity_test.go
@@ -38,6 +38,10 @@ func TestTaxIdentityRules(t *testing.T) {
 			name: "valid CUIT - prefix 33 (company conflict resolution)",
 			code: "33000000049",
 		},
+		{
+			name: "valid CUIL - prefix 24 (individual contingency prefix)",
+			code: "24000000007",
+		},
 
 		// Invalid - wrong length
 		{


### PR DESCRIPTION
Fixes APP-785

The `24` prefix is a valid individual contingency code, used when the standard `20`/`27` prefixes can't be assigned (e.g. a shared DNI). Such IDs have a correct modulo-11 check digit but were previously rejected as having an invalid prefix.

**Example:** a `24`-prefixed CUIL with a valid check digit (e.g. `24000000007`) now validates instead of being rejected.

**Changes**
- `regimes/ar`: add `24` to the accepted CUIT/CUIL type prefixes.
- Tests: add a case for a valid `24`-prefixed identity.
- CHANGELOG updated.

**Reference:** [Argentinian CUIT/CUIL generator & validator (whiz.tools)](https://whiz.tools/en/legal-business/argentinian-cuit-cuil-generator-validator) — explains the CUIT/CUIL structure, prefixes, and the modulo-11 check-digit algorithm.

## Pre-Review Checklist

- [x] Opened this PR as a draft
- [x] Read the CONTRIBUTING.md guide.
- [x] Performed a self-review of my code.
- [x] Added thorough tests with at **least** 90% code coverage.
- [ ] Modified or created example GOBL documents to show my changes in use, if appropriate.
- [x] Added links to the source of the changes in tax regimes or addons, either structured or in the comments.
- [x] Run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [x] Reviewed and fixed all linter warnings.
- [x] Been obsessive with pointer nil checks to avoid panics.
- [x] Updated the CHANGELOG.md with an overview of my changes.
- [x] Marked this PR as ready for review.

And if you are part of the org:
- [ ] Requested a review from Copilot and fixed or dismissed (with a reason) all the feedback raised.
- [ ] Requested a review from @samlown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)