### PR TITLE
org: skip URL/email sniffing on inbox codes with a scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Fixed
+
+- `org`: `Inbox` normalization no longer re-interprets the `code` as a URL or email
+  when a `scheme` is set or the key is `peppol`. Dotted participant IDs such as French
+  `0225` routing codes were previously moved into the `url` field on every save.
+
 ## [v0.505.0]
 
 ### Added

--- a/org/inbox.go
+++ b/org/inbox.go
@@ -89,13 +89,20 @@ func AddInbox(in []*Inbox, i *Inbox) []*Inbox {
 
 func normalizeInbox(i *Inbox) {
 	uuid.Normalize(&i.UUID)
+	// Only sniff the code for an email or URL when there is no scheme and the
+	// inbox is not a Peppol participant. Once a scheme is present (or the key is
+	// peppol), the code is a participant ID by definition and must not be
+	// re-interpreted, as dotted IDs (e.g. French 0225 routing codes) would
+	// otherwise be mistaken for URLs.
 	code := i.Code.String()
-	if is.EmailFormat.Check(code) {
-		i.Email = code
-		i.Code = ""
-	} else if is.URL.Check(code) {
-		i.URL = code
-		i.Code = ""
+	if i.Scheme == "" && i.Key != InboxKeyPeppol {
+		if is.EmailFormat.Check(code) {
+			i.Email = code
+			i.Code = ""
+		} else if is.URL.Check(code) {
+			i.URL = code
+			i.Code = ""
+		}
 	}
 	i.Label = cbc.NormalizeString(i.Label)
 	i.Scheme = cbc.NormalizeUpperCode(i.Scheme)

--- a/org/inbox_test.go
+++ b/org/inbox_test.go
@@ -107,6 +107,27 @@ func TestInboxNormalize(t *testing.T) {
 		assert.Empty(t, id.Email)
 		assert.Equal(t, "https://inbox.example.com", id.URL)
 	})
+	t.Run("with scheme and dotted code", func(t *testing.T) {
+		id := &org.Inbox{
+			Scheme: "0225",
+			Code:   "12345678900012.001",
+		}
+		norm.Normalize(id)
+		assert.Equal(t, "0225", id.Scheme.String())
+		assert.Equal(t, "12345678900012.001", id.Code.String())
+		assert.Empty(t, id.URL)
+		assert.Empty(t, id.Email)
+	})
+	t.Run("with peppol key and dotted code", func(t *testing.T) {
+		id := &org.Inbox{
+			Key:  org.InboxKeyPeppol,
+			Code: "0225:12345678900012.001",
+		}
+		norm.Normalize(id)
+		assert.Equal(t, "0225", id.Scheme.String())
+		assert.Equal(t, "12345678900012.001", id.Code.String())
+		assert.Empty(t, id.URL)
+	})
 	t.Run("with peppol participant code", func(t *testing.T) {
 		id := &org.Inbox{
 			Key:  org.InboxKeyPeppol,


### PR DESCRIPTION
Fixes GOBL-97

## Summary written by the author

Peppol inboxes can look like TLDs:


```
"inboxes": [
    { "key": "peppol", "scheme": "0225", "code": "XXXXXX_maxpower.studio" }
]
```

The problem is that we look at the code and convert it into `url` because it looks like a URL!

```
"inboxes": [
    { "key": "peppol", "scheme": "0225", "url": "XXXXXX_maxpower.studio" }
]
```

Claude proposes to retain the functionality but skip when there's a scheme (required for peppol inboxes).

## What

`normalizeInbox` now only re-interprets `code` as a URL or email when the inbox has no `scheme` and its key is not `peppol`. Once a scheme is present, the code is a participant ID by definition and is left untouched.

## Why

govalidator's `IsURL` returns true for anything shaped like `host.tld`. Dotted participant IDs, such as French `0225` routing codes like `12345678900012.001`, were therefore moved into the `url` field on every `Calculate()`. Downstream, `gobl.ubl` builds `cbc:EndpointID` from `Inboxes[0].Code`, so the document ended up with `<cbc:EndpointID schemeID="0225"></cbc:EndpointID>` and an empty value. Because the same normalization runs on every save, no client-side workaround was possible (Console edits, PATCH, or workflow steps all reverted).

Plain SIRET numbers without a dot were unaffected, which is why this only surfaced for dotted French addresses.

## Changes

- `org/inbox.go`: guard the email/URL sniffing behind `i.Scheme == "" && i.Key != InboxKeyPeppol`.
- `org/inbox_test.go`: new cases for a `0225` scheme with a dotted code, and the `peppol`-key `0225:...` form which still splits into scheme and code.
- `CHANGELOG.md`: entry under Unreleased / Fixed.

## Reviewer notes

- Inboxes with no scheme keep the existing sniffing, so `Code: "dev@invopop.com"` and `Code: "https://..."` still migrate to `email` / `url` as before.
- After release, the silo and FR PA workers need a GOBL bump for affected entries to heal on their next re-save.
- Also affects inbound French invoices parsed via `gobl.ubl` `party_parse.go`, which writes into `org.Inbox`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
