### PR TITLE
Add Costa Rica (CR) tax regime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Added
+
+- `regimes/cr`: new tax regime for Costa Rica.
+
 ## [v0.505.0]
 
 ### Added

--- a/data/regimes/cr.json
+++ b/data/regimes/cr.json
@@ -1,0 +1,251 @@
+{
+  "$schema": "https://gobl.org/draft-0/tax/regime-def",
+  "name": {
+    "en": "Costa Rica",
+    "es": "Costa Rica"
+  },
+  "description": {
+    "en": "Costa Rica's tax system is administered by the Dirección General\nde Tributación (DGT) of the Ministerio de Hacienda. IVA (Impuesto\nal Valor Agregado) has applied since 1 July 2019, when Title I of\nLaw 9635 reformed the former general sales tax law (Law 6826)\ninto a value added tax; ISC (Impuesto Selectivo de Consumo) is an\nad valorem excise on selected goods.\n\nTaxpayers are identified by the same documents used for civil\nidentification (cédula física, cédula jurídica, DIMEX, or NITE),\nnone of which carry a check digit. Electronic invoicing is\nmandatory for most taxpayers, and issued documents may only be\ncorrected with electronic credit or debit notes.",
+    "es": "El sistema tributario de Costa Rica es administrado por la\nDirección General de Tributación (DGT) del Ministerio de\nHacienda. El IVA (Impuesto al Valor Agregado) se aplica desde el\n1 de julio de 2019, cuando el Título I de la Ley 9635 reformó la\nanterior ley del impuesto general sobre las ventas (Ley 6826) en\nun impuesto al valor agregado; el ISC (Impuesto Selectivo de\nConsumo) es un impuesto ad valorem sobre mercancías\nseleccionadas.\n\nLos contribuyentes se identifican con los mismos documentos de\nidentificación civil (cédula física, cédula jurídica, DIMEX o\nNITE), ninguno de los cuales incluye dígito verificador. La\nfactura electrónica es obligatoria para la mayoría de los\ncontribuyentes y los comprobantes emitidos solo pueden corregirse\nmediante notas de crédito o débito electrónicas."
+  },
+  "sources": [
+    {
+      "title": {
+        "en": "Ministerio de Hacienda - Dirección General de Tributación"
+      },
+      "url": "https://www.hacienda.go.cr/"
+    },
+    {
+      "title": {
+        "en": "OECD - Costa Rica Tax Identification Numbers"
+      },
+      "url": "https://www.oecd.org/content/dam/oecd/en/topics/policy-issue-focus/aeoi/costa-rica-tin.pdf"
+    },
+    {
+      "title": {
+        "en": "Reglamento de Comprobantes Electrónicos para Efectos Tributarios"
+      },
+      "url": "https://sinalevi.go.cr/ResultadosNormativa/Informacion?param1=103206\u0026param2=143152\u0026param3=1"
+    },
+    {
+      "title": {
+        "en": "Anexos y Estructuras de Comprobantes Electrónicos v4.4"
+      },
+      "url": "https://www.hacienda.go.cr/docs/ANEXOS_Y_ESTRUCTURAS_V4.4.pdf"
+    }
+  ],
+  "time_zone": "America/Costa_Rica",
+  "country": "CR",
+  "currency": "CRC",
+  "tax_scheme": "VAT",
+  "corrections": [
+    {
+      "schema": "bill/invoice",
+      "types": [
+        "credit-note",
+        "debit-note"
+      ]
+    }
+  ],
+  "categories": [
+    {
+      "code": "VAT",
+      "name": {
+        "en": "VAT",
+        "es": "IVA"
+      },
+      "title": {
+        "en": "Value Added Tax",
+        "es": "Impuesto al Valor Agregado"
+      },
+      "keys": [
+        {
+          "key": "standard",
+          "name": {
+            "en": "Standard"
+          }
+        },
+        {
+          "key": "zero",
+          "name": {
+            "en": "Zero"
+          }
+        },
+        {
+          "key": "reverse-charge",
+          "name": {
+            "en": "Reverse charge"
+          },
+          "no_percent": true
+        },
+        {
+          "key": "exempt",
+          "name": {
+            "en": "Exempt"
+          },
+          "no_percent": true
+        },
+        {
+          "key": "export",
+          "name": {
+            "en": "Export"
+          },
+          "no_percent": true
+        },
+        {
+          "key": "intra-community",
+          "name": {
+            "en": "Intra-community"
+          },
+          "no_percent": true
+        },
+        {
+          "key": "outside-scope",
+          "name": {
+            "en": "Outside scope"
+          },
+          "no_percent": true
+        }
+      ],
+      "rates": [
+        {
+          "rate": "general",
+          "keys": [
+            "standard"
+          ],
+          "name": {
+            "en": "General Rate",
+            "es": "Tarifa General"
+          },
+          "desc": {
+            "en": "Officially \"tarifa general 13%\": all operations subject to the tax not covered by a reduced rate (art. 10, Ley 6826).",
+            "es": "Oficialmente \"tarifa general 13%\": todas las operaciones sujetas al impuesto no cubiertas por una tarifa reducida (art. 10, Ley 6826)."
+          },
+          "values": [
+            {
+              "since": "2019-07-01",
+              "percent": "13.0%"
+            }
+          ]
+        },
+        {
+          "rate": "intermediate",
+          "keys": [
+            "standard"
+          ],
+          "name": {
+            "en": "Intermediate Rate",
+            "es": "Tarifa Intermedia"
+          },
+          "desc": {
+            "en": "Officially \"tarifa reducida 4%\": air tickets with origin or destination in Costa Rica, and private health services (art. 11.1, Ley 6826).",
+            "es": "Oficialmente \"tarifa reducida 4%\": boletos aéreos con origen o destino en Costa Rica y servicios de salud privados (art. 11.1, Ley 6826)."
+          },
+          "values": [
+            {
+              "since": "2019-07-01",
+              "percent": "4.0%"
+            }
+          ]
+        },
+        {
+          "rate": "reduced",
+          "keys": [
+            "standard"
+          ],
+          "name": {
+            "en": "Reduced Rate",
+            "es": "Tarifa Reducida"
+          },
+          "desc": {
+            "en": "Officially \"tarifa reducida 2%\": medicines and their production inputs, non-exempt private education, personal insurance premiums, and purchases by state higher-education institutions (art. 11.2, Ley 6826).",
+            "es": "Oficialmente \"tarifa reducida 2%\": medicamentos y sus insumos de producción, educación privada no exenta, primas de seguros personales y compras de las instituciones estatales de educación superior (art. 11.2, Ley 6826)."
+          },
+          "values": [
+            {
+              "since": "2019-07-01",
+              "percent": "2.0%"
+            }
+          ]
+        },
+        {
+          "rate": "super-reduced",
+          "keys": [
+            "standard"
+          ],
+          "name": {
+            "en": "Super-Reduced Rate",
+            "es": "Tarifa Superreducida"
+          },
+          "desc": {
+            "en": "Officially \"tarifa reducida 1%\": the basic tax basket (canasta básica) and its production chain, named grains for animal feed, veterinary products, agricultural and non-sport fishing inputs, and reef-safe sunscreens (art. 11.3, Ley 6826).",
+            "es": "Oficialmente \"tarifa reducida 1%\": la canasta básica tributaria y su cadena de producción, granos para alimentación animal, productos veterinarios, insumos agropecuarios y de pesca no deportiva, y protectores solares que no dañan los arrecifes (art. 11.3, Ley 6826)."
+          },
+          "values": [
+            {
+              "since": "2019-07-01",
+              "percent": "1.0%"
+            }
+          ]
+        },
+        {
+          "rate": "special",
+          "keys": [
+            "standard"
+          ],
+          "name": {
+            "en": "Special Rate",
+            "es": "Tarifa Especial"
+          },
+          "desc": {
+            "en": "Officially \"tarifa reducida 0,5%\": registered and certified organic agricultural and agro-industrial products, and production inputs of organized organic producer groups (art. 11.4, Ley 6826, added by Ley 10256).",
+            "es": "Oficialmente \"tarifa reducida 0,5%\": productos agropecuarios y agroindustriales orgánicos registrados y certificados, e insumos de producción de grupos de personas productoras orgánicas organizadas (art. 11.4, Ley 6826, adicionado por la Ley 10256)."
+          },
+          "values": [
+            {
+              "since": "2022-09-29",
+              "percent": "0.5%"
+            }
+          ]
+        }
+      ],
+      "sources": [
+        {
+          "title": {
+            "en": "Ley 6826, Ley del Impuesto al Valor Agregado, arts. 10-11"
+          },
+          "url": "https://sinalevi.go.cr/ResultadosNormativa/Informacion?param1=32526\u0026param2=150649\u0026param3=1"
+        },
+        {
+          "title": {
+            "en": "Anexos y Estructuras de Comprobantes Electrónicos v4.4, nota 8.1"
+          },
+          "url": "https://www.hacienda.go.cr/docs/ANEXOS_Y_ESTRUCTURAS_V4.4.pdf"
+        }
+      ]
+    },
+    {
+      "code": "ISC",
+      "name": {
+        "en": "ISC",
+        "es": "ISC"
+      },
+      "title": {
+        "en": "Selective Consumption Tax",
+        "es": "Impuesto Selectivo de Consumo"
+      },
+      "desc": {
+        "en": "Single-stage ad valorem excise on selected goods established by Title II of Ley 4961, with rates set per product by decree.",
+        "es": "Impuesto monofásico ad valorem sobre mercancías seleccionadas establecido por el Título II de la Ley 4961, con tarifas fijadas por decreto para cada producto."
+      },
+      "sources": [
+        {
+          "title": {
+            "en": "Ley 4961, Ley de Reforma Tributaria, Título II (Consolidación de Impuestos Selectivos de Consumo)"
+          },
+          "url": "https://sinalevi.go.cr/ResultadosNormativa/Informacion?param1=18507\u0026param2=151936\u0026param3=1"
+        }
+      ]
+    }
+  ]
+}

