### PR TITLE
bill: use a value alias in Invoice.UnmarshalJSON

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,8 +8,24 @@ on:
   pull_request:
 jobs:
   test:
-    name: Test
+    name: Test (Go ${{ matrix.go-version }})
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # The three most recent Go releases. The oldest matches the go
+        # directive in go.mod, and 1.27 is the first release to enable the
+        # jsonv2 implementation of encoding/json by default.
+        go-version: ["1.25.x", "1.26.x", "1.27.x"]
+        include:
+          - go-version: "1.27.x"
+            coverage: true
+
+    env:
+      # Run on the toolchain the matrix installed instead of downloading a
+      # newer one when a module in the graph asks for it.
+      GOTOOLCHAIN: local
 
     steps:
       - name: Check out code
@@ -18,7 +34,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: "go.mod"
+          go-version: ${{ matrix.go-version }}
 
       - name: Install Dependencies
         env:
@@ -33,6 +49,7 @@ jobs:
         run: go test -race -coverprofile=coverage.out -covermode=atomic -coverpkg=./... ./...
 
       - name: Upload coverage reports to Codecov
+        if: matrix.coverage
         uses: codecov/codecov-action@v5.1.2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
   signature entries instead of panicking.
 - `regimes/ar`: CUIT/CUIL tax identities with the `24` prefix (an individual
   contingency prefix) are no longer wrongly rejected as having an invalid prefix.
+- `bill`: `Invoice.UnmarshalJSON` no longer recurses infinitely under the `jsonv2` implementation of `encoding/json`, enabled by default from Go 1.27. The method used a defined pointer type (`type Alias *Invoice`) to strip itself before delegating, which has an empty method set under the v1 implementation but not under v2, where the decoder dereferences through the named pointer and finds `UnmarshalJSON` again. Unmarshalling any invoice on Go 1.27 ended in `fatal error: stack overflow`, which callers cannot recover from. The alias is now value-typed (`type Alias Invoice`), matching every other alias site in the codebase and behaving identically under both implementations.
 
 ## [v0.504.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
   signature entries instead of panicking.
 - `regimes/ar`: CUIT/CUIL tax identities with the `24` prefix (an individual
   contingency prefix) are no longer wrongly rejected as having an invalid prefix.
-- `bill`: `Invoice.UnmarshalJSON` no longer recurses infinitely under the `jsonv2` implementation of `encoding/json`, enabled by default from Go 1.27. The method used a defined pointer type (`type Alias *Invoice`) to strip itself before delegating, which has an empty method set under the v1 implementation but not under v2, where the decoder dereferences through the named pointer and finds `UnmarshalJSON` again. Unmarshalling any invoice on Go 1.27 ended in `fatal error: stack overflow`, which callers cannot recover from. The alias is now value-typed (`type Alias Invoice`), matching every other alias site in the codebase and behaving identically under both implementations.
+- `bill`: unmarshalling an `Invoice` under the `jsonv2` implementation of
+  `encoding/json`, the default from Go 1.27, no longer re-enters
+  `Invoice.UnmarshalJSON` until the process dies with a fatal stack overflow.
 
 ## [v0.504.0]
 

