### PR TITLE
cal: accept a single bound on Period (EN 16931 BR-CO-19 / BR-CO-20)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Changed
 
-- `cal`: `Period` now accepts a single bound. Only one of `start` or `end` is
-  required, matching EN 16931 BR-CO-19 / BR-CO-20 where the invoicing and line
-  period dates are each optional. The absent bound is omitted from JSON instead
-  of being serialized as `0000-00-00`. A period with neither bound fails with
-  the new `GOBL-CAL-PERIOD-03`; the field-level codes `GOBL-CAL-PERIOD-01` and
-  `GOBL-CAL-PERIOD-02` are retired.
+- `cal`: **breaking**: `Period` `start` and `end` are now pointers, and only one
+  of the two is required. A period with neither fails with the new
+  `GOBL-CAL-PERIOD-11`.
 - `addons/it/sdi`: **breaking**: the Italian SDI FatturaPA (`it-sdi-v1`) addon moved to the standalone [`github.com/invopop/gobl.it.sdi`](https://github.com/invopop/gobl.it.sdi) module. Add a blank import (`_ "github.com/invopop/gobl.it.sdi/addon"`) to keep using the `it-sdi-v1` addon key.
 - `gr-mydata-v1`: the `gr-mydata-income-cat` extension may now be set to
   `category1_95` (Other Income-related Information) without an accompanying

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - `cal`: `Period` now accepts a single bound. Only one of `start` or `end` is
   required, matching EN 16931 BR-CO-19 / BR-CO-20 where the invoicing and line
   period dates are each optional. The absent bound is omitted from JSON instead
-  of being serialized as `0000-00-00`. A period with neither bound still fails
-  with `GOBL-CAL-PERIOD-01` and `GOBL-CAL-PERIOD-02`.
+  of being serialized as `0000-00-00`. A period with neither bound fails with
+  the new `GOBL-CAL-PERIOD-03`; the field-level codes `GOBL-CAL-PERIOD-01` and
+  `GOBL-CAL-PERIOD-02` are retired.
 - `addons/it/sdi`: **breaking**: the Italian SDI FatturaPA (`it-sdi-v1`) addon moved to the standalone [`github.com/invopop/gobl.it.sdi`](https://github.com/invopop/gobl.it.sdi) module. Add a blank import (`_ "github.com/invopop/gobl.it.sdi/addon"`) to keep using the `it-sdi-v1` addon key.
 - `gr-mydata-v1`: the `gr-mydata-income-cat` extension may now be set to
   `category1_95` (Other Income-related Information) without an accompanying

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Changed
 
+- `cal`: `Period` now accepts a single bound. Only one of `start` or `end` is
+  required, matching EN 16931 BR-CO-19 / BR-CO-20 where the invoicing and line
+  period dates are each optional. The absent bound is omitted from JSON instead
+  of being serialized as `0000-00-00`. A period with neither bound still fails
+  with `GOBL-CAL-PERIOD-01` and `GOBL-CAL-PERIOD-02`.
 - `addons/it/sdi`: **breaking**: the Italian SDI FatturaPA (`it-sdi-v1`) addon moved to the standalone [`github.com/invopop/gobl.it.sdi`](https://github.com/invopop/gobl.it.sdi) module. Add a blank import (`_ "github.com/invopop/gobl.it.sdi/addon"`) to keep using the `it-sdi-v1` addon key.
 - `gr-mydata-v1`: the `gr-mydata-income-cat` extension may now be set to
   `category1_95` (Other Income-related Information) without an accompanying

--- a/addons/ar/arca/bill_invoice_test.go
+++ b/addons/ar/arca/bill_invoice_test.go
@@ -1828,8 +1828,8 @@ func testInvoiceTypeC(t *testing.T) *bill.Invoice {
 func testOrdering() *bill.Ordering {
 	return &bill.Ordering{
 		Period: &cal.Period{
-			Start: cal.MakeDate(2024, 1, 1),
-			End:   cal.MakeDate(2024, 1, 31),
+			Start: cal.NewDate(2024, 1, 1),
+			End:   cal.NewDate(2024, 1, 31),
 		},
 	}
 }

--- a/cal/period.go
+++ b/cal/period.go
@@ -21,26 +21,26 @@ type Period struct {
 
 func periodRules() *rules.Set {
 	return rules.For(new(Period),
-		rules.When(is.Expr(`End.IsZero()`),
-			rules.Field("start",
-				rules.Assert("01", "start date cannot be zero",
-					DateNotZero(),
-				),
-			),
-		),
-		rules.When(is.Expr(`Start.IsZero()`),
-			rules.Field("end",
-				rules.Assert("02", "end date cannot be zero",
-					DateNotZero(),
-				),
-			),
-		),
 		rules.Object(
+			rules.Assert("03", "either a start or end date is required",
+				is.Func("has start or end", periodHasBound),
+			),
 			rules.Assert("10", "end date must be on or after start date",
 				is.Func("end not before start", periodEndNotBeforeStart),
 			),
 		),
 	)
+}
+
+// periodHasBound checks that at least one of the two dates is set. Which one
+// is irrelevant: EN 16931 BR-CO-19 and BR-CO-20 allow either bound alone, so
+// this is reported once against the period rather than against each field.
+func periodHasBound(val any) bool {
+	p, ok := val.(*Period)
+	if !ok || p == nil {
+		return true
+	}
+	return !p.Start.IsZero() || !p.End.IsZero()
 }
 
 func periodEndNotBeforeStart(val any) bool {

--- a/cal/period.go
+++ b/cal/period.go
@@ -5,26 +5,34 @@ import (
 	"github.com/invopop/gobl/rules/is"
 )
 
-// Period represents two dates with a start and finish.
+// Period represents a span of time bounded by a start and/or an end date.
+// At least one of the two bounds must be provided, but either may be omitted
+// on its own, mirroring EN 16931 (BR-CO-19 and BR-CO-20) where the invoicing
+// and line period start and end dates are each optional.
 type Period struct {
 	// Label is a short description of the period.
 	Label string `json:"label,omitempty" jsonschema:"title=Label"`
-	// Start indicates when this period starts.
-	Start Date `json:"start" jsonschema:"title=Start"`
-	// End indicates when the period ends, and must be after the start date.
-	End Date `json:"end" jsonschema:"title=End"`
+	// Start indicates when this period starts. Required if no end date is provided.
+	Start Date `json:"start,omitzero" jsonschema:"title=Start"`
+	// End indicates when the period ends, and must be on or after the start
+	// date when both are present. Required if no start date is provided.
+	End Date `json:"end,omitzero" jsonschema:"title=End"`
 }
 
 func periodRules() *rules.Set {
 	return rules.For(new(Period),
-		rules.Field("start",
-			rules.Assert("01", "start date cannot be zero",
-				DateNotZero(),
+		rules.When(is.Expr(`End.IsZero()`),
+			rules.Field("start",
+				rules.Assert("01", "start date cannot be zero",
+					DateNotZero(),
+				),
 			),
 		),
-		rules.Field("end",
-			rules.Assert("02", "end date cannot be zero",
-				DateNotZero(),
+		rules.When(is.Expr(`Start.IsZero()`),
+			rules.Field("end",
+				rules.Assert("02", "end date cannot be zero",
+					DateNotZero(),
+				),
 			),
 		),
 		rules.Object(

--- a/cal/period.go
+++ b/cal/period.go
@@ -6,46 +6,53 @@ import (
 )
 
 // Period represents a span of time bounded by a start and/or an end date.
-// At least one of the two bounds must be provided, but either may be omitted
-// on its own, mirroring EN 16931 (BR-CO-19 and BR-CO-20) where the invoicing
-// and line period start and end dates are each optional.
 type Period struct {
 	// Label is a short description of the period.
 	Label string `json:"label,omitempty" jsonschema:"title=Label"`
-	// Start indicates when this period starts. Required if no end date is provided.
-	Start Date `json:"start,omitzero" jsonschema:"title=Start"`
-	// End indicates when the period ends, and must be on or after the start
-	// date when both are present. Required if no start date is provided.
-	End Date `json:"end,omitzero" jsonschema:"title=End"`
+	// Start indicates when this period starts, required if there is no end date.
+	Start *Date `json:"start,omitempty" jsonschema:"title=Start"`
+	// End indicates when the period ends, required if there is no start date,
+	// and must be on or after the start date.
+	End *Date `json:"end,omitempty" jsonschema:"title=End"`
 }
 
 func periodRules() *rules.Set {
 	return rules.For(new(Period),
-		rules.Object(
-			rules.Assert("03", "either a start or end date is required",
-				is.Func("has start or end", periodHasBound),
+		rules.Field("start",
+			rules.AssertIfPresent("01", "start date cannot be zero",
+				DateNotZero(),
 			),
+		),
+		rules.Field("end",
+			rules.AssertIfPresent("02", "end date cannot be zero",
+				DateNotZero(),
+			),
+		),
+		rules.Object(
 			rules.Assert("10", "end date must be on or after start date",
 				is.Func("end not before start", periodEndNotBeforeStart),
+			),
+			rules.Assert("11", "either a start or end date is required",
+				is.Func("has start or end", periodHasBound),
 			),
 		),
 	)
 }
 
-// periodHasBound checks that at least one of the two dates is set. Which one
-// is irrelevant: EN 16931 BR-CO-19 and BR-CO-20 allow either bound alone, so
-// this is reported once against the period rather than against each field.
 func periodHasBound(val any) bool {
 	p, ok := val.(*Period)
 	if !ok || p == nil {
 		return true
 	}
-	return !p.Start.IsZero() || !p.End.IsZero()
+	return p.Start != nil || p.End != nil
 }
 
 func periodEndNotBeforeStart(val any) bool {
 	p, ok := val.(*Period)
-	if !ok || p == nil || p.Start.IsZero() || p.End.IsZero() {
+	if !ok || p == nil || p.Start == nil || p.End == nil {
+		return true
+	}
+	if p.Start.IsZero() || p.End.IsZero() {
 		return true
 	}
 	return p.End.DaysSince(p.Start.Date) >= 0

--- a/cal/period_internal_test.go
+++ b/cal/period_internal_test.go
@@ -6,8 +6,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// The rules engine never hands a nil pointer or a foreign type to a test
-// function, so the defensive guards can only be exercised directly.
 func TestPeriodHasBound(t *testing.T) {
 	assert.True(t, periodHasBound(nil))
 	assert.True(t, periodHasBound((*Period)(nil)))
@@ -15,11 +13,11 @@ func TestPeriodHasBound(t *testing.T) {
 
 	assert.False(t, periodHasBound(&Period{}))
 	assert.False(t, periodHasBound(&Period{Label: "Q3"}))
-	assert.True(t, periodHasBound(&Period{Start: MakeDate(2022, 1, 25)}))
-	assert.True(t, periodHasBound(&Period{End: MakeDate(2022, 2, 28)}))
+	assert.True(t, periodHasBound(&Period{Start: NewDate(2022, 1, 25)}))
+	assert.True(t, periodHasBound(&Period{End: NewDate(2022, 2, 28)}))
 	assert.True(t, periodHasBound(&Period{
-		Start: MakeDate(2022, 1, 25),
-		End:   MakeDate(2022, 2, 28),
+		Start: NewDate(2022, 1, 25),
+		End:   NewDate(2022, 2, 28),
 	}))
 }
 
@@ -28,16 +26,23 @@ func TestPeriodEndNotBeforeStart(t *testing.T) {
 	assert.True(t, periodEndNotBeforeStart((*Period)(nil)))
 	assert.True(t, periodEndNotBeforeStart("not a period"))
 
-	// One-sided periods have nothing to compare.
-	assert.True(t, periodEndNotBeforeStart(&Period{Start: MakeDate(2022, 1, 25)}))
-	assert.True(t, periodEndNotBeforeStart(&Period{End: MakeDate(2022, 2, 28)}))
+	assert.True(t, periodEndNotBeforeStart(&Period{Start: NewDate(2022, 1, 25)}))
+	assert.True(t, periodEndNotBeforeStart(&Period{End: NewDate(2022, 2, 28)}))
+	assert.True(t, periodEndNotBeforeStart(&Period{
+		Start: new(Date),
+		End:   NewDate(2022, 2, 28),
+	}))
+	assert.True(t, periodEndNotBeforeStart(&Period{
+		Start: NewDate(2022, 1, 25),
+		End:   new(Date),
+	}))
 
 	assert.True(t, periodEndNotBeforeStart(&Period{
-		Start: MakeDate(2022, 1, 25),
-		End:   MakeDate(2022, 1, 25),
+		Start: NewDate(2022, 1, 25),
+		End:   NewDate(2022, 1, 25),
 	}))
 	assert.False(t, periodEndNotBeforeStart(&Period{
-		Start: MakeDate(2022, 1, 25),
-		End:   MakeDate(2022, 1, 20),
+		Start: NewDate(2022, 1, 25),
+		End:   NewDate(2022, 1, 20),
 	}))
 }

--- a/cal/period_internal_test.go
+++ b/cal/period_internal_test.go
@@ -1,0 +1,43 @@
+package cal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// The rules engine never hands a nil pointer or a foreign type to a test
+// function, so the defensive guards can only be exercised directly.
+func TestPeriodHasBound(t *testing.T) {
+	assert.True(t, periodHasBound(nil))
+	assert.True(t, periodHasBound((*Period)(nil)))
+	assert.True(t, periodHasBound("not a period"))
+
+	assert.False(t, periodHasBound(&Period{}))
+	assert.False(t, periodHasBound(&Period{Label: "Q3"}))
+	assert.True(t, periodHasBound(&Period{Start: MakeDate(2022, 1, 25)}))
+	assert.True(t, periodHasBound(&Period{End: MakeDate(2022, 2, 28)}))
+	assert.True(t, periodHasBound(&Period{
+		Start: MakeDate(2022, 1, 25),
+		End:   MakeDate(2022, 2, 28),
+	}))
+}
+
+func TestPeriodEndNotBeforeStart(t *testing.T) {
+	assert.True(t, periodEndNotBeforeStart(nil))
+	assert.True(t, periodEndNotBeforeStart((*Period)(nil)))
+	assert.True(t, periodEndNotBeforeStart("not a period"))
+
+	// One-sided periods have nothing to compare.
+	assert.True(t, periodEndNotBeforeStart(&Period{Start: MakeDate(2022, 1, 25)}))
+	assert.True(t, periodEndNotBeforeStart(&Period{End: MakeDate(2022, 2, 28)}))
+
+	assert.True(t, periodEndNotBeforeStart(&Period{
+		Start: MakeDate(2022, 1, 25),
+		End:   MakeDate(2022, 1, 25),
+	}))
+	assert.False(t, periodEndNotBeforeStart(&Period{
+		Start: MakeDate(2022, 1, 25),
+		End:   MakeDate(2022, 1, 20),
+	}))
+}

--- a/cal/period_test.go
+++ b/cal/period_test.go
@@ -1,6 +1,7 @@
 package cal_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/invopop/gobl/cal"
@@ -28,26 +29,21 @@ func TestPeriodValidation(t *testing.T) {
 		assert.NoError(t, rules.Validate(&p))
 	})
 
-	t.Run("missing start", func(t *testing.T) {
+	// EN 16931 BR-CO-19 / BR-CO-20: a period only needs one of its bounds.
+	t.Run("end only", func(t *testing.T) {
 		p := cal.Period{
 			End: cal.MakeDate(2022, 2, 28),
 		}
-		faults := rules.Validate(p)
-		require.NotNil(t, faults)
-		assert.True(t, faults.HasCode("GOBL-CAL-PERIOD-01"))
-		assert.True(t, faults.HasPath("$.start"))
-		assert.Equal(t, "start date cannot be zero", faults.First().Message())
+		assert.NoError(t, rules.Validate(p))
+		assert.NoError(t, rules.Validate(&p))
 	})
 
-	t.Run("missing end", func(t *testing.T) {
+	t.Run("start only", func(t *testing.T) {
 		p := cal.Period{
 			Start: cal.MakeDate(2022, 1, 25),
 		}
-		faults := rules.Validate(p)
-		require.NotNil(t, faults)
-		assert.True(t, faults.HasCode("GOBL-CAL-PERIOD-02"))
-		assert.True(t, faults.HasPath("$.end"))
-		assert.Equal(t, "end date cannot be zero", faults.First().Message())
+		assert.NoError(t, rules.Validate(p))
+		assert.NoError(t, rules.Validate(&p))
 	})
 
 	t.Run("end before start", func(t *testing.T) {
@@ -70,6 +66,63 @@ func TestPeriodValidation(t *testing.T) {
 		faults := rules.Validate(p)
 		require.NotNil(t, faults)
 		assert.True(t, faults.HasCode("GOBL-CAL-PERIOD-01"))
+		assert.True(t, faults.HasPath("$.start"))
 		assert.True(t, faults.HasCode("GOBL-CAL-PERIOD-02"))
+		assert.True(t, faults.HasPath("$.end"))
+		assert.False(t, faults.HasCode("GOBL-CAL-PERIOD-10"))
+	})
+}
+
+func TestPeriodJSON(t *testing.T) {
+	t.Run("both bounds", func(t *testing.T) {
+		p := cal.Period{
+			Start: cal.MakeDate(2022, 1, 25),
+			End:   cal.MakeDate(2022, 2, 28),
+		}
+		data, err := json.Marshal(p)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"start":"2022-01-25","end":"2022-02-28"}`, string(data))
+	})
+
+	t.Run("end only omits start", func(t *testing.T) {
+		p := cal.Period{
+			End: cal.MakeDate(2022, 2, 28),
+		}
+		data, err := json.Marshal(p)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"end":"2022-02-28"}`, string(data))
+		assert.NotContains(t, string(data), "0000-00-00")
+
+		var out cal.Period
+		require.NoError(t, json.Unmarshal(data, &out))
+		assert.Equal(t, p, out)
+		assert.True(t, out.Start.IsZero())
+	})
+
+	t.Run("start only omits end", func(t *testing.T) {
+		p := cal.Period{
+			Start: cal.MakeDate(2022, 1, 25),
+		}
+		data, err := json.Marshal(p)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"start":"2022-01-25"}`, string(data))
+		assert.NotContains(t, string(data), "0000-00-00")
+
+		var out cal.Period
+		require.NoError(t, json.Unmarshal(data, &out))
+		assert.Equal(t, p, out)
+		assert.True(t, out.End.IsZero())
+	})
+
+	t.Run("legacy zero date input", func(t *testing.T) {
+		// Older documents may carry "0000-00-00" for the missing bound; it
+		// must still parse and then be dropped on re-serialization.
+		var p cal.Period
+		require.NoError(t, json.Unmarshal([]byte(`{"start":"0000-00-00","end":"2022-02-28"}`), &p))
+		assert.True(t, p.Start.IsZero())
+		assert.NoError(t, rules.Validate(p))
+		data, err := json.Marshal(p)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"end":"2022-02-28"}`, string(data))
 	})
 }

--- a/cal/period_test.go
+++ b/cal/period_test.go
@@ -13,8 +13,8 @@ import (
 func TestPeriodValidation(t *testing.T) {
 	t.Run("valid", func(t *testing.T) {
 		p := cal.Period{
-			Start: cal.MakeDate(2022, 1, 25),
-			End:   cal.MakeDate(2022, 2, 28),
+			Start: cal.NewDate(2022, 1, 25),
+			End:   cal.NewDate(2022, 2, 28),
 		}
 		assert.NoError(t, rules.Validate(p))
 		assert.NoError(t, rules.Validate(&p))
@@ -22,17 +22,16 @@ func TestPeriodValidation(t *testing.T) {
 
 	t.Run("same day", func(t *testing.T) {
 		p := cal.Period{
-			Start: cal.MakeDate(2022, 1, 25),
-			End:   cal.MakeDate(2022, 1, 25),
+			Start: cal.NewDate(2022, 1, 25),
+			End:   cal.NewDate(2022, 1, 25),
 		}
 		assert.NoError(t, rules.Validate(p))
 		assert.NoError(t, rules.Validate(&p))
 	})
 
-	// EN 16931 BR-CO-19 / BR-CO-20: a period only needs one of its bounds.
 	t.Run("end only", func(t *testing.T) {
 		p := cal.Period{
-			End: cal.MakeDate(2022, 2, 28),
+			End: cal.NewDate(2022, 2, 28),
 		}
 		assert.NoError(t, rules.Validate(p))
 		assert.NoError(t, rules.Validate(&p))
@@ -40,16 +39,38 @@ func TestPeriodValidation(t *testing.T) {
 
 	t.Run("start only", func(t *testing.T) {
 		p := cal.Period{
-			Start: cal.MakeDate(2022, 1, 25),
+			Start: cal.NewDate(2022, 1, 25),
 		}
 		assert.NoError(t, rules.Validate(p))
 		assert.NoError(t, rules.Validate(&p))
 	})
 
+	t.Run("zero start", func(t *testing.T) {
+		p := cal.Period{
+			Start: new(cal.Date),
+			End:   cal.NewDate(2022, 2, 28),
+		}
+		faults := rules.Validate(p)
+		require.NotNil(t, faults)
+		assert.True(t, faults.HasCode("GOBL-CAL-PERIOD-01"))
+		assert.Equal(t, "start date cannot be zero", faults.First().Message())
+	})
+
+	t.Run("zero end", func(t *testing.T) {
+		p := cal.Period{
+			Start: cal.NewDate(2022, 1, 25),
+			End:   new(cal.Date),
+		}
+		faults := rules.Validate(p)
+		require.NotNil(t, faults)
+		assert.True(t, faults.HasCode("GOBL-CAL-PERIOD-02"))
+		assert.Equal(t, "end date cannot be zero", faults.First().Message())
+	})
+
 	t.Run("end before start", func(t *testing.T) {
 		p := cal.Period{
-			Start: cal.MakeDate(2022, 1, 25),
-			End:   cal.MakeDate(2022, 1, 20),
+			Start: cal.NewDate(2022, 1, 25),
+			End:   cal.NewDate(2022, 1, 20),
 		}
 		faults := rules.Validate(p)
 		require.NotNil(t, faults)
@@ -65,32 +86,31 @@ func TestPeriodValidation(t *testing.T) {
 		p := cal.Period{}
 		faults := rules.Validate(p)
 		require.NotNil(t, faults)
-		assert.True(t, faults.HasCode("GOBL-CAL-PERIOD-03"))
+		assert.True(t, faults.HasCode("GOBL-CAL-PERIOD-11"))
 		assert.True(t, faults.HasPath("$"))
 		assert.Equal(t, "either a start or end date is required", faults.First().Message())
-		// A single fault: the retired field-level codes must not reappear.
 		assert.False(t, faults.HasCode("GOBL-CAL-PERIOD-01"))
 		assert.False(t, faults.HasCode("GOBL-CAL-PERIOD-02"))
 		assert.False(t, faults.HasCode("GOBL-CAL-PERIOD-10"))
 
 		faults = rules.Validate(&p)
 		require.NotNil(t, faults)
-		assert.True(t, faults.HasCode("GOBL-CAL-PERIOD-03"))
+		assert.True(t, faults.HasCode("GOBL-CAL-PERIOD-11"))
 	})
 
 	t.Run("label only", func(t *testing.T) {
 		p := cal.Period{Label: "Q3"}
 		faults := rules.Validate(p)
 		require.NotNil(t, faults)
-		assert.True(t, faults.HasCode("GOBL-CAL-PERIOD-03"))
+		assert.True(t, faults.HasCode("GOBL-CAL-PERIOD-11"))
 	})
 }
 
 func TestPeriodJSON(t *testing.T) {
 	t.Run("both bounds", func(t *testing.T) {
 		p := cal.Period{
-			Start: cal.MakeDate(2022, 1, 25),
-			End:   cal.MakeDate(2022, 2, 28),
+			Start: cal.NewDate(2022, 1, 25),
+			End:   cal.NewDate(2022, 2, 28),
 		}
 		data, err := json.Marshal(p)
 		require.NoError(t, err)
@@ -99,43 +119,40 @@ func TestPeriodJSON(t *testing.T) {
 
 	t.Run("end only omits start", func(t *testing.T) {
 		p := cal.Period{
-			End: cal.MakeDate(2022, 2, 28),
+			End: cal.NewDate(2022, 2, 28),
 		}
 		data, err := json.Marshal(p)
 		require.NoError(t, err)
 		assert.JSONEq(t, `{"end":"2022-02-28"}`, string(data))
-		assert.NotContains(t, string(data), "0000-00-00")
 
 		var out cal.Period
 		require.NoError(t, json.Unmarshal(data, &out))
 		assert.Equal(t, p, out)
-		assert.True(t, out.Start.IsZero())
+		assert.Nil(t, out.Start)
 	})
 
 	t.Run("start only omits end", func(t *testing.T) {
 		p := cal.Period{
-			Start: cal.MakeDate(2022, 1, 25),
+			Start: cal.NewDate(2022, 1, 25),
 		}
 		data, err := json.Marshal(p)
 		require.NoError(t, err)
 		assert.JSONEq(t, `{"start":"2022-01-25"}`, string(data))
-		assert.NotContains(t, string(data), "0000-00-00")
 
 		var out cal.Period
 		require.NoError(t, json.Unmarshal(data, &out))
 		assert.Equal(t, p, out)
-		assert.True(t, out.End.IsZero())
+		assert.Nil(t, out.End)
 	})
 
-	t.Run("legacy zero date input", func(t *testing.T) {
-		// Older documents may carry "0000-00-00" for the missing bound; it
-		// must still parse and then be dropped on re-serialization.
+	t.Run("zero date input", func(t *testing.T) {
 		var p cal.Period
 		require.NoError(t, json.Unmarshal([]byte(`{"start":"0000-00-00","end":"2022-02-28"}`), &p))
+		require.NotNil(t, p.Start)
 		assert.True(t, p.Start.IsZero())
-		assert.NoError(t, rules.Validate(p))
-		data, err := json.Marshal(p)
-		require.NoError(t, err)
-		assert.JSONEq(t, `{"end":"2022-02-28"}`, string(data))
+
+		faults := rules.Validate(p)
+		require.NotNil(t, faults)
+		assert.True(t, faults.HasCode("GOBL-CAL-PERIOD-01"))
 	})
 }

--- a/cal/period_test.go
+++ b/cal/period_test.go
@@ -65,11 +65,24 @@ func TestPeriodValidation(t *testing.T) {
 		p := cal.Period{}
 		faults := rules.Validate(p)
 		require.NotNil(t, faults)
-		assert.True(t, faults.HasCode("GOBL-CAL-PERIOD-01"))
-		assert.True(t, faults.HasPath("$.start"))
-		assert.True(t, faults.HasCode("GOBL-CAL-PERIOD-02"))
-		assert.True(t, faults.HasPath("$.end"))
+		assert.True(t, faults.HasCode("GOBL-CAL-PERIOD-03"))
+		assert.True(t, faults.HasPath("$"))
+		assert.Equal(t, "either a start or end date is required", faults.First().Message())
+		// A single fault: the retired field-level codes must not reappear.
+		assert.False(t, faults.HasCode("GOBL-CAL-PERIOD-01"))
+		assert.False(t, faults.HasCode("GOBL-CAL-PERIOD-02"))
 		assert.False(t, faults.HasCode("GOBL-CAL-PERIOD-10"))
+
+		faults = rules.Validate(&p)
+		require.NotNil(t, faults)
+		assert.True(t, faults.HasCode("GOBL-CAL-PERIOD-03"))
+	})
+
+	t.Run("label only", func(t *testing.T) {
+		p := cal.Period{Label: "Q3"}
+		faults := rules.Validate(p)
+		require.NotNil(t, faults)
+		assert.True(t, faults.HasCode("GOBL-CAL-PERIOD-03"))
 	})
 }
 

--- a/data/rules/cal.json
+++ b/data/rules/cal.json
@@ -29,14 +29,46 @@
       "object": "cal.Period",
       "assert": [
         {
-          "id": "GOBL-CAL-PERIOD-03",
-          "desc": "either a start or end date is required",
-          "tests": "has start or end"
-        },
-        {
           "id": "GOBL-CAL-PERIOD-10",
           "desc": "end date must be on or after start date",
           "tests": "end not before start"
+        },
+        {
+          "id": "GOBL-CAL-PERIOD-11",
+          "desc": "either a start or end date is required",
+          "tests": "has start or end"
+        }
+      ],
+      "subsets": [
+        {
+          "field": "start",
+          "subsets": [
+            {
+              "guard": "present",
+              "assert": [
+                {
+                  "id": "GOBL-CAL-PERIOD-01",
+                  "desc": "start date cannot be zero",
+                  "tests": "not zero"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "field": "end",
+          "subsets": [
+            {
+              "guard": "present",
+              "assert": [
+                {
+                  "id": "GOBL-CAL-PERIOD-02",
+                  "desc": "end date cannot be zero",
+                  "tests": "not zero"
+                }
+              ]
+            }
+          ]
         }
       ]
     },

--- a/data/rules/cal.json
+++ b/data/rules/cal.json
@@ -29,41 +29,14 @@
       "object": "cal.Period",
       "assert": [
         {
+          "id": "GOBL-CAL-PERIOD-03",
+          "desc": "either a start or end date is required",
+          "tests": "has start or end"
+        },
+        {
           "id": "GOBL-CAL-PERIOD-10",
           "desc": "end date must be on or after start date",
           "tests": "end not before start"
-        }
-      ],
-      "subsets": [
-        {
-          "guard": "End.IsZero()",
-          "subsets": [
-            {
-              "field": "start",
-              "assert": [
-                {
-                  "id": "GOBL-CAL-PERIOD-01",
-                  "desc": "start date cannot be zero",
-                  "tests": "not zero"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "guard": "Start.IsZero()",
-          "subsets": [
-            {
-              "field": "end",
-              "assert": [
-                {
-                  "id": "GOBL-CAL-PERIOD-02",
-                  "desc": "end date cannot be zero",
-                  "tests": "not zero"
-                }
-              ]
-            }
-          ]
         }
       ]
     },

--- a/data/rules/cal.json
+++ b/data/rules/cal.json
@@ -36,22 +36,32 @@
       ],
       "subsets": [
         {
-          "field": "start",
-          "assert": [
+          "guard": "End.IsZero()",
+          "subsets": [
             {
-              "id": "GOBL-CAL-PERIOD-01",
-              "desc": "start date cannot be zero",
-              "tests": "not zero"
+              "field": "start",
+              "assert": [
+                {
+                  "id": "GOBL-CAL-PERIOD-01",
+                  "desc": "start date cannot be zero",
+                  "tests": "not zero"
+                }
+              ]
             }
           ]
         },
         {
-          "field": "end",
-          "assert": [
+          "guard": "Start.IsZero()",
+          "subsets": [
             {
-              "id": "GOBL-CAL-PERIOD-02",
-              "desc": "end date cannot be zero",
-              "tests": "not zero"
+              "field": "end",
+              "assert": [
+                {
+                  "id": "GOBL-CAL-PERIOD-02",
+                  "desc": "end date cannot be zero",
+                  "tests": "not zero"
+                }
+              ]
             }
           ]
         }

--- a/data/schemas/cal/period.json
+++ b/data/schemas/cal/period.json
@@ -13,12 +13,12 @@
         "start": {
           "$ref": "https://gobl.org/draft-0/cal/date",
           "title": "Start",
-          "description": "Start indicates when this period starts. Required if no end date is provided."
+          "description": "Start indicates when this period starts, required if there is no end date."
         },
         "end": {
           "$ref": "https://gobl.org/draft-0/cal/date",
           "title": "End",
-          "description": "End indicates when the period ends, and must be on or after the start\ndate when both are present. Required if no start date is provided."
+          "description": "End indicates when the period ends, required if there is no start date,\nand must be on or after the start date."
         }
       },
       "type": "object",

--- a/data/schemas/cal/period.json
+++ b/data/schemas/cal/period.json
@@ -13,20 +13,16 @@
         "start": {
           "$ref": "https://gobl.org/draft-0/cal/date",
           "title": "Start",
-          "description": "Start indicates when this period starts."
+          "description": "Start indicates when this period starts. Required if no end date is provided."
         },
         "end": {
           "$ref": "https://gobl.org/draft-0/cal/date",
           "title": "End",
-          "description": "End indicates when the period ends, and must be after the start date."
+          "description": "End indicates when the period ends, and must be on or after the start\ndate when both are present. Required if no start date is provided."
         }
       },
       "type": "object",
-      "required": [
-        "start",
-        "end"
-      ],
-      "description": "Period represents two dates with a start and finish."
+      "description": "Period represents a span of time bounded by a start and/or an end date."
     }
   }
 }

--- a/examples/fr/invoice-fr-fr-period.yaml
+++ b/examples/fr/invoice-fr-fr-period.yaml
@@ -1,0 +1,64 @@
+# Regression fixture for GBL-93: EN 16931 BR-CO-19 / BR-CO-20 allow a period
+# to carry only one of its bounds. Modelled on an inbound supplier invoice
+# where the header invoicing period only had an end date (BT-74 without
+# BT-73), and lines for one-off services only had a start date (BT-134
+# without BT-135).
+$schema: "https://gobl.org/draft-0/bill/invoice"
+uuid: "0195f7c2-7d1a-7b00-8c7e-3c1c0d5e9a11"
+currency: "EUR"
+issue_date: "2026-09-01"
+series: "SAMPLE"
+code: "002"
+
+supplier:
+  tax_id:
+    country: "FR"
+    code: "44732829320" # random
+  name: "Provide One Inc."
+  emails:
+    - addr: "billing@example.com"
+  addresses:
+    - num: "42"
+      street: "Calle Pradillo"
+      locality: "Madrid"
+      region: "Madrid"
+      code: "28002"
+      country: "ES"
+
+customer:
+  tax_id:
+    country: "FR"
+    code: "356000000"
+  name: "Sample Consumer"
+  emails:
+    - addr: "email@sample.com"
+  addresses:
+    - num: "1"
+      street: "Rue Sundacsakn"
+      locality: "Saint-Germain-En-Laye"
+      code: "75050"
+      country: "FR"
+
+ordering:
+  period:
+    end: "2026-08-31"
+
+lines:
+  - quantity: 1
+    period:
+      start: "2026-08-12"
+    item:
+      name: "Transport service"
+      price: "180.00"
+    taxes:
+      - cat: VAT
+        rate: standard
+  - quantity: 1
+    period:
+      start: "2026-08-20"
+    item:
+      name: "Handling fee"
+      price: "25.00"
+    taxes:
+      - cat: VAT
+        rate: standard

--- a/examples/fr/invoice-fr-fr-period.yaml
+++ b/examples/fr/invoice-fr-fr-period.yaml
@@ -1,8 +1,3 @@
-# Regression fixture for GBL-93: EN 16931 BR-CO-19 / BR-CO-20 allow a period
-# to carry only one of its bounds. Modelled on an inbound supplier invoice
-# where the header invoicing period only had an end date (BT-74 without
-# BT-73), and lines for one-off services only had a start date (BT-134
-# without BT-135).
 $schema: "https://gobl.org/draft-0/bill/invoice"
 uuid: "0195f7c2-7d1a-7b00-8c7e-3c1c0d5e9a11"
 currency: "EUR"

--- a/examples/fr/out/invoice-fr-fr-period.json
+++ b/examples/fr/out/invoice-fr-fr-period.json
@@ -1,0 +1,136 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
+		"dig": {
+			"alg": "sha256",
+			"val": "0c4e3b6a4b4b4e09172813040c47e0d78fa64998d72cf9e3d3c3efd73f8a9c10"
+		}
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"$regime": "FR",
+		"uuid": "0195f7c2-7d1a-7b00-8c7e-3c1c0d5e9a11",
+		"type": "standard",
+		"series": "SAMPLE",
+		"code": "002",
+		"issue_date": "2026-09-01",
+		"currency": "EUR",
+		"supplier": {
+			"name": "Provide One Inc.",
+			"tax_id": {
+				"country": "FR",
+				"code": "44732829320"
+			},
+			"addresses": [
+				{
+					"num": "42",
+					"street": "Calle Pradillo",
+					"locality": "Madrid",
+					"region": "Madrid",
+					"code": "28002",
+					"country": "ES"
+				}
+			],
+			"emails": [
+				{
+					"addr": "billing@example.com"
+				}
+			]
+		},
+		"customer": {
+			"name": "Sample Consumer",
+			"tax_id": {
+				"country": "FR",
+				"code": "39356000000"
+			},
+			"addresses": [
+				{
+					"num": "1",
+					"street": "Rue Sundacsakn",
+					"locality": "Saint-Germain-En-Laye",
+					"code": "75050",
+					"country": "FR"
+				}
+			],
+			"emails": [
+				{
+					"addr": "email@sample.com"
+				}
+			]
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "1",
+				"period": {
+					"start": "2026-08-12"
+				},
+				"item": {
+					"name": "Transport service",
+					"price": "180.00"
+				},
+				"sum": "180.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "general",
+						"percent": "20%"
+					}
+				],
+				"total": "180.00"
+			},
+			{
+				"i": 2,
+				"quantity": "1",
+				"period": {
+					"start": "2026-08-20"
+				},
+				"item": {
+					"name": "Handling fee",
+					"price": "25.00"
+				},
+				"sum": "25.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "general",
+						"percent": "20%"
+					}
+				],
+				"total": "25.00"
+			}
+		],
+		"ordering": {
+			"period": {
+				"end": "2026-08-31"
+			}
+		},
+		"totals": {
+			"sum": "205.00",
+			"total": "205.00",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"base": "205.00",
+								"percent": "20%",
+								"amount": "41.00"
+							}
+						],
+						"amount": "41.00"
+					}
+				],
+				"sum": "41.00"
+			},
+			"tax": "41.00",
+			"total_with_tax": "246.00",
+			"payable": "246.00"
+		}
+	}
+}


### PR DESCRIPTION
Resolves [GBL-93](https://linear.app/invopop/issue/GBL-93/calperiod-accept-a-single-bound-to-match-en-16931-br-co-19-br-co-20).

## Problem

`cal.Period` required both a start and an end date, but EN 16931 only requires at least one of BT-73/BT-74 (BR-CO-19) and BT-134/BT-135 (BR-CO-20). Conformant inbound invoices carrying a one-sided period (e.g. the STEF Transport case from Pylon #6193) were converted into GOBL documents that could not be validated or signed.

## Changes

- `cal.Period`: **breaking**: `Start` and `End` are now `*Date` pointers, so an absent bound is `nil` and omitted from JSON instead of being serialized as `"0000-00-00"`. Legacy `"0000-00-00"` input still parses.
- At least one of `start` / `end` is required. A period with neither fails once, on the period itself, with the new `GOBL-CAL-PERIOD-11`.
- `GOBL-CAL-PERIOD-01` / `-02` ("date cannot be zero") are kept, but as `rules.AssertIfPresent`: they only apply to a bound that is actually supplied, so an explicit zero date is still rejected while a missing one is not.
- Rule `10` (end on or after start) applies only when both bounds are present and non-zero, so a zero date reports one fault rather than two.
- Regenerated `data/schemas/cal/period.json` (no longer requires both fields) and `data/rules/cal.json`.
- New FR example fixture `examples/fr/invoice-fr-fr-period.yaml` with an end-only header period and start-only line periods, mirroring the reported invoice.
- CHANGELOG entry.

## Verified against the reported invoice

Parsing the actual STEF UBL file with `gobl.ubl`: on v0.504.0 the only faults are the period codes (header start, all 11 line ends). On this branch the document validates cleanly under the FR regime with the EN 16931 and FR CTC flow 2 addons. That check was run before the switch to pointer dates; the accepted-document behavior is unchanged, only the fault code for a bound-less period moved from `-03` to `-11`.

## Consumer audit

No code in `bill`, `org`, `tax`, `pay`, `addons` or `regimes` reads `Period.Start` / `Period.End` directly; the only reference is a nil check in `SubLine.IsEmpty`. Regimes whose authorities require both bounds (e.g. Argentina ARCA for service invoices) previously relied on this core rule implicitly and may want an explicit "both required" rule; tracked as a follow-up.

## Companion PRs

- invopop/gobl.cii#94: guards on the CII exporter plus round-trip fixtures.
- invopop/gobl.ubl#140: round-trip fixtures (exporter already safe).

Both companions were written against the value-typed fields and need updating for the pointer change before they merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