--- a/data/regimes/cr.json
+++ b/data/regimes/cr.json
@@ -17,12 +17,6 @@
     },
     {
       "title": {
-        "en": "OECD - Costa Rica Tax Identification Numbers"
-      },
-      "url": "https://www.oecd.org/content/dam/oecd/en/topics/policy-issue-focus/aeoi/costa-rica-tin.pdf"
-    },
-    {
-      "title": {
         "en": "Reglamento de Comprobantes Electrónicos para Efectos Tributarios"
       },
       "url": "https://sinalevi.go.cr/ResultadosNormativa/Informacion?param1=103206\u0026param2=143152\u0026param3=1"

--- a/data/rules/cr.json
+++ b/data/rules/cr.json
@@ -1,0 +1,52 @@
+{
+  "id": "GOBL-CR",
+  "package": "cr",
+  "subsets": [
+    {
+      "id": "GOBL-CR-TAX-IDENTITY",
+      "object": "tax.Identity",
+      "subsets": [
+        {
+          "guard": "code in [CR]",
+          "subsets": [
+            {
+              "field": "code",
+              "subsets": [
+                {
+                  "guard": "present",
+                  "assert": [
+                    {
+                      "id": "GOBL-CR-TAX-IDENTITY-01",
+                      "desc": "must be 9 to 12 characters long",
+                      "tests": "length between 9 and 12"
+                    }
+                  ]
+                },
+                {
+                  "guard": "present",
+                  "assert": [
+                    {
+                      "id": "GOBL-CR-TAX-IDENTITY-02",
+                      "desc": "must contain only digits, or digits and letters when 10 characters long",
+                      "tests": "valid characters"
+                    }
+                  ]
+                },
+                {
+                  "guard": "present",
+                  "assert": [
+                    {
+                      "id": "GOBL-CR-TAX-IDENTITY-03",
+                      "desc": "must not start with a zero",
+                      "tests": "no leading zero"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/data/rules/cr.json
+++ b/data/rules/cr.json
@@ -17,28 +17,8 @@
                   "assert": [
                     {
                       "id": "GOBL-CR-TAX-IDENTITY-01",
-                      "desc": "must be 9 to 12 characters long",
-                      "tests": "length between 9 and 12"
-                    }
-                  ]
-                },
-                {
-                  "guard": "present",
-                  "assert": [
-                    {
-                      "id": "GOBL-CR-TAX-IDENTITY-02",
-                      "desc": "must contain only digits, or digits and letters when 10 characters long",
-                      "tests": "valid characters"
-                    }
-                  ]
-                },
-                {
-                  "guard": "present",
-                  "assert": [
-                    {
-                      "id": "GOBL-CR-TAX-IDENTITY-03",
-                      "desc": "must not start with a zero",
-                      "tests": "no leading zero"
+                      "desc": "tax id code must be 9, 11 or 12 digits without a leading zero, or 10 alphanumeric characters",
+                      "tests": "matches ^([1-9]\\d{8}|[0-9A-Z]{10}|[1-9]\\d{10,11})$"
                     }
                   ]
                 }

--- a/data/schemas/tax/regime-code.json
+++ b/data/schemas/tax/regime-code.json
@@ -42,6 +42,10 @@
           "title": "Colombia"
         },
         {
+          "const": "CR",
+          "title": "Costa Rica"
+        },
+        {
           "const": "DE",
           "title": "Germany"
         },

--- a/examples/cr/credit-note-cr.yaml
+++ b/examples/cr/credit-note-cr.yaml
@@ -1,0 +1,41 @@
+$schema: https://gobl.org/draft-0/bill/invoice
+$regime: "CR"
+uuid: "0193e2c1-6c9f-7e5a-9d7c-8b0f4a3e6d9c"
+type: credit-note
+currency: CRC
+series: "2026"
+code: "0003"
+issue_date: "2026-06-02"
+
+preceding:
+  - code: "2026/0001"
+    issue_date: "2026-05-12"
+
+supplier:
+  name: Distribuidora del Valle S.A.
+  tax_id:
+    country: "CR"
+    code: "3-101-123456"
+  addresses:
+    - street: Avenida Central, Calle 5
+      locality: San José
+      country: "CR"
+
+customer:
+  name: María Rodríguez Jiménez
+  tax_id:
+    country: "CR"
+    code: "1-0998-0456"
+  addresses:
+    - street: Barrio Escalante
+      locality: San José
+      country: "CR"
+
+lines:
+  - quantity: "1"
+    item:
+      name: Licencia de software
+      price: "250000.00"
+    taxes:
+      - cat: VAT
+        rate: general

--- a/examples/cr/invoice-cr-multi-rate.yaml
+++ b/examples/cr/invoice-cr-multi-rate.yaml
@@ -1,0 +1,65 @@
+$schema: https://gobl.org/draft-0/bill/invoice
+$regime: "CR"
+uuid: "0193e2c1-5b8e-7d4f-8c6b-7a9e3f2d5c8b"
+currency: CRC
+series: "2026"
+code: "0002"
+issue_date: "2026-05-20"
+
+supplier:
+  name: Farmacia y Abastecedor La Sabana S.A.
+  tax_id:
+    country: "CR"
+    code: "3101654321"
+  addresses:
+    - street: La Sabana Norte
+      locality: San José
+      country: "CR"
+
+customer:
+  name: Hotel Monteverde Verde S.R.L.
+  tax_id:
+    country: "CR"
+    code: "3102987654"
+  addresses:
+    - street: Cerro Plano
+      locality: Monteverde
+      region: Puntarenas
+      country: "CR"
+
+lines:
+  - quantity: "1"
+    item:
+      name: Consulta médica privada
+      price: "45000.00"
+    taxes:
+      - cat: VAT
+        rate: intermediate
+  - quantity: "24"
+    item:
+      name: Acetaminofén 500mg
+      price: "2500.00"
+    taxes:
+      - cat: VAT
+        rate: reduced
+  - quantity: "50"
+    item:
+      name: Arroz 95% grano entero (canasta básica)
+      price: "1200.00"
+    taxes:
+      - cat: VAT
+        rate: super-reduced
+  - quantity: "20"
+    item:
+      name: Café orgánico certificado
+      price: "5500.00"
+    taxes:
+      - cat: VAT
+        rate: special
+  - quantity: "5"
+    item:
+      name: Utensilios de cocina
+      price: "12000.00"
+    taxes:
+      - cat: VAT
+        rate: general

--- a/examples/cr/invoice-cr-standard.yaml
+++ b/examples/cr/invoice-cr-standard.yaml
@@ -1,0 +1,43 @@
+$schema: https://gobl.org/draft-0/bill/invoice
+$regime: "CR"
+uuid: "0193e2c1-4a7d-7c3e-9b5a-6f8d2e1c4b7a"
+currency: CRC
+series: "2026"
+code: "0001"
+issue_date: "2026-05-12"
+
+supplier:
+  name: Distribuidora del Valle S.A.
+  tax_id:
+    country: "CR"
+    code: "3-101-123456"
+  addresses:
+    - street: Avenida Central, Calle 5
+      locality: San José
+      country: "CR"
+
+customer:
+  name: María Rodríguez Jiménez
+  tax_id:
+    country: "CR"
+    code: "1-0998-0456"
+  addresses:
+    - street: Barrio Escalante
+      locality: San José
+      country: "CR"
+
+lines:
+  - quantity: "10"
+    item:
+      name: Servicios de consultoría
+      price: "150000.00"
+    taxes:
+      - cat: VAT
+        rate: general
+  - quantity: "2"
+    item:
+      name: Licencia de software
+      price: "250000.00"
+    taxes:
+      - cat: VAT
+        rate: general

--- a/examples/cr/out/credit-note-cr.json
+++ b/examples/cr/out/credit-note-cr.json
@@ -1,0 +1,98 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
+		"dig": {
+			"alg": "sha256",
+			"val": "5ad8eda9e2a1ad1b720fab23a799a71481b42cbda6da56dc2cfe0b9e72528f12"
+		}
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"$regime": "CR",
+		"uuid": "0193e2c1-6c9f-7e5a-9d7c-8b0f4a3e6d9c",
+		"type": "credit-note",
+		"series": "2026",
+		"code": "0003",
+		"issue_date": "2026-06-02",
+		"currency": "CRC",
+		"preceding": [
+			{
+				"issue_date": "2026-05-12",
+				"code": "2026/0001"
+			}
+		],
+		"supplier": {
+			"name": "Distribuidora del Valle S.A.",
+			"tax_id": {
+				"country": "CR",
+				"code": "3101123456"
+			},
+			"addresses": [
+				{
+					"street": "Avenida Central, Calle 5",
+					"locality": "San José",
+					"country": "CR"
+				}
+			]
+		},
+		"customer": {
+			"name": "María Rodríguez Jiménez",
+			"tax_id": {
+				"country": "CR",
+				"code": "109980456"
+			},
+			"addresses": [
+				{
+					"street": "Barrio Escalante",
+					"locality": "San José",
+					"country": "CR"
+				}
+			]
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "1",
+				"item": {
+					"name": "Licencia de software",
+					"price": "250000.00"
+				},
+				"sum": "250000.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "general",
+						"percent": "13.0%"
+					}
+				],
+				"total": "250000.00"
+			}
+		],
+		"totals": {
+			"sum": "250000.00",
+			"total": "250000.00",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"base": "250000.00",
+								"percent": "13.0%",
+								"amount": "32500.00"
+							}
+						],
+						"amount": "32500.00"
+					}
+				],
+				"sum": "32500.00"
+			},
+			"tax": "32500.00",
+			"total_with_tax": "282500.00",
+			"payable": "282500.00"
+		}
+	}
+}

