### PR TITLE
Suppress staticcheck SA1019 for deprecated Type in IT party test

### DIFF
--- a/regimes/it/org_party_test.go
+++ b/regimes/it/org_party_test.go
@@ -16,7 +16,7 @@ func TestPartyNormalization(t *testing.T) {
 		cus.TaxID = &tax.Identity{
 			Country: "IT",
 			Code:    "RSSGNN60R30H501U",
-			Type:    "individual",
+			Type:    "individual", //nolint:staticcheck
 		}
 		norm.Normalize(cus, tax.RegimeContext("IT"))
 		assert.Empty(t, cus.TaxID.Code)
@@ -31,7 +31,7 @@ func TestPartyNormalization(t *testing.T) {
 		cus.TaxID = &tax.Identity{
 			Country: "XX",
 			Code:    "RSSGNN60R30H501U",
-			Type:    "individual",
+			Type:    "individual", //nolint:staticcheck
 		}
 		norm.Normalize(cus, tax.RegimeContext("IT"))
 		assert.Equal(t, "RSSGNN60R30H501U", cus.TaxID.Code.String())


### PR DESCRIPTION
- `regimes/it`: annotate the two `Type: "individual"` struct-literal lines in the party normalization test with `//nolint:staticcheck`, matching the directive already used where the deprecated `tax.Identity.Type` field is read (and elsewhere in the repo).
- Resolves the only two `SA1019` findings repo-wide, so the full-repo lint passes under golangci-lint v2.13.2 — unblocking CI on `main` and open PRs (e.g. #943). Test-only, no behaviour change.

## Pre-Review Checklist

- [x] Opened this PR as a draft
- [x] Read the CONTRIBUTING.md guide.
- [x] Performed a self-review of my code.
- [ ] Added thorough tests with at **least** 90% code coverage.
- [ ] Modified or created example GOBL documents to show my changes in use, if appropriate.
- [ ] Added links to the source of the changes in tax regimes or addons, either structured or in the comments.
- [ ] Run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [x] Reviewed and fixed all linter warnings.
- [ ] Been obsessive with pointer nil checks to avoid panics.
- [ ] Updated the CHANGELOG.md with an overview of my changes.
- [x] Marked this PR as ready for review.

And if you are part of the org:
- [ ] Requested a review from Copilot and fixed or dismissed (with a reason) all the feedback raised.
- [ ] Requested a review from @samlown.