--- a/bill/invoice.go
+++ b/bill/invoice.go
@@ -403,8 +403,8 @@ func (inv *Invoice) ToEndpoint() *org.Endpoint {
 // UnmarshalJSON implements the json.Unmarshaler interface and provides any
 // data migrations that might be required.
 func (inv *Invoice) UnmarshalJSON(data []byte) error {
-	type Alias *Invoice
-	if err := json.Unmarshal(data, (Alias)(inv)); err != nil {
+	type Alias Invoice
+	if err := json.Unmarshal(data, (*Alias)(inv)); err != nil {
 		return err
 	}
 	// Ensure there is regime set when coming in from a raw JSON source.

--- a/bill/invoice_test.go
+++ b/bill/invoice_test.go
@@ -2,6 +2,7 @@ package bill_test
 
 import (
 	"encoding/json"
+	"reflect"
 	"testing"
 	"time"
 
@@ -1185,6 +1186,27 @@ func TestInvoiceUnmarshalJSON(t *testing.T) {
 		inv := new(bill.Invoice)
 		require.NoError(t, json.Unmarshal([]byte(raw), inv))
 		assert.Equal(t, "ES", inv.Regime.Country.String())
+	})
+
+	t.Run("does not re-enter itself", func(t *testing.T) {
+		// A self-re-entering UnmarshalJSON ends in a fatal stack overflow,
+		// which takes the test binary down rather than failing here.
+		inv := new(bill.Invoice)
+		assert.NotPanics(t, func() {
+			_ = json.Unmarshal([]byte(`{"code": "ABC"}`), inv)
+		})
+	})
+
+	t.Run("alias sheds decoding methods", func(t *testing.T) {
+		// UnmarshalJSON delegates through a defined type to shed itself. An
+		// embedded field carrying its own JSON or text decoding puts a
+		// method back on that type, and decoding re-enters it.
+		type alias bill.Invoice
+		typ := reflect.TypeOf(new(alias))
+		for _, method := range []string{"UnmarshalJSON", "UnmarshalJSONFrom", "UnmarshalText"} {
+			_, ok := typ.MethodByName(method)
+			assert.False(t, ok, "alias promotes %s from an embedded field", method)
+		}
 	})
 }
 


### PR DESCRIPTION
fixes #954 

## Problem

`(*Invoice).UnmarshalJSON` strips its own method with `type Alias *Invoice` before delegating to `json.Unmarshal`. A defined *pointer* type has an empty method set under the `encoding/json` v1 implementation, so this works there.

Under the v2 implementation — enabled by default in Go 1.27 — the decoder dereferences through the named pointer type before checking for `json.Unmarshaler`, finds `(*Invoice).UnmarshalJSON` again, and re-enters it with the same data. Every `json.Unmarshal` into a `*bill.Invoice` recurses until `fatal error: stack overflow`, which callers cannot recover from.

gobl's own `TestInvoiceUnmarshalJSON` crashes on Go 1.27 today.

## Change

One line, in `bill/invoice.go`:

```diff
 func (inv *Invoice) UnmarshalJSON(data []byte) error {
-	type Alias *Invoice
-	if err := json.Unmarshal(data, (Alias)(inv)); err != nil {
+	type Alias Invoice
+	if err := json.Unmarshal(data, (*Alias)(inv)); err != nil {
 		return err
 	}
```

A value-typed alias has an empty method set under both implementations. This is the form already used at every other alias site in the codebase (`bill/tax.go`, `bill/payment.go`, `pay/terms.go`, `pay/instructions.go`, `pay/record.go`, `tax/combo.go`); `bill/invoice.go` was the only outlier.

## A note on embedded types

`type Alias *Invoice` has a genuinely empty method set. `type Alias Invoice` does not: methods promoted from embedded fields are part of the new type's method set.

`Invoice` embeds `tax.Regime`, `tax.Addons`, `tax.Tags` and `uuid.Identify`. None of them declares `UnmarshalJSON`, so nothing is promoted and the recursion does not reappear by another route. It is a constraint a future embed could silently break, so I am happy to add a comment on the `type Alias` line — or a guard test — if you would like one.

## Testing

On `go1.27.0` (jsonv2 on by default):

- `go test ./...` — passes. Fails with `fatal error: stack overflow` before this change.

With the experiment disabled:

- `GOEXPERIMENT=nojsonv2 go test ./...` — passes. No regression against the v1 implementation.

Also verified against a downstream consumer (a UBL/CII e-invoicing service): its suite crashes with unpatched gobl under Go 1.27 and passes with this change, with no `GOEXPERIMENT=nojsonv2` workaround needed.

## Why it matters

Go 1.27 makes this the default path. Downstream projects currently have to build and test with `GOEXPERIMENT=nojsonv2` to use gobl at all, and that flag will not exist forever.