--- a/examples/cr/out/invoice-cr-multi-rate.json
+++ b/examples/cr/out/invoice-cr-multi-rate.json
@@ -1,0 +1,189 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
+		"dig": {
+			"alg": "sha256",
+			"val": "97da076ac70feb2131f34d73eff374f6cc80b9a98f6469c3009457d12fd8eeb2"
+		}
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"$regime": "CR",
+		"uuid": "0193e2c1-5b8e-7d4f-8c6b-7a9e3f2d5c8b",
+		"type": "standard",
+		"series": "2026",
+		"code": "0002",
+		"issue_date": "2026-05-20",
+		"currency": "CRC",
+		"supplier": {
+			"name": "Farmacia y Abastecedor La Sabana S.A.",
+			"tax_id": {
+				"country": "CR",
+				"code": "3101654321"
+			},
+			"addresses": [
+				{
+					"street": "La Sabana Norte",
+					"locality": "San José",
+					"country": "CR"
+				}
+			]
+		},
+		"customer": {
+			"name": "Hotel Monteverde Verde S.R.L.",
+			"tax_id": {
+				"country": "CR",
+				"code": "3102987654"
+			},
+			"addresses": [
+				{
+					"street": "Cerro Plano",
+					"locality": "Monteverde",
+					"region": "Puntarenas",
+					"country": "CR"
+				}
+			]
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "1",
+				"item": {
+					"name": "Consulta médica privada",
+					"price": "45000.00"
+				},
+				"sum": "45000.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "intermediate",
+						"percent": "4.0%"
+					}
+				],
+				"total": "45000.00"
+			},
+			{
+				"i": 2,
+				"quantity": "24",
+				"item": {
+					"name": "Acetaminofén 500mg",
+					"price": "2500.00"
+				},
+				"sum": "60000.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "reduced",
+						"percent": "2.0%"
+					}
+				],
+				"total": "60000.00"
+			},
+			{
+				"i": 3,
+				"quantity": "50",
+				"item": {
+					"name": "Arroz 95% grano entero (canasta básica)",
+					"price": "1200.00"
+				},
+				"sum": "60000.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "super-reduced",
+						"percent": "1.0%"
+					}
+				],
+				"total": "60000.00"
+			},
+			{
+				"i": 4,
+				"quantity": "20",
+				"item": {
+					"name": "Café orgánico certificado",
+					"price": "5500.00"
+				},
+				"sum": "110000.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "special",
+						"percent": "0.5%"
+					}
+				],
+				"total": "110000.00"
+			},
+			{
+				"i": 5,
+				"quantity": "5",
+				"item": {
+					"name": "Utensilios de cocina",
+					"price": "12000.00"
+				},
+				"sum": "60000.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "general",
+						"percent": "13.0%"
+					}
+				],
+				"total": "60000.00"
+			}
+		],
+		"totals": {
+			"sum": "335000.00",
+			"total": "335000.00",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"base": "45000.00",
+								"percent": "4.0%",
+								"amount": "1800.00"
+							},
+							{
+								"key": "standard",
+								"base": "60000.00",
+								"percent": "2.0%",
+								"amount": "1200.00"
+							},
+							{
+								"key": "standard",
+								"base": "60000.00",
+								"percent": "1.0%",
+								"amount": "600.00"
+							},
+							{
+								"key": "standard",
+								"base": "110000.00",
+								"percent": "0.5%",
+								"amount": "550.00"
+							},
+							{
+								"key": "standard",
+								"base": "60000.00",
+								"percent": "13.0%",
+								"amount": "7800.00"
+							}
+						],
+						"amount": "11950.00"
+					}
+				],
+				"sum": "11950.00"
+			},
+			"tax": "11950.00",
+			"total_with_tax": "346950.00",
+			"payable": "346950.00"
+		}
+	}
+}

