### PR TITLE
Add Estonia (EE) tax regime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Added
+- `regimes/fi`: New tax regime for Estonia and VAT number validation.
+
 ## [v0.505.0]
 
 ### Added

--- a/data/regimes/ee.json
+++ b/data/regimes/ee.json
@@ -1,0 +1,211 @@
+{
+  "$schema": "https://gobl.org/draft-0/tax/regime-def",
+  "name": {
+    "en": "Estonia",
+    "et": "Eesti"
+  },
+  "description": {
+    "en": "Estonia's tax system is administered by the Estonian Tax and Customs Board (Maksu- ja Tolliamet or EMTA).\nAs an EU member state, Estonia follows the EU VAT Directive.\nA general, intermediate, reduced, and zero rates apply, with certain exemptions for specific goods and services.\nEstonian businesses are required to register for the VAT system if their revenue exceeds the 40,000 EUR threshold.\nBusinesses are identified by a unique VAT number (käibemaksukohustuslase number) with prefix EE.\nE-invoicing is mandated for accounting entities regiistered as e-invoice recipients in the commerical register.\nGiven that all public sector entities are registered as e-invoice recipients, this effectively mandates e-invoicing for all B2G transactions.\nThe European standard for e-invoicing (EN 16931) is used. There is no mandate for B2C e-invoicing."
+  },
+  "sources": [
+    {
+      "title": {
+        "en": "Estonian Tax and Customs Board - Value Added Tax"
+      },
+      "url": "https://www.emta.ee/en/business-client/taxes-and-payment/value-added-tax"
+    },
+    {
+      "title": {
+        "en": "Riigi Teataja - Käibemaksuseadus"
+      },
+      "url": "https://www.riigiteataja.ee/en/akt/511072022006"
+    },
+    {
+      "title": {
+        "en": "Estonian Tax and Customs Board - VAT rates and supply exempt from tax"
+      },
+      "url": "https://www.emta.ee/en/business-client/taxes-and-payment/value-added-tax/vat-rates-and-supply-exempt-tax/standard-vat-rate"
+    },
+    {
+      "title": {
+        "en": "European Commission - eInvoicing in Estonia"
+      },
+      "url": "https://ec.europa.eu/digital-building-blocks/sites/spaces/DIGITAL/pages/467108883/eInvoicing+in+Estonia"
+    }
+  ],
+  "time_zone": "Europe/Tallinn",
+  "country": "EE",
+  "currency": "EUR",
+  "tax_scheme": "VAT",
+  "scenarios": [
+    {
+      "schema": "bill/invoice",
+      "list": [
+        {
+          "tags": [
+            "reverse-charge"
+          ],
+          "cat": [
+            "VAT"
+          ],
+          "note": {
+            "cat": "VAT",
+            "key": "reverse-charge",
+            "text": "Reverse charge: Customer to account for VAT to the relevant tax authority."
+          }
+        }
+      ]
+    }
+  ],
+  "categories": [
+    {
+      "code": "VAT",
+      "name": {
+        "en": "VAT",
+        "et": "KM"
+      },
+      "title": {
+        "en": "Value Added Tax",
+        "et": "Käibemaks"
+      },
+      "keys": [
+        {
+          "key": "standard",
+          "name": {
+            "en": "Standard"
+          }
+        },
+        {
+          "key": "zero",
+          "name": {
+            "en": "Zero"
+          }
+        },
+        {
+          "key": "reverse-charge",
+          "name": {
+            "en": "Reverse charge"
+          },
+          "no_percent": true
+        },
+        {
+          "key": "exempt",
+          "name": {
+            "en": "Exempt"
+          },
+          "no_percent": true
+        },
+        {
+          "key": "export",
+          "name": {
+            "en": "Export"
+          },
+          "no_percent": true
+        },
+        {
+          "key": "intra-community",
+          "name": {
+            "en": "Intra-community"
+          },
+          "no_percent": true
+        },
+        {
+          "key": "outside-scope",
+          "name": {
+            "en": "Outside scope"
+          },
+          "no_percent": true
+        }
+      ],
+      "rates": [
+        {
+          "rate": "general",
+          "keys": [
+            "standard"
+          ],
+          "name": {
+            "en": "Standard Rate",
+            "et": "Tavakäibemaks"
+          },
+          "values": [
+            {
+              "since": "2025-07-01",
+              "percent": "24.0%"
+            },
+            {
+              "since": "2024-01-01",
+              "percent": "22.0%"
+            },
+            {
+              "since": "2009-07-01",
+              "percent": "20.0%"
+            },
+            {
+              "since": "1993-01-01",
+              "percent": "18.0%"
+            },
+            {
+              "since": "1991-01-01",
+              "percent": "10.0%"
+            }
+          ]
+        },
+        {
+          "rate": "intermediate",
+          "keys": [
+            "standard"
+          ],
+          "name": {
+            "en": "Intermediate Rate",
+            "et": "Keskmine käibemaks"
+          },
+          "values": [
+            {
+              "since": "2025-01-01",
+              "percent": "13.0%"
+            }
+          ]
+        },
+        {
+          "rate": "reduced",
+          "keys": [
+            "standard"
+          ],
+          "name": {
+            "en": "Reduced Rate",
+            "et": "Alandatud käibemaks"
+          },
+          "values": [
+            {
+              "since": "2013-01-01",
+              "percent": "9.0%"
+            }
+          ]
+        },
+        {
+          "rate": "zero",
+          "keys": [
+            "zero"
+          ],
+          "name": {
+            "en": "Zero Rate",
+            "et": "Nullkäibemaks"
+          },
+          "values": [
+            {
+              "percent": "0.0%"
+            }
+          ]
+        }
+      ],
+      "sources": [
+        {
+          "title": {
+            "en": "Estonian Tax and Customs Board - Value Added Tax"
+          },
+          "url": "https://www.emta.ee/en/business-client/taxes-and-payment/value-added-tax"
+        }
+      ]
+    }
+  ]
+}

