### PR TITLE
Allow attributes identified only by a label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Changed
 
+- `org`: `Attribute` no longer requires a `key` or `type` when a `label` is present.
 - `net`: signatures are no longer interpreted by position. `Client.VerifyEnvelope`
   is replaced by `Client.VerifyParty`, which verifies the address declared by a
   party, and `Client.VerifyDelivery`, which finds the sole issuer bound to an

--- a/data/rules/org.json
+++ b/data/rules/org.json
@@ -45,7 +45,7 @@
         {
           "id": "GOBL-ORG-ATTRIBUTE-02",
           "desc": "attribute must have at least one of the text, code, amount, or date values",
-          "tests": "(Text == \"\" ? 0 : 1) + (string(Code) == \"\" ? 0 : 1) + (Amount == nil ? 0 : 1) + (Date == nil ? 0 : 1) \u003e= 1"
+          "tests": "text, code, amount, or date present"
         }
       ],
       "subsets": [

--- a/data/rules/org.json
+++ b/data/rules/org.json
@@ -39,8 +39,8 @@
       "assert": [
         {
           "id": "GOBL-ORG-ATTRIBUTE-01",
-          "desc": "attribute must have either a key or a type, but not both",
-          "tests": "(string(Key) == \"\") != (string(Type) == \"\")"
+          "desc": "attribute must not have both a key and a type",
+          "tests": "not both key and type"
         },
         {
           "id": "GOBL-ORG-ATTRIBUTE-02",
@@ -49,6 +49,16 @@
         }
       ],
       "subsets": [
+        {
+          "guard": "no label",
+          "assert": [
+            {
+              "id": "GOBL-ORG-ATTRIBUTE-04",
+              "desc": "attribute must have a key, a type, or a label",
+              "tests": "key or type present"
+            }
+          ]
+        },
         {
           "guard": "string(Unit) != \"\"",
           "assert": [

--- a/data/schemas/org/attribute.json
+++ b/data/schemas/org/attribute.json
@@ -8,7 +8,7 @@
         "label": {
           "type": "string",
           "title": "Label",
-          "description": "Label for the attribute, used for presentation in converted outputs\nsuch as PDFs."
+          "description": "Label for the attribute, used for presentation in converted outputs\nsuch as PDFs, and may identify the attribute when no key or type is set."
         },
         "key": {
           "$ref": "https://gobl.org/draft-0/cbc/key",

--- a/org/attribute.go
+++ b/org/attribute.go
@@ -194,7 +194,7 @@ func attributeRules() *rules.Set {
 			),
 		),
 		rules.Assert("02", "attribute must have at least one of the text, code, amount, or date values",
-			is.Expr(`(Text == "" ? 0 : 1) + (string(Code) == "" ? 0 : 1) + (Amount == nil ? 0 : 1) + (Date == nil ? 0 : 1) >= 1`),
+			is.Func("text, code, amount, or date present", attributeHasValue),
 		),
 		rules.When(is.Expr(`string(Unit) != ""`),
 			rules.Assert("03", "attribute unit may only be used alongside an amount",
@@ -217,6 +217,11 @@ func attributeHasNoLabel(val any) bool {
 func attributeHasKeyOrType(val any) bool {
 	a, ok := val.(*Attribute)
 	return ok && (a.Key != "" || a.Type != "")
+}
+
+func attributeHasValue(val any) bool {
+	a, ok := val.(*Attribute)
+	return ok && (a.Text != "" || a.Code != "" || a.Amount != nil || a.Date != nil)
 }
 
 func normalizeAttribute(a *Attribute) {

--- a/org/attribute.go
+++ b/org/attribute.go
@@ -151,14 +151,14 @@ var AttributeKeyDefinitions = []*cbc.Definition{
 
 // Attribute describes a named feature or property of the parent object,
 // such as the color or size of an item. Attributes are identified by
-// either a key or a type, and hold at least one of the text, code, amount,
-// or date value fields.
+// a key or a type, or presented with just a label, and hold at least
+// one of the text, code, amount, or date value fields.
 type Attribute struct {
 	// Label for the attribute, used for presentation in converted outputs
-	// such as PDFs.
+	// such as PDFs, and may identify the attribute when no key or type is set.
 	Label string `json:"label,omitempty" jsonschema:"title=Label"`
 
-	// Identifier fields; either key or type must be provided, but not both.
+	// Identifier fields; at most one of key or type may be provided.
 
 	// Key that identifies the attribute, either from the list pre-defined by
 	// GOBL or an alternative agreed upon between the supplier and customer.
@@ -185,8 +185,13 @@ type Attribute struct {
 
 func attributeRules() *rules.Set {
 	return rules.For(new(Attribute),
-		rules.Assert("01", "attribute must have either a key or a type, but not both",
-			is.Expr(`(string(Key) == "") != (string(Type) == "")`),
+		rules.Assert("01", "attribute must not have both a key and a type",
+			is.Func("not both key and type", attributeNotBothKeyAndType),
+		),
+		rules.When(is.Func("no label", attributeHasNoLabel),
+			rules.Assert("04", "attribute must have a key, a type, or a label",
+				is.Func("key or type present", attributeHasKeyOrType),
+			),
 		),
 		rules.Assert("02", "attribute must have at least one of the text, code, amount, or date values",
 			is.Expr(`(Text == "" ? 0 : 1) + (string(Code) == "" ? 0 : 1) + (Amount == nil ? 0 : 1) + (Date == nil ? 0 : 1) >= 1`),
@@ -197,6 +202,21 @@ func attributeRules() *rules.Set {
 			),
 		),
 	)
+}
+
+func attributeNotBothKeyAndType(val any) bool {
+	a, ok := val.(*Attribute)
+	return ok && (a.Key == "" || a.Type == "")
+}
+
+func attributeHasNoLabel(val any) bool {
+	a, ok := val.(*Attribute)
+	return ok && a.Label == ""
+}
+
+func attributeHasKeyOrType(val any) bool {
+	a, ok := val.(*Attribute)
+	return ok && (a.Key != "" || a.Type != "")
 }
 
 func normalizeAttribute(a *Attribute) {

--- a/org/attribute_test.go
+++ b/org/attribute_test.go
@@ -60,11 +60,18 @@ func TestAttributeValidation(t *testing.T) {
 		}
 		assert.NoError(t, rules.Validate(a))
 	})
-	t.Run("missing key and type", func(t *testing.T) {
+	t.Run("valid with label instead of key or type", func(t *testing.T) {
+		a := &org.Attribute{
+			Label: "SubitemValue3",
+			Text:  "850,36",
+		}
+		assert.NoError(t, rules.Validate(a))
+	})
+	t.Run("missing label, key, and type", func(t *testing.T) {
 		a := &org.Attribute{
 			Text: "Black",
 		}
-		assert.ErrorContains(t, rules.Validate(a), "attribute must have either a key or a type, but not both")
+		assert.ErrorContains(t, rules.Validate(a), "attribute must have a key, a type, or a label")
 	})
 	t.Run("both key and type", func(t *testing.T) {
 		a := &org.Attribute{
@@ -72,7 +79,16 @@ func TestAttributeValidation(t *testing.T) {
 			Type: "X01",
 			Text: "Black",
 		}
-		assert.ErrorContains(t, rules.Validate(a), "attribute must have either a key or a type, but not both")
+		assert.ErrorContains(t, rules.Validate(a), "attribute must not have both a key and a type")
+	})
+	t.Run("both key and type with label", func(t *testing.T) {
+		a := &org.Attribute{
+			Label: "Color",
+			Key:   org.AttributeKeyColor,
+			Type:  "X01",
+			Text:  "Black",
+		}
+		assert.ErrorContains(t, rules.Validate(a), "attribute must not have both a key and a type")
 	})
 	t.Run("valid with text and date", func(t *testing.T) {
 		a := &org.Attribute{


### PR DESCRIPTION
- `org`: `Attribute` no longer requires a `key` or `type` when a `label` is present. UBL imports (e.g. France) map each `AdditionalItemProperty` to an attribute with only `label` and `text`, which failed `GOBL-ORG-ATTRIBUTE-01` since the label is presentation-only.
- `GOBL-ORG-ATTRIBUTE-01` now only rejects attributes that set both `key` and `type`; the new `GOBL-ORG-ATTRIBUTE-04` ("attribute must have a key, a type, or a label") is only checked when there is no `label`, so attributes such as `{ "label": "SubitemValue3", "text": "850,36" }` are now valid.
- The identification rules and the large value rule (`02`) use named `is.Func` predicates, following the prevailing style in the codebase; the small unit rule (`03`) expressions are untouched.
- Updated struct docs, regenerated `data/rules/org.json` and `data/schemas/org/attribute.json`, and added a changelog entry.

## Pre-Review Checklist

- [x] Opened this PR as a draft
- [x] Read the CONTRIBUTING.md guide.
- [x] Performed a self-review of my code.
- [x] Added thorough tests with at **least** 90% code coverage.
- [x] Modified or created example GOBL documents to show my changes in use, if appropriate.
- [x] Added links to the source of the changes in tax regimes or addons, either structured or in the comments.
- [x] Run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [x] Reviewed and fixed all linter warnings.
- [x] Been obsessive with pointer nil checks to avoid panics.
- [x] Updated the CHANGELOG.md with an overview of my changes.
- [ ] Marked this PR as ready for review.

And if you are part of the org:
- [ ] Requested a review from Copilot and fixed or dismissed (with a reason) all the feedback raised.
- [ ] Requested a review from @samlown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