--- a/examples/cr/out/invoice-cr-standard.json
+++ b/examples/cr/out/invoice-cr-standard.json
@@ -1,0 +1,110 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
+		"dig": {
+			"alg": "sha256",
+			"val": "9d4a586f981bc15e3ce5f7fc9ac00821c7a48ffabfb6b3cdbb72e52ce43e8aaa"
+		}
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"$regime": "CR",
+		"uuid": "0193e2c1-4a7d-7c3e-9b5a-6f8d2e1c4b7a",
+		"type": "standard",
+		"series": "2026",
+		"code": "0001",
+		"issue_date": "2026-05-12",
+		"currency": "CRC",
+		"supplier": {
+			"name": "Distribuidora del Valle S.A.",
+			"tax_id": {
+				"country": "CR",
+				"code": "3101123456"
+			},
+			"addresses": [
+				{
+					"street": "Avenida Central, Calle 5",
+					"locality": "San José",
+					"country": "CR"
+				}
+			]
+		},
+		"customer": {
+			"name": "María Rodríguez Jiménez",
+			"tax_id": {
+				"country": "CR",
+				"code": "109980456"
+			},
+			"addresses": [
+				{
+					"street": "Barrio Escalante",
+					"locality": "San José",
+					"country": "CR"
+				}
+			]
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "10",
+				"item": {
+					"name": "Servicios de consultoría",
+					"price": "150000.00"
+				},
+				"sum": "1500000.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "general",
+						"percent": "13.0%"
+					}
+				],
+				"total": "1500000.00"
+			},
+			{
+				"i": 2,
+				"quantity": "2",
+				"item": {
+					"name": "Licencia de software",
+					"price": "250000.00"
+				},
+				"sum": "500000.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "general",
+						"percent": "13.0%"
+					}
+				],
+				"total": "500000.00"
+			}
+		],
+		"totals": {
+			"sum": "2000000.00",
+			"total": "2000000.00",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"base": "2000000.00",
+								"percent": "13.0%",
+								"amount": "260000.00"
+							}
+						],
+						"amount": "260000.00"
+					}
+				],
+				"sum": "260000.00"
+			},
+			"tax": "260000.00",
+			"total_with_tax": "2260000.00",
+			"payable": "2260000.00"
+		}
+	}
+}