--- a/data/rules/ee.json
+++ b/data/rules/ee.json
@@ -1,0 +1,32 @@
+{
+  "id": "GOBL-EE",
+  "package": "ee",
+  "subsets": [
+    {
+      "id": "GOBL-EE-TAX-IDENTITY",
+      "object": "tax.Identity",
+      "subsets": [
+        {
+          "guard": "code in [EE]",
+          "subsets": [
+            {
+              "field": "code",
+              "subsets": [
+                {
+                  "guard": "present",
+                  "assert": [
+                    {
+                      "id": "GOBL-EE-TAX-IDENTITY-01",
+                      "desc": "invalid Estonian VAT identity code",
+                      "tests": "valid"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/data/schemas/tax/regime-code.json
+++ b/data/schemas/tax/regime-code.json
@@ -50,6 +50,10 @@
           "title": "Denmark"
         },
         {
+          "const": "EE",
+          "title": "Estonia"
+        },
+        {
           "const": "EL",
           "title": "Greece"
         },

--- a/examples/ee/invoice-ee-ee.yaml
+++ b/examples/ee/invoice-ee-ee.yaml
@@ -1,0 +1,63 @@
+$schema: "https://gobl.org/draft-0/bill/invoice"
+uuid: "f24aaf52-5ce3-4ff2-bbf1-ca9d2f778897" 
+series: "SAMPLE"
+code: "001"
+issue_date: "2026-09-09"
+
+supplier:
+  name: "Paul Keres"
+  tax_id:
+    country: "EE"
+    code: "100366327"
+  addresses:
+    - num: "315"
+      street: "Jõe tn"
+      locality: "Narva"
+      code: "20306"
+      country: "EE"
+  emails:
+    - addr: "billing@example.ee"
+
+customer:
+  name: "Raul Keres"
+  tax_id:
+    country: "EE"
+    code: "102090374"
+  addresses:
+    - num: "4"
+      street: "Kiriku tn"
+      locality: "Kihelkonna"
+      code: "93401"
+      country: "EE"
+
+lines:
+  - quantity: "10"
+    item:
+      name: "Software development services"
+      price: "120.00"
+      unit: "h"
+    taxes:
+      - cat: VAT
+        rate: "standard"
+  - quantity: "1"
+    item:
+      name: "Accommodation"
+      price: "500.00"
+    taxes:
+      - cat: VAT
+        rate: "intermediate"
+  - quantity: "1"
+    item:
+      name: "Medical devices"
+      price: "1000.00"
+    taxes:
+      - cat: VAT
+        rate: "reduced"
+  - quantity: "5"
+    item:
+      name: "Exempt community export"
+      price: "200.00"
+    taxes:
+      - cat: VAT
+        rate: "zero"
+

--- a/examples/ee/out/invoice-ee-ee.json
+++ b/examples/ee/out/invoice-ee-ee.json
@@ -1,0 +1,173 @@
+{
+	"$schema": "https://gobl.org/draft-0/envelope",
+	"head": {
+		"uuid": "8a51fd30-2a27-11ee-be56-0242ac120002",
+		"dig": {
+			"alg": "sha256",
+			"val": "4b73e61863b5a03dc0e0cf89338d291098fab9b73999c8283959ace80e1dbe9d"
+		}
+	},
+	"doc": {
+		"$schema": "https://gobl.org/draft-0/bill/invoice",
+		"$regime": "EE",
+		"uuid": "f24aaf52-5ce3-4ff2-bbf1-ca9d2f778897",
+		"type": "standard",
+		"series": "SAMPLE",
+		"code": "001",
+		"issue_date": "2026-09-09",
+		"currency": "EUR",
+		"supplier": {
+			"name": "Paul Keres",
+			"tax_id": {
+				"country": "EE",
+				"code": "100366327"
+			},
+			"addresses": [
+				{
+					"num": "315",
+					"street": "Jõe tn",
+					"locality": "Narva",
+					"code": "20306",
+					"country": "EE"
+				}
+			],
+			"emails": [
+				{
+					"addr": "billing@example.ee"
+				}
+			]
+		},
+		"customer": {
+			"name": "Raul Keres",
+			"tax_id": {
+				"country": "EE",
+				"code": "102090374"
+			},
+			"addresses": [
+				{
+					"num": "4",
+					"street": "Kiriku tn",
+					"locality": "Kihelkonna",
+					"code": "93401",
+					"country": "EE"
+				}
+			]
+		},
+		"lines": [
+			{
+				"i": 1,
+				"quantity": "10",
+				"item": {
+					"name": "Software development services",
+					"price": "120.00",
+					"unit": "h"
+				},
+				"sum": "1200.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "general",
+						"percent": "24.0%"
+					}
+				],
+				"total": "1200.00"
+			},
+			{
+				"i": 2,
+				"quantity": "1",
+				"item": {
+					"name": "Accommodation",
+					"price": "500.00"
+				},
+				"sum": "500.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "intermediate",
+						"percent": "13.0%"
+					}
+				],
+				"total": "500.00"
+			},
+			{
+				"i": 3,
+				"quantity": "1",
+				"item": {
+					"name": "Medical devices",
+					"price": "1000.00"
+				},
+				"sum": "1000.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "standard",
+						"rate": "reduced",
+						"percent": "9.0%"
+					}
+				],
+				"total": "1000.00"
+			},
+			{
+				"i": 4,
+				"quantity": "5",
+				"item": {
+					"name": "Exempt community export",
+					"price": "200.00"
+				},
+				"sum": "1000.00",
+				"taxes": [
+					{
+						"cat": "VAT",
+						"key": "zero",
+						"percent": "0%"
+					}
+				],
+				"total": "1000.00"
+			}
+		],
+		"totals": {
+			"sum": "3700.00",
+			"total": "3700.00",
+			"taxes": {
+				"categories": [
+					{
+						"code": "VAT",
+						"rates": [
+							{
+								"key": "standard",
+								"base": "1200.00",
+								"percent": "24.0%",
+								"amount": "288.00"
+							},
+							{
+								"key": "standard",
+								"base": "500.00",
+								"percent": "13.0%",
+								"amount": "65.00"
+							},
+							{
+								"key": "standard",
+								"base": "1000.00",
+								"percent": "9.0%",
+								"amount": "90.00"
+							},
+							{
+								"key": "zero",
+								"base": "1000.00",
+								"percent": "0%",
+								"amount": "0.00"
+							}
+						],
+						"amount": "443.00"
+					}
+				],
+				"sum": "443.00"
+			},
+			"tax": "443.00",
+			"total_with_tax": "4143.00",
+			"payable": "4143.00"
+		}
+	}
+}

--- a/regimes/ee/ee.go
+++ b/regimes/ee/ee.go
@@ -1,0 +1,72 @@
+// Package ee provides tax regime support for Estonia.
+package ee
+
+import (
+	"github.com/invopop/gobl/bill"
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/currency"
+	"github.com/invopop/gobl/i18n"
+	"github.com/invopop/gobl/norm"
+	"github.com/invopop/gobl/pkg/here"
+	"github.com/invopop/gobl/rules"
+	"github.com/invopop/gobl/tax"
+)
+
+// CountryCode is the ISO 3166-1 alpha-2 code for Estonia.
+const CountryCode = "EE"
+
+func init() {
+	tax.RegisterRegimeDef(New())
+	rules.Register("ee", rules.GOBL.Add(CountryCode),
+		taxIdentityRules(),
+	)
+	norm.Register(
+		norm.When(tax.IdentityIn(CountryCode), norm.For(func(tID *tax.Identity) { tax.NormalizeIdentity(tID) })),
+	)
+}
+
+// New instantiates a new Estonia regime
+func New() *tax.RegimeDef {
+	return &tax.RegimeDef{
+		Country:   CountryCode,
+		Currency:  currency.EUR,
+		TaxScheme: tax.CategoryVAT,
+		Name: i18n.String{
+			i18n.EN: "Estonia",
+			i18n.ET: "Eesti",
+		},
+		Description: i18n.String{
+			i18n.EN: here.Doc(`
+				Estonia's tax system is administered by the Estonian Tax and Customs Board (Maksu- ja Tolliamet or EMTA).
+				As an EU member state, Estonia follows the EU VAT Directive.
+				A general, intermediate, reduced, and zero rates apply, with certain exemptions for specific goods and services.
+				Estonian businesses are required to register for the VAT system if their revenue exceeds the 40,000 EUR threshold.
+				Businesses are identified by a unique VAT number (käibemaksukohustuslase number) with prefix EE.
+				E-invoicing is mandated for accounting entities regiistered as e-invoice recipients in the commerical register.
+				Given that all public sector entities are registered as e-invoice recipients, this effectively mandates e-invoicing for all B2G transactions.
+				The European standard for e-invoicing (EN 16931) is used. There is no mandate for B2C e-invoicing.
+			`),
+		},
+		Sources: []*cbc.Source{
+			{
+				Title: i18n.NewString("Estonian Tax and Customs Board - Value Added Tax"),
+				URL:   "https://www.emta.ee/en/business-client/taxes-and-payment/value-added-tax",
+			},
+			{
+				Title: i18n.NewString("Riigi Teataja - Käibemaksuseadus"),
+				URL:   "https://www.riigiteataja.ee/en/akt/511072022006",
+			},
+			{
+				Title: i18n.NewString("Estonian Tax and Customs Board - VAT rates and supply exempt from tax"),
+				URL:   "https://www.emta.ee/en/business-client/taxes-and-payment/value-added-tax/vat-rates-and-supply-exempt-tax/standard-vat-rate",
+			},
+			{
+				Title: i18n.NewString("European Commission - eInvoicing in Estonia"),
+				URL:   "https://ec.europa.eu/digital-building-blocks/sites/spaces/DIGITAL/pages/467108883/eInvoicing+in+Estonia",
+			},
+		},
+		TimeZone:   "Europe/Tallinn",
+		Categories: taxCategories,
+		Scenarios:  []*tax.ScenarioSet{bill.InvoiceScenarios()},
+	}
+}

--- a/regimes/ee/tax_categories.go
+++ b/regimes/ee/tax_categories.go
@@ -1,0 +1,104 @@
+package ee
+
+import (
+	"github.com/invopop/gobl/cal"
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/i18n"
+	"github.com/invopop/gobl/num"
+	"github.com/invopop/gobl/tax"
+)
+
+var taxCategories = []*tax.CategoryDef{
+	{
+		Code: tax.CategoryVAT,
+		Name: i18n.String{
+			i18n.EN: "VAT",
+			i18n.ET: "KM",
+		},
+		Title: i18n.String{
+			i18n.EN: "Value Added Tax",
+			i18n.ET: "Käibemaks",
+		},
+		Sources: []*cbc.Source{
+			{
+				Title: i18n.NewString("Estonian Tax and Customs Board - Value Added Tax"),
+				URL:   "https://www.emta.ee/en/business-client/taxes-and-payment/value-added-tax",
+			},
+		},
+		Retained: false,
+		Keys:     tax.GlobalVATKeys(),
+		Rates: []*tax.RateDef{
+			{
+				Keys: []cbc.Key{tax.KeyStandard},
+				Rate: tax.RateGeneral,
+				Name: i18n.String{
+					i18n.EN: "Standard Rate",
+					i18n.ET: "Tavakäibemaks",
+				},
+				Values: []*tax.RateValueDef{
+					{
+						Since:   cal.NewDate(2025, 7, 1),
+						Percent: num.MakePercentage(240, 3), // 24.0%
+					},
+					{
+						Since:   cal.NewDate(2024, 1, 1),
+						Percent: num.MakePercentage(220, 3), // 22.0%
+					},
+					{
+						Since:   cal.NewDate(2009, 7, 1),
+						Percent: num.MakePercentage(200, 3), // 20.0%
+					},
+					{
+						Since:   cal.NewDate(1993, 1, 1),
+						Percent: num.MakePercentage(180, 3), // 18.0%
+					},
+					{
+						Since:   cal.NewDate(1991, 1, 1),
+						Percent: num.MakePercentage(100, 3), // 10.0%
+					},
+				},
+			},
+			{ // intermediate rate for "accommodation or accommodation with breakfast"
+				Keys: []cbc.Key{tax.KeyStandard},
+				Rate: tax.RateIntermediate,
+				Name: i18n.String{
+					i18n.EN: "Intermediate Rate",
+					i18n.ET: "Keskmine käibemaks",
+				},
+				Values: []*tax.RateValueDef{
+					{
+						Since:   cal.NewDate(2025, 1, 1),    // previous to 1 Jan 2025 this was included in 9% reduced rate
+						Percent: num.MakePercentage(130, 3), // 13.0%
+					},
+				},
+			},
+			{ // reduced rate for books, medical equipment, press publications
+				Keys: []cbc.Key{tax.KeyStandard},
+				Rate: tax.RateReduced,
+				Name: i18n.String{
+					i18n.EN: "Reduced Rate",
+					i18n.ET: "Alandatud käibemaks",
+				},
+				Values: []*tax.RateValueDef{
+					{
+						Since:   cal.NewDate(2013, 1, 1),
+						Percent: num.MakePercentage(90, 3), // 9.0%
+					},
+				},
+			},
+			{ // zero rate for exports, intra-community supplies, certain other goods & services
+				Keys: []cbc.Key{tax.KeyZero},
+				Rate: tax.RateZero,
+				Name: i18n.String{
+					i18n.EN: "Zero Rate",
+					i18n.ET: "Nullkäibemaks",
+				},
+				Values: []*tax.RateValueDef{
+					{
+						Percent: num.MakePercentage(0, 3), // 0.0%
+					},
+				},
+			},
+		},
+	},
+}

--- a/regimes/ee/tax_identity.go
+++ b/regimes/ee/tax_identity.go
@@ -1,0 +1,63 @@
+package ee
+
+import (
+	"regexp"
+
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/rules"
+	"github.com/invopop/gobl/rules/is"
+	"github.com/invopop/gobl/tax"
+)
+
+var taxCodeRegexps = []*regexp.Regexp{
+	regexp.MustCompile(`^\d{9}$`),
+}
+
+func taxIdentityRules() *rules.Set {
+	return rules.For(new(tax.Identity),
+		rules.When(tax.IdentityIn(CountryCode),
+			rules.Field("code",
+				rules.AssertIfPresent("01", "invalid Estonian VAT identity code",
+					is.Func("valid", validateTaxCode),
+				),
+			),
+		),
+	)
+}
+
+func validateTaxCode(value any) bool {
+	code, ok := value.(cbc.Code)
+	if !ok {
+		return false
+	}
+	val := code.String()
+
+	for _, re := range taxCodeRegexps {
+		if re.MatchString(val) {
+			return validateTaxCodeChecksum(val)
+		}
+	}
+	return false
+}
+
+// Estonia's VAT number (käibemaksukohustuslase number)
+// Finding any info on the algorithm was quite difficult,
+// using what was stated in the docs for vat-validator
+// Reference: https://vat-validator.readthedocs.io/en/latest/_modules/vat_validator/countries.html
+// Format: EE + 9 digits
+// Validation: weighted sum of first 8 digits with weights [3, 7, 1, 3, 7, 1, 3, 7]
+//
+// 9th digit is check digit, must equal (10 - (sum % 10)) % 10
+
+func validateTaxCodeChecksum(val string) bool {
+	weights := []int{3, 7, 1, 3, 7, 1, 3, 7}
+	sum := 0
+
+	for i := range 8 {
+		sum += int(val[i]-'0') * weights[i]
+	}
+
+	expected := (10 - (sum % 10)) % 10
+
+	return int(val[8]-'0') == expected
+}

--- a/regimes/ee/tax_identity_test.go
+++ b/regimes/ee/tax_identity_test.go
@@ -1,0 +1,79 @@
+package ee_test
+
+import (
+	"testing"
+
+	"github.com/invopop/gobl/cbc"
+	"github.com/invopop/gobl/rules"
+	"github.com/invopop/gobl/tax"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTaxIdentityRules(t *testing.T) {
+	tests := []struct {
+		name        string
+		inputCode   cbc.Code
+		expectedErr string
+	}{
+		// Valid cases, verified against estonian VAT number validator and EU VIES
+		{
+			name:      "valid 1",
+			inputCode: "100366327",
+		},
+		{
+			name:      "valid 2",
+			inputCode: "102090374",
+		},
+		{
+			name:      "empty code",
+			inputCode: "",
+		},
+
+		// Format errors
+		{
+			name:        "too short",
+			inputCode:   "1234567",
+			expectedErr: "IDENTITY-01",
+		},
+		{
+			name:        "too long",
+			inputCode:   "1234567890",
+			expectedErr: "IDENTITY-01",
+		},
+		{
+			name:        "not normalized",
+			inputCode:   "EE100366327",
+			expectedErr: "IDENTITY-01",
+		},
+		{
+			name:        "contains letters",
+			inputCode:   "1234567A",
+			expectedErr: "IDENTITY-01",
+		},
+		// Checksum errors
+		{
+			name:        "bad checksum",
+			inputCode:   "100366326",
+			expectedErr: "IDENTITY-01",
+		},
+		{
+			name:        "remainder 1 - no valid check digit",
+			inputCode:   "80000000",
+			expectedErr: "IDENTITY-01",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tID := &tax.Identity{Country: "EE", Code: tt.inputCode}
+			err := rules.Validate(tID)
+			if tt.expectedErr == "" {
+				assert.NoError(t, err)
+			} else {
+				if assert.Error(t, err) {
+					assert.Contains(t, err.Error(), tt.expectedErr)
+				}
+			}
+		})
+	}
+}

--- a/regimes/regimes.go
+++ b/regimes/regimes.go
@@ -16,6 +16,7 @@ import (
 	_ "github.com/invopop/gobl/regimes/co"
 	_ "github.com/invopop/gobl/regimes/de"
 	_ "github.com/invopop/gobl/regimes/dk"
+	_ "github.com/invopop/gobl/regimes/ee"
 	_ "github.com/invopop/gobl/regimes/es"
 	_ "github.com/invopop/gobl/regimes/fi"
 	_ "github.com/invopop/gobl/regimes/fr"


### PR DESCRIPTION
## Summary

- Introduced new tax regime for Estonia (EE) with the following VAT categories:
    - standard (24.0%)
    - Intermediate (13.0%)
    - reduced (9.0%)
    - zero (0%)
- Added historical VAT rates (1991-2026)
- Implemented VAT number (käibemaksukohustuslase number) validation
- Added a B2B invoice example in YAML
- Added tests for all regime-specific logic

## Pre-Review Checklist

- [x] Opened this PR as a draft
- [x] Read the CONTRIBUTING.md guide.
- [x] Performed a self-review of my code.
- [x] Added thorough tests with at **least** 90% code coverage.
- [x] Modified or created example GOBL documents to show my changes in use, if appropriate.
- [x] Added links to the source of the changes in tax regimes or addons, either structured or in the comments.
- [x] Run `go generate .` to ensure that the Schemas and Regime data are up to date.
- [x] Reviewed and fixed all linter warnings.
- [x] Been obsessive with pointer nil checks to avoid panics.
- [x] Updated the CHANGELOG.md with an overview of my changes.
- [x] Marked this PR as ready for review.

And if you are part of the org:
- [ ] Requested a review from Copilot and fixed or dismissed (with a reason) all the feedback raised.
- [ ] Requested a review from @samlown.