--- a/regimes/cr/cr.go
+++ b/regimes/cr/cr.go
@@ -1,0 +1,104 @@
+// Package cr provides the tax regime definition for Costa Rica.
+package cr
+
+import (
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/currency"
+	"github.com/invopop/gobl/i18n"
+	"github.com/invopop/gobl/norm"
+	"github.com/invopop/gobl/pkg/here"
+	"github.com/invopop/gobl/rules"
+	"github.com/invopop/gobl/tax"
+)
+
+// CountryCode is the tax country code for Costa Rica.
+const CountryCode = "CR"
+
+func init() {
+	tax.RegisterRegimeDef(New())
+	rules.Register("cr", rules.GOBL.Add(CountryCode),
+		taxIdentityRules(),
+	)
+	norm.Register(
+		norm.When(tax.IdentityIn(CountryCode), norm.For(normalizeTaxIdentity)),
+	)
+}
+
+// New provides the tax regime definition for Costa Rica.
+func New() *tax.RegimeDef {
+	return &tax.RegimeDef{
+		Country:   CountryCode,
+		Currency:  currency.CRC,
+		TaxScheme: tax.CategoryVAT,
+		Name: i18n.String{
+			i18n.EN: "Costa Rica",
+			i18n.ES: "Costa Rica",
+		},
+		Description: i18n.String{
+			i18n.EN: here.Doc(`
+				Costa Rica's tax system is administered by the Dirección General
+				de Tributación (DGT) of the Ministerio de Hacienda. IVA (Impuesto
+				al Valor Agregado) has applied since 1 July 2019, when Title I of
+				Law 9635 reformed the former general sales tax law (Law 6826)
+				into a value added tax; ISC (Impuesto Selectivo de Consumo) is an
+				ad valorem excise on selected goods.
+
+				Taxpayers are identified by the same documents used for civil
+				identification (cédula física, cédula jurídica, DIMEX, or NITE),
+				none of which carry a check digit. Electronic invoicing is
+				mandatory for most taxpayers, and issued documents may only be
+				corrected with electronic credit or debit notes.
+			`),
+			i18n.ES: here.Doc(`
+				El sistema tributario de Costa Rica es administrado por la
+				Dirección General de Tributación (DGT) del Ministerio de
+				Hacienda. El IVA (Impuesto al Valor Agregado) se aplica desde el
+				1 de julio de 2019, cuando el Título I de la Ley 9635 reformó la
+				anterior ley del impuesto general sobre las ventas (Ley 6826) en
+				un impuesto al valor agregado; el ISC (Impuesto Selectivo de
+				Consumo) es un impuesto ad valorem sobre mercancías
+				seleccionadas.
+
+				Los contribuyentes se identifican con los mismos documentos de
+				identificación civil (cédula física, cédula jurídica, DIMEX o
+				NITE), ninguno de los cuales incluye dígito verificador. La
+				factura electrónica es obligatoria para la mayoría de los
+				contribuyentes y los comprobantes emitidos solo pueden corregirse
+				mediante notas de crédito o débito electrónicas.
+			`),
+		},
+		Sources: []*cbc.Source{
+			{
+				Title: i18n.NewString("Ministerio de Hacienda - Dirección General de Tributación"),
+				URL:   "https://www.hacienda.go.cr/",
+			},
+			{
+				Title: i18n.NewString("OECD - Costa Rica Tax Identification Numbers"),
+				URL:   "https://www.oecd.org/content/dam/oecd/en/topics/policy-issue-focus/aeoi/costa-rica-tin.pdf",
+			},
+			{
+				Title: i18n.NewString("Reglamento de Comprobantes Electrónicos para Efectos Tributarios"),
+				URL:   "https://sinalevi.go.cr/ResultadosNormativa/Informacion?param1=103206&param2=143152&param3=1",
+			},
+			{
+				Title: i18n.NewString("Anexos y Estructuras de Comprobantes Electrónicos v4.4"),
+				URL:   "https://www.hacienda.go.cr/docs/ANEXOS_Y_ESTRUCTURAS_V4.4.pdf",
+			},
+		},
+		TimeZone:   "America/Costa_Rica",
+		Categories: taxCategories,
+		// Issued documents are immutable and may only be corrected with
+		// electronic credit or debit notes (Reglamento de Comprobantes
+		// Electrónicos, art. 10).
+		Corrections: []*tax.CorrectionDefinition{
+			{
+				Schema: bill.ShortSchemaInvoice,
+				Types: []cbc.Key{
+					bill.InvoiceTypeCreditNote,
+					bill.InvoiceTypeDebitNote,
+				},
+			},
+		},
+	}
+}

--- a/regimes/cr/cr.go
+++ b/regimes/cr/cr.go
@@ -74,10 +74,6 @@ func New() *tax.RegimeDef {
 				URL:   "https://www.hacienda.go.cr/",
 			},
 			{
-				Title: i18n.NewString("OECD - Costa Rica Tax Identification Numbers"),
-				URL:   "https://www.oecd.org/content/dam/oecd/en/topics/policy-issue-focus/aeoi/costa-rica-tin.pdf",
-			},
-			{
 				Title: i18n.NewString("Reglamento de Comprobantes Electrónicos para Efectos Tributarios"),
 				URL:   "https://sinalevi.go.cr/ResultadosNormativa/Informacion?param1=103206&param2=143152&param3=1",
 			},

--- a/regimes/cr/tax_categories.go
+++ b/regimes/cr/tax_categories.go
@@ -1,0 +1,162 @@
+package cr
+
+import (
+	"github.com/invopop/gobl/cal"
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/i18n"
+	"github.com/invopop/gobl/num"
+	"github.com/invopop/gobl/tax"
+)
+
+// TaxCategoryISC is the code for the Impuesto Selectivo de Consumo.
+const TaxCategoryISC cbc.Code = "ISC"
+
+// Rates and official names per Ley 6826, arts. 10-11, and "Anexos y
+// Estructuras v4.4", nota 8.1.
+var taxCategories = []*tax.CategoryDef{
+	//
+	// IVA
+	//
+	{
+		Code:     tax.CategoryVAT,
+		Retained: false,
+		Name: i18n.String{
+			i18n.EN: "VAT",
+			i18n.ES: "IVA",
+		},
+		Title: i18n.String{
+			i18n.EN: "Value Added Tax",
+			i18n.ES: "Impuesto al Valor Agregado",
+		},
+		Keys: tax.GlobalVATKeys(),
+		Rates: []*tax.RateDef{
+			{
+				Keys: []cbc.Key{tax.KeyStandard},
+				Rate: tax.RateGeneral,
+				Name: i18n.String{
+					i18n.EN: "General Rate",
+					i18n.ES: "Tarifa General",
+				},
+				Description: i18n.String{
+					i18n.EN: "Officially \"tarifa general 13%\": all operations subject to the tax not covered by a reduced rate (art. 10, Ley 6826).",
+					i18n.ES: "Oficialmente \"tarifa general 13%\": todas las operaciones sujetas al impuesto no cubiertas por una tarifa reducida (art. 10, Ley 6826).",
+				},
+				Values: []*tax.RateValueDef{
+					{
+						Since:   cal.NewDate(2019, 7, 1),
+						Percent: num.MakePercentage(130, 3),
+					},
+				},
+			},
+			{
+				Keys: []cbc.Key{tax.KeyStandard},
+				Rate: tax.RateIntermediate,
+				Name: i18n.String{
+					i18n.EN: "Intermediate Rate",
+					i18n.ES: "Tarifa Intermedia",
+				},
+				Description: i18n.String{
+					i18n.EN: "Officially \"tarifa reducida 4%\": air tickets with origin or destination in Costa Rica, and private health services (art. 11.1, Ley 6826).",
+					i18n.ES: "Oficialmente \"tarifa reducida 4%\": boletos aéreos con origen o destino en Costa Rica y servicios de salud privados (art. 11.1, Ley 6826).",
+				},
+				Values: []*tax.RateValueDef{
+					{
+						Since:   cal.NewDate(2019, 7, 1),
+						Percent: num.MakePercentage(40, 3),
+					},
+				},
+			},
+			{
+				Keys: []cbc.Key{tax.KeyStandard},
+				Rate: tax.RateReduced,
+				Name: i18n.String{
+					i18n.EN: "Reduced Rate",
+					i18n.ES: "Tarifa Reducida",
+				},
+				Description: i18n.String{
+					i18n.EN: "Officially \"tarifa reducida 2%\": medicines and their production inputs, non-exempt private education, personal insurance premiums, and purchases by state higher-education institutions (art. 11.2, Ley 6826).",
+					i18n.ES: "Oficialmente \"tarifa reducida 2%\": medicamentos y sus insumos de producción, educación privada no exenta, primas de seguros personales y compras de las instituciones estatales de educación superior (art. 11.2, Ley 6826).",
+				},
+				Values: []*tax.RateValueDef{
+					{
+						Since:   cal.NewDate(2019, 7, 1),
+						Percent: num.MakePercentage(20, 3),
+					},
+				},
+			},
+			{
+				Keys: []cbc.Key{tax.KeyStandard},
+				Rate: tax.RateSuperReduced,
+				Name: i18n.String{
+					i18n.EN: "Super-Reduced Rate",
+					i18n.ES: "Tarifa Superreducida",
+				},
+				Description: i18n.String{
+					i18n.EN: "Officially \"tarifa reducida 1%\": the basic tax basket (canasta básica) and its production chain, named grains for animal feed, veterinary products, agricultural and non-sport fishing inputs, and reef-safe sunscreens (art. 11.3, Ley 6826).",
+					i18n.ES: "Oficialmente \"tarifa reducida 1%\": la canasta básica tributaria y su cadena de producción, granos para alimentación animal, productos veterinarios, insumos agropecuarios y de pesca no deportiva, y protectores solares que no dañan los arrecifes (art. 11.3, Ley 6826).",
+				},
+				Values: []*tax.RateValueDef{
+					{
+						Since:   cal.NewDate(2019, 7, 1),
+						Percent: num.MakePercentage(10, 3),
+					},
+				},
+			},
+			{
+				Keys: []cbc.Key{tax.KeyStandard},
+				Rate: tax.RateSpecial,
+				Name: i18n.String{
+					i18n.EN: "Special Rate",
+					i18n.ES: "Tarifa Especial",
+				},
+				Description: i18n.String{
+					i18n.EN: "Officially \"tarifa reducida 0,5%\": registered and certified organic agricultural and agro-industrial products, and production inputs of organized organic producer groups (art. 11.4, Ley 6826, added by Ley 10256).",
+					i18n.ES: "Oficialmente \"tarifa reducida 0,5%\": productos agropecuarios y agroindustriales orgánicos registrados y certificados, e insumos de producción de grupos de personas productoras orgánicas organizadas (art. 11.4, Ley 6826, adicionado por la Ley 10256).",
+				},
+				Values: []*tax.RateValueDef{
+					{
+						// Ley 10256, published in La Gaceta 185, Alcance 207.
+						Since:   cal.NewDate(2022, 9, 29),
+						Percent: num.MakePercentage(5, 3),
+					},
+				},
+			},
+		},
+		Sources: []*cbc.Source{
+			{
+				Title: i18n.NewString("Ley 6826, Ley del Impuesto al Valor Agregado, arts. 10-11"),
+				URL:   "https://sinalevi.go.cr/ResultadosNormativa/Informacion?param1=32526&param2=150649&param3=1",
+			},
+			{
+				Title: i18n.NewString("Anexos y Estructuras de Comprobantes Electrónicos v4.4, nota 8.1"),
+				URL:   "https://www.hacienda.go.cr/docs/ANEXOS_Y_ESTRUCTURAS_V4.4.pdf",
+			},
+		},
+	},
+	//
+	// ISC - rates are set per product by decree, so invoice lines supply the
+	// percentage directly.
+	//
+	{
+		Code:     TaxCategoryISC,
+		Retained: false,
+		Name: i18n.String{
+			i18n.EN: "ISC",
+			i18n.ES: "ISC",
+		},
+		Title: i18n.String{
+			i18n.EN: "Selective Consumption Tax",
+			i18n.ES: "Impuesto Selectivo de Consumo",
+		},
+		Description: &i18n.String{
+			i18n.EN: "Single-stage ad valorem excise on selected goods established by Title II of Ley 4961, with rates set per product by decree.",
+			i18n.ES: "Impuesto monofásico ad valorem sobre mercancías seleccionadas establecido por el Título II de la Ley 4961, con tarifas fijadas por decreto para cada producto.",
+		},
+		Sources: []*cbc.Source{
+			{
+				Title: i18n.NewString("Ley 4961, Ley de Reforma Tributaria, Título II (Consolidación de Impuestos Selectivos de Consumo)"),
+				URL:   "https://sinalevi.go.cr/ResultadosNormativa/Informacion?param1=18507&param2=151936&param3=1",
+			},
+		},
+	},
+}

--- a/regimes/cr/tax_identity.go
+++ b/regimes/cr/tax_identity.go
@@ -1,0 +1,92 @@
+package cr
+
+import (
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/rules"
+	"github.com/invopop/gobl/rules/is"
+	"github.com/invopop/gobl/tax"
+)
+
+// Costa Rican tax identities reuse the party's identity document and carry no
+// check digit, so validation is structural ("Anexos y Estructuras v4.4", campo
+// "Número de cédula" and the OECD TIN profile for Costa Rica):
+//
+//   - Cédula física: 9 digits, no leading zero.
+//   - Cédula jurídica or NITE: 10 characters (v4.4 permits letters).
+//   - DIMEX: 11 or 12 digits, no leading zero.
+
+func normalizeTaxIdentity(tID *tax.Identity) {
+	tax.NormalizeIdentity(tID)
+}
+
+func taxIdentityRules() *rules.Set {
+	return rules.For(new(tax.Identity),
+		rules.When(tax.IdentityIn(CountryCode),
+			rules.Field("code",
+				rules.AssertIfPresent("01", "must be 9 to 12 characters long",
+					is.Length(9, 12),
+				),
+				rules.AssertIfPresent("02", "must contain only digits, or digits and letters when 10 characters long",
+					codeTest("valid characters", hasValidCharacters),
+				),
+				rules.AssertIfPresent("03", "must not start with a zero",
+					codeTest("no leading zero", hasNoLeadingZero),
+				),
+			),
+		),
+	)
+}
+
+// codeTest adapts a check on the code's string form into a rule test,
+// converting the field value once for all assertions that use it.
+func codeTest(name string, fn func(string) bool) is.FuncTest {
+	return is.Func(name, func(value any) bool {
+		code, ok := value.(cbc.Code)
+		if !ok || code == "" {
+			return false
+		}
+		return fn(code.String())
+	})
+}
+
+// hasValidCharacters checks the content for the format implied by the length:
+// 10-character codes (cédula jurídica or NITE) may combine digits and letters,
+// every other format is digits only. Codes with an invalid length are left to
+// the length rule.
+func hasValidCharacters(s string) bool {
+	switch len(s) {
+	case 9, 11, 12:
+		return isDigits(s)
+	case 10:
+		return isAlphanumeric(s)
+	}
+	return true
+}
+
+// hasNoLeadingZero rejects leading zeros on cédula física and DIMEX codes, the
+// two formats the v4.4 annex forbids them for.
+func hasNoLeadingZero(s string) bool {
+	switch len(s) {
+	case 9, 11, 12:
+		return s[0] != '0'
+	}
+	return true
+}
+
+func isDigits(s string) bool {
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func isAlphanumeric(s string) bool {
+	for _, r := range s {
+		if (r < '0' || r > '9') && (r < 'A' || r > 'Z') {
+			return false
+		}
+	}
+	return true
+}

--- a/regimes/cr/tax_identity.go
+++ b/regimes/cr/tax_identity.go
@@ -1,19 +1,24 @@
 package cr
 
 import (
-	"github.com/invopop/gobl/cbc"
+	"regexp"
+
 	"github.com/invopop/gobl/rules"
 	"github.com/invopop/gobl/rules/is"
 	"github.com/invopop/gobl/tax"
 )
 
-// Costa Rican tax identities reuse the party's identity document and carry no
-// check digit, so validation is structural ("Anexos y Estructuras v4.4", campo
-// "Número de cédula" and the OECD TIN profile for Costa Rica):
+// Costa Rica issues four tax identity numbers, none carrying a check digit
+// ("Anexos y Estructuras v4.4", campo "Número de cédula"):
 //
 //   - Cédula física: 9 digits, no leading zero.
-//   - Cédula jurídica or NITE: 10 characters (v4.4 permits letters).
+//   - Cédula jurídica or NITE: 10 characters, alphanumeric for legal entities.
 //   - DIMEX: 11 or 12 digits, no leading zero.
+//
+// Numbers are stored unpadded; the zero-padded form belongs to the clave
+// numérica. "Extranjero No Domiciliado" and "No Contribuyente" are excluded, as
+// the annex exempts both from registration with the tax administration.
+var taxCodeRegexp = regexp.MustCompile(`^([1-9]\d{8}|[0-9A-Z]{10}|[1-9]\d{10,11})$`)
 
 func normalizeTaxIdentity(tID *tax.Identity) {
 	tax.NormalizeIdentity(tID)
@@ -23,70 +28,10 @@ func taxIdentityRules() *rules.Set {
 	return rules.For(new(tax.Identity),
 		rules.When(tax.IdentityIn(CountryCode),
 			rules.Field("code",
-				rules.AssertIfPresent("01", "must be 9 to 12 characters long",
-					is.Length(9, 12),
-				),
-				rules.AssertIfPresent("02", "must contain only digits, or digits and letters when 10 characters long",
-					codeTest("valid characters", hasValidCharacters),
-				),
-				rules.AssertIfPresent("03", "must not start with a zero",
-					codeTest("no leading zero", hasNoLeadingZero),
+				rules.AssertIfPresent("01", "tax id code must be 9, 11 or 12 digits without a leading zero, or 10 alphanumeric characters",
+					is.MatchesRegexp(taxCodeRegexp),
 				),
 			),
 		),
 	)
-}
-
-// codeTest adapts a check on the code's string form into a rule test,
-// converting the field value once for all assertions that use it.
-func codeTest(name string, fn func(string) bool) is.FuncTest {
-	return is.Func(name, func(value any) bool {
-		code, ok := value.(cbc.Code)
-		if !ok || code == "" {
-			return false
-		}
-		return fn(code.String())
-	})
-}
-
-// hasValidCharacters checks the content for the format implied by the length:
-// 10-character codes (cédula jurídica or NITE) may combine digits and letters,
-// every other format is digits only. Codes with an invalid length are left to
-// the length rule.
-func hasValidCharacters(s string) bool {
-	switch len(s) {
-	case 9, 11, 12:
-		return isDigits(s)
-	case 10:
-		return isAlphanumeric(s)
-	}
-	return true
-}
-
-// hasNoLeadingZero rejects leading zeros on cédula física and DIMEX codes, the
-// two formats the v4.4 annex forbids them for.
-func hasNoLeadingZero(s string) bool {
-	switch len(s) {
-	case 9, 11, 12:
-		return s[0] != '0'
-	}
-	return true
-}
-
-func isDigits(s string) bool {
-	for _, r := range s {
-		if r < '0' || r > '9' {
-			return false
-		}
-	}
-	return true
-}
-
-func isAlphanumeric(s string) bool {
-	for _, r := range s {
-		if (r < '0' || r > '9') && (r < 'A' || r > 'Z') {
-			return false
-		}
-	}
-	return true
 }

--- a/regimes/cr/tax_identity_test.go
+++ b/regimes/cr/tax_identity_test.go
@@ -1,0 +1,81 @@
+package cr_test
+
+import (
+	"testing"
+
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/norm"
+	"github.com/invopop/gobl/regimes/cr"
+	"github.com/invopop/gobl/rules"
+	"github.com/invopop/gobl/tax"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizeTaxIdentity(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		input    cbc.Code
+		expected cbc.Code
+	}{
+		{name: "already normalized", input: "3101123456", expected: "3101123456"},
+		{name: "cedula juridica with hyphens", input: "3-101-123456", expected: "3101123456"},
+		{name: "cedula fisica with hyphens", input: "1-0998-0456", expected: "109980456"},
+		{name: "with country prefix", input: "CR3101123456", expected: "3101123456"},
+		{name: "with spaces", input: "3 101 123456", expected: "3101123456"},
+		{name: "lowercase with prefix and hyphens", input: "cr 3-101-123456", expected: "3101123456"},
+		{name: "dimex with spaces", input: "1558 1234 5678", expected: "155812345678"},
+		{name: "empty", input: "", expected: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tID := &tax.Identity{Country: cr.CountryCode, Code: tt.input}
+			norm.Normalize(tID)
+			assert.Equal(t, tt.expected, tID.Code)
+		})
+	}
+}
+
+func TestValidateTaxIdentity(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		code cbc.Code
+		err  string
+	}{
+		// Cédula física: 9 digits, no leading zero.
+		{name: "cedula fisica", code: "109980456"},
+		{name: "cedula fisica high province", code: "901230456"},
+		{name: "cedula fisica leading zero", code: "012345678", err: "must not start with a zero"},
+		{name: "cedula fisica with letter", code: "1A9980456", err: "must contain only digits"},
+		// Cédula jurídica or NITE: 10 characters.
+		{name: "cedula juridica", code: "3101123456"},
+		{name: "cedula juridica public entity", code: "2100042005"},
+		{name: "nite natural person", code: "3120456789"},
+		{name: "nite corporation", code: "3130456789"},
+		{name: "cedula juridica with letter", code: "3101A23456"},
+		{name: "ten characters with symbol", code: "3101-23456", err: "must contain only digits"},
+		// DIMEX: 11 or 12 digits, no leading zero.
+		{name: "dimex 11 digits", code: "15581234567"},
+		{name: "dimex 12 digits", code: "155812345678"},
+		{name: "dimex leading zero", code: "015581234567", err: "must not start with a zero"},
+		{name: "dimex with letter", code: "15581234567A", err: "must contain only digits"},
+		// Anything else.
+		{name: "too short", code: "12345678", err: "must be 9 to 12 characters long"},
+		{name: "too long", code: "1234567890123", err: "must be 9 to 12 characters long"},
+		{name: "empty code", code: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tID := &tax.Identity{Country: cr.CountryCode, Code: tt.code}
+			err := rules.Validate(tID)
+			if tt.err == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tt.err)
+			}
+		})
+	}
+}

--- a/regimes/cr/tax_identity_test.go
+++ b/regimes/cr/tax_identity_test.go
@@ -40,30 +40,31 @@ func TestNormalizeTaxIdentity(t *testing.T) {
 func TestValidateTaxIdentity(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name string
-		code cbc.Code
-		err  string
+		name    string
+		code    cbc.Code
+		invalid bool
 	}{
 		// Cédula física: 9 digits, no leading zero.
 		{name: "cedula fisica", code: "109980456"},
 		{name: "cedula fisica high province", code: "901230456"},
-		{name: "cedula fisica leading zero", code: "012345678", err: "must not start with a zero"},
-		{name: "cedula fisica with letter", code: "1A9980456", err: "must contain only digits"},
-		// Cédula jurídica or NITE: 10 characters.
+		{name: "cedula fisica leading zero", code: "012345678", invalid: true},
+		{name: "cedula fisica with letter", code: "1A9980456", invalid: true},
+		// Cédula jurídica or NITE: 10 characters, leading zeros allowed.
 		{name: "cedula juridica", code: "3101123456"},
 		{name: "cedula juridica public entity", code: "2100042005"},
+		{name: "cedula juridica leading zero", code: "0101123456"},
 		{name: "nite natural person", code: "3120456789"},
 		{name: "nite corporation", code: "3130456789"},
 		{name: "cedula juridica with letter", code: "3101A23456"},
-		{name: "ten characters with symbol", code: "3101-23456", err: "must contain only digits"},
+		{name: "ten characters with symbol", code: "3101-23456", invalid: true},
 		// DIMEX: 11 or 12 digits, no leading zero.
 		{name: "dimex 11 digits", code: "15581234567"},
 		{name: "dimex 12 digits", code: "155812345678"},
-		{name: "dimex leading zero", code: "015581234567", err: "must not start with a zero"},
-		{name: "dimex with letter", code: "15581234567A", err: "must contain only digits"},
+		{name: "dimex leading zero", code: "015581234567", invalid: true},
+		{name: "dimex with letter", code: "15581234567A", invalid: true},
 		// Anything else.
-		{name: "too short", code: "12345678", err: "must be 9 to 12 characters long"},
-		{name: "too long", code: "1234567890123", err: "must be 9 to 12 characters long"},
+		{name: "too short", code: "12345678", invalid: true},
+		{name: "too long", code: "1234567890123", invalid: true},
 		{name: "empty code", code: ""},
 	}
 
@@ -71,10 +72,10 @@ func TestValidateTaxIdentity(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			tID := &tax.Identity{Country: cr.CountryCode, Code: tt.code}
 			err := rules.Validate(tID)
-			if tt.err == "" {
-				assert.NoError(t, err)
+			if tt.invalid {
+				assert.ErrorContains(t, err, "CR-TAX-IDENTITY-01")
 			} else {
-				assert.ErrorContains(t, err, tt.err)
+				assert.NoError(t, err)
 			}
 		})
 	}

--- a/regimes/regimes.go
+++ b/regimes/regimes.go
@@ -14,6 +14,7 @@ import (
 	_ "github.com/invopop/gobl/regimes/ca"
 	_ "github.com/invopop/gobl/regimes/ch"
 	_ "github.com/invopop/gobl/regimes/co"
+	_ "github.com/invopop/gobl/regimes/cr"
 	_ "github.com/invopop/gobl/regimes/de"
 	_ "github.com/invopop/gobl/regimes/dk"
 	_ "github.com/invopop/gobl/regimes/es"


### PR DESCRIPTION
## Summary

Adds Costa Rica (`CR`) as a new tax regime:

- **IVA** (Ley 6826, reformed by Ley 9635, in force since 1 July 2019) with its five current bands: 13% general, 4%, 2%, 1%, and the 0.5% organic-production rate added by Ley 10256. Zero, exempt, and outside-scope come from `tax.GlobalVATKeys()`.
- **ISC** (Impuesto Selectivo de Consumo) as a category with no predefined rates: they are set per product by decree, so invoice lines supply the percentage directly.
- **Tax identity** normalization and validation for the four identifier forms used as tax IDs (cédula física, cédula jurídica, DIMEX, NITE), as three assertions — length, character content, leading zero — each with its own rule code and message.
- **Corrections** restricted to credit and debit notes: issued comprobantes are immutable (Reglamento de Comprobantes Electrónicos, art. 10).
- `CRC`, `America/Costa_Rica`, Spanish translations alongside English, three examples, tests, generated data, CHANGELOG.

## Design decisions

- **Five bands on standard rate keys.** The law names the sub-13% bands only collectively ("tarifa reducida"), so no local key is needed. Each key maps one-to-one onto the e-invoice tariff codes (Anexos v4.4, nota 8.1), so a future addon can derive `CodigoTarifaIVA` without extensions:

  | GOBL key | Rate | Nota 8.1 code |
  | --- | --- | --- |
  | `general` | 13% | 08 |
  | `intermediate` | 4% | 04 |
  | `reduced` | 2% | 03 |
  | `super-reduced` | 1% | 02 |
  | `special` | 0.5% | 09 |
  | key `zero` | 0% | 01 |
  | key `exempt` | — | 10 |
  | key `outside-scope` | — | 11 |

- **One `Since` date per rate.** The percentages have never changed since the IVA's introduction; only coverage has.
- **Structural identity validation.** Costa Rican identifiers carry no check digit, so validation applies the v4.4 format rules: 9 digits (física), 10 characters (jurídica or NITE), 11–12 digits (DIMEX), no leading zeros where the annex forbids them. The 10-character form accepts letters — v4.4 says "caracteres" for it where it says "dígitos" for the rest, and letter-bearing cédulas jurídicas have been announced. Class blocks (`3-101`, …) are deliberately not validated to avoid rejecting legal identifiers. The identity type is not stored: `tax.Identity.Type` is deprecated, and the e-invoice type code is derivable from the structure.

## Out of scope

- The remaining nota 8 taxes (fuel, alcohol, packaged beverages and soaps, tobacco, cement): per-unit amounts rather than percentages, and single-stage — better expressed as line charges than tax categories. The IVA special-base variants (codes 07/08) are an addon concern.
- Withholdings: Costa Rica has none at invoice level — the card-acquirer IVA retention (art. 29) is settled at payment time on separate documents.
- The pre-2019 general sales tax, and the transitional rates (nota 8.1 codes 05–07, valid only on credit/debit notes correcting pre-2023 documents).
- Invoice-level rules.
- The e-invoicing addon (identification type codes, clave numérica, CABYS).

## Pre-Review Checklist

- [x] Opened this PR as a draft
- [x] Read the CONTRIBUTING.md guide.
- [x] Performed a self-review of my code.
- [x] Added thorough tests with at **least** 90% code coverage.
- [x] Modified or created example GOBL documents to show my changes in use, if appropriate.
- [x] Added links to the source of the changes in tax regimes or addons, either structured or in the comments.
- [x] Run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [x] Reviewed and fixed all linter warnings.
- [x] Been obsessive with pointer nil checks to avoid panics.
- [x] Updated the CHANGELOG.md with an overview of my changes.
- [x] Marked this PR as ready for review